### PR TITLE
Post-v0.1.0 bugfix pass + session persistence + styled dialogs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,38 @@ UI/UX decisions are documented in `docs/DESIGN.md` and `docs/DECISIONS.md`. Mirr
 - `var` always unless the type isn't obvious from the right-hand side
 - 4-space indent, 120 char line length guideline
 
+## Running side-by-side with an installed build
+
+The user develops CodeScope *inside* CodeScope — the installed v0.1.0+ build
+hosts the sessions that work on this repo, so closing it to test a dev build
+would kill every other project's session. Dev runs therefore need to coexist
+with the installed app.
+
+Start the dev build with the `CODESCOPE_DEV` env var set:
+
+```pwsh
+$env:CODESCOPE_DEV = "1"
+dotnet run --project src/CodeScope.App
+```
+
+`NoScope.CodeScope.Core.AppPaths` resolves the env var once at process start
+and redirects:
+
+- single-instance mutex → `Global\CodeScope.SingleInstance.Dev`
+- `%APPDATA%\CodeScope\` → `%APPDATA%\CodeScope.Dev\` (projects.json)
+- `%LOCALAPPDATA%\CodeScope\` → `%LOCALAPPDATA%\CodeScope.Dev\` (layout.json,
+  window.json, console.log, crash.log)
+- window title → `CodeScope [dev] — …`
+
+The Dev store is independent — projects opened in the dev build are separate
+from the installed build's projects. Typical loop: keep v0.1.0 running with
+real work, launch dev with a subset of projects (or different ones) to
+exercise changes. Claude telemetry tails at `~/.claude/projects/…` are shared
+by design — two FSWatchers, no state conflict.
+
+When adding new on-disk state, thread it through `AppPaths.AppFolderName` so
+dev-mode separation keeps working.
+
 ## Workflow
 
 - **First, on any fresh session, read `docs/HANDOFF.md`** — it holds the cursor (what we were doing), current build/test status, roadmap state, open rough edges, and suggested next entry points. It is updated at the end of each session.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -331,6 +331,30 @@ docs/
 - **Gitea CI rollup is always `None`** — `tea pulls status`/REST integration deferred.
 - **Session-exit toasts deferred** — `SessionManager` starts pwsh with `-NoExit`; detecting agent exit needs `SessionManager` refactor or pty-output parsing.
 - **Drag tab between groups restarts pwsh** — agent resumes via `--continue`/`--resume` but the scroll buffer is lost. Fix needs a shared SessionTabView host pool (see `memory/project_terminal_lifecycle.md`).
+- **Terminal right-click opens no context menu** — parked for a dedicated
+  research pass. Short version: `Microsoft.Terminal.Wpf` hosts a native
+  Win32 child HWND (`TerminalContainer : HwndHost`) that intercepts
+  `WM_RBUTTONUP` at the native layer, so WPF's routed mouse events never
+  fire and `Grid.ContextMenu` / `PreviewMouseRightButtonUp` / the
+  top-level `HwndSource.AddHook` all see nothing. Tested three tunneling
+  routes via wpf-cli — the right-click instead pasted the clipboard into
+  pwsh (the terminal's own right-click-to-paste path). `PreviewKeyDown`
+  is unaffected because it rides tunneling at the keyboard layer, which
+  is why the current build ships `Ctrl+Shift+O` / `Ctrl+Shift+C` /
+  `Ctrl+Shift+V` via the keyboard handler in `SessionTabView.xaml.cs`.
+  Options to investigate later:
+  * Subclass the terminal's native HWND via `SetWindowLongPtr(GWLP_WNDPROC)`
+    to peek `WM_RBUTTONUP` and forward → most robust but fragile across
+    `Microsoft.Terminal.Wpf` versions; P/Invoke heavy.
+  * Flip `Win32InputMode="False"` and rebuild keyboard forwarding
+    ourselves → recovers WPF mouse events but is a big rewrite of the
+    keyboard path.
+  * Keyboard-only fallback: `Shift+F10` / Apps-key handler that opens a
+    WPF ContextMenu programmatically (small, but no mouse UX).
+  * Upstream a right-click event in `Microsoft.Terminal.Wpf` so no
+    subclassing is needed.
+  Context-menu XAML + click handlers were prototyped and reverted in
+  `3bef676` (see diff — can be resurrected once a reach route lands).
 
 ## Dev loop quick-reference
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -5,24 +5,108 @@
 > **Intent:** cursor + last 1–2 sessions in depth, everything else a one-liner.
 > Old detail lives in `git log` — don't duplicate it here.
 
-**Last updated:** 2026-04-24 (session 19)
-**Branch:** `main`.
-**Head:** `a0df3cc` — `Add Velopack distribution and v0.1.0 release workflow (#1)`
+**Last updated:** 2026-04-24 (session 20)
+**Branch:** `bugfix/post-v0.1.0` — 5 commits ahead of `origin/main`, pushed to origin.
+**Head:** `bd882eb` — `fix(telemetry): keep adoption watch alive across /clear rotations`
 **Release:** `v0.1.0` shipped via GitHub Actions — https://github.com/maui1911/CodeScope/releases/tag/v0.1.0
-**Build status:** ✅ `dotnet build` clean. `dotnet test` 145/145 green.
+**Build status:** ✅ `dotnet build` clean. `dotnet test` 147/147 green.
 **Uncommitted work:** none.
-**Unpushed commits:** none — pushed via PR #1.
+**Unpushed commits:** none — branch is up to date with `origin/bugfix/post-v0.1.0`; no PR opened yet.
 
 ---
 
 ## Cursor — current focus
 
-**Distribution is live.** Session 19 wired Velopack end-to-end and cut the
-first public release. Push a SemVer tag `v*.*.*` and CI handles the rest:
-`dotnet publish` → `vpk pack` (auto-downloads the prior release first so
-delta nupkgs compute) → `vpk upload github` creates the Release with
-installer + full/delta packages + `releases.win.json` attached. For v0.1.1+
-the flow is: commit → `git tag v0.1.1` → `git push origin v0.1.1`.
+**Post-v0.1.0 bugfix pass.** Session 20 shipped six fixes hit in daily use
+of the v0.1.0 install, plus a dev-mode env var so a debug build can run
+alongside the installed app. Branch `bugfix/post-v0.1.0` is pushed; next
+concrete step is a PR to `main`. After merge, bump the tag to `v0.1.1`
+and let the Session-19 release pipeline cut the update.
+
+### Session 20 — post-v0.1.0 bugfixes + dev-mode side-by-side (shipped)
+
+- `7e284ae` — **Six-in-one bundle** (separated here, kept together because
+  the shared files `MainViewModel.cs` and `SessionTabView.xaml.cs` touch
+  multiple concerns and splitting would have required hunk-level staging):
+  * **Worktree delete cascade.** Right-click → Remove now closes any open
+    tabs pinned to the worktree first (via a `CloseWorktreeSessionsAsync`
+    callback the `MainViewModel` wires onto the sidebar VM) so pwsh
+    releases its Windows cwd lock before `git worktree remove` runs.
+    Failure surfaces as a toast plus an optional `--force` retry dialog.
+    `SessionTabView` gained an `Unloaded` teardown
+    (`DisconnectConPTYTerm` + `CloseStdinToApp` + `StopExternalTermOnly`)
+    so the ConPTY child actually dies when the tab VM leaves its group.
+    `IGitService.RemoveWorktreeAsync` + `ISessionStore.RemoveWorktreeAsync`
+    grew a `bool force = false` param; existing NSubstitute stub widened.
+  * **Terminal clipboard.** Windows-Terminal semantics in a
+    `PreviewKeyDown` handler: `Ctrl+C` copies on a non-empty selection
+    else falls through as SIGINT; `Ctrl+Shift+C` always copies;
+    `Ctrl+V` / `Ctrl+Shift+V` paste with `\r\n` → `\r` normalisation
+    (otherwise each CR is an Enter and multiline pastes emit blank
+    commands). Clipboard contention gets one retry.
+  * **URL open via selection.** `Ctrl+Shift+O` on a selected URL opens
+    the default browser via `Process.Start(UseShellExecute=true)`.
+    Multi-line terminal-wrapped URLs are stitched before validation.
+    A WPF ContextMenu was prototyped for right-click access but is
+    unreachable — see rough-edges below.
+  * **Drag-resume Claude cross-group.** `AgentRegistry` restored
+    `ResumeByIdArgs = ["--resume"]` for the claude profile so a
+    cross-group drop relaunches `claude --resume <id>` instead of a
+    bare session. `MainViewModel.MoveTabToGroup` preserves the
+    telemetry tail when we can resume by id (same jsonl gets appended).
+  * **Status-bar token semantics.** `ClaudeSessionTelemetry.TotalTokens`
+    → `ContextTokens`, semantically the *latest* assistant turn's
+    `input + cache_read + cache_creation + output` (overwrite, not
+    accumulate). Claude is stateless per request so each turn's
+    `input_tokens` already covers the prior conversation — summing
+    double-counts and blew the % past 100 within a handful of turns.
+  * **Dev-mode isolation.** New `NoScope.CodeScope.Core.AppPaths`
+    resolves `CODESCOPE_DEV=1` at process start and redirects the
+    single-instance mutex, `%APPDATA%\CodeScope\`, and
+    `%LOCALAPPDATA%\CodeScope\` to `.Dev` variants. Window title
+    suffix `[dev]`. CLAUDE.md documents the workflow.
+- `3bef676` — **Drop dead WPF ContextMenu.** Right-click on the terminal
+  couldn't open any WPF context menu: `Microsoft.Terminal.Wpf`'s HwndHost
+  child captures `WM_RBUTTONUP` at the native layer, so WPF's routed
+  mouse events (`Grid.ContextMenu`, `PreviewMouseRightButtonUp`, and a
+  top-level `HwndSource.AddHook`) all see nothing. Confirmed via wpf-cli
+  — right-click pasted the clipboard into pwsh via the terminal's
+  own right-click-to-paste path. Keyboard shortcuts remain as the
+  supported clipboard/URL surface.
+- `a5aefea` — **Park right-click research** in the rough-edges list with
+  four fix options (native HWND subclass / `Win32InputMode` flip /
+  keyboard-only fallback / upstream event) so the next pass doesn't
+  re-derive them.
+- `d75097d` — **Model catalog: Opus 4.x defaults to 1M.** Real Claude
+  Code CLI transcripts carry `message.model = claude-opus-4-7` with no
+  `[1m]` tag — the 1M SKU is selected out of band. The old substring
+  rule matched `claude && opus` and returned 200k, so the status bar
+  divided ~30k context by the wrong cap and reported ~15% while Claude
+  Code itself showed ~3% against the real 1M cap. Catalog now: explicit
+  `1m` tag wins, sonnet/haiku stay 200k, `claude-3*` is 200k, every
+  other `claude-opus-*` defaults to 1M.
+- `bd882eb` — **Continuous adoption for `/clear` rotations.**
+  `ClaudeSessionDiscovery.Watch` was one-shot — after the first
+  adoption it disposed. Claude rotates its session id on `/clear` by
+  writing a brand new jsonl in the same cwd dir, so every `/clear`
+  stranded telemetry on the abandoned transcript and the status bar
+  froze. `WatchHandle` now tracks fired paths in a set and keeps the
+  watch alive for the tab's lifetime; `MainViewModel.BeginClaudeAdoption`
+  short-circuits when the adopted id already matches the persisted one
+  (stops churn on startup/poll re-fires) and otherwise unregisters the
+  old telemetry, registers the new id, and persists. Single-tab
+  `/clear` verified in the dev build against a real Opus 4.7 session.
+  Multi-tab same-cwd is an accepted limitation: both tabs would see
+  a rotation event for either; flag if it ever surfaces.
+
+**Test coverage added/updated this session:**
+- `SessionStoreTests` — mock signature widened for `force` param
+- `ClaudeTelemetryServiceTests.ContextTokens` — expects latest-turn
+  context size (was cumulative sum)
+- `ClaudeModelCatalogTests` — Opus 4.x ids now expect 1M
+- `ClaudeSessionDiscoveryTests.Callback_Fires_For_Each_New_Jsonl…` — new,
+  covers the `/clear` rotation path
+- Total 147/147 green (145 pre-session + 2 new)
 
 ### Session 19 — Velopack + GitHub Actions release pipeline (shipped)
 
@@ -110,150 +194,16 @@ cap is now model-aware instead of a baked 1M default.
   default `SubmenuHeader` template via `Ctx.Menu.PrimaryTemplate` and
   strips the chevron — don't set it on submenu parents, only leaves.
 
-### Session 17 — Claude CLI v2.1.118 adoption fix (shipped)
+### Sessions 13–18 (one-liners — see `git log` for detail)
 
-- `86f874b` — **Claude Code v2.1.118 rotates session ids.** Two
-  symptoms the user hit on cold hydrate: (a) `claude --continue`
-  errored with `No deferred tool marker found in the resumed session`
-  and exited, so every Claude tab terminated instantly; (b) persisted
-  `agentSessionId` values in `projects.json` pointed at abandoned
-  transcripts (Claude rotates the UUID on `/clear` and on resume), so
-  the telemetry tail had nothing to watch — status dot, tokens, turns,
-  activity FSM, Wait pulse, and notifications all went dark. New
-  shape: **stop owning the id, adopt from disk.** `IClaudeSessionDiscovery`
-  + `ClaudeSessionDiscovery` do a one-shot FSWatcher+350 ms poll over
-  `~/.claude/projects/<enc-cwd>/*.jsonl`, filter by `CreationTimeUtc
-  >= since`, fire once with `(adoptedId, path)`, then self-dispose.
-  `AgentRegistry` drops Claude's `SessionIdFlag` / `ResumeArgs` /
-  `ResumeByIdArgs` — `SessionManager` now launches a bare
-  `pwsh -Command "& { claude }"` from every path (fresh, duplicate,
-  cross-group drag, hydrate). `MainViewModel.BeginClaudeAdoption`
-  starts a watch per tab, dispatcher-marshals the callback, calls
-  `ISessionStore.UpdateAgentSessionIdAsync` to persist the adopted id,
-  then `IClaudeTelemetryService.Register` so the status bar wakes up.
-  Watches are torn down on adoption, tab close, and cross-group drop.
-  Old persisted ids become harmless — overwritten on first launch.
-  6 new unit tests cover fresh-create, pre-existing-via-poll, age
-  filter, non-UUID rejection, once-only firing, dispose-before-discovery.
-  Total 145/145 green.
-
-### Session 16 — notifications cluster (shipped)
-
-- `49fdd60` — **Status-bar bell + popover, activity-driven queue.**
-  Core gains `INotificationService` / `NotificationService` —
-  thread-safe in-memory ring buffer (cap 50) with `Push`, `MarkRead`,
-  `MarkSessionRead`, `MarkAllRead`, `Clear`, and a single `Changed`
-  event. `NotificationEntry` carries id + sessionId + kind
-  (SessionReady / SessionWaiting / Generic) + title + detail +
-  timestamp + IsRead. `MainViewModel` tracks each session's last
-  `ClaudeActivityState` and pushes entries on semantic transitions:
-  * → `PendingToolUse` → "Needs attention"; `PendingToolUse` /
-  `Composing` → `Idle` → "Ready · Turn complete · <duration>".
-  Suppresses the push when the transitioning tab is already the
-  window-selected one; focusing a tab calls `MarkSessionRead` for
-  its AgentSessionId so badges clear on reveal. `StatusBarView.xaml`
-  gains the rightmost cluster — 1×14 separator + bell-glyph Button
-  (12×12 path per spec §11) + 4 px Accent.Primary unread dot
-  overlaid top-right. Clicking the bell opens a 360 px `Popup`
-  (`Placement=Top`, fade, `StaysOpen=False`, 8 px radius,
-  SurfaceDialog bg + drop-shadow) with "Notifications" header +
-  "Clear" action, "No notifications yet." empty state, scrollable
-  `ItemsControl` of entries (kind-coloured dot · title · detail ·
-  session · HH:mm) and a "Click an entry to jump to its session"
-  footer. Entry clicks invoke the VM's `ActivateCommand`, which flips
-  `SelectedTab` via the Claude AgentSessionId match and closes the
-  popover. 9 new unit tests cover ordering, MaxEntries trim, unread
-  count, mark semantics, Clear, event firing. Total 139/139 green.
-
-### Session 15 — telemetry polish + chrome polish (shipped)
-
-- `abf4e45` — **250 ms poll fallback.** Shared `Timer` in
-  `ClaudeTelemetryService` stats each watched file and re-reads when
-  `Length > Offset` — zero-cost on quiet sessions, closes the
-  FSWatcher latency gap so the Wait pulse feels instant. New
-  three-arg ctor opts polling in; two-arg test-seam stays
-  deterministic. Added `Polling_Picks_Up_Appended_Lines…` test.
-- `4b45770` — **Per-model context window detection.**
-  `ClaudeTranscriptParser` now extracts `message.model`; new
-  `ClaudeModelCatalog.GetContextWindow` maps ids to 200k (standard)
-  or 1M (any id containing `1m`). `ClaudeSessionTelemetry` carries
-  `ModelId` + `ContextWindowTokens`; `SessionTabViewModel` mirrors
-  the cap; `MainViewModel.StatusBar.ContextWindowFor` prefers the
-  detected value over the baked `AgentProfile` default. 9 catalog
-  cases + 1 end-to-end telemetry test.
-- `b97788c` — **Caption-cluster margin on rightmost strip.**
-  `RebuildGroupLayout` now stamps a 184 px right-margin (4 × 46 px
-  `CaptionButton`) on the last `GroupStripView` so its tabs + `+`
-  button can't sit under the window caption overlay. Zero margin on
-  the others so column alignment to `WorkspacesHost` is preserved.
-- `5239ea0` — **Empty-project placeholder.** `ProjectViewModel.HasNoWorktrees`
-  + a `MultiDataTrigger` in the project `HierarchicalDataTemplate`
-  render a muted "(no worktrees)" row beneath an expanded empty
-  project. Collapsed stays a one-line row.
-- `b551730` — **Fase-7 token polish pass.** `Fig.Style.Dialog` +
-  the three dialog outer borders point at `Fig.Radius.Medium` (8 px,
-  was `Radius.Panel` 15 px / hard-coded). `Fig.Style.Button.*` swap
-  `Framer.FocusVisual` → `Fig.FocusVisual` (dashed 2,2). Tab-strip
-  titles drop to variable-weight 340 unselected with a Medium trigger
-  on `IsSelected`, `TextFormattingMode=Ideal` for the sub-integer
-  weight. "Pill on hero CTAs" pile item dropped — current hero buttons
-  match HTML mocks pixel-for-pixel.
-- `39d2786` — **Diff panel: stats header + line-number gutters + row
-  tints.** `DiffPanelViewModel.RefreshAsync` now walks the patch once
-  and tracks old/new counters seeded from each hunk header; `DiffLine`
-  grew `OldLine` / `NewLine`. New `Summary` + `HasSummary` feed a muted
-  mono "N files · +A −B" stats pill next to the panel's DIFF label.
-  View rebuilt to a 44 / 44 / * grid (old gutter, new gutter, code)
-  with per-kind row backgrounds (Added / Removed / Hunk); Context rows
-  get an explicit `Fig.Brush.Ink` foreground to stop them falling
-  through to SystemColors black. Also dropped the empty-state status
-  duplication — `StatusBarText` now returns "" when `wts == 0` so it
-  no longer collides with `StatusEmptyMessage`.
-- `93cde45` — **Focused-group hairline accent (later reverted in `071da29`).**
-  Shipped a bottom-border accent on the focused strip; user called it out as
-  a redundant double-line against the already-present selected-tab rail.
-  Reverted with the Tab Motion pass.
-- `071da29` — **Tab Motion single-rail animation.** Per-tab `TabRail`
-  border replaced with one shared `Border` in a `Canvas` above `StripList`.
-  `SelectionChanged`/`Loaded`/`SizeChanged` measure the selected
-  `ListBoxItem` via `TranslatePoint` and animate `Canvas.Left` + `Width`
-  with a 200 ms `CubicEase` ease-out. First paint snaps without animation;
-  `DispatcherPriority.Loaded` retry handles the "container not realised
-  yet" race. Same commit reverts the `93cde45` hairline and drops the
-  outer strip border's bottom thickness (`0,0,1,1` → `0,0,1,0`) so
-  unselected tabs don't show a leftover grey line.
-
-### Session 14 — wait-state propagation (shipped)
-
-- `4455c42` — Single-page deck recapping sessions 10–13 (four
-  CSS-rebuilt status bars, flow diagram, four idea cards, live
-  shot, commit log). *(Deck file removed during 2026-04-24 cleanup;
-  still reachable via the commit.)*
-- `792505f` — Sidebar propagation. `WorktreeViewModel.DotState` +
-  `StatusLabel` now reflect child `TabStatus.Wait`; subscribes
-  per-session `PropertyChanged(Status)`. `ProjectViewModel.HasWaitingChild`
-  lives via per-child `PropertyChanged(DotState)`. Cross-instance fix:
-  `ApplyTelemetry` stamps both the tab-strip VM *and* the sidebar
-  mirror (distinct refs per the sidebar-flatten pattern).
-- `0400fda` — Top-bar §3 pulse. Halo `Ellipse` behind the 6px tab
-  dot, 1.4s scale 1→2.4× + opacity .55→0, `DataTrigger` on
-  `Status == Wait`. Same timing as the sidebar so they read as one
-  system.
-
-**Known latency:** `FileSystemWatcher` + JSONL flush boundaries mean
-Wait surfaces 100–500 ms after Claude emits the `tool_use` line.
-Acceptable; a 250 ms poll fallback over the watcher would close the
-gap if it ever feels laggy.
-
-### Session 13 — transcript-driven activity state (shipped)
-
-- `2ee7b1d` — `TranscriptEntry.StopReason` +
-  `UserCarriesToolResult`; new `ClaudeActivityState` enum + FSM
-  (`user` → Composing; `assistant end_turn` → Idle;
-  `assistant tool_use` → PendingToolUse).
-- `3b0f5b4` — `MainViewModel.ApplyActivityToStatus` projects
-  activity onto `TabStatus` (PendingToolUse → Wait, etc.).
-- `86291f2` — handoff update.
+| # | Gist |
+|---|---|
+| 18 | **ConPTY std-handle rebind + agent picker** (`8edf392`) — fresh `AllocConsole` + `SetStdHandle(CONIN$/CONOUT$)` so pwsh/claude don't die on inherited redirected stdio. Worktree-ctx "New session" / "Open in new group" turned into agent submenus. |
+| 17 | **Claude CLI session-id adoption** (`86f874b`) — stop owning the id, adopt from disk via `IClaudeSessionDiscovery` FSWatcher tail. `AgentRegistry` drops Claude's resume flags (all bare launches); status bar wakes via `Register(adoptedId, workingDir)`. 6 discovery tests. *(Superseded in session 20: continuous adoption + resume-by-id restored.)* |
+| 16 | **Notifications cluster** (`49fdd60`) — `INotificationService` ring buffer (cap 50), status-bar bell + 360 px popover, activity-driven pushes on `→PendingToolUse` / `→Idle`. Entry click jumps via Claude AgentSessionId match. |
+| 15 | **Telemetry polish + chrome polish** (`abf4e45` poll fallback, `4b45770` per-model cap, `b97788c` caption margin, `5239ea0` empty-project placeholder, `b551730` Fig token pass, `39d2786` diff panel gutters, `071da29` single-rail tab motion). |
+| 14 | **Wait-state propagation** (`792505f` sidebar → project → worktree rollup, `0400fda` top-bar tab-dot halo pulse). Note: 100–500 ms FSWatcher latency is accepted; poll fallback landed in 15. |
+| 13 | **Transcript-driven activity FSM** (`2ee7b1d` + `3b0f5b4`) — user → Composing; assistant end_turn → Idle; assistant tool_use → PendingToolUse. |
 
 ### Earlier sessions (one-liners)
 
@@ -330,7 +280,7 @@ docs/
 
 - **Gitea CI rollup is always `None`** — `tea pulls status`/REST integration deferred.
 - **Session-exit toasts deferred** — `SessionManager` starts pwsh with `-NoExit`; detecting agent exit needs `SessionManager` refactor or pty-output parsing.
-- **Drag tab between groups restarts pwsh** — agent resumes via `--continue`/`--resume` but the scroll buffer is lost. Fix needs a shared SessionTabView host pool (see `memory/project_terminal_lifecycle.md`).
+- **Drag tab between groups loses scroll buffer** — pwsh respawns because WPF unloads the `SessionTabView` (HWND lifecycle) when the VM leaves its group. As of session 20 Claude resumes its conversation via `claude --resume <id>` and telemetry keeps tracking (same jsonl), but the terminal scrollback is gone. Fix still needs a shared `SessionTabView` host pool — see `memory/project_terminal_lifecycle.md`.
 - **Terminal right-click opens no context menu** — parked for a dedicated
   research pass. Short version: `Microsoft.Terminal.Wpf` hosts a native
   Win32 child HWND (`TerminalContainer : HwndHost`) that intercepts

--- a/docs/design/html/CodeScope - Dialog System.html
+++ b/docs/design/html/CodeScope - Dialog System.html
@@ -1,0 +1,781 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>CodeScope — Dialog system</title>
+<meta name="viewport" content="width=1600" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg:#000; --panel:#0A0A0A; --elev:#141414; --elev-2:#1A1A1A;
+    --border:#1F1F1F; --border-2:#2A2A2A;
+    --text:#fff; --text-2:#A0A0A0; --text-3:#606060;
+    --accent:#0099FF; --ok:#4BD87B; --warn:#FF5A5A;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin:0; padding:0; min-height:100%;
+    background: radial-gradient(1100px 600px at 30% 15%, rgba(0,153,255,0.05), transparent 60%), #000;
+    color:#fff;
+    font-family:'Inter',-apple-system,system-ui,sans-serif;
+    font-feature-settings:"cv01","cv05","cv09","cv11","ss03","ss07";
+    -webkit-font-smoothing:antialiased;
+  }
+  .page { max-width:1520px; margin:0 auto; padding:56px 48px 80px; }
+
+  .doc-head { margin-bottom:40px; display:flex; align-items:flex-end; gap:20px; }
+  .eyebrow {
+    font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--accent);
+    letter-spacing:0.16em; text-transform:uppercase;
+    padding:4px 8px; border:1px solid rgba(0,153,255,0.3); border-radius:3px;
+    background:rgba(0,153,255,0.05); align-self:flex-start; margin-top:6px;
+  }
+  .doc-head h1 { font-size:36px; font-weight:600; letter-spacing:-0.02em; margin:0; line-height:1.1; }
+  .doc-head .sub { margin-left:auto; color:var(--text-2); font-size:13px; max-width:460px; line-height:1.5; text-align:right; }
+  .doc-head .sub b { color:#fff; font-weight:500; }
+
+  /* section */
+  .sec { margin-bottom: 56px; }
+  .sec-label {
+    font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--accent);
+    letter-spacing:0.16em; text-transform:uppercase; margin-bottom:16px;
+  }
+  .sec h2 { font-size:22px; font-weight:600; letter-spacing:-0.015em; margin:0 0 10px; }
+  .sec .sec-sub { color:var(--text-2); font-size:13px; line-height:1.55; max-width:820px; margin:0 0 24px; }
+  .sec .sec-sub b { color:#fff; font-weight:500; }
+  .sec .sec-sub code { font-family:'JetBrains Mono',monospace; font-size:11.5px; color:var(--accent); background:rgba(0,153,255,0.08); padding:1px 5px; border-radius:3px; }
+
+  /* stage that holds each dialog sample */
+  .stage {
+    position:relative;
+    background:
+      linear-gradient(to right, rgba(255,255,255,0.025) 1px, transparent 1px) 0 0 / 80px 80px,
+      linear-gradient(to bottom, rgba(255,255,255,0.025) 1px, transparent 1px) 0 0 / 80px 80px,
+      #000;
+    border:1px solid var(--border); border-radius:10px;
+    padding: 60px;
+    display:flex; justify-content:center; align-items:flex-start;
+    min-height: 420px;
+  }
+  .stage.scrim::before {
+    content:""; position:absolute; inset:0; border-radius:10px;
+    background: rgba(0,0,0,0.55);
+    backdrop-filter: blur(2px);
+  }
+
+  /* dialog primitive */
+  .dlg {
+    position:relative; z-index:1;
+    background: var(--panel);
+    border: 1px solid var(--border-2);
+    border-radius: 12px;
+    box-shadow: 0 30px 80px rgba(0,0,0,0.55), 0 0 0 1px rgba(0,0,0,0.2);
+    color:#fff;
+    overflow:hidden;
+  }
+  .dlg.w-sm { width: 420px; }
+  .dlg.w-md { width: 480px; }
+  .dlg.w-lg { width: 560px; }
+  .dlg.w-xl { width: 640px; }
+
+  .dlg-head {
+    padding: 20px 24px 4px;
+    display:flex; align-items:flex-start; gap:14px;
+  }
+  .dlg-icon {
+    width: 32px; height: 32px; flex: 0 0 32px;
+    border-radius: 8px;
+    display:flex; align-items:center; justify-content:center;
+    background: rgba(0,153,255,0.1);
+    color: var(--accent);
+    border: 1px solid rgba(0,153,255,0.25);
+  }
+  .dlg-icon.warn { background: rgba(255,90,90,0.1); border-color: rgba(255,90,90,0.3); color: var(--warn); }
+  .dlg-icon.ok { background: rgba(75,216,123,0.08); border-color: rgba(75,216,123,0.25); color: var(--ok); }
+  .dlg-icon.neutral { background: var(--elev); border-color: var(--border-2); color: var(--text-2); }
+  .dlg-icon svg { width: 16px; height: 16px; }
+
+  .dlg-title-wrap { flex:1 1 auto; min-width:0; padding-top:4px; }
+  .dlg-title {
+    font-size: 16px; font-weight: 600; letter-spacing: -0.01em;
+    margin: 0; line-height: 1.3;
+  }
+  .dlg-subtitle {
+    display:block;
+    font-family:'JetBrains Mono',monospace; font-size: 10.5px;
+    color: var(--text-3); letter-spacing: 0.06em;
+    text-transform: uppercase;
+    margin-bottom: 4px;
+  }
+  .dlg-close {
+    width: 24px; height: 24px; border-radius: 4px;
+    display:flex; align-items:center; justify-content:center;
+    color: var(--text-3); background:transparent; border:0; cursor:pointer;
+    flex: 0 0 24px;
+  }
+  .dlg-close svg { width: 12px; height: 12px; }
+
+  .dlg-body { padding: 10px 24px 20px; }
+  .dlg-body p { margin: 0; font-size: 13px; line-height: 1.55; color: var(--text-2); }
+  .dlg-body p + p { margin-top: 10px; }
+  .dlg-body p b { color:#fff; font-weight: 500; }
+  .dlg-body code {
+    font-family:'JetBrains Mono',monospace; font-size: 12px;
+    color: var(--accent); background: rgba(0,153,255,0.08); padding: 1px 5px; border-radius: 3px;
+  }
+
+  /* foot */
+  .dlg-foot {
+    display: flex; align-items: center; gap: 8px;
+    padding: 14px 20px;
+    background: #070707;
+    border-top: 1px solid var(--border);
+  }
+  .dlg-foot .space { flex: 1 1 auto; }
+  .dlg-foot .meta { font-size: 11px; color: var(--text-3); font-family:'JetBrains Mono',monospace; }
+
+  /* buttons */
+  .btn {
+    height: 32px; padding: 0 14px;
+    border-radius: 6px;
+    font: 500 12.5px/1 'Inter', sans-serif; letter-spacing: -0.005em;
+    display: inline-flex; align-items: center; gap: 8px;
+    border: 0; cursor: pointer; color:#fff;
+    background: transparent;
+    transition: background 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out;
+  }
+  .btn.ghost { color: var(--text-2); }
+  .btn.ghost:hover { background: var(--elev); color:#fff; }
+  .btn.secondary { background: var(--elev); color:#fff; box-shadow: inset 0 0 0 1px var(--border-2); }
+  .btn.secondary:hover { background: var(--elev-2); }
+  .btn.primary { background: var(--accent); color:#000; font-weight: 600; }
+  .btn.primary:hover { background: #1AA8FF; }
+  .btn.destructive { background: var(--warn); color:#000; font-weight: 600; }
+  .btn.destructive:hover { background: #FF7474; }
+  .btn .kbd {
+    font-family:'JetBrains Mono',monospace; font-size: 10px;
+    padding: 1px 4px; border-radius: 3px;
+    background: rgba(255,255,255,0.1); color: rgba(0,0,0,0.7);
+    margin-left: 2px;
+  }
+  .btn.ghost .kbd, .btn.secondary .kbd {
+    background: var(--elev-2); color: var(--text-3);
+  }
+
+  /* form controls used inside dialog bodies */
+  .field { display:flex; flex-direction:column; gap:6px; margin-bottom: 14px; }
+  .field:last-child { margin-bottom: 0; }
+  .field label {
+    font-size: 11px; font-weight: 500; color: var(--text-2);
+    letter-spacing: 0.02em; text-transform: uppercase;
+  }
+  .field .help { font-size: 11.5px; color: var(--text-3); margin-top: 4px; line-height: 1.45; }
+  .input, .select, .textarea {
+    width: 100%; height: 34px;
+    background: #000;
+    border: 1px solid var(--border-2); border-radius: 6px;
+    color: #fff;
+    font: 500 13px/1 'Inter', sans-serif;
+    padding: 0 12px;
+    outline: none;
+  }
+  .input:focus, .select:focus, .textarea:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(0,153,255,0.15);
+  }
+  .input.mono { font-family: 'JetBrains Mono', monospace; font-size: 12.5px; }
+  .textarea { height: auto; padding: 10px 12px; resize: vertical; min-height: 72px; line-height: 1.45; }
+  .select-wrap { position: relative; }
+  .select { appearance: none; padding-right: 32px; cursor: pointer; }
+  .select-wrap::after {
+    content:""; position:absolute; right: 12px; top: 50%;
+    width: 6px; height: 6px; border-right: 1.5px solid var(--text-2); border-bottom: 1.5px solid var(--text-2);
+    transform: translateY(-70%) rotate(45deg);
+    pointer-events:none;
+  }
+
+  /* toggle row */
+  .trow {
+    display:flex; align-items:center; gap:12px;
+    padding: 12px 14px;
+    background: #050505;
+    border: 1px solid var(--border); border-radius: 8px;
+  }
+  .trow .txt { flex: 1 1 auto; min-width: 0; }
+  .trow .tt { font-size: 13px; font-weight: 500; }
+  .trow .th { font-size: 11.5px; color: var(--text-3); margin-top: 2px; }
+  .toggle {
+    width: 30px; height: 18px; border-radius: 999px;
+    background: var(--elev-2); position: relative; flex: 0 0 30px;
+    transition: background 140ms ease-out;
+  }
+  .toggle::after {
+    content:""; position:absolute; top: 2px; left: 2px;
+    width: 14px; height: 14px; border-radius: 50%;
+    background:#fff;
+    transition: transform 140ms ease-out;
+  }
+  .toggle.on { background: var(--accent); }
+  .toggle.on::after { transform: translateX(12px); }
+
+  /* checkbox list */
+  .chk {
+    display:flex; align-items:flex-start; gap:10px;
+    padding: 8px 0; border-bottom: 1px solid var(--border);
+    font-size: 12.5px;
+  }
+  .chk:last-child { border-bottom: 0; }
+  .chk-box {
+    width: 14px; height: 14px; border-radius: 3px;
+    border: 1.5px solid var(--text-3); flex: 0 0 14px; margin-top: 1px;
+    display:flex; align-items:center; justify-content:center;
+  }
+  .chk-box.on { background: var(--accent); border-color: var(--accent); }
+  .chk-box.on::after { content:""; width: 3px; height: 7px; border-right: 2px solid #000; border-bottom: 2px solid #000; transform: rotate(45deg) translate(-1px, -1px); }
+  .chk .tt { color:#fff; font-weight: 500; }
+  .chk .th { color: var(--text-3); font-size: 11px; margin-top: 2px; line-height: 1.4; }
+
+  /* callouts (anatomy) */
+  .cx { position: absolute; inset: 0; z-index: 3; pointer-events: none; }
+  .cx .dot {
+    position: absolute; width: 8px; height: 8px; border-radius: 50%;
+    background: var(--accent); box-shadow: 0 0 0 3px rgba(0,153,255,0.18);
+    transform: translate(-50%, -50%);
+  }
+  .cx .line { position: absolute; background: rgba(0,153,255,0.45); }
+  .cx .line.h { height: 1px; }
+  .cx .line.v { width: 1px; }
+  .cx .label {
+    position: absolute;
+    background: #0A0A0A; border: 1px solid #1F1F1F; border-radius: 6px;
+    padding: 10px 12px; width: 240px;
+    color: #fff; font-size: 12px; line-height: 1.5;
+    letter-spacing: -0.005em;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+  }
+  .cx .label .num {
+    display: inline-block; width: 18px; height: 18px;
+    border-radius: 3px; background: var(--accent); color: #000;
+    font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 600;
+    text-align: center; line-height: 18px;
+    margin-right: 8px; vertical-align: 1px;
+  }
+  .cx .label b { font-weight: 600; }
+  .cx .label code {
+    font-family: 'JetBrains Mono', monospace; font-size: 10.5px;
+    color: var(--accent); background: rgba(0,153,255,0.08);
+    padding: 1px 5px; border-radius: 3px;
+  }
+  .cx .label .hint { display: block; color: var(--text-2); margin-top: 4px; font-size: 11.5px; }
+
+  /* variants grid */
+  .vgrid {
+    display:grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+  }
+  .vcard {
+    background: var(--panel); border:1px solid var(--border); border-radius:10px;
+    padding: 16px;
+  }
+  .vcard .vlabel {
+    display:flex; align-items:center; justify-content:space-between;
+    font-family:'JetBrains Mono',monospace; font-size:10px;
+    color: var(--text-3); letter-spacing:0.14em; text-transform:uppercase;
+    margin-bottom: 14px;
+  }
+  .vcard .vlabel .pill {
+    color:var(--accent); border:1px solid rgba(0,153,255,0.3);
+    padding:2px 6px; border-radius:3px; background:rgba(0,153,255,0.05);
+  }
+  .vcard .vstage {
+    background:
+      linear-gradient(to right, rgba(255,255,255,0.025) 1px, transparent 1px) 0 0 / 80px 80px,
+      linear-gradient(to bottom, rgba(255,255,255,0.025) 1px, transparent 1px) 0 0 / 80px 80px,
+      #000;
+    border-radius: 8px;
+    min-height: 360px;
+    display:flex; align-items:center; justify-content:center;
+    padding: 24px;
+  }
+  .vcard .vnote {
+    margin-top: 12px;
+    font-size: 12px; color: var(--text-2); line-height: 1.5;
+  }
+  .vcard .vnote b { color:#fff; font-weight: 500; }
+  .vcard .vnote code {
+    font-family:'JetBrains Mono',monospace; font-size:11.5px; color:var(--accent);
+    background:rgba(0,153,255,0.08); padding:1px 5px; border-radius:3px;
+  }
+
+  /* tokens panels */
+  .spec-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:16px; }
+  .panel { background:var(--panel); border:1px solid var(--border); border-radius:8px; padding:20px; }
+  .panel h3 { font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--accent); letter-spacing:0.16em; text-transform:uppercase; margin:0 0 14px; }
+  .panel ul { list-style:none; padding:0; margin:0; }
+  .panel li { display:grid; grid-template-columns:110px 1fr; gap:10px; padding:8px 0; border-bottom:1px solid #141414; font-size:12px; line-height:1.4; }
+  .panel li:last-child { border-bottom:0; }
+  .panel li .k { font-family:'JetBrains Mono',monospace; color:var(--text-3); font-size:11px; }
+  .panel li .v { color:#E6E6E6; }
+  .swatch { display:inline-block; width:10px; height:10px; border-radius:2px; vertical-align:-1px; margin-right:6px; border:1px solid rgba(255,255,255,0.08); }
+
+  .notes { display:grid; grid-template-columns:repeat(2,1fr); gap:16px; }
+  .note {
+    background:var(--panel); border:1px solid var(--border);
+    border-left:2px solid var(--accent);
+    border-radius:6px; padding:14px 16px;
+    font-size:12.5px; line-height:1.5; color:#E6E6E6;
+  }
+  .note b { color:#fff; }
+  .note .t {
+    display:block; font-family:'JetBrains Mono',monospace; font-size:10px;
+    color:var(--accent); letter-spacing:0.14em; text-transform:uppercase; margin-bottom:6px;
+  }
+  .note code { font-family:'JetBrains Mono',monospace; font-size:11.5px; color:var(--accent); background:rgba(0,153,255,0.08); padding:1px 5px; border-radius:3px; }
+
+  .impl { background:#070707; border:1px solid var(--border); border-radius:8px; padding:28px 32px; }
+  .impl h3 { font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--accent); letter-spacing:0.16em; text-transform:uppercase; margin:0 0 16px; }
+  .impl pre { margin:0; font-family:'JetBrains Mono',monospace; font-size:12.5px; line-height:1.65; color:#E6E6E6; white-space:pre-wrap; }
+  .impl .c { color:var(--text-3); font-style:italic; }
+  .impl .k { color:var(--accent); }
+  .impl .s { color:#8FD679; }
+  .impl .t { color:#E8A857; }
+</style>
+</head>
+<body>
+<div class="page" data-screen-label="Dialog system — handoff">
+
+  <div class="doc-head">
+    <span class="eyebrow">Component spec</span>
+    <div><h1>Dialog system</h1></div>
+    <div class="sub">
+      One <b>Dialog</b> primitive, five recurring flavors: <b>Confirm</b>, <b>Destructive</b>, <b>Info</b>, <b>Form</b>, and <b>Choice</b>. Every dialog in CodeScope should compose from these parts — don't build bespoke modals. Handoff for Claude Code.
+    </div>
+  </div>
+
+  <!-- =================== ANATOMY =================== -->
+  <div class="sec">
+    <div class="sec-label">01 · Anatomy</div>
+    <h2>The dialog primitive</h2>
+    <p class="sec-sub">
+      Every dialog is the same 7 slots: <b>scrim</b>, <b>icon</b>, <b>eyebrow</b>, <b>title</b>, <b>close</b>, <b>body</b>, <b>footer</b>. Width picked from the <code>w-sm / w-md / w-lg / w-xl</code> scale (420 / 480 / 560 / 640). Height grows to fit content; there is no fixed height.
+    </p>
+
+    <div class="stage scrim" style="min-height: 580px; padding: 0; display: block; position: relative;">
+      <div class="dlg w-md" id="anatomy-dlg" style="position: absolute; left: 80px; top: 110px; margin: 0">
+        <div class="dlg-head">
+          <div class="dlg-icon"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="6"/><path d="M8 5v3.5"/><circle cx="8" cy="11" r="0.6" fill="currentColor"/></svg></div>
+          <div class="dlg-title-wrap">
+            <span class="dlg-subtitle">Confirm</span>
+            <h3 class="dlg-title">Delete worktree &ldquo;feat/reporting&rdquo;?</h3>
+          </div>
+          <button class="dlg-close"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M2 2l8 8M10 2l-8 8"/></svg></button>
+        </div>
+        <div class="dlg-body">
+          <p>This will remove the worktree directory and end the Claude session running in it. The branch <code>feat/reporting</code> and its commits stay in the repo.</p>
+        </div>
+        <div class="dlg-foot">
+          <span class="meta">⎋ to cancel</span>
+          <div class="space"></div>
+          <button class="btn ghost">Cancel</button>
+          <button class="btn primary">Delete<span class="kbd">↵</span></button>
+        </div>
+      </div>
+
+      <!-- callouts — anchored to measured dialog geometry: dlg at L81–561, T111–331.
+           Layout: labels 2 & 4 go LEFT of the dialog (left column at L0–250).
+                   labels 1, 3, 5, 6, 7 go RIGHT of the dialog (right column at L620–1140),
+                   stacked in 5 vertical bands so none touch. -->
+      <div class="cx">
+
+        <!-- LEFT COLUMN -->
+
+        <!-- 2 icon tile @ L105–137, T132–164 → label LEFT of dialog, band 1 -->
+        <div class="dot" style="left:121px;top:148px"></div>
+        <div class="line v" style="left:121px;top:70px;height:78px"></div>
+        <div class="line h" style="left:30px;top:70px;width:91px"></div>
+        <div class="label" style="left:30px;top:10px">
+          <span class="num">2</span><b>Icon tile</b>
+          <span class="hint">32 × 32 · radius 8 · tinted bg + border. Color follows the dialog intent (info / warn / ok / neutral).</span>
+        </div>
+
+        <!-- 4 title @ ~L151, T164 → label LEFT of dialog, band 2 (lower) -->
+        <div class="dot" style="left:300px;top:164px"></div>
+        <div class="line h" style="left:30px;top:400px;width:0"></div>
+        <div class="line v" style="left:30px;top:164px;height:236px"></div>
+        <div class="line h" style="left:30px;top:164px;width:270px"></div>
+        <div class="label" style="left:30px;top:410px">
+          <span class="num">4</span><b>Title</b>
+          <span class="hint">16px Inter 600 · <code>-0.01em</code> · sentence case. Phrases the user's question — not a noun.</span>
+        </div>
+
+        <!-- RIGHT COLUMN (5 bands) -->
+
+        <!-- 1 scrim → point to empty scrim area, top band -->
+        <div class="dot" style="left:780px;top:60px"></div>
+        <div class="line h" style="left:780px;top:60px;width:110px"></div>
+        <div class="label" style="left:890px;top:20px">
+          <span class="num">1</span><b>Scrim</b>
+          <span class="hint"><code>rgba(0,0,0,0.55)</code> + 2px blur. Click = cancel, unless destructive.</span>
+        </div>
+
+        <!-- 3 eyebrow @ ~L200, T143 → right column, band 2 -->
+        <div class="dot" style="left:230px;top:143px"></div>
+        <div class="line h" style="left:230px;top:143px;width:660px"></div>
+        <div class="label" style="left:890px;top:135px">
+          <span class="num">3</span><b>Eyebrow</b>
+          <span class="hint">10.5px JB Mono · <code>#606060</code> · uppercase. Category label — constant per flavor.</span>
+        </div>
+
+        <!-- 5 close @ L511–535, T132–156 → right column, band 3 -->
+        <div class="dot" style="left:523px;top:144px"></div>
+        <div class="line h" style="left:523px;top:144px;width:0"></div>
+        <div class="line v" style="left:523px;top:144px;height:100px"></div>
+        <div class="line h" style="left:523px;top:244px;width:367px"></div>
+        <div class="label" style="left:890px;top:245px">
+          <span class="num">5</span><b>Close</b>
+          <span class="hint">Only on <i>dismissible</i> dialogs. Absent on required / blocking confirmations.</span>
+        </div>
+
+        <!-- 6 body @ L81–561, T179–269 → right column, band 4 -->
+        <div class="dot" style="left:561px;top:260px"></div>
+        <div class="line h" style="left:561px;top:260px;width:90px"></div>
+        <div class="line v" style="left:651px;top:260px;height:80px"></div>
+        <div class="line h" style="left:651px;top:340px;width:239px"></div>
+        <div class="label" style="left:890px;top:340px">
+          <span class="num">6</span><b>Body</b>
+          <span class="hint">13px · line-height 1.55 · <code>#A0A0A0</code>. Max 2 paragraphs; beyond that, use a form dialog.</span>
+        </div>
+
+        <!-- 7 footer @ L81–561, T269–330 → right column, band 5 -->
+        <div class="dot" style="left:561px;top:300px"></div>
+        <div class="line h" style="left:561px;top:300px;width:60px"></div>
+        <div class="line v" style="left:621px;top:300px;height:150px"></div>
+        <div class="line h" style="left:621px;top:450px;width:269px"></div>
+        <div class="label" style="left:890px;top:450px">
+          <span class="num">7</span><b>Footer</b>
+          <span class="hint">Right-aligned: <b>cancel</b> (ghost) then <b>primary</b>. Left side is the keyboard hint — never a third button.</span>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- =================== VARIANTS =================== -->
+  <div class="sec">
+    <div class="sec-label">02 · Variants</div>
+    <h2>Five flavors · five specimens</h2>
+    <p class="sec-sub">
+      Every real dialog maps to one of these. Icon, eyebrow, primary-button style, and dismissal behavior change; the primitive doesn't.
+    </p>
+
+    <div class="vgrid">
+
+      <!-- CONFIRM -->
+      <div class="vcard">
+        <div class="vlabel"><span>Confirm</span><span class="pill">primary</span></div>
+        <div class="vstage">
+          <div class="dlg w-sm">
+            <div class="dlg-head">
+              <div class="dlg-icon"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="6"/><path d="M8 5v3.5"/><circle cx="8" cy="11" r="0.6" fill="currentColor"/></svg></div>
+              <div class="dlg-title-wrap">
+                <span class="dlg-subtitle">Confirm</span>
+                <h3 class="dlg-title">Switch model for this session?</h3>
+              </div>
+              <button class="dlg-close"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M2 2l8 8M10 2l-8 8"/></svg></button>
+            </div>
+            <div class="dlg-body">
+              <p>You're mid-turn on <b>feat/reporting</b>. Switching to <code>claude-opus-4</code> will finish the current reply on the old model, then swap.</p>
+            </div>
+            <div class="dlg-foot">
+              <div class="space"></div>
+              <button class="btn ghost">Cancel</button>
+              <button class="btn primary">Switch<span class="kbd">↵</span></button>
+            </div>
+          </div>
+        </div>
+        <p class="vnote"><b>When.</b> Reversible, low-risk actions. Primary CTA is Framer Blue. Scrim click dismisses. <code>↵</code> confirms, <code>⎋</code> cancels.</p>
+      </div>
+
+      <!-- DESTRUCTIVE -->
+      <div class="vcard">
+        <div class="vlabel"><span>Destructive</span><span class="pill" style="color:var(--warn);border-color:rgba(255,90,90,0.3);background:rgba(255,90,90,0.05)">danger</span></div>
+        <div class="vstage">
+          <div class="dlg w-sm">
+            <div class="dlg-head">
+              <div class="dlg-icon warn"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2L14.5 13H1.5Z"/><path d="M8 6v3.5"/><circle cx="8" cy="11.5" r="0.6" fill="currentColor"/></svg></div>
+              <div class="dlg-title-wrap">
+                <span class="dlg-subtitle" style="color:var(--warn)">Destructive</span>
+                <h3 class="dlg-title">Delete project &ldquo;PestScope&rdquo;?</h3>
+              </div>
+            </div>
+            <div class="dlg-body">
+              <p>This removes <b>3 worktrees</b> and ends <b>2 active sessions</b>. The cloned repo at <code>~/code/pest-scope</code> stays on disk.</p>
+              <div class="field" style="margin-top:14px">
+                <label>Type <b style="color:#fff;font-family:'JetBrains Mono',monospace;text-transform:none;letter-spacing:0">PestScope</b> to confirm</label>
+                <input class="input mono" value="PestSc" />
+              </div>
+            </div>
+            <div class="dlg-foot">
+              <div class="space"></div>
+              <button class="btn ghost">Cancel</button>
+              <button class="btn destructive" style="opacity:.5">Delete project</button>
+            </div>
+          </div>
+        </div>
+        <p class="vnote"><b>When.</b> Irreversible. No close icon · scrim click does <i>not</i> dismiss · primary is red · ↵ never auto-confirms. High-value ones require typed confirmation.</p>
+      </div>
+
+      <!-- INFO / SUCCESS -->
+      <div class="vcard">
+        <div class="vlabel"><span>Info / Success</span><span class="pill" style="color:var(--ok);border-color:rgba(75,216,123,0.3);background:rgba(75,216,123,0.05)">ok</span></div>
+        <div class="vstage">
+          <div class="dlg w-sm">
+            <div class="dlg-head">
+              <div class="dlg-icon ok"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 8.5 L7 12 L13 5"/></svg></div>
+              <div class="dlg-title-wrap">
+                <span class="dlg-subtitle" style="color:var(--ok)">Session ready</span>
+                <h3 class="dlg-title">Worktree spawned</h3>
+              </div>
+              <button class="dlg-close"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M2 2l8 8M10 2l-8 8"/></svg></button>
+            </div>
+            <div class="dlg-body">
+              <p><code>feat/export-pdf</code> is checked out at <code>~/code/pest-scope/wt/export-pdf</code>. A Claude session is attached and warm.</p>
+            </div>
+            <div class="dlg-foot">
+              <span class="meta">1 of 3 this week</span>
+              <div class="space"></div>
+              <button class="btn ghost">Dismiss</button>
+              <button class="btn primary">Open<span class="kbd">↵</span></button>
+            </div>
+          </div>
+        </div>
+        <p class="vnote"><b>When.</b> Non-blocking confirmations of async success. Usually auto-dismiss after 6s unless hovered.</p>
+      </div>
+
+      <!-- FORM -->
+      <div class="vcard">
+        <div class="vlabel"><span>Form</span><span class="pill">input</span></div>
+        <div class="vstage">
+          <div class="dlg w-md">
+            <div class="dlg-head">
+              <div class="dlg-icon neutral"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="10" height="10" rx="1.5"/><path d="M3 6h10"/><path d="M6 13V6"/></svg></div>
+              <div class="dlg-title-wrap">
+                <span class="dlg-subtitle">New worktree</span>
+                <h3 class="dlg-title">Spawn a parallel session</h3>
+              </div>
+              <button class="dlg-close"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M2 2l8 8M10 2l-8 8"/></svg></button>
+            </div>
+            <div class="dlg-body">
+              <div class="field">
+                <label>Branch</label>
+                <div class="select-wrap"><select class="select"><option>feat/export-pdf</option></select></div>
+              </div>
+              <div class="field">
+                <label>Worktree name</label>
+                <input class="input mono" value="export-pdf" />
+                <span class="help">Will live at <code>~/code/pest-scope/wt/export-pdf</code>.</span>
+              </div>
+              <div class="trow">
+                <div class="txt"><div class="tt">Spawn Claude session on creation</div><div class="th">Opens a new session pre-attached to the worktree.</div></div>
+                <div class="toggle on"></div>
+              </div>
+            </div>
+            <div class="dlg-foot">
+              <div class="space"></div>
+              <button class="btn ghost">Cancel</button>
+              <button class="btn primary">Create<span class="kbd">⌘↵</span></button>
+            </div>
+          </div>
+        </div>
+        <p class="vnote"><b>When.</b> Asking for &gt;1 input. Uses <code>w-md</code> (480) or <code>w-lg</code>. Primary CTA commits the form · <code>⌘↵</code> submits from any field.</p>
+      </div>
+
+      <!-- CHOICE -->
+      <div class="vcard" style="grid-column: span 2">
+        <div class="vlabel"><span>Choice · list picker</span><span class="pill">select</span></div>
+        <div class="vstage">
+          <div class="dlg w-md">
+            <div class="dlg-head">
+              <div class="dlg-icon neutral"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4h10M3 8h10M3 12h10"/><circle cx="3" cy="4" r="0.5" fill="currentColor"/><circle cx="3" cy="8" r="0.5" fill="currentColor"/><circle cx="3" cy="12" r="0.5" fill="currentColor"/></svg></div>
+              <div class="dlg-title-wrap">
+                <span class="dlg-subtitle">Session handling</span>
+                <h3 class="dlg-title">What to do with the 2 running sessions?</h3>
+              </div>
+              <button class="dlg-close"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M2 2l8 8M10 2l-8 8"/></svg></button>
+            </div>
+            <div class="dlg-body">
+              <div class="chk"><div class="chk-box on"></div><div><div class="tt">Let them finish, then quit</div><div class="th">CodeScope stays open until every session reaches idle.</div></div></div>
+              <div class="chk"><div class="chk-box"></div><div><div class="tt">Interrupt and quit</div><div class="th">Sends <code>SIGINT</code> to each session. Pending tool calls are cancelled.</div></div></div>
+              <div class="chk"><div class="chk-box"></div><div><div class="tt">Detach &amp; keep running in background</div><div class="th">Sessions continue headless. Reattach from the tray next launch.</div></div></div>
+            </div>
+            <div class="dlg-foot">
+              <span class="meta">↑ ↓ to navigate · ↵ to pick</span>
+              <div class="space"></div>
+              <button class="btn ghost">Cancel</button>
+              <button class="btn primary">Continue</button>
+            </div>
+          </div>
+        </div>
+        <p class="vnote"><b>When.</b> One-of-N decisions with enough detail per option that a dropdown feels cramped. Radio-style checkboxes with a description under each title.</p>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- =================== TOKENS =================== -->
+  <div class="sec">
+    <div class="sec-label">03 · Tokens</div>
+    <h2>Every measurable value</h2>
+    <div class="spec-grid">
+
+      <div class="panel">
+        <h3>Dimensions</h3>
+        <ul>
+          <li><span class="k">w-sm</span><span class="v">420px</span></li>
+          <li><span class="k">w-md</span><span class="v">480px</span></li>
+          <li><span class="k">w-lg</span><span class="v">560px</span></li>
+          <li><span class="k">w-xl</span><span class="v">640px</span></li>
+          <li><span class="k">radius</span><span class="v">12px</span></li>
+          <li><span class="k">pad head</span><span class="v">20 · 24 · 4</span></li>
+          <li><span class="k">pad body</span><span class="v">10 · 24 · 20</span></li>
+          <li><span class="k">pad foot</span><span class="v">14 · 20</span></li>
+          <li><span class="k">icon tile</span><span class="v">32 × 32 · r 8</span></li>
+          <li><span class="k">icon</span><span class="v">16 × 16 · stroke 1.5</span></li>
+          <li><span class="k">btn H</span><span class="v">32 · pad-x 14 · r 6</span></li>
+          <li><span class="k">max viewport</span><span class="v">min(content, 85vh)</span></li>
+        </ul>
+      </div>
+
+      <div class="panel">
+        <h3>Colors</h3>
+        <ul>
+          <li><span class="k"><span class="swatch" style="background:#0A0A0A"></span>surface</span><span class="v">#0A0A0A</span></li>
+          <li><span class="k"><span class="swatch" style="background:#070707"></span>footer bg</span><span class="v">#070707</span></li>
+          <li><span class="k"><span class="swatch" style="background:#2A2A2A"></span>border</span><span class="v">#2A2A2A</span></li>
+          <li><span class="k"><span class="swatch" style="background:rgba(0,0,0,0.55)"></span>scrim</span><span class="v">rgba(0,0,0,.55) + blur 2</span></li>
+          <li><span class="k"><span class="swatch" style="background:#0099FF"></span>accent</span><span class="v">#0099FF · btn text #000</span></li>
+          <li><span class="k"><span class="swatch" style="background:#FF5A5A"></span>danger</span><span class="v">#FF5A5A</span></li>
+          <li><span class="k"><span class="swatch" style="background:#4BD87B"></span>ok</span><span class="v">#4BD87B</span></li>
+          <li><span class="k">shadow</span><span class="v">0 30 80 rgba(0,0,0,.55)</span></li>
+        </ul>
+      </div>
+
+      <div class="panel">
+        <h3>Type &amp; motion</h3>
+        <ul>
+          <li><span class="k">eyebrow</span><span class="v">JB Mono · 10.5px · 0.06em UP</span></li>
+          <li><span class="k">title</span><span class="v">Inter 600 · 16px · -0.01em</span></li>
+          <li><span class="k">body</span><span class="v">Inter 400 · 13px · 1.55</span></li>
+          <li><span class="k">label</span><span class="v">Inter 500 · 11px UP</span></li>
+          <li><span class="k">btn</span><span class="v">Inter 500 · 12.5px</span></li>
+          <li><span class="k">open</span><span class="v">scale .96→1 · fade · 160ms ease-out</span></li>
+          <li><span class="k">close</span><span class="v">fade · 120ms ease-in</span></li>
+          <li><span class="k">scrim in</span><span class="v">fade · 120ms</span></li>
+          <li><span class="k">shake (err)</span><span class="v">±4px · 200ms</span></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- =================== BUILD NOTES =================== -->
+  <div class="sec">
+    <div class="sec-label">04 · Build notes</div>
+    <h2>Rules that aren't obvious from the pixels</h2>
+    <div class="notes">
+
+      <div class="note">
+        <span class="t">One primitive, five flavors</span>
+        Never branch on visual structure — branch on <code>flavor</code> (<code>confirm | destructive | info | form | choice</code>). The primitive picks icon, eyebrow color, primary-button style, dismiss behavior.
+      </div>
+      <div class="note">
+        <span class="t">Buttons always right-aligned</span>
+        Order: <b>ghost cancel</b> → <b>primary</b>. Destructive replaces primary with the red button but keeps the position — muscle memory never moves.
+      </div>
+      <div class="note">
+        <span class="t">Title is a question, body is context</span>
+        Write titles as the user's question to themselves (&ldquo;Delete worktree?&rdquo;), not a system noun (&ldquo;Deletion&rdquo;). Body fills in consequences and scope, never restates the title.
+      </div>
+      <div class="note">
+        <span class="t">Destructive defaults are strict</span>
+        No close icon · no scrim-click dismiss · <code>↵</code> doesn't auto-confirm · typed-name confirmation for project-level deletes. Red only for destructive — never for &ldquo;save,&rdquo; &ldquo;submit,&rdquo; &ldquo;error&rdquo;.
+      </div>
+      <div class="note">
+        <span class="t">Keyboard map</span>
+        <code>⎋</code> cancel (unless strict) · <code>↵</code> primary (unless destructive) · <code>⌘↵</code> submit from anywhere in a form · <code>Tab</code> trap inside dialog · focus returns to the trigger on close.
+      </div>
+      <div class="note">
+        <span class="t">Stacking</span>
+        Max one dialog at a time. Opening a second dismisses the first. For wizards, use the same dialog and swap body — don't stack.
+      </div>
+      <div class="note">
+        <span class="t">Loading + error inside the dialog</span>
+        When the primary action is async: disable buttons, show a spinner on the primary, freeze the body. On error, shake ±4px (200ms) and surface a red helper under the offending field — never a second dialog.
+      </div>
+      <div class="note">
+        <span class="t">Mobile / narrow</span>
+        Below 520px viewport, dialogs pin to bottom and span full width (radius 12px top corners only, 0 bottom). Footer buttons stack, primary on top.
+      </div>
+
+    </div>
+  </div>
+
+  <!-- =================== IMPLEMENTATION =================== -->
+  <div class="sec">
+    <div class="sec-label">05 · Implementation</div>
+    <h2>Suggested component shape</h2>
+    <div class="impl">
+<pre><span class="c">// Single primitive. Flavor drives visual + behavioral defaults.</span>
+
+<span class="k">type</span> <span class="t">DialogFlavor</span> = <span class="s">"confirm"</span> | <span class="s">"destructive"</span> | <span class="s">"info"</span> | <span class="s">"form"</span> | <span class="s">"choice"</span>;
+<span class="k">type</span> <span class="t">DialogSize</span>   = <span class="s">"sm"</span> | <span class="s">"md"</span> | <span class="s">"lg"</span> | <span class="s">"xl"</span>;
+
+<span class="k">type</span> <span class="t">DialogButton</span> = {
+  <span class="t">label</span>: string;
+  <span class="t">intent</span>?: <span class="s">"primary"</span> | <span class="s">"destructive"</span> | <span class="s">"ghost"</span> | <span class="s">"secondary"</span>;
+  <span class="t">kbd</span>?: string;                 <span class="c">// e.g. "↵" or "⌘↵"</span>
+  <span class="t">loading</span>?: boolean;
+  <span class="t">disabled</span>?: boolean;
+  <span class="t">onClick</span>(): void | Promise&lt;void&gt;;
+};
+
+<span class="k">type</span> <span class="t">DialogProps</span> = {
+  <span class="t">open</span>: boolean;
+  <span class="t">flavor</span>: DialogFlavor;
+  <span class="t">size</span>?: DialogSize;               <span class="c">// default md</span>
+  <span class="t">eyebrow</span>?: string;                <span class="c">// e.g. "Confirm", "Destructive"</span>
+  <span class="t">title</span>: string;                   <span class="c">// phrased as a question</span>
+  <span class="t">icon</span>?: ReactNode;                 <span class="c">// override the flavor icon</span>
+  <span class="t">body</span>: ReactNode;
+
+  <span class="t">buttons</span>: DialogButton[];          <span class="c">// right-aligned, max 2</span>
+  <span class="t">keyboardHint</span>?: string;           <span class="c">// left-side meta text</span>
+
+  <span class="t">strict</span>?: boolean;                 <span class="c">// true on destructive — no ⎋/scrim</span>
+  <span class="t">requireTypedConfirm</span>?: string;    <span class="c">// e.g. "PestScope"</span>
+
+  <span class="t">onDismiss</span>?(): void;
+};
+
+<span class="c">// Convenience wrappers — build in terms of the primitive:</span>
+<span class="k">function</span> <span class="t">ConfirmDialog</span>(p: …)     { <span class="c">/* flavor=confirm */</span> }
+<span class="k">function</span> <span class="t">DestructiveDialog</span>(p: …) { <span class="c">/* flavor=destructive, strict=true */</span> }
+<span class="k">function</span> <span class="t">InfoDialog</span>(p: …)        { <span class="c">/* flavor=info, auto-dismiss 6s */</span> }
+<span class="k">function</span> <span class="t">FormDialog</span>(p: …)        { <span class="c">/* flavor=form, ⌘↵ submits */</span> }
+<span class="k">function</span> <span class="t">ChoiceDialog</span>(p: …)      { <span class="c">/* flavor=choice, ↑↓ + ↵ */</span> }
+
+<span class="c">// Imperative API for firing from anywhere (menu handlers, shortcuts):
+//   const ok = await confirm({ title: "Switch model?", body: "…" });
+//   if (!ok) return;
+//
+//   const result = await dialog({
+//     flavor: "form", title: "…", render: ({ close }) =&gt; &lt;…/&gt;,
+//   });</span></pre>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -51,11 +51,9 @@ public partial class App : Application
         _singleInstanceMutex = new Mutex(initiallyOwned: true, SingleInstanceMutexName, out var createdNew);
         if (!createdNew)
         {
-            MessageBox.Show(
-                "CodeScope is already running.",
-                "CodeScope",
-                MessageBoxButton.OK,
-                MessageBoxImage.Information);
+            NoScope.CodeScope.Ui.Dialogs.ConfirmDialog.Inform(
+                title: "CodeScope is already running",
+                body: "Another instance of CodeScope owns the single-instance mutex. Activate the running window instead.");
             Shutdown();
             return;
         }

--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -18,7 +18,7 @@ namespace NoScope.CodeScope.App;
 /// </summary>
 public partial class App : Application
 {
-    private const string SingleInstanceMutexName = "Global\\CodeScope.SingleInstance";
+    private static readonly string SingleInstanceMutexName = NoScope.CodeScope.Core.AppPaths.SingleInstanceMutexName;
 
     private IHost? _host;
     private Mutex? _singleInstanceMutex;
@@ -225,7 +225,7 @@ public partial class App : Application
     {
         try
         {
-            var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CodeScope");
+            var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), NoScope.CodeScope.Core.AppPaths.AppFolderName);
             Directory.CreateDirectory(dir);
             File.AppendAllText(Path.Combine(dir, "console.log"),
                 $"{DateTime.Now:HH:mm:ss.fff} {msg}{Environment.NewLine}");
@@ -278,7 +278,7 @@ public partial class App : Application
     {
         try
         {
-            var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CodeScope");
+            var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), NoScope.CodeScope.Core.AppPaths.AppFolderName);
             Directory.CreateDirectory(dir);
             var path = Path.Combine(dir, "crash.log");
             var line = $"[{DateTime.Now:O}] {source}: {ex}\n";

--- a/src/CodeScope.App/LayoutStore.cs
+++ b/src/CodeScope.App/LayoutStore.cs
@@ -22,7 +22,7 @@ public static class LayoutStore
     {
         get
         {
-            var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CodeScope");
+            var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), NoScope.CodeScope.Core.AppPaths.AppFolderName);
             Directory.CreateDirectory(dir);
             return Path.Combine(dir, "layout.json");
         }

--- a/src/CodeScope.App/MainWindow.xaml.cs
+++ b/src/CodeScope.App/MainWindow.xaml.cs
@@ -79,11 +79,9 @@ public partial class MainWindow : FluentWindow
         }
         catch (Exception ex)
         {
-            System.Windows.MessageBox.Show(
-                $"Failed to initialize: {ex.Message}",
-                "CodeScope",
-                System.Windows.MessageBoxButton.OK,
-                System.Windows.MessageBoxImage.Warning);
+            NoScope.CodeScope.Ui.Dialogs.ConfirmDialog.Inform(
+                title: "Failed to initialize",
+                body: ex.Message);
         }
     }
 

--- a/src/CodeScope.App/WindowGeometryStore.cs
+++ b/src/CodeScope.App/WindowGeometryStore.cs
@@ -17,7 +17,7 @@ public static class WindowGeometryStore
     {
         get
         {
-            var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CodeScope");
+            var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), NoScope.CodeScope.Core.AppPaths.AppFolderName);
             Directory.CreateDirectory(dir);
             return Path.Combine(dir, "window.json");
         }

--- a/src/CodeScope.Core/AppPaths.cs
+++ b/src/CodeScope.Core/AppPaths.cs
@@ -1,0 +1,34 @@
+namespace NoScope.CodeScope.Core;
+
+/// <summary>
+/// Shared app-identity shims. When the environment variable <c>CODESCOPE_DEV</c> is set to a
+/// truthy value at process start the folder name under <c>%APPDATA%</c> / <c>%LOCALAPPDATA%</c>
+/// and the single-instance mutex name shift to a <c>.Dev</c> variant, so a locally-built
+/// debug instance can run next to an installed v0.1.0+ without colliding on config, layout,
+/// or the single-instance guard.
+/// <para>
+/// Resolved once at class-init so the rest of the code can treat it as a constant — toggling
+/// the env var at runtime has no effect.
+/// </para>
+/// </summary>
+public static class AppPaths
+{
+    /// <summary>Env var that flips the app into dev-mode paths/mutex. <c>1</c>, <c>true</c>, <c>yes</c> (case-insensitive) are truthy.</summary>
+    public const string DevEnvVar = "CODESCOPE_DEV";
+
+    /// <summary>True when the dev-mode env var was set at process start.</summary>
+    public static bool IsDevMode { get; } = ParseDev(Environment.GetEnvironmentVariable(DevEnvVar));
+
+    /// <summary><c>CodeScope</c> normally; <c>CodeScope.Dev</c> when <see cref="IsDevMode"/> is true.</summary>
+    public static string AppFolderName { get; } = IsDevMode ? "CodeScope.Dev" : "CodeScope";
+
+    /// <summary>Single-instance mutex name — gets a <c>.Dev</c> suffix in dev mode.</summary>
+    public static string SingleInstanceMutexName { get; } =
+        IsDevMode ? @"Global\CodeScope.SingleInstance.Dev" : @"Global\CodeScope.SingleInstance";
+
+    private static bool ParseDev(string? value) =>
+        !string.IsNullOrWhiteSpace(value)
+        && (value.Equals("1", StringComparison.Ordinal)
+            || value.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("yes", StringComparison.OrdinalIgnoreCase));
+}

--- a/src/CodeScope.Core/Models/Session.cs
+++ b/src/CodeScope.Core/Models/Session.cs
@@ -36,4 +36,11 @@ public sealed record Session
     /// <see cref="AgentProfile.SessionIdFlag"/>.
     /// </summary>
     public string? AgentSessionId { get; init; }
+
+    /// <summary>
+    /// Soft-close marker. Non-null means the tab was closed but the conversation
+    /// is kept on disk so the next <c>New session</c> on the same worktree/agent
+    /// can resume it via <c>--resume &lt;AgentSessionId&gt;</c>. Null = live.
+    /// </summary>
+    public DateTimeOffset? ClosedAt { get; init; }
 }

--- a/src/CodeScope.Core/Services/AgentRegistry.cs
+++ b/src/CodeScope.Core/Services/AgentRegistry.cs
@@ -38,14 +38,16 @@ public sealed class AgentRegistry : IAgentRegistry
             Id = "claude",
             DisplayName = "Claude Code",
             Command = "claude",
-            // Claude Code v2.1.118+ broke client-minted session ids and `--continue` / `--resume`
-            // on fresh hydrates (no deferred tool marker; forks session id on /clear). CodeScope
-            // now always launches `claude` bare and adopts whichever UUID the CLI picks by
-            // watching the transcript directory — see `IClaudeSessionDiscovery`.
+            // Fresh launches (no known id) go through NewSessionArgs = [] → bare `claude`, and
+            // `IClaudeSessionDiscovery` adopts whichever UUID the CLI mints. When we already
+            // know the session id — cross-group drag, layout hydrate — we resume it via
+            // `claude --resume <id>` (ResumeByIdArgs) so the conversation continues instead
+            // of the user landing on a fresh agent. SessionIdFlag stays null because v2.1.118+
+            // still refuses client-minted ids on new sessions.
             ResumeArgs = [],
             NewSessionArgs = [],
             SessionIdFlag = null,
-            ResumeByIdArgs = [],
+            ResumeByIdArgs = ["--resume"],
             IsDefault = true,
             Icon = "✶",
             ContextWindowTokens = 1_000_000,

--- a/src/CodeScope.Core/Services/ClaudeModelCatalog.cs
+++ b/src/CodeScope.Core/Services/ClaudeModelCatalog.cs
@@ -27,14 +27,20 @@ public static class ClaudeModelCatalog
         if (string.IsNullOrWhiteSpace(modelId)) { return 0; }
         var id = modelId.ToLowerInvariant();
 
-        // Extended-context SKUs — either a "[1m]" tag or an embedded "-1m-" / "-1m" segment.
+        // Explicit 1M marker always wins — overrides any family default (e.g. a future
+        // `claude-sonnet-*-1m` SKU or the legacy `claude-opus-4-7[1m]` tag).
         if (id.Contains("1m")) { return ExtendedContextTokens; }
 
-        if (id.Contains("claude")
-            && (id.Contains("opus") || id.Contains("sonnet") || id.Contains("haiku")))
-        {
-            return StandardContextTokens;
-        }
+        // Sonnet / Haiku — 200k; no current 1M SKU.
+        if (id.Contains("sonnet") || id.Contains("haiku")) { return StandardContextTokens; }
+
+        // Claude 3.x Opus — 200k. Matches "claude-3-opus-*" without catching "claude-opus-4-*".
+        if (id.Contains("claude-3")) { return StandardContextTokens; }
+
+        // Opus 4.x (and later) ships the 1M context window by default in Claude Code CLI —
+        // the transcript's `message.model` is a plain `claude-opus-4-7` with no `[1m]` suffix,
+        // so we treat the Opus 4+ family as 1M by default.
+        if (id.Contains("claude") && id.Contains("opus")) { return ExtendedContextTokens; }
 
         return 0;
     }

--- a/src/CodeScope.Core/Services/ClaudeSessionDiscovery.cs
+++ b/src/CodeScope.Core/Services/ClaudeSessionDiscovery.cs
@@ -61,7 +61,6 @@ public sealed class ClaudeSessionDiscovery : IClaudeSessionDiscovery
                 foreach (var path in Directory.EnumerateFiles(dir, "*.jsonl"))
                 {
                     handle.TryConsider(path);
-                    if (handle.IsDone) { break; }
                 }
             }
             catch (Exception ex) { _logger.LogTrace(ex, "Claude discovery poll failed for {Dir}", dir); }
@@ -75,15 +74,21 @@ public sealed class ClaudeSessionDiscovery : IClaudeSessionDiscovery
 
     private sealed class WatchHandle(DateTime sinceUtc, Action<string, string> onDiscovered, ILogger logger) : IDisposable
     {
-        private int _done;
-        public bool IsDone => Volatile.Read(ref _done) != 0;
+        // Keeps the watch running for the tab's lifetime. Claude Code rotates its session id
+        // on `/clear` by writing a brand new jsonl in the same cwd dir — a one-shot watcher
+        // would miss every rotation and leave telemetry pinned to the abandoned transcript.
+        // Each unique jsonl path fires the callback once; the caller (MainViewModel) decides
+        // whether to actually re-adopt by comparing against its current persisted id.
+        private readonly HashSet<string> _fired = new(StringComparer.OrdinalIgnoreCase);
+        private readonly object _firedLock = new();
+        private int _disposed;
 
         public FileSystemWatcher? Watcher;
         public Timer? PollTimer;
 
         public void TryConsider(string path)
         {
-            if (IsDone) { return; }
+            if (Volatile.Read(ref _disposed) != 0) { return; }
             try
             {
                 var info = new FileInfo(path);
@@ -96,13 +101,13 @@ public sealed class ClaudeSessionDiscovery : IClaudeSessionDiscovery
                 var id = Path.GetFileNameWithoutExtension(path);
                 if (!IsValidSessionId(id)) { return; }
 
-                if (Interlocked.CompareExchange(ref _done, 1, 0) != 0) { return; }
+                lock (_firedLock)
+                {
+                    if (!_fired.Add(path)) { return; }
+                }
 
                 try { onDiscovered(id, path); }
                 catch (Exception ex) { logger.LogWarning(ex, "Claude discovery: subscriber threw"); }
-
-                // One-shot: tear the watcher down after the first successful adoption.
-                Dispose();
             }
             catch (Exception ex) { logger.LogTrace(ex, "Claude discovery: consider failed for {Path}", path); }
         }
@@ -112,6 +117,7 @@ public sealed class ClaudeSessionDiscovery : IClaudeSessionDiscovery
 
         public void Dispose()
         {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) { return; }
             try { Watcher?.Dispose(); }
             catch (Exception ex) { logger.LogTrace(ex, "Claude discovery: watcher dispose threw"); }
             try { PollTimer?.Dispose(); }

--- a/src/CodeScope.Core/Services/ClaudeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/ClaudeTelemetryService.cs
@@ -122,7 +122,7 @@ public sealed class ClaudeTelemetryService : IClaudeTelemetryService
                 fs.Seek(watch.Offset, SeekOrigin.Begin);
                 using var reader = new StreamReader(fs);
 
-                var total = watch.Snapshot?.TotalTokens ?? 0;
+                var contextTokens = watch.Snapshot?.ContextTokens ?? 0;
                 var turns = watch.Snapshot?.TurnCount ?? 0;
                 var lastAt = watch.Snapshot?.LastTurnAt;
                 var lastDuration = watch.Snapshot?.LastTurnDuration;
@@ -175,7 +175,10 @@ public sealed class ClaudeTelemetryService : IClaudeTelemetryService
                         if (detected > 0) { contextCap = detected; }
                     }
 
-                    total += entry.BillableTokens;
+                    // Overwrite, not accumulate — see the ClaudeSessionTelemetry docstring for why.
+                    // Cache-read IS included here (it's in-context even if prefilled), unlike
+                    // BillableTokens which excludes it to reflect Anthropic's metered pricing.
+                    contextTokens = entry.InputTokens + entry.CacheReadTokens + entry.CacheCreationTokens + entry.OutputTokens;
                     turns += 1;
                     if (entry.Timestamp is { } ts)
                     {
@@ -192,7 +195,7 @@ public sealed class ClaudeTelemetryService : IClaudeTelemetryService
                 if (changed)
                 {
                     var snap = new ClaudeSessionTelemetry(
-                        watch.SessionId, total, turns, lastAt, lastDuration, activity, modelId, contextCap);
+                        watch.SessionId, contextTokens, turns, lastAt, lastDuration, activity, modelId, contextCap);
                     watch.Snapshot = snap;
                     try { Updated?.Invoke(this, snap); }
                     catch (Exception ex) { _logger.LogWarning(ex, "Claude telemetry subscriber threw"); }

--- a/src/CodeScope.Core/Services/GitService.cs
+++ b/src/CodeScope.Core/Services/GitService.cs
@@ -78,11 +78,12 @@ public sealed class GitService : IGitService
         return Result<IReadOnlyList<BranchInfo>>.Ok(list);
     }
 
-    public async Task<Result<bool>> RemoveWorktreeAsync(string repoPath, string worktreePath, CancellationToken ct = default)
+    public async Task<Result<bool>> RemoveWorktreeAsync(string repoPath, string worktreePath, bool force = false, CancellationToken ct = default)
     {
-        var result = await RunAsync(repoPath,
-            $"worktree remove \"{worktreePath}\"",
-            ct).ConfigureAwait(false);
+        var args = force
+            ? $"worktree remove --force \"{worktreePath}\""
+            : $"worktree remove \"{worktreePath}\"";
+        var result = await RunAsync(repoPath, args, ct).ConfigureAwait(false);
         return result.IsSuccess ? Result<bool>.Ok(true) : Result<bool>.Fail(result.Error);
     }
 

--- a/src/CodeScope.Core/Services/IClaudeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/IClaudeTelemetryService.cs
@@ -1,9 +1,20 @@
 namespace NoScope.CodeScope.Core.Services;
 
-/// <summary>Snapshot of live telemetry for a single Claude Code session.</summary>
+/// <summary>
+/// Snapshot of live telemetry for a single Claude Code session.
+/// <para>
+/// <see cref="ContextTokens"/> is the most recent assistant turn's total context size
+/// (<c>input + cache_read + cache_creation + output</c>) — a close proxy for "how full is
+/// the context window right now". It overwrites on each assistant turn, it does NOT
+/// accumulate across turns. Summing would double-count: each turn's <c>input_tokens</c>
+/// already covers the full prior conversation (Claude is stateless per request), so a
+/// running sum explodes past the cap within a handful of turns and the percentage goes
+/// nonsensical.
+/// </para>
+/// </summary>
 public sealed record ClaudeSessionTelemetry(
     string SessionId,
-    int TotalTokens,
+    int ContextTokens,
     int TurnCount,
     DateTimeOffset? LastTurnAt,
     TimeSpan? LastTurnDuration,

--- a/src/CodeScope.Core/Services/IGitService.cs
+++ b/src/CodeScope.Core/Services/IGitService.cs
@@ -28,8 +28,13 @@ public interface IGitService
     /// </summary>
     Task<Result<IReadOnlyList<Models.BranchInfo>>> ListBranchesAsync(string repoPath, CancellationToken ct = default);
 
-    /// <summary>Runs <c>git worktree remove &lt;worktreePath&gt;</c> in <paramref name="repoPath"/>.</summary>
-    Task<Result<bool>> RemoveWorktreeAsync(string repoPath, string worktreePath, CancellationToken ct = default);
+    /// <summary>
+    /// Runs <c>git worktree remove &lt;worktreePath&gt;</c> in <paramref name="repoPath"/>.
+    /// <paramref name="force"/> appends <c>--force</c>, which lets git drop the worktree even when it
+    /// still has uncommitted changes or untracked files. Windows file locks (processes holding the
+    /// directory as cwd) are not bypassed by <c>--force</c> — callers must close those first.
+    /// </summary>
+    Task<Result<bool>> RemoveWorktreeAsync(string repoPath, string worktreePath, bool force = false, CancellationToken ct = default);
 
     /// <summary>
     /// Runs <c>git worktree move &lt;oldPath&gt; &lt;newPath&gt;</c> in <paramref name="repoPath"/>.

--- a/src/CodeScope.Core/Services/ISessionStore.cs
+++ b/src/CodeScope.Core/Services/ISessionStore.cs
@@ -22,6 +22,20 @@ public interface ISessionStore
 
     Task<Result<bool>> RemoveSessionAsync(string sessionId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Marks a session as closed without discarding it — persists a <see cref="Session.ClosedAt"/>
+    /// timestamp so the next <c>New session</c> on the same worktree + agent can resume it via
+    /// <c>--resume &lt;AgentSessionId&gt;</c>. Raises <see cref="SessionStoreChange.SessionRemoved"/>
+    /// so listeners drop their tab/row; <see cref="RestoreSessionAsync"/> brings it back.
+    /// </summary>
+    Task<Result<bool>> SoftCloseSessionAsync(string sessionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Clears <see cref="Session.ClosedAt"/> on a previously soft-closed session and re-publishes it
+    /// via <see cref="SessionStoreChange.SessionAdded"/>. Returns the restored <see cref="Session"/>.
+    /// </summary>
+    Task<Result<Session>> RestoreSessionAsync(string sessionId, CancellationToken ct = default);
+
     Task<Result<bool>> RenameSessionAsync(string sessionId, string? newName, CancellationToken ct = default);
 
     /// <summary>

--- a/src/CodeScope.Core/Services/ISessionStore.cs
+++ b/src/CodeScope.Core/Services/ISessionStore.cs
@@ -37,8 +37,12 @@ public interface ISessionStore
     /// </summary>
     Task<Result<Worktree>> AddWorktreeAsync(string projectId, string newWorktreePath, string newBranch, string? baseBranch = null, CancellationToken ct = default);
 
-    /// <summary>Runs <c>git worktree remove</c> and removes the worktree from the project. Primary worktrees are rejected.</summary>
-    Task<Result<bool>> RemoveWorktreeAsync(string projectId, string worktreeId, CancellationToken ct = default);
+    /// <summary>
+    /// Runs <c>git worktree remove</c> and removes the worktree from the project. Primary worktrees are rejected.
+    /// <paramref name="force"/> passes <c>--force</c> through to git, which discards uncommitted changes /
+    /// untracked files in the worktree. Callers must confirm with the user first.
+    /// </summary>
+    Task<Result<bool>> RemoveWorktreeAsync(string projectId, string worktreeId, bool force = false, CancellationToken ct = default);
 
     /// <summary>
     /// Runs <c>git worktree move</c> to relocate the worktree folder, then cascades the new path

--- a/src/CodeScope.Core/Services/ProjectStore.cs
+++ b/src/CodeScope.Core/Services/ProjectStore.cs
@@ -121,6 +121,6 @@ public sealed class ProjectStore : IProjectStore
     private static string DefaultConfigPath()
     {
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        return Path.Combine(appData, "CodeScope", "projects.json");
+        return Path.Combine(appData, AppPaths.AppFolderName, "projects.json");
     }
 }

--- a/src/CodeScope.Core/Services/SessionStore.cs
+++ b/src/CodeScope.Core/Services/SessionStore.cs
@@ -194,7 +194,25 @@ public sealed class SessionStore : ISessionStore
         }
         if (!changed) { return Result<bool>.Fail($"Session '{sessionId}' not found"); }
         var saved = await SaveSnapshotAsync(ct).ConfigureAwait(false);
-        if (saved.IsFailure) { return saved; }
+        if (saved.IsFailure)
+        {
+            // Rollback the in-memory mutation so a retry doesn't hit the idempotency guard
+            // and silently succeed without ever persisting.
+            lock (_lock)
+            {
+                for (var i = 0; i < _projects.Count; i++)
+                {
+                    var p = _projects[i];
+                    var sessions = p.Sessions.ToList();
+                    var idx = sessions.FindIndex(s => s.Id == sessionId);
+                    if (idx < 0) { continue; }
+                    sessions[idx] = sessions[idx] with { ClosedAt = null };
+                    _projects[i] = p with { Sessions = sessions };
+                    break;
+                }
+            }
+            return saved;
+        }
         // Fire SessionRemoved so the sidebar/tab strip drop the row — restore emits SessionAdded.
         Raise(new SessionStoreChange.SessionRemoved(sessionId));
         return Result<bool>.Ok(true);

--- a/src/CodeScope.Core/Services/SessionStore.cs
+++ b/src/CodeScope.Core/Services/SessionStore.cs
@@ -173,6 +173,62 @@ public sealed class SessionStore : ISessionStore
         return Result<bool>.Ok(true);
     }
 
+    public async Task<Result<bool>> SoftCloseSessionAsync(string sessionId, CancellationToken ct = default)
+    {
+        var changed = false;
+        lock (_lock)
+        {
+            for (var i = 0; i < _projects.Count; i++)
+            {
+                var p = _projects[i];
+                var sessions = p.Sessions.ToList();
+                var idx = sessions.FindIndex(s => s.Id == sessionId);
+                if (idx < 0) { continue; }
+                // Idempotent — re-closing an already-closed session is a no-op, not an error.
+                if (sessions[idx].ClosedAt is not null) { return Result<bool>.Ok(true); }
+                sessions[idx] = sessions[idx] with { ClosedAt = DateTimeOffset.UtcNow };
+                _projects[i] = p with { Sessions = sessions };
+                changed = true;
+                break;
+            }
+        }
+        if (!changed) { return Result<bool>.Fail($"Session '{sessionId}' not found"); }
+        var saved = await SaveSnapshotAsync(ct).ConfigureAwait(false);
+        if (saved.IsFailure) { return saved; }
+        // Fire SessionRemoved so the sidebar/tab strip drop the row — restore emits SessionAdded.
+        Raise(new SessionStoreChange.SessionRemoved(sessionId));
+        return Result<bool>.Ok(true);
+    }
+
+    public async Task<Result<Session>> RestoreSessionAsync(string sessionId, CancellationToken ct = default)
+    {
+        Session? restored = null;
+        string? projectId = null;
+        lock (_lock)
+        {
+            for (var i = 0; i < _projects.Count; i++)
+            {
+                var p = _projects[i];
+                var sessions = p.Sessions.ToList();
+                var idx = sessions.FindIndex(s => s.Id == sessionId);
+                if (idx < 0) { continue; }
+                restored = sessions[idx] with { ClosedAt = null, LastOpened = DateTimeOffset.UtcNow };
+                sessions[idx] = restored;
+                _projects[i] = p with { Sessions = sessions };
+                projectId = p.Id;
+                break;
+            }
+        }
+        if (restored is null || projectId is null)
+        {
+            return Result<Session>.Fail($"Session '{sessionId}' not found");
+        }
+        var saved = await SaveSnapshotAsync(ct).ConfigureAwait(false);
+        if (saved.IsFailure) { return Result<Session>.Fail(saved.Error); }
+        Raise(new SessionStoreChange.SessionAdded(projectId, restored));
+        return Result<Session>.Ok(restored);
+    }
+
     public async Task<Result<bool>> RenameSessionAsync(string sessionId, string? newName, CancellationToken ct = default)
     {
         var renamed = false;

--- a/src/CodeScope.Core/Services/SessionStore.cs
+++ b/src/CodeScope.Core/Services/SessionStore.cs
@@ -283,7 +283,7 @@ public sealed class SessionStore : ISessionStore
         return Result<Worktree>.Ok(worktree);
     }
 
-    public async Task<Result<bool>> RemoveWorktreeAsync(string projectId, string worktreeId, CancellationToken ct = default)
+    public async Task<Result<bool>> RemoveWorktreeAsync(string projectId, string worktreeId, bool force = false, CancellationToken ct = default)
     {
         Project? project;
         Worktree? worktree;
@@ -302,7 +302,7 @@ public sealed class SessionStore : ISessionStore
             return Result<bool>.Fail("Primary worktrees cannot be removed");
         }
 
-        var gitResult = await _git.RemoveWorktreeAsync(project.Path, worktree.Path, ct).ConfigureAwait(false);
+        var gitResult = await _git.RemoveWorktreeAsync(project.Path, worktree.Path, force, ct).ConfigureAwait(false);
         if (gitResult.IsFailure)
         {
             return Result<bool>.Fail(gitResult.Error);

--- a/src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml
+++ b/src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml
@@ -201,17 +201,31 @@
                           Color="Black" />
     </Window.Resources>
 
-    <!-- The surface. Margin:30 leaves room for the drop shadow inside the transparent window. -->
-    <Border
-        Background="{StaticResource Dlg.Surface}"
-        BorderBrush="{StaticResource Dlg.Border}"
-        BorderThickness="1"
-        CornerRadius="12"
-        Margin="30"
-        Effect="{StaticResource Dlg.Shadow}"
-        MouseLeftButtonDown="OnChromeDrag"
-        SnapsToDevicePixels="True"
-        UseLayoutRounding="True">
+    <!-- Scrim: spec §03 — rgba(0,0,0,.55) + 2px blur. Covers the entire transparent window so
+         the owner dims visually. On non-strict dialogs, clicking the scrim dismisses (same as
+         Cancel). Strict/destructive: scrim is visual-only, click does nothing. The dialog
+         surface sits on top of the scrim inside the same Grid. -->
+    <Grid>
+        <Border
+            x:Name="ScrimBorder"
+            Background="#8C000000"
+            MouseLeftButtonDown="OnScrimClick">
+            <Border.Effect>
+                <BlurEffect Radius="2" />
+            </Border.Effect>
+        </Border>
+
+        <!-- The surface. Margin:30 leaves room for the drop shadow inside the transparent window. -->
+        <Border
+            Background="{StaticResource Dlg.Surface}"
+            BorderBrush="{StaticResource Dlg.Border}"
+            BorderThickness="1"
+            CornerRadius="12"
+            Margin="30"
+            Effect="{StaticResource Dlg.Shadow}"
+            MouseLeftButtonDown="OnChromeDrag"
+            SnapsToDevicePixels="True"
+            UseLayoutRounding="True">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" /> <!-- head -->
@@ -337,4 +351,5 @@
             </Border>
         </Grid>
     </Border>
+    </Grid>
 </Window>

--- a/src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml
+++ b/src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml
@@ -1,0 +1,340 @@
+<Window
+    x:Class="NoScope.CodeScope.Ui.Dialogs.ConfirmDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="CodeScope"
+    Width="480"
+    SizeToContent="Height"
+    ResizeMode="NoResize"
+    WindowStartupLocation="CenterOwner"
+    ShowInTaskbar="False"
+    WindowStyle="None"
+    AllowsTransparency="True"
+    Background="Transparent"
+    TextElement.FontFamily="Inter"
+    TextElement.FontSize="13"
+    TextElement.Foreground="#FFFFFF"
+    SnapsToDevicePixels="True"
+    UseLayoutRounding="True">
+
+    <!-- Resources: tokens lifted 1:1 from docs/design/html/CodeScope - Dialog System.html §03.
+         Hard-coded (not via DynamicResource) so the dialog doesn't drift when app brushes
+         evolve — the spec is the source of truth for this primitive. -->
+    <Window.Resources>
+        <!-- Colors -->
+        <SolidColorBrush x:Key="Dlg.Surface"   Color="#0A0A0A" />
+        <SolidColorBrush x:Key="Dlg.FooterBg"  Color="#070707" />
+        <SolidColorBrush x:Key="Dlg.Border"    Color="#2A2A2A" />
+        <SolidColorBrush x:Key="Dlg.BorderDim" Color="#1F1F1F" />
+        <SolidColorBrush x:Key="Dlg.Elev"      Color="#141414" />
+        <SolidColorBrush x:Key="Dlg.Elev2"     Color="#1A1A1A" />
+        <SolidColorBrush x:Key="Dlg.Text"      Color="#FFFFFF" />
+        <SolidColorBrush x:Key="Dlg.Text2"     Color="#A0A0A0" />
+        <SolidColorBrush x:Key="Dlg.Text3"     Color="#606060" />
+        <SolidColorBrush x:Key="Dlg.Accent"    Color="#0099FF" />
+        <SolidColorBrush x:Key="Dlg.AccentHov" Color="#1AA8FF" />
+        <SolidColorBrush x:Key="Dlg.Danger"    Color="#FF5A5A" />
+        <SolidColorBrush x:Key="Dlg.DangerHov" Color="#FF7474" />
+        <SolidColorBrush x:Key="Dlg.Ok"        Color="#4BD87B" />
+
+        <SolidColorBrush x:Key="Dlg.IconBg.Info"    Color="#1A0099FF" />
+        <SolidColorBrush x:Key="Dlg.IconBrd.Info"   Color="#400099FF" />
+        <SolidColorBrush x:Key="Dlg.IconBg.Warn"    Color="#1AFF5A5A" />
+        <SolidColorBrush x:Key="Dlg.IconBrd.Warn"   Color="#4DFF5A5A" />
+        <SolidColorBrush x:Key="Dlg.IconBg.Ok"      Color="#144BD87B" />
+        <SolidColorBrush x:Key="Dlg.IconBrd.Ok"     Color="#404BD87B" />
+        <SolidColorBrush x:Key="Dlg.IconBg.Neutral" Color="#141414" />
+
+        <!-- Ghost button (Cancel). Transparent by default, elev on hover. -->
+        <Style x:Key="Dlg.Btn.Ghost" TargetType="Button">
+            <Setter Property="Height" Value="32" />
+            <Setter Property="Padding" Value="14,0" />
+            <Setter Property="MinWidth" Value="72" />
+            <Setter Property="FontFamily" Value="Inter" />
+            <Setter Property="FontSize" Value="12.5" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Foreground" Value="{StaticResource Dlg.Text2}" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="6"
+                                Padding="{TemplateBinding Padding}"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                TextBlock.Foreground="{TemplateBinding Foreground}"
+                                TextBlock.FontFamily="{TemplateBinding FontFamily}"
+                                TextBlock.FontSize="{TemplateBinding FontSize}"
+                                TextBlock.FontWeight="{TemplateBinding FontWeight}" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="{StaticResource Dlg.Elev}" />
+                                <Setter Property="Foreground" Value="{StaticResource Dlg.Text}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Primary button (accent, black text, semibold). Confirm / Form / Info primaries use this. -->
+        <Style x:Key="Dlg.Btn.Primary" TargetType="Button">
+            <Setter Property="Height" Value="32" />
+            <Setter Property="Padding" Value="14,0" />
+            <Setter Property="MinWidth" Value="80" />
+            <Setter Property="FontFamily" Value="Inter" />
+            <Setter Property="FontSize" Value="12.5" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="#000000" />
+            <Setter Property="Background" Value="{StaticResource Dlg.Accent}" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="6"
+                                Padding="{TemplateBinding Padding}"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                TextBlock.Foreground="{TemplateBinding Foreground}"
+                                TextBlock.FontFamily="{TemplateBinding FontFamily}"
+                                TextBlock.FontSize="{TemplateBinding FontSize}"
+                                TextBlock.FontWeight="{TemplateBinding FontWeight}" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="{StaticResource Dlg.AccentHov}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Destructive button: same shape, red fill. Replaces the primary slot on destructive dialogs. -->
+        <Style x:Key="Dlg.Btn.Destructive" TargetType="Button" BasedOn="{StaticResource Dlg.Btn.Primary}">
+            <Setter Property="Background" Value="{StaticResource Dlg.Danger}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="6"
+                                Padding="{TemplateBinding Padding}"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                TextBlock.Foreground="{TemplateBinding Foreground}"
+                                TextBlock.FontFamily="{TemplateBinding FontFamily}"
+                                TextBlock.FontSize="{TemplateBinding FontSize}"
+                                TextBlock.FontWeight="{TemplateBinding FontWeight}" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="{StaticResource Dlg.DangerHov}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Close glyph (X). Visible on non-strict dialogs only — set by code-behind. -->
+        <Style x:Key="Dlg.Btn.Close" TargetType="Button">
+            <Setter Property="Width" Value="24" />
+            <Setter Property="Height" Value="24" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Foreground" Value="{StaticResource Dlg.Text3}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="4"
+                                SnapsToDevicePixels="True">
+                            <Path x:Name="X"
+                                  Width="12" Height="12"
+                                  Stretch="None"
+                                  Stroke="{TemplateBinding Foreground}"
+                                  StrokeThickness="1.4"
+                                  StrokeStartLineCap="Round"
+                                  StrokeEndLineCap="Round"
+                                  Data="M 2,2 L 10,10 M 10,2 L 2,10"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="{StaticResource Dlg.Elev}" />
+                                <Setter Property="Foreground" Value="{StaticResource Dlg.Text}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Drop shadow: spec §03 · tokens — 0 30 80 rgba(0,0,0,.55). -->
+        <DropShadowEffect x:Key="Dlg.Shadow"
+                          BlurRadius="80"
+                          Direction="270"
+                          ShadowDepth="30"
+                          Opacity="0.55"
+                          Color="Black" />
+    </Window.Resources>
+
+    <!-- The surface. Margin:30 leaves room for the drop shadow inside the transparent window. -->
+    <Border
+        Background="{StaticResource Dlg.Surface}"
+        BorderBrush="{StaticResource Dlg.Border}"
+        BorderThickness="1"
+        CornerRadius="12"
+        Margin="30"
+        Effect="{StaticResource Dlg.Shadow}"
+        MouseLeftButtonDown="OnChromeDrag"
+        SnapsToDevicePixels="True"
+        UseLayoutRounding="True">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" /> <!-- head -->
+                <RowDefinition Height="Auto" /> <!-- body -->
+                <RowDefinition Height="Auto" /> <!-- foot -->
+            </Grid.RowDefinitions>
+
+            <!-- HEAD: 20 24 4 per spec. Icon · eyebrow+title · close. -->
+            <Grid Grid.Row="0" Margin="24,20,24,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <!-- Icon tile: 32×32, radius 8, tinted bg + border (flavor-dependent). -->
+                <Border
+                    x:Name="IconTile"
+                    Grid.Column="0"
+                    Width="32" Height="32"
+                    Margin="0,0,14,0"
+                    VerticalAlignment="Top"
+                    CornerRadius="8"
+                    BorderThickness="1"
+                    Background="{StaticResource Dlg.IconBg.Info}"
+                    BorderBrush="{StaticResource Dlg.IconBrd.Info}">
+                    <!-- Actual glyph is swapped in code-behind per flavor — keeps XAML a single primitive. -->
+                    <Viewbox Width="16" Height="16">
+                        <Path x:Name="IconGlyph"
+                              Width="16" Height="16"
+                              Stretch="None"
+                              StrokeThickness="1.5"
+                              StrokeStartLineCap="Round"
+                              StrokeEndLineCap="Round"
+                              StrokeLineJoin="Round"
+                              Stroke="{StaticResource Dlg.Accent}"
+                              Fill="Transparent" />
+                    </Viewbox>
+                </Border>
+
+                <!-- Eyebrow + title -->
+                <StackPanel Grid.Column="1" VerticalAlignment="Top" Margin="0,4,0,0">
+                    <TextBlock
+                        x:Name="EyebrowText"
+                        FontFamily="Consolas, 'JetBrains Mono'"
+                        FontSize="10.5"
+                        FontWeight="Medium"
+                        Foreground="{StaticResource Dlg.Text3}"
+                        Typography.Capitals="AllSmallCaps"
+                        Text="CONFIRM"
+                        Margin="0,0,0,4" />
+                    <TextBlock
+                        x:Name="TitleText"
+                        FontFamily="Inter"
+                        FontSize="16"
+                        FontWeight="SemiBold"
+                        LineHeight="21"
+                        TextWrapping="Wrap"
+                        Foreground="{StaticResource Dlg.Text}" />
+                </StackPanel>
+
+                <!-- Close button — hidden on strict (destructive) dialogs. -->
+                <Button
+                    x:Name="CloseButton"
+                    Grid.Column="2"
+                    VerticalAlignment="Top"
+                    Style="{StaticResource Dlg.Btn.Close}"
+                    Click="OnCancel" />
+            </Grid>
+
+            <!-- BODY: 10 24 20 per spec. -->
+            <TextBlock
+                Grid.Row="1"
+                x:Name="BodyText"
+                Margin="24,10,24,20"
+                TextWrapping="Wrap"
+                FontFamily="Inter"
+                FontSize="13"
+                LineHeight="20"
+                Foreground="{StaticResource Dlg.Text2}" />
+
+            <!-- FOOT: 14 20 per spec. Hint meta on the left, ghost → primary on the right. -->
+            <Border
+                Grid.Row="2"
+                Background="{StaticResource Dlg.FooterBg}"
+                BorderBrush="{StaticResource Dlg.BorderDim}"
+                BorderThickness="0,1,0,0"
+                CornerRadius="0,0,12,12"
+                Padding="20,14">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock
+                        x:Name="HintText"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        FontFamily="Consolas, 'JetBrains Mono'"
+                        FontSize="11"
+                        Foreground="{StaticResource Dlg.Text3}"
+                        Visibility="Collapsed" />
+
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button
+                            x:Name="CancelButton"
+                            AutomationProperties.AutomationId="ConfirmCancelBtn"
+                            Style="{StaticResource Dlg.Btn.Ghost}"
+                            Content="Cancel"
+                            IsCancel="True"
+                            Click="OnCancel" />
+                        <Button
+                            x:Name="ConfirmButton"
+                            AutomationProperties.AutomationId="ConfirmOkBtn"
+                            Style="{StaticResource Dlg.Btn.Primary}"
+                            Content="OK"
+                            Margin="8,0,0,0"
+                            IsDefault="True"
+                            Click="OnConfirm" />
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml.cs
+++ b/src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml.cs
@@ -1,0 +1,213 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace NoScope.CodeScope.Ui.Dialogs;
+
+/// <summary>
+/// In-app modal primitive — the single source of dialog visuals in CodeScope. Every prompt,
+/// destructive confirm, or info note composes from the same 7 slots: icon · eyebrow · title ·
+/// close · body · hint · footer (ghost → primary). See
+/// <c>docs/design/html/CodeScope - Dialog System.html</c> for the full spec; this class is the
+/// <see cref="Flavor.Confirm"/>, <see cref="Flavor.Destructive"/>, and <see cref="Flavor.Info"/>
+/// implementation — form/choice flavors stay in their own dialog files.
+/// </summary>
+public partial class ConfirmDialog : Window
+{
+    public enum Flavor
+    {
+        /// <summary>Reversible action, primary CTA accent-blue. Esc cancels, scrim click cancels.</summary>
+        Confirm,
+        /// <summary>Irreversible — no close icon, no scrim dismiss, Enter does not auto-confirm, red button.</summary>
+        Destructive,
+        /// <summary>Non-blocking success/info — green eyebrow, check icon, OK-only.</summary>
+        Info,
+    }
+
+    public enum Size { Sm, Md, Lg, Xl }
+
+    private bool _strict;
+
+    private void OnChromeDrag(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton == MouseButton.Left) { DragMove(); }
+    }
+
+    private ConfirmDialog(
+        Flavor flavor,
+        Size size,
+        string title,
+        string body,
+        string confirmLabel,
+        string? cancelLabel,
+        string? hint)
+    {
+        InitializeComponent();
+        Width = size switch
+        {
+            Size.Sm => 420,
+            Size.Md => 480,
+            Size.Lg => 560,
+            Size.Xl => 640,
+            _ => 480,
+        };
+        // Account for the 30px shadow margin around the surface — the visible dialog is still
+        // the spec width (420/480/560/640), but the Window is wider to make room for the shadow.
+        Width += 60;
+
+        TitleText.Text = title;
+        BodyText.Text = body;
+        ConfirmButton.Content = confirmLabel;
+        if (cancelLabel is null)
+        {
+            CancelButton.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            CancelButton.Content = cancelLabel;
+        }
+
+        if (hint is null)
+        {
+            HintText.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            HintText.Text = hint;
+            HintText.Visibility = Visibility.Visible;
+        }
+
+        ApplyFlavor(flavor);
+    }
+
+    /// <summary>Reversible confirmation. Returns <c>true</c> on confirm, <c>false</c> on cancel/Esc/close.</summary>
+    public static bool Confirm(
+        string title,
+        string body,
+        string confirmLabel = "OK",
+        string cancelLabel = "Cancel",
+        string? hint = null,
+        Size size = Size.Md,
+        Window? owner = null)
+        => Show(Flavor.Confirm, title, body, confirmLabel, cancelLabel, hint, size, owner);
+
+    /// <summary>Irreversible destructive confirmation. <paramref name="confirmLabel"/> becomes red.</summary>
+    public static bool Destructive(
+        string title,
+        string body,
+        string confirmLabel,
+        string cancelLabel = "Cancel",
+        string? hint = null,
+        Size size = Size.Md,
+        Window? owner = null)
+        => Show(Flavor.Destructive, title, body, confirmLabel, cancelLabel, hint, size, owner);
+
+    /// <summary>OK-only informational dialog. Hides the cancel button.</summary>
+    public static void Inform(
+        string title,
+        string body,
+        string okLabel = "OK",
+        string? hint = null,
+        Size size = Size.Sm,
+        Window? owner = null)
+        => Show(Flavor.Info, title, body, okLabel, cancelLabel: null, hint, size, owner);
+
+    private static bool Show(
+        Flavor flavor,
+        string title,
+        string body,
+        string confirmLabel,
+        string? cancelLabel,
+        string? hint,
+        Size size,
+        Window? owner)
+    {
+        var dlg = new ConfirmDialog(flavor, size, title, body, confirmLabel, cancelLabel, hint)
+        {
+            Owner = owner ?? Application.Current?.MainWindow,
+        };
+        return dlg.ShowDialog() == true;
+    }
+
+    private void ApplyFlavor(Flavor flavor)
+    {
+        // Icon glyph data — 16×16 SVG paths transcribed from the spec. Each entry is:
+        //   (eyebrow text, eyebrow brush key, icon path data, icon stroke key, icon bg key, icon brd key)
+        var (eyebrow, eyebrowKey, glyph, strokeKey, bgKey, brdKey, glyphStrokeThickness) = flavor switch
+        {
+            // Info flavor in the spec uses the green check — §02 "Info / Success".
+            Flavor.Info => (
+                "SESSION READY",
+                "Dlg.Ok",
+                "M 3.5 8.5 L 7 12 L 13 5",
+                "Dlg.Ok",
+                "Dlg.IconBg.Ok",
+                "Dlg.IconBrd.Ok",
+                1.7),
+            // Destructive flavor: warn triangle with exclamation.
+            Flavor.Destructive => (
+                "DESTRUCTIVE",
+                "Dlg.Danger",
+                "M 8 2 L 14.5 13 L 1.5 13 Z M 8 6 L 8 9.5 M 8 11.5 L 8 11.52",
+                "Dlg.Danger",
+                "Dlg.IconBg.Warn",
+                "Dlg.IconBrd.Warn",
+                1.5),
+            // Default Confirm: circle with 'i'.
+            _ => (
+                "CONFIRM",
+                "Dlg.Text3",
+                "M 8 2 A 6 6 0 1 1 7.99 2 Z M 8 5 L 8 8.5 M 8 11 L 8 11.02",
+                "Dlg.Accent",
+                "Dlg.IconBg.Info",
+                "Dlg.IconBrd.Info",
+                1.5),
+        };
+
+        EyebrowText.Text = eyebrow;
+        ApplyBrush(EyebrowText, TextBlock.ForegroundProperty, eyebrowKey);
+        IconGlyph.Data = Geometry.Parse(glyph);
+        IconGlyph.StrokeThickness = glyphStrokeThickness;
+        ApplyBrush(IconGlyph, System.Windows.Shapes.Shape.StrokeProperty, strokeKey);
+        ApplyBrush(IconTile, Border.BackgroundProperty, bgKey);
+        ApplyBrush(IconTile, Border.BorderBrushProperty, brdKey);
+
+        // Destructive-flavor behavior per spec §04:
+        //   • no close icon
+        //   • no Esc cancel (via CancelButton.IsCancel=false)
+        //   • no ↵ auto-confirm (via ConfirmButton.IsDefault=false)
+        //   • primary swaps to the red destructive button
+        _strict = flavor == Flavor.Destructive;
+        if (_strict)
+        {
+            CloseButton.Visibility = Visibility.Collapsed;
+            ConfirmButton.IsDefault = false;
+            CancelButton.IsCancel = false;
+            if (TryFindResource("Dlg.Btn.Destructive") is Style destStyle)
+            {
+                ConfirmButton.Style = destStyle;
+            }
+        }
+    }
+
+    private void ApplyBrush(DependencyObject target, DependencyProperty property, string resourceKey)
+    {
+        if (TryFindResource(resourceKey) is Brush brush)
+        {
+            target.SetValue(property, brush);
+        }
+    }
+
+    private void OnConfirm(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true;
+        Close();
+    }
+
+    private void OnCancel(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+}

--- a/src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml.cs
+++ b/src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml.cs
@@ -199,6 +199,13 @@ public partial class ConfirmDialog : Window
         }
     }
 
+    private void OnScrimClick(object sender, MouseButtonEventArgs e)
+    {
+        if (_strict) { return; }
+        DialogResult = false;
+        Close();
+    }
+
     private void OnConfirm(object sender, RoutedEventArgs e)
     {
         DialogResult = true;

--- a/src/CodeScope.Ui/ViewModels/DiffPanelViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/DiffPanelViewModel.cs
@@ -28,11 +28,24 @@ public sealed partial class DiffPanelViewModel : ObservableObject
         Lines = [];
 
         // Re-render on each status tick: cheap since diff runs only when the panel is expanded.
+        // WorktreeStatusUpdated is raised by the status poller on a thread-pool thread, so we
+        // must marshal onto the dispatcher before kicking off RefreshAsync — otherwise
+        // Lines.Clear() / Lines.Add() below mutate an ObservableCollection off the UI thread
+        // and WPF raises "SourceCollection from a thread different from the Dispatcher thread".
         _store.Changed += (_, change) =>
         {
-            if (change is SessionStoreChange.WorktreeStatusUpdated updated
-                && _worktree is { } wvm
-                && updated.WorktreeId == wvm.Id)
+            if (change is not SessionStoreChange.WorktreeStatusUpdated updated
+                || _worktree is not { } wvm
+                || updated.WorktreeId != wvm.Id)
+            {
+                return;
+            }
+            var app = Application.Current;
+            if (app?.Dispatcher is { } d && !d.CheckAccess())
+            {
+                d.BeginInvoke(new Action(() => { _ = RefreshAsync(); }));
+            }
+            else
             {
                 _ = RefreshAsync();
             }

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -534,19 +534,67 @@ public sealed partial class MainViewModel : ObservableObject
         {
             var targetSessionIds = _store.Projects
                 .FirstOrDefault(p => p.Id == projectId)?.Sessions
-                .Where(s => s.WorktreeId == worktreeId)
+                .Where(s => s.WorktreeId == worktreeId && s.ClosedAt is null)
                 .Select(s => s.Id)
                 .ToHashSet() ?? [];
-            if (targetSessionIds.Count == 0) { return; }
+            if (targetSessionIds.Count == 0) { return () => Task.CompletedTask; }
 
-            var tabs = Groups
-                .SelectMany(g => g.Tabs)
-                .Where(t => targetSessionIds.Contains(t.Descriptor.Id))
-                .ToList();
-            foreach (var tab in tabs)
+            // Snapshot each target tab's (stored state · group · index) so a failed remove can
+            // reinsert them in place. FindStoredSession is called *before* CloseTabAsync since
+            // soft-close erases the AgentSessionId from memory state the restore needs.
+            var snapshots = new List<(Session stored, EditorGroupViewModel group, int indexInGroup)>();
+            foreach (var group in Groups)
             {
-                await CloseTabAsync(tab).ConfigureAwait(true);
+                for (var i = 0; i < group.Tabs.Count; i++)
+                {
+                    var tab = group.Tabs[i];
+                    if (!targetSessionIds.Contains(tab.Descriptor.Id)) { continue; }
+                    if (FindStoredSession(tab) is { } stored)
+                    {
+                        snapshots.Add((stored, group, i));
+                    }
+                }
             }
+
+            foreach (var (stored, _, _) in snapshots)
+            {
+                var tab = Groups.SelectMany(g => g.Tabs).FirstOrDefault(t => t.Descriptor.Id == stored.Id);
+                if (tab is not null) { await CloseTabAsync(tab).ConfigureAwait(true); }
+            }
+
+            // Rollback lambda: only touches sessions that are *still* soft-closed at rollback
+            // time (a user might have already resumed one manually between close and failure).
+            return async () =>
+            {
+                foreach (var (stored, group, indexInGroup) in snapshots)
+                {
+                    var current = FindStoredSessionById(stored.Id);
+                    if (current is null || current.ClosedAt is null) { continue; }
+                    var restored = await _store.RestoreSessionAsync(stored.Id).ConfigureAwait(true);
+                    if (restored.IsFailure) { continue; }
+
+                    var agent = string.IsNullOrEmpty(stored.AgentId)
+                        || string.Equals(stored.AgentId, ShellSentinel, StringComparison.OrdinalIgnoreCase)
+                        ? null
+                        : _agents.GetById(stored.AgentId!);
+                    var descriptor = agent is null
+                        ? _sessionManager.CreateShellSession(stored.WorktreePath, stored.Id)
+                        : _sessionManager.CreateAgentSession(stored.WorktreePath, agent, stored.Id,
+                            resume: true, agentSessionId: stored.AgentSessionId);
+                    var vm = new SessionTabViewModel(descriptor, projectId, stored.AgentId, stored.DisplayName, agent?.Icon);
+                    var insertAt = Math.Clamp(indexInGroup, 0, group.Tabs.Count);
+                    group.Tabs.Insert(insertAt, vm);
+
+                    if (string.Equals(stored.AgentId, "claude", StringComparison.OrdinalIgnoreCase)
+                        && stored.AgentSessionId is { Length: > 0 } sid)
+                    {
+                        _telemetry?.Register(sid, stored.WorktreePath);
+                    }
+                    BeginClaudeAdoption(descriptor.Id, stored.AgentId, stored.WorktreePath, DateTimeOffset.UtcNow);
+                }
+                CloseGroupCommand.NotifyCanExecuteChanged();
+                OnPropertyChanged(nameof(CanCloseGroup));
+            };
         };
 
         // Status-bar metrics recompute on any worktree status / PR event.
@@ -1322,6 +1370,18 @@ public sealed partial class MainViewModel : ObservableObject
             {
                 // Skip watches for soft-closed sessions — no tab to update.
                 if (s.ClosedAt is not null) { continue; }
+
+                // Eager telemetry register for hydrated Claude tabs. Resume-by-id (`claude
+                // --resume <id>`) reuses the existing jsonl, so ClaudeSessionDiscovery's
+                // `since >= file.LastWrite` filter skips it and the status bar would stay
+                // frozen until the user fires the next turn. Registering here synchronously
+                // replays the persisted transcript and seeds the snapshot immediately; the
+                // adoption watch still runs in parallel to catch `/clear` rotations.
+                if (string.Equals(s.AgentId, "claude", StringComparison.OrdinalIgnoreCase)
+                    && s.AgentSessionId is { Length: > 0 } sid)
+                {
+                    _telemetry?.Register(sid, s.WorktreePath);
+                }
                 BeginClaudeAdoption(s.Id, s.AgentId, s.WorktreePath, now);
             }
         }

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -449,7 +449,17 @@ public sealed partial class MainViewModel : ObservableObject
     private SessionTabViewModel? _selectedTab;
 
     /// <summary>Title bar text: "CodeScope — {tab}" when a tab is active, else just "CodeScope".</summary>
-    public string WindowTitle => SelectedTab is { } t ? $"CodeScope — {t.DisplayName}" : "CodeScope";
+    public string WindowTitle
+    {
+        get
+        {
+            // Visual delimiter between an installed build and a side-by-side dev run —
+            // CODESCOPE_DEV=1 also routes the config/layout/mutex to a `.Dev` namespace,
+            // so the suffix mirrors that split in the titlebar.
+            var brand = NoScope.CodeScope.Core.AppPaths.IsDevMode ? "CodeScope [dev]" : "CodeScope";
+            return SelectedTab is { } t ? $"{brand} — {t.DisplayName}" : brand;
+        }
+    }
 
     partial void OnSelectedTabChanged(SessionTabViewModel? value)
     {
@@ -514,6 +524,29 @@ public sealed partial class MainViewModel : ObservableObject
         sidebar.SpawnSessionRequested += async (_, _) =>
         {
             await NewSessionAsync().ConfigureAwait(true);
+        };
+
+        // Worktree deletion needs every tab pinned to that worktree closed first so the
+        // pwsh children release their Windows cwd lock. Match via the persisted Session
+        // (authoritative WorktreeId link); tabs without a stored session are transient
+        // and tear themselves down on group removal anyway.
+        sidebar.CloseWorktreeSessionsAsync = async (projectId, worktreeId) =>
+        {
+            var targetSessionIds = _store.Projects
+                .FirstOrDefault(p => p.Id == projectId)?.Sessions
+                .Where(s => s.WorktreeId == worktreeId)
+                .Select(s => s.Id)
+                .ToHashSet() ?? [];
+            if (targetSessionIds.Count == 0) { return; }
+
+            var tabs = Groups
+                .SelectMany(g => g.Tabs)
+                .Where(t => targetSessionIds.Contains(t.Descriptor.Id))
+                .ToList();
+            foreach (var tab in tabs)
+            {
+                await CloseTabAsync(tab).ConfigureAwait(true);
+            }
         };
 
         // Status-bar metrics recompute on any worktree status / PR event.
@@ -949,10 +982,15 @@ public sealed partial class MainViewModel : ObservableObject
             var resumed = _sessionManager.CreateAgentSession(old.WorkingDirectory, agent, id: old.Id, resume: true, agentSessionId: storedAgentId)
                 with { Title = old.Title };
             tab.Rebind(resumed);
-            // Cross-group respawn = new pwsh process = new claude session id. Tear down the
-            // old telemetry watch and start fresh adoption so the status bar keeps tracking.
-            if (storedAgentId is { Length: > 0 } oldId) { _telemetry?.Unregister(oldId); }
-            BeginClaudeAdoption(tab.Descriptor.Id, agent.Id, old.WorkingDirectory, DateTimeOffset.UtcNow);
+            // Resume-by-id (e.g. `claude --resume <id>`) appends to the existing jsonl, so the
+            // telemetry watcher keeps tracking the same file across the pwsh respawn. Only when
+            // we can't resume by id do we need to tear the tail down and rediscover a fresh one.
+            var resumesById = storedAgentId is { Length: > 0 } && agent.ResumeByIdArgs.Count > 0;
+            if (!resumesById)
+            {
+                if (storedAgentId is { Length: > 0 } oldId) { _telemetry?.Unregister(oldId); }
+                BeginClaudeAdoption(tab.Descriptor.Id, agent.Id, old.WorkingDirectory, DateTimeOffset.UtcNow);
+            }
         }
 
         sourceGroup.Tabs.Remove(tab);
@@ -1311,7 +1349,7 @@ public sealed partial class MainViewModel : ObservableObject
             var stored = FindStoredSession(tab);
             if (stored?.AgentSessionId == snap.SessionId)
             {
-                tab.TokensUsed = snap.TotalTokens;
+                tab.TokensUsed = snap.ContextTokens;
                 tab.TurnCount = snap.TurnCount;
                 tab.LastTurnDurationSec = snap.LastTurnDuration?.TotalSeconds ?? 0;
                 if (snap.ContextWindowTokens > 0) { tab.ContextWindowTokens = snap.ContextWindowTokens; }

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -539,24 +539,27 @@ public sealed partial class MainViewModel : ObservableObject
                 .ToHashSet() ?? [];
             if (targetSessionIds.Count == 0) { return () => Task.CompletedTask; }
 
-            // Snapshot each target tab's (stored state · group · index) so a failed remove can
-            // reinsert them in place. FindStoredSession is called *before* CloseTabAsync since
-            // soft-close erases the AgentSessionId from memory state the restore needs.
-            var snapshots = new List<(Session stored, EditorGroupViewModel group, int indexInGroup)>();
-            foreach (var group in Groups)
+            // Snapshot each target tab's (stored state · group · groupIndex · indexInGroup) so
+            // a failed remove can reinsert them in place. FindStoredSession is called *before*
+            // CloseTabAsync since soft-close erases the AgentSessionId from memory state the
+            // restore needs. groupIndex is captured now because CloseTabAsync can auto-remove a
+            // group that ends up empty — on rollback we use that index to re-insert the group.
+            var snapshots = new List<(Session stored, EditorGroupViewModel group, int groupIndex, int indexInGroup)>();
+            for (var gi = 0; gi < Groups.Count; gi++)
             {
+                var group = Groups[gi];
                 for (var i = 0; i < group.Tabs.Count; i++)
                 {
                     var tab = group.Tabs[i];
                     if (!targetSessionIds.Contains(tab.Descriptor.Id)) { continue; }
                     if (FindStoredSession(tab) is { } stored)
                     {
-                        snapshots.Add((stored, group, i));
+                        snapshots.Add((stored, group, gi, i));
                     }
                 }
             }
 
-            foreach (var (stored, _, _) in snapshots)
+            foreach (var (stored, _, _, _) in snapshots)
             {
                 var tab = Groups.SelectMany(g => g.Tabs).FirstOrDefault(t => t.Descriptor.Id == stored.Id);
                 if (tab is not null) { await CloseTabAsync(tab).ConfigureAwait(true); }
@@ -566,7 +569,18 @@ public sealed partial class MainViewModel : ObservableObject
             // time (a user might have already resumed one manually between close and failure).
             return async () =>
             {
-                foreach (var (stored, group, indexInGroup) in snapshots)
+                // Group-level roll-back: CloseTabAsync auto-removes a now-empty non-focused group,
+                // which orphans that EditorGroupViewModel. Re-insert any such group at its original
+                // index before we start re-adding tabs — otherwise the restored tabs land in a
+                // detached group that isn't in `Groups` and effectively disappear.
+                foreach (var (_, group, groupIndex, _) in snapshots)
+                {
+                    if (Groups.Contains(group)) { continue; }
+                    var targetIndex = Math.Clamp(groupIndex, 0, Groups.Count);
+                    Groups.Insert(targetIndex, group);
+                }
+
+                foreach (var (stored, group, _, indexInGroup) in snapshots)
                 {
                     var current = FindStoredSessionById(stored.Id);
                     if (current is null || current.ClosedAt is null) { continue; }
@@ -949,6 +963,14 @@ public sealed partial class MainViewModel : ObservableObject
         var vm = new SessionTabViewModel(descriptor, project.Id, closed.AgentId, closed.DisplayName, agent.Icon);
         FocusedGroup.Tabs.Add(vm);
         SelectedTab = vm;
+        // Eager telemetry seed — same reasoning as the hydrate path: `claude --resume <id>`
+        // reuses the existing jsonl, so the adoption watch won't fire until the next turn
+        // and the status bar would stay frozen on the just-restored tab.
+        if (string.Equals(closed.AgentId, "claude", StringComparison.OrdinalIgnoreCase)
+            && closed.AgentSessionId is { Length: > 0 } sid)
+        {
+            _telemetry?.Register(sid, worktree.Path);
+        }
         BeginClaudeAdoption(descriptor.Id, closed.AgentId, worktree.Path, DateTimeOffset.UtcNow);
         OnPropertyChanged(nameof(CanCloseGroup));
         CloseGroupCommand.NotifyCanExecuteChanged();

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -1221,18 +1221,33 @@ public sealed partial class MainViewModel : ObservableObject
 
         StopClaudeAdoption(storedSessionId);
 
+        // Watch stays alive for the tab's lifetime: Claude Code rotates its session id on
+        // `/clear` by writing a fresh jsonl in the same cwd dir. Each rotation fires the
+        // callback with the new id; we unregister the old telemetry tail, persist the new
+        // id, and register the new tail so the status bar keeps tracking. Disposed on
+        // tab close / cross-group drop via StopClaudeAdoption.
         var handle = _discovery.Watch(workingDir, since, (adoptedId, _path) =>
         {
             var app = Application.Current;
             async Task ApplyAsync()
             {
+                // Skip if this id is already the one we're persisting — the initial launch
+                // adoption fires on startup and the poll fallback can re-fire on a live file.
+                var currentId = FindStoredSessionById(storedSessionId)?.AgentSessionId;
+                if (string.Equals(currentId, adoptedId, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Still make sure telemetry is registered — a just-loaded hydrate may need it.
+                    _telemetry?.Register(adoptedId, workingDir);
+                    return;
+                }
+
+                if (!string.IsNullOrEmpty(currentId)) { _telemetry?.Unregister(currentId!); }
                 _telemetry?.Register(adoptedId, workingDir);
                 var result = await _store.UpdateAgentSessionIdAsync(storedSessionId, adoptedId).ConfigureAwait(true);
                 if (result.IsFailure)
                 {
                     _logger.LogDebug("Adoption persist failed for {Sid}: {Error}", storedSessionId, result.Error);
                 }
-                StopClaudeAdoption(storedSessionId);
             }
             if (app?.Dispatcher is { } d && !d.CheckAccess())
             {
@@ -1244,6 +1259,18 @@ public sealed partial class MainViewModel : ObservableObject
             }
         });
         _discoveryWatches[storedSessionId] = handle;
+    }
+
+    private Session? FindStoredSessionById(string storedSessionId)
+    {
+        foreach (var p in _store.Projects)
+        {
+            foreach (var s in p.Sessions)
+            {
+                if (s.Id == storedSessionId) { return s; }
+            }
+        }
+        return null;
     }
 
     private void StopClaudeAdoption(string storedSessionId)

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -756,6 +756,27 @@ public sealed partial class MainViewModel : ObservableObject
 
         if (project is null) { return; }
 
+        // Soft-close resume — if this worktree has a closed session that would match the agent
+        // the user is about to spawn, restore it instead of minting a new one. Restart is the
+        // explicit "start fresh" escape hatch; New session gives you back whatever was live
+        // last time. Keeps the 1-session-per-worktree invariant (we match on WorktreeId +
+        // resolved agent id).
+        var resolvedAgentId = ResolveAgentIdForNewSession(project, agentId);
+        if (worktree is not null
+            && resolvedAgentId is not null
+            && !string.Equals(resolvedAgentId, ShellSentinel, StringComparison.OrdinalIgnoreCase))
+        {
+            var closed = project.Sessions.FirstOrDefault(s =>
+                s.ClosedAt is not null
+                && string.Equals(s.WorktreeId, worktree.Id, StringComparison.Ordinal)
+                && string.Equals(s.AgentId, resolvedAgentId, StringComparison.OrdinalIgnoreCase)
+                && s.AgentSessionId is { Length: > 0 });
+            if (closed is not null && await TryRestoreSessionAsync(project, worktree, closed).ConfigureAwait(true))
+            {
+                return;
+            }
+        }
+
         // Resolve agent / shell. Priority: explicit arg → project's DefaultAgentId → global default.
         var useShell = string.Equals(agentId, ShellSentinel, StringComparison.OrdinalIgnoreCase);
         AgentProfile? agent;
@@ -822,6 +843,71 @@ public sealed partial class MainViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Resolves the agent id that <see cref="NewSessionAsync"/> would end up using, mirroring
+    /// its priority (explicit arg → project default → global default). Used to look up a
+    /// matching soft-closed session *before* we spawn anything. Returns null for the global
+    /// default when no profile is registered — caller treats null as "no resume candidate".
+    /// </summary>
+    private string? ResolveAgentIdForNewSession(Project project, string? explicitAgentId)
+    {
+        if (!string.IsNullOrEmpty(explicitAgentId))
+        {
+            return string.Equals(explicitAgentId, ShellSentinel, StringComparison.OrdinalIgnoreCase)
+                ? ShellSentinel
+                : _agents.GetById(explicitAgentId)?.Id;
+        }
+        if (string.Equals(project.DefaultAgentId, ShellSentinel, StringComparison.OrdinalIgnoreCase))
+        {
+            return ShellSentinel;
+        }
+        if (!string.IsNullOrEmpty(project.DefaultAgentId))
+        {
+            return _agents.GetById(project.DefaultAgentId!)?.Id ?? _agents.GetDefault()?.Id;
+        }
+        return _agents.GetDefault()?.Id;
+    }
+
+    /// <summary>
+    /// Restores a soft-closed session: clears <see cref="Session.ClosedAt"/> in the store,
+    /// spawns a resume-flavoured descriptor (<c>--resume &lt;AgentSessionId&gt;</c> via
+    /// <see cref="SessionManager.CreateAgentSession"/> with <c>resume: true</c>), adds the tab,
+    /// and kicks off Claude adoption so telemetry follows across the rotation. Returns
+    /// <c>false</c> when the restore couldn't be persisted or the agent profile has vanished.
+    /// </summary>
+    private async Task<bool> TryRestoreSessionAsync(Project project, Worktree worktree, Session closed)
+    {
+        if (string.IsNullOrEmpty(closed.AgentId)
+            || string.Equals(closed.AgentId, ShellSentinel, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+        var agent = _agents.GetById(closed.AgentId);
+        if (agent is null) { return false; }
+
+        var restored = await _store.RestoreSessionAsync(closed.Id).ConfigureAwait(true);
+        if (restored.IsFailure)
+        {
+            _logger.LogWarning("RestoreSession: {Error}", restored.Error);
+            return false;
+        }
+
+        var descriptor = _sessionManager.CreateAgentSession(
+            worktree.Path, agent, closed.Id, resume: true, agentSessionId: closed.AgentSessionId);
+        if (worktree.Branch is { Length: > 0 } branch)
+        {
+            descriptor = descriptor with { Title = $"{project.Name} · {branch}" };
+        }
+
+        var vm = new SessionTabViewModel(descriptor, project.Id, closed.AgentId, closed.DisplayName, agent.Icon);
+        FocusedGroup.Tabs.Add(vm);
+        SelectedTab = vm;
+        BeginClaudeAdoption(descriptor.Id, closed.AgentId, worktree.Path, DateTimeOffset.UtcNow);
+        OnPropertyChanged(nameof(CanCloseGroup));
+        CloseGroupCommand.NotifyCanExecuteChanged();
+        return true;
+    }
+
+    /// <summary>
     /// Spawns a fresh session at the same worktree + agent as <paramref name="tab"/>.
     /// Use-case: keep one tab for long-running work and duplicate a parallel shell for ad-hoc commands.
     /// </summary>
@@ -873,7 +959,16 @@ public sealed partial class MainViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private async Task CloseTabAsync(SessionTabViewModel? tab)
+    private Task CloseTabAsync(SessionTabViewModel? tab) => CloseTabAsync(tab, hardRemove: false);
+
+    /// <summary>
+    /// Closes a tab. When <paramref name="hardRemove"/> is <c>false</c> (default) the session is
+    /// <em>soft-closed</em> for agents that can resume (<see cref="AgentProfile.ResumeByIdArgs"/> +
+    /// persisted <see cref="Session.AgentSessionId"/>) — next <c>New session</c> on the same worktree
+    /// restores the conversation. Shells and agents without resume support are always hard-removed.
+    /// Callers that definitely want the session gone (Restart, worktree cascade) pass <c>true</c>.
+    /// </summary>
+    private async Task CloseTabAsync(SessionTabViewModel? tab, bool hardRemove)
     {
         tab ??= SelectedTab;
         if (tab is null)
@@ -892,7 +987,22 @@ public sealed partial class MainViewModel : ObservableObject
         var storedForTab = FindStoredSession(tab);
         if (storedForTab?.AgentSessionId is { Length: > 0 } tsid) { _telemetry?.Unregister(tsid); }
         StopClaudeAdoption(tab.Descriptor.Id);
-        await _store.RemoveSessionAsync(tab.Descriptor.Id).ConfigureAwait(true);
+
+        // Resumable = agent with ResumeByIdArgs and a persisted AgentSessionId.
+        var resumable = !hardRemove
+            && storedForTab?.AgentSessionId is { Length: > 0 }
+            && !string.IsNullOrEmpty(storedForTab.AgentId)
+            && !string.Equals(storedForTab.AgentId, ShellSentinel, StringComparison.OrdinalIgnoreCase)
+            && _agents.GetById(storedForTab.AgentId!)?.ResumeByIdArgs.Count > 0;
+
+        if (resumable)
+        {
+            await _store.SoftCloseSessionAsync(tab.Descriptor.Id).ConfigureAwait(true);
+        }
+        else
+        {
+            await _store.RemoveSessionAsync(tab.Descriptor.Id).ConfigureAwait(true);
+        }
 
         // Auto-collapse a group when its last tab closes and another group exists — the
         // invariant is "groups exist to hold sessions; an empty one adds visual noise".
@@ -1035,7 +1145,11 @@ public sealed partial class MainViewModel : ObservableObject
         if (tab is null) { return; }
 
         await DuplicateTabAsync(tab).ConfigureAwait(true);
-        await CloseTabAsync(tab).ConfigureAwait(true);
+        // Hard-remove: Restart is "throw away the old conversation and start fresh" — without
+        // hardRemove the old row would linger as a soft-closed entry and get resumed the next
+        // time the user clicks New session on this worktree, which is exactly the opposite of
+        // what Restart means.
+        await CloseTabAsync(tab, hardRemove: true).ConfigureAwait(true);
     }
 
     [RelayCommand]
@@ -1134,6 +1248,10 @@ public sealed partial class MainViewModel : ObservableObject
         {
             foreach (var s in p.Sessions)
             {
+                // Soft-closed sessions are kept on disk for resume-on-next-NewSession but
+                // don't materialise as tabs at startup — they'd spawn dozens of ghost pwsh
+                // children otherwise.
+                if (s.ClosedAt is not null) { continue; }
                 if (!Directory.Exists(s.WorktreePath)) { continue; }
                 var agent = string.IsNullOrEmpty(s.AgentId) || string.Equals(s.AgentId, ShellSentinel, StringComparison.OrdinalIgnoreCase)
                     ? null
@@ -1202,6 +1320,8 @@ public sealed partial class MainViewModel : ObservableObject
         {
             foreach (var s in p.Sessions)
             {
+                // Skip watches for soft-closed sessions — no tab to update.
+                if (s.ClosedAt is not null) { continue; }
                 BeginClaudeAdoption(s.Id, s.AgentId, s.WorktreePath, now);
             }
         }

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
@@ -374,8 +374,52 @@ public sealed partial class SidebarViewModel
             System.Windows.MessageBoxImage.Warning);
         if (confirm != System.Windows.MessageBoxResult.OK) { return; }
 
+        // Close any tabs pinned to this worktree first so pwsh releases the cwd lock on
+        // the directory. Without this `git worktree remove` fails on Windows with a file-
+        // in-use error and the sidebar silently stays stale.
+        if (CloseWorktreeSessionsAsync is { } closeSessions)
+        {
+            try { await closeSessions(worktree.ProjectId, worktree.Id).ConfigureAwait(true); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Closing sessions for worktree {Id} failed", worktree.Id); }
+
+            // Give WPF a beat to run the SessionTabView Unloaded teardown and let ConPTY
+            // kill the pwsh child — otherwise we race the file lock into `git worktree remove`.
+            await Task.Delay(250).ConfigureAwait(true);
+        }
+
         var r = await _store.RemoveWorktreeAsync(worktree.ProjectId, worktree.Id).ConfigureAwait(true);
-        if (r.IsFailure) { _logger.LogWarning("RemoveWorktree failed: {Error}", r.Error); }
+        if (r.IsSuccess)
+        {
+            Toast("Worktree removed", worktree.DisplayBranch, ControlAppearance.Success);
+            return;
+        }
+
+        _logger.LogWarning("RemoveWorktree failed: {Error}", r.Error);
+
+        // Offer --force when the normal remove is rejected — typically dirty worktree or
+        // a lingering lock. Force still can't beat a live Windows file lock, but it covers
+        // the common "you have uncommitted changes" case cleanly.
+        var retry = System.Windows.MessageBox.Show(
+            $"Couldn't remove worktree:\n\n{r.Error}\n\nForce remove? Uncommitted changes and untracked files in the worktree will be lost.",
+            "CodeScope — Force remove worktree",
+            System.Windows.MessageBoxButton.OKCancel,
+            System.Windows.MessageBoxImage.Warning);
+        if (retry != System.Windows.MessageBoxResult.OK)
+        {
+            Toast("Remove failed", r.Error, ControlAppearance.Danger);
+            return;
+        }
+
+        var forced = await _store.RemoveWorktreeAsync(worktree.ProjectId, worktree.Id, force: true).ConfigureAwait(true);
+        if (forced.IsSuccess)
+        {
+            Toast("Worktree force-removed", worktree.DisplayBranch, ControlAppearance.Success);
+        }
+        else
+        {
+            _logger.LogWarning("Force RemoveWorktree failed: {Error}", forced.Error);
+            Toast("Remove failed", forced.Error, ControlAppearance.Danger);
+        }
     }
 
     /// <summary>Unwraps the ProjectViewModel / WorktreeViewModel / string alternatives passed by menus.</summary>

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
@@ -367,10 +367,13 @@ public sealed partial class SidebarViewModel
 
         // Close any tabs pinned to this worktree first so pwsh releases the cwd lock on
         // the directory. Without this `git worktree remove` fails on Windows with a file-
-        // in-use error and the sidebar silently stays stale.
+        // in-use error and the sidebar silently stays stale. The close callback returns a
+        // rollback lambda we invoke if the whole remove flow ultimately fails — without it,
+        // a failed delete would leave the worktree in place but with its tabs vanished.
+        Func<Task>? rollback = null;
         if (CloseWorktreeSessionsAsync is { } closeSessions)
         {
-            try { await closeSessions(worktree.ProjectId, worktree.Id).ConfigureAwait(true); }
+            try { rollback = await closeSessions(worktree.ProjectId, worktree.Id).ConfigureAwait(true); }
             catch (Exception ex) { _logger.LogWarning(ex, "Closing sessions for worktree {Id} failed", worktree.Id); }
 
             // Give WPF a beat to run the SessionTabView Unloaded teardown and let ConPTY
@@ -396,6 +399,7 @@ public sealed partial class SidebarViewModel
             confirmLabel: "Force remove");
         if (!retry)
         {
+            await InvokeRollbackAsync(rollback).ConfigureAwait(true);
             Toast("Remove failed", r.Error, ControlAppearance.Danger);
             return;
         }
@@ -408,8 +412,16 @@ public sealed partial class SidebarViewModel
         else
         {
             _logger.LogWarning("Force RemoveWorktree failed: {Error}", forced.Error);
+            await InvokeRollbackAsync(rollback).ConfigureAwait(true);
             Toast("Remove failed", forced.Error, ControlAppearance.Danger);
         }
+    }
+
+    private async Task InvokeRollbackAsync(Func<Task>? rollback)
+    {
+        if (rollback is null) { return; }
+        try { await rollback().ConfigureAwait(true); }
+        catch (Exception ex) { _logger.LogWarning(ex, "Worktree close rollback threw"); }
     }
 
     /// <summary>Unwraps the ProjectViewModel / WorktreeViewModel / string alternatives passed by menus.</summary>

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
@@ -148,15 +148,11 @@ public sealed partial class SidebarViewModel
         var defaultBranch = string.IsNullOrWhiteSpace(project?.DefaultBranch) ? "main" : project!.DefaultBranch;
         var baseRef = $"origin/{defaultBranch}";
 
-        var confirm = System.Windows.MessageBox.Show(
-            $"Rebase '{worktree.DisplayBranch}' onto {baseRef}?\n\n" +
-            $"Conflicts (if any) will leave the rebase in progress — resolve them in the worktree " +
-            $"and run `git rebase --continue` / `--abort` manually.\n\n" +
-            $"Path: {worktree.Path}",
-            "CodeScope — Rebase onto default branch",
-            System.Windows.MessageBoxButton.OKCancel,
-            System.Windows.MessageBoxImage.Question);
-        if (confirm != System.Windows.MessageBoxResult.OK) { return; }
+        var confirm = Dialogs.ConfirmDialog.Confirm(
+            title: $"Rebase '{worktree.DisplayBranch}' onto {baseRef}?",
+            body: $"Conflicts (if any) will leave the rebase in progress — resolve them in the worktree and run `git rebase --continue` / `--abort` manually.\n\nPath: {worktree.Path}",
+            confirmLabel: "Rebase");
+        if (!confirm) { return; }
 
         var r = await _git.RebaseOntoAsync(worktree.Path, baseRef).ConfigureAwait(true);
         if (r.IsSuccess)
@@ -174,15 +170,11 @@ public sealed partial class SidebarViewModel
     private async Task DiscardChangesAsync(WorktreeViewModel? worktree)
     {
         if (worktree is null || _git is null || string.IsNullOrWhiteSpace(worktree.Path)) { return; }
-        var confirm = System.Windows.MessageBox.Show(
-            $"Discard ALL local changes in '{worktree.DisplayBranch}'?\n\n" +
-            $"This resets the worktree to HEAD and removes untracked files/dirs.\n" +
-            $"Unsaved work cannot be recovered.\n\n" +
-            $"Path: {worktree.Path}",
-            "CodeScope — Discard changes",
-            System.Windows.MessageBoxButton.OKCancel,
-            System.Windows.MessageBoxImage.Warning);
-        if (confirm != System.Windows.MessageBoxResult.OK) { return; }
+        var confirm = Dialogs.ConfirmDialog.Destructive(
+            title: $"Discard ALL local changes in '{worktree.DisplayBranch}'?",
+            body: $"This resets the worktree to HEAD and removes untracked files/dirs. Unsaved work cannot be recovered.\n\nPath: {worktree.Path}",
+            confirmLabel: "Discard");
+        if (!confirm) { return; }
 
         var r = await _git.DiscardChangesAsync(worktree.Path).ConfigureAwait(true);
         if (r.IsSuccess)
@@ -367,12 +359,11 @@ public sealed partial class SidebarViewModel
     private async Task RemoveWorktreeAsync(WorktreeViewModel? worktree)
     {
         if (worktree is null || worktree.IsPrimary) { return; }
-        var confirm = System.Windows.MessageBox.Show(
-            $"Delete worktree '{worktree.DisplayBranch}' at\n{worktree.Path}?",
-            "CodeScope — Remove worktree",
-            System.Windows.MessageBoxButton.OKCancel,
-            System.Windows.MessageBoxImage.Warning);
-        if (confirm != System.Windows.MessageBoxResult.OK) { return; }
+        var confirm = Dialogs.ConfirmDialog.Destructive(
+            title: $"Delete worktree '{worktree.DisplayBranch}'?",
+            body: $"Path: {worktree.Path}\n\nOpen sessions will be closed first. Unpushed commits stay on the branch.",
+            confirmLabel: "Delete");
+        if (!confirm) { return; }
 
         // Close any tabs pinned to this worktree first so pwsh releases the cwd lock on
         // the directory. Without this `git worktree remove` fails on Windows with a file-
@@ -399,12 +390,11 @@ public sealed partial class SidebarViewModel
         // Offer --force when the normal remove is rejected — typically dirty worktree or
         // a lingering lock. Force still can't beat a live Windows file lock, but it covers
         // the common "you have uncommitted changes" case cleanly.
-        var retry = System.Windows.MessageBox.Show(
-            $"Couldn't remove worktree:\n\n{r.Error}\n\nForce remove? Uncommitted changes and untracked files in the worktree will be lost.",
-            "CodeScope — Force remove worktree",
-            System.Windows.MessageBoxButton.OKCancel,
-            System.Windows.MessageBoxImage.Warning);
-        if (retry != System.Windows.MessageBoxResult.OK)
+        var retry = Dialogs.ConfirmDialog.Destructive(
+            title: "Couldn't remove worktree — force?",
+            body: $"{r.Error}\n\nForce remove will discard uncommitted changes and untracked files in the worktree.",
+            confirmLabel: "Force remove");
+        if (!retry)
         {
             Toast("Remove failed", r.Error, ControlAppearance.Danger);
             return;

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.StoreSync.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.StoreSync.cs
@@ -72,7 +72,10 @@ public sealed partial class SidebarViewModel
         foreach (var wt in p.Worktrees)
         {
             var wvm = new WorktreeViewModel(p.Id, wt);
-            foreach (var s in p.Sessions.Where(x => x.WorktreeId == wt.Id))
+            // Soft-closed sessions persist on disk but have no live tab — skip them in the tree
+            // so the worktree row reflects "no active session" and offers New session (which
+            // will resume the soft-closed conversation transparently).
+            foreach (var s in p.Sessions.Where(x => x.WorktreeId == wt.Id && x.ClosedAt is null))
             {
                 wvm.Sessions.Add(BuildSessionRow(p.Id, wt.Id, s));
             }

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
@@ -100,8 +100,14 @@ public sealed partial class SidebarViewModel : ObservableObject
     /// Hook wired by <see cref="MainViewModel.AttachSidebar"/> to close any tabs currently pinned
     /// to a worktree before it is removed. Without this, the pwsh processes hosting those tabs
     /// keep Windows file locks on the worktree directory and <c>git worktree remove</c> fails.
+    ///
+    /// <para>Returns a rollback delegate that the caller invokes if the destructive operation
+    /// ultimately fails (git refuses + user declines the force retry). The rollback restores each
+    /// soft-closed session and re-adds its tab to the original group, so a failed delete doesn't
+    /// leave the user with a still-present worktree but an empty tab strip. A no-op lambda is
+    /// returned when nothing was closed.</para>
     /// </summary>
-    public Func<string, string, Task>? CloseWorktreeSessionsAsync { get; set; }
+    public Func<string, string, Task<Func<Task>>>? CloseWorktreeSessionsAsync { get; set; }
 
     private void Toast(string title, string message, ControlAppearance appearance)
     {

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
@@ -96,6 +96,13 @@ public sealed partial class SidebarViewModel : ObservableObject
     internal void RaiseSpawnSessionRequested(WorktreeViewModel worktree)
         => SpawnSessionRequested?.Invoke(this, worktree);
 
+    /// <summary>
+    /// Hook wired by <see cref="MainViewModel.AttachSidebar"/> to close any tabs currently pinned
+    /// to a worktree before it is removed. Without this, the pwsh processes hosting those tabs
+    /// keep Windows file locks on the worktree directory and <c>git worktree remove</c> fails.
+    /// </summary>
+    public Func<string, string, Task>? CloseWorktreeSessionsAsync { get; set; }
+
     private void Toast(string title, string message, ControlAppearance appearance)
     {
         if (_snackbar is null) { return; }

--- a/src/CodeScope.Ui/Views/SessionTabView.xaml
+++ b/src/CodeScope.Ui/Views/SessionTabView.xaml
@@ -8,6 +8,14 @@
     mc:Ignorable="d"
     Background="#FF0A0A0A">
     <Grid>
+        <Grid.ContextMenu>
+            <ContextMenu x:Name="TerminalContextMenu" Opened="OnContextMenuOpened">
+                <MenuItem x:Name="MenuOpenUrl" Header="Open link" InputGestureText="Ctrl+Shift+O" Click="OnOpenUrlClicked" />
+                <Separator />
+                <MenuItem x:Name="MenuCopy" Header="Copy" InputGestureText="Ctrl+Shift+C" Click="OnCopyClicked" />
+                <MenuItem Header="Paste" InputGestureText="Ctrl+Shift+V" Click="OnPasteClicked" />
+            </ContextMenu>
+        </Grid.ContextMenu>
         <term:EasyTerminalControl
             x:Name="Terminal"
             AutomationProperties.AutomationId="SessionTerminal"

--- a/src/CodeScope.Ui/Views/SessionTabView.xaml
+++ b/src/CodeScope.Ui/Views/SessionTabView.xaml
@@ -8,14 +8,6 @@
     mc:Ignorable="d"
     Background="#FF0A0A0A">
     <Grid>
-        <Grid.ContextMenu>
-            <ContextMenu x:Name="TerminalContextMenu" Opened="OnContextMenuOpened">
-                <MenuItem x:Name="MenuOpenUrl" Header="Open link" InputGestureText="Ctrl+Shift+O" Click="OnOpenUrlClicked" />
-                <Separator />
-                <MenuItem x:Name="MenuCopy" Header="Copy" InputGestureText="Ctrl+Shift+C" Click="OnCopyClicked" />
-                <MenuItem Header="Paste" InputGestureText="Ctrl+Shift+V" Click="OnPasteClicked" />
-            </ContextMenu>
-        </Grid.ContextMenu>
         <term:EasyTerminalControl
             x:Name="Terminal"
             AutomationProperties.AutomationId="SessionTerminal"

--- a/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using NoScope.CodeScope.Ui.ViewModels;
 using EasyWindowsTerminalControl;
 using Microsoft.Terminal.Wpf;
@@ -32,6 +33,151 @@ public partial class SessionTabView : UserControl
         Terminal.Theme = BuildTheme();
         DataContextChanged += (_, _) => TryStartShell();
         Loaded += (_, _) => { _isLoaded = true; TryStartShell(); };
+        Unloaded += (_, _) => TeardownShell();
+        // Tunneling preview so we win over the inner TerminalControl's Win32 input path.
+        PreviewKeyDown += OnTerminalPreviewKeyDown;
+    }
+
+    /// <summary>
+    /// Terminal-friendly clipboard bindings. Windows-Terminal-style semantics:
+    /// <list type="bullet">
+    ///   <item><c>Ctrl+C</c> with a non-empty selection → copy &amp; clear selection; empty selection
+    ///     falls through as <c>SIGINT</c> to the shell.</item>
+    ///   <item><c>Ctrl+Shift+C</c> → always copy (never SIGINT).</item>
+    ///   <item><c>Ctrl+V</c> / <c>Ctrl+Shift+V</c> → paste clipboard text into the ConPTY. Line
+    ///     endings are normalised to <c>\r</c> because the shell treats each CR as Enter —
+    ///     forwarding <c>\r\n</c> would insert blank commands between pasted lines.</item>
+    /// </list>
+    /// </summary>
+    private void OnTerminalPreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        var ctrl = (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control;
+        if (!ctrl) { return; }
+        var shift = (Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift;
+
+        if (e.Key == Key.C)
+        {
+            var sel = Terminal.Terminal?.GetSelectedText();
+            if (!string.IsNullOrEmpty(sel))
+            {
+                TrySetClipboard(sel);
+                e.Handled = true;
+                return;
+            }
+            // No selection: only swallow on Shift (explicit copy shortcut). Plain Ctrl+C
+            // drops through so pwsh / claude / etc. get their SIGINT.
+            if (shift) { e.Handled = true; }
+        }
+        else if (e.Key == Key.V)
+        {
+            var text = TryGetClipboardText();
+            if (string.IsNullOrEmpty(text)) { return; }
+            var normalised = text.Replace("\r\n", "\r").Replace("\n", "\r");
+            Terminal.ConPTYTerm?.WriteToTerm(normalised.AsSpan());
+            e.Handled = true;
+        }
+        else if (e.Key == Key.O && shift)
+        {
+            // Ctrl+Shift+O → treat the current selection as a URL and open it in the default
+            // browser. Microsoft.Terminal.Wpf does not implement OSC-8 hyperlinks or Ctrl+click
+            // URL detection, so selection-then-shortcut is the pragmatic substitute.
+            if (TryOpenSelectedUrl()) { e.Handled = true; }
+        }
+    }
+
+    private bool TryOpenSelectedUrl()
+    {
+        var sel = Terminal.Terminal?.GetSelectedText();
+        if (string.IsNullOrWhiteSpace(sel)) { return false; }
+        var trimmed = sel.Trim();
+        // The terminal wraps long URLs with newlines when they hit the right edge — stitch the
+        // line fragments back together before validation or a perfectly good URL looks malformed.
+        trimmed = trimmed.Replace("\r\n", string.Empty).Replace("\n", string.Empty).Replace("\r", string.Empty);
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri)) { return false; }
+        if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) { return false; }
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
+            return true;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[SessionTabView] Open URL failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private void OnContextMenuOpened(object sender, RoutedEventArgs e)
+    {
+        var sel = Terminal.Terminal?.GetSelectedText();
+        var hasSelection = !string.IsNullOrEmpty(sel);
+        MenuCopy.IsEnabled = hasSelection;
+        MenuOpenUrl.IsEnabled = hasSelection && LooksLikeUrl(sel);
+    }
+
+    private static bool LooksLikeUrl(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) { return false; }
+        var t = text.Trim().Replace("\r\n", string.Empty).Replace("\n", string.Empty).Replace("\r", string.Empty);
+        return Uri.TryCreate(t, UriKind.Absolute, out var uri)
+            && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+    }
+
+    private void OnOpenUrlClicked(object sender, RoutedEventArgs e) => TryOpenSelectedUrl();
+
+    private void OnCopyClicked(object sender, RoutedEventArgs e)
+    {
+        var sel = Terminal.Terminal?.GetSelectedText();
+        if (!string.IsNullOrEmpty(sel)) { TrySetClipboard(sel); }
+    }
+
+    private void OnPasteClicked(object sender, RoutedEventArgs e)
+    {
+        var text = TryGetClipboardText();
+        if (string.IsNullOrEmpty(text)) { return; }
+        var normalised = text.Replace("\r\n", "\r").Replace("\n", "\r");
+        Terminal.ConPTYTerm?.WriteToTerm(normalised.AsSpan());
+    }
+
+    private static void TrySetClipboard(string text)
+    {
+        // Clipboard is a shared resource — another app can hold OpenClipboard momentarily and
+        // WPF raises COMException. One retry is enough in practice; silently dropping the copy
+        // is friendlier than crashing the terminal.
+        try { Clipboard.SetText(text); }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            try { Clipboard.SetText(text); }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[SessionTabView] Clipboard set: {ex.Message}"); }
+        }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[SessionTabView] Clipboard set: {ex.Message}"); }
+    }
+
+    private static string? TryGetClipboardText()
+    {
+        try { return Clipboard.ContainsText() ? Clipboard.GetText() : null; }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[SessionTabView] Clipboard get: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Kills the ConPTY child + pipes when the hosting tab is removed. Without this the pwsh
+    /// process lingers (ref'd only via the local <c>term</c> captured in <see cref="TryStartShell"/>)
+    /// and keeps a Windows file lock on its cwd — which breaks <c>git worktree remove</c>
+    /// downstream when the user deletes the worktree the session was pinned to.
+    /// </summary>
+    private void TeardownShell()
+    {
+        if (!_started) { return; }
+        var term = Terminal.DisconnectConPTYTerm();
+        try { term?.CloseStdinToApp(); }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[SessionTabView] Teardown CloseStdin: {ex.Message}"); }
+        try { term?.StopExternalTermOnly(); }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[SessionTabView] Teardown StopExternal: {ex.Message}"); }
+        _started = false;
     }
 
     private static TerminalTheme BuildTheme() => new()

--- a/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
@@ -35,6 +35,14 @@ public partial class SessionTabView : UserControl
         Loaded += (_, _) => { _isLoaded = true; TryStartShell(); };
         Unloaded += (_, _) => TeardownShell();
         // Tunneling preview so we win over the inner TerminalControl's Win32 input path.
+        // Keyboard events tunnel through WPF fine even with Win32InputMode=True, but mouse
+        // events are another story: the Microsoft.Terminal.Wpf HwndHost child captures
+        // WM_*BUTTON* messages at the native layer, so WPF's routed mouse events never
+        // fire on this UserControl. That rules out a native right-click ContextMenu —
+        // a WPF ContextMenu on the Grid, PreviewMouseRightButtonUp, and HwndSource.AddHook
+        // on the top-level window were all tried and none reach this code path. Subclassing
+        // the terminal's native HWND would work but is fragile. The keyboard shortcuts
+        // below are the supported path for copy / paste / open-url.
         PreviewKeyDown += OnTerminalPreviewKeyDown;
     }
 
@@ -107,37 +115,6 @@ public partial class SessionTabView : UserControl
         }
     }
 
-    private void OnContextMenuOpened(object sender, RoutedEventArgs e)
-    {
-        var sel = Terminal.Terminal?.GetSelectedText();
-        var hasSelection = !string.IsNullOrEmpty(sel);
-        MenuCopy.IsEnabled = hasSelection;
-        MenuOpenUrl.IsEnabled = hasSelection && LooksLikeUrl(sel);
-    }
-
-    private static bool LooksLikeUrl(string? text)
-    {
-        if (string.IsNullOrWhiteSpace(text)) { return false; }
-        var t = text.Trim().Replace("\r\n", string.Empty).Replace("\n", string.Empty).Replace("\r", string.Empty);
-        return Uri.TryCreate(t, UriKind.Absolute, out var uri)
-            && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
-    }
-
-    private void OnOpenUrlClicked(object sender, RoutedEventArgs e) => TryOpenSelectedUrl();
-
-    private void OnCopyClicked(object sender, RoutedEventArgs e)
-    {
-        var sel = Terminal.Terminal?.GetSelectedText();
-        if (!string.IsNullOrEmpty(sel)) { TrySetClipboard(sel); }
-    }
-
-    private void OnPasteClicked(object sender, RoutedEventArgs e)
-    {
-        var text = TryGetClipboardText();
-        if (string.IsNullOrEmpty(text)) { return; }
-        var normalised = text.Replace("\r\n", "\r").Replace("\n", "\r");
-        Terminal.ConPTYTerm?.WriteToTerm(normalised.AsSpan());
-    }
 
     private static void TrySetClipboard(string text)
     {

--- a/src/CodeScope.Ui/Views/SidebarView.xaml
+++ b/src/CodeScope.Ui/Views/SidebarView.xaml
@@ -407,39 +407,49 @@
 
                         <!-- Chevron — rotates 0→90° when the project expands (spec §4). Bound to the
                              ancestor TreeViewItem's IsExpanded (not VM's, because the outer template
-                             uses TreeViewItem.IsExpanded to drive ItemsHost visibility). -->
-                        <Path
+                             uses TreeViewItem.IsExpanded to drive ItemsHost visibility). Wrapped
+                             in a transparent hit-target Border so clicking the chevron toggles
+                             expand/collapse (without this, the Path's stroke-only hit area means
+                             most clicks miss and the row swallows them as selection). -->
+                        <Border
                             Grid.Column="1"
-                            Width="10" Height="10"
-                            Stretch="Uniform"
-                            Data="M4.5 3 L8 6 L4.5 9"
-                            Stroke="{DynamicResource Text.Secondary}"
-                            StrokeThickness="1.5"
-                            StrokeStartLineCap="Round"
-                            StrokeEndLineCap="Round"
-                            StrokeLineJoin="Round"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            RenderTransformOrigin="0.5,0.5">
-                            <Path.Style>
-                                <Style TargetType="Path">
-                                    <Setter Property="RenderTransform">
-                                        <Setter.Value>
-                                            <RotateTransform Angle="0" />
-                                        </Setter.Value>
-                                    </Setter>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding Path=IsExpanded, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
-                                            <Setter Property="RenderTransform">
-                                                <Setter.Value>
-                                                    <RotateTransform Angle="90" />
-                                                </Setter.Value>
-                                            </Setter>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Path.Style>
-                        </Path>
+                            Background="Transparent"
+                            Cursor="Hand"
+                            ToolTip="Expand / collapse"
+                            PreviewMouseLeftButtonDown="OnChevronClick">
+                            <Path
+                                Width="10" Height="10"
+                                Stretch="Uniform"
+                                Data="M4.5 3 L8 6 L4.5 9"
+                                Stroke="{DynamicResource Text.Secondary}"
+                                StrokeThickness="1.5"
+                                StrokeStartLineCap="Round"
+                                StrokeEndLineCap="Round"
+                                StrokeLineJoin="Round"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                IsHitTestVisible="False"
+                                RenderTransformOrigin="0.5,0.5">
+                                <Path.Style>
+                                    <Style TargetType="Path">
+                                        <Setter Property="RenderTransform">
+                                            <Setter.Value>
+                                                <RotateTransform Angle="0" />
+                                            </Setter.Value>
+                                        </Setter>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Path=IsExpanded, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
+                                                <Setter Property="RenderTransform">
+                                                    <Setter.Value>
+                                                        <RotateTransform Angle="90" />
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Path.Style>
+                            </Path>
+                        </Border>
 
                         <TextBlock
                             Grid.Column="2"

--- a/src/CodeScope.Ui/Views/SidebarView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SidebarView.xaml.cs
@@ -20,6 +20,20 @@ public partial class SidebarView : UserControl
     /// handler still binds. We may re-surface filtering via the command palette instead.</summary>
     public void FocusFilter() { }
 
+    /// <summary>
+    /// Chevron click toggles the owning TreeViewItem's expansion. Without this, the chevron
+    /// is a decorative Path and only a double-click on the row expands/collapses — which is
+    /// what users report as "clicking the chevron doesn't do anything."
+    /// </summary>
+    private void OnChevronClick(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is not DependencyObject origin) { return; }
+        var item = FindAncestor<TreeViewItem>(origin);
+        if (item is null) { return; }
+        item.IsExpanded = !item.IsExpanded;
+        e.Handled = true;
+    }
+
     /// <summary>Accept drops only when the payload contains at least one directory.</summary>
     private void OnDragOver(object sender, DragEventArgs e)
     {

--- a/tests/CodeScope.Core.Tests/ClaudeModelCatalogTests.cs
+++ b/tests/CodeScope.Core.Tests/ClaudeModelCatalogTests.cs
@@ -10,8 +10,11 @@ public sealed class ClaudeModelCatalogTests
     [InlineData("claude-opus-4-7[1m]", 1_000_000)]
     [InlineData("claude-opus-4-7-1m-20260115", 1_000_000)]
     [InlineData("claude-sonnet-4-6-1m", 1_000_000)]
-    [InlineData("claude-opus-4-7", 200_000)]
-    [InlineData("claude-opus-4-7-20260115", 200_000)]
+    // Plain Opus 4.x model ids — Claude Code CLI uses 1M by default without embedding a tag.
+    [InlineData("claude-opus-4-7", 1_000_000)]
+    [InlineData("claude-opus-4-7-20260115", 1_000_000)]
+    // Claude 3 Opus keeps the 200k cap.
+    [InlineData("claude-3-opus-20240229", 200_000)]
     [InlineData("claude-sonnet-4-6", 200_000)]
     [InlineData("claude-haiku-4-5-20251001", 200_000)]
     public void Known_Models_Resolve_To_Expected_Capacity(string id, int expected) =>

--- a/tests/CodeScope.Core.Tests/ClaudeSessionDiscoveryTests.cs
+++ b/tests/CodeScope.Core.Tests/ClaudeSessionDiscoveryTests.cs
@@ -119,6 +119,46 @@ public sealed class ClaudeSessionDiscoveryTests : IDisposable
     }
 
     [Fact]
+    public async Task Callback_Fires_For_Each_New_Jsonl_So_Clear_Rotations_Are_Adopted()
+    {
+        var sut = NewSut();
+        var adopted = new List<string>();
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (id, _) =>
+        {
+            lock (adopted) { adopted.Add(id); }
+        });
+
+        Directory.CreateDirectory(_encodedDir);
+
+        var id1 = Guid.NewGuid().ToString("D");
+        await File.WriteAllTextAsync(Path.Combine(_encodedDir, id1 + ".jsonl"), "{}");
+
+        await WaitForAsync(() => { lock (adopted) { return adopted.Count >= 1; } }, TimeSpan.FromSeconds(3));
+
+        // Simulates what Claude Code does on `/clear`: a fresh session id ⇒ a fresh jsonl.
+        var id2 = Guid.NewGuid().ToString("D");
+        await File.WriteAllTextAsync(Path.Combine(_encodedDir, id2 + ".jsonl"), "{}");
+
+        await WaitForAsync(() => { lock (adopted) { return adopted.Count >= 2; } }, TimeSpan.FromSeconds(3));
+
+        lock (adopted)
+        {
+            adopted.Should().Contain(id1);
+            adopted.Should().Contain(id2);
+        }
+    }
+
+    private static async Task WaitForAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) { return; }
+            await Task.Delay(50);
+        }
+    }
+
+    [Fact]
     public async Task Dispose_Before_Discovery_Suppresses_Callback()
     {
         var sut = NewSut();

--- a/tests/CodeScope.Core.Tests/ClaudeTelemetryServiceTests.cs
+++ b/tests/CodeScope.Core.Tests/ClaudeTelemetryServiceTests.cs
@@ -39,8 +39,10 @@ public sealed class ClaudeTelemetryServiceTests : IDisposable
         last.Should().NotBeNull();
         last!.SessionId.Should().Be(sessionId);
         last.TurnCount.Should().Be(2);
-        // Billable: (10+20+100) + (5+15+0) = 150
-        last.TotalTokens.Should().Be(150);
+        // ContextTokens is the LATEST assistant turn's full context size, not a running sum —
+        // Claude carries the whole prior conversation in every request's input_tokens, so a
+        // cumulative total double-counts. Last turn = 5 + 15 + 0 + 200 = 220.
+        last.ContextTokens.Should().Be(220);
         last.LastTurnAt.Should().NotBeNull();
         // Pair: user@08:00:00 → assistant@08:01:00 → 1 min; then later user absent between
         // 08:01 and 08:02 so the duration from 08:00 (still the last-seen user turn) holds.

--- a/tests/CodeScope.Core.Tests/SessionStoreTests.cs
+++ b/tests/CodeScope.Core.Tests/SessionStoreTests.cs
@@ -500,4 +500,97 @@ public sealed class SessionStoreTests
             .Should().ContainSingle()
             .Which.PullRequest.Should().BeNull();
     }
+
+    [Fact]
+    public async Task SoftCloseSessionAsync_Marks_Closed_And_Emits_Removed()
+    {
+        var (store, _, _) = Make();
+        var project = (await store.AddProjectAsync(@"C:\demo", "D")).Value;
+        var sid = Guid.NewGuid().ToString("n");
+        await store.AddSessionAsync(project.Id, new Session
+        {
+            Id = sid, WorktreePath = @"C:\demo", AgentId = "claude",
+            AgentSessionId = "abc",
+        });
+
+        var events = new List<SessionStoreChange>();
+        store.Changed += (_, c) => events.Add(c);
+
+        var result = await store.SoftCloseSessionAsync(sid);
+
+        result.IsSuccess.Should().BeTrue();
+        var after = store.Projects.SelectMany(p => p.Sessions).Single(s => s.Id == sid);
+        after.ClosedAt.Should().NotBeNull();
+        after.AgentSessionId.Should().Be("abc", "the resume id must survive soft-close");
+        events.OfType<SessionStoreChange.SessionRemoved>().Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RestoreSessionAsync_Clears_ClosedAt_And_Emits_Added()
+    {
+        var (store, _, _) = Make();
+        var project = (await store.AddProjectAsync(@"C:\demo", "D")).Value;
+        var sid = Guid.NewGuid().ToString("n");
+        await store.AddSessionAsync(project.Id, new Session
+        {
+            Id = sid, WorktreePath = @"C:\demo", AgentId = "claude",
+            AgentSessionId = "abc",
+        });
+        await store.SoftCloseSessionAsync(sid);
+
+        var events = new List<SessionStoreChange>();
+        store.Changed += (_, c) => events.Add(c);
+
+        var restored = await store.RestoreSessionAsync(sid);
+
+        restored.IsSuccess.Should().BeTrue();
+        restored.Value.ClosedAt.Should().BeNull();
+        restored.Value.AgentSessionId.Should().Be("abc");
+        events.OfType<SessionStoreChange.SessionAdded>().Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task SoftClose_Is_Idempotent()
+    {
+        var (store, _, _) = Make();
+        var project = (await store.AddProjectAsync(@"C:\demo", "D")).Value;
+        var sid = Guid.NewGuid().ToString("n");
+        await store.AddSessionAsync(project.Id, new Session
+        {
+            Id = sid, WorktreePath = @"C:\demo", AgentId = "claude",
+            AgentSessionId = "abc",
+        });
+
+        (await store.SoftCloseSessionAsync(sid)).IsSuccess.Should().BeTrue();
+
+        var events = new List<SessionStoreChange>();
+        store.Changed += (_, c) => events.Add(c);
+        var second = await store.SoftCloseSessionAsync(sid);
+
+        second.IsSuccess.Should().BeTrue();
+        events.OfType<SessionStoreChange.SessionRemoved>().Should().BeEmpty("re-close should not emit a second event");
+    }
+
+    [Fact]
+    public async Task RemoveWorktree_Cascades_Over_Soft_Closed_Sessions()
+    {
+        // Worktree delete should wipe both live and soft-closed sessions — a resurrected tree
+        // shouldn't resurrect a ghost conversation that no longer has a working directory.
+        var (store, _, _) = Make();
+        var project = (await store.AddProjectAsync(@"C:\demo", "D")).Value;
+        var wt = (await store.AddWorktreeAsync(project.Id, @"C:\demo.wt\feat-x", "feat/x")).Value;
+        var sid = Guid.NewGuid().ToString("n");
+        await store.AddSessionAsync(project.Id, new Session
+        {
+            Id = sid, WorktreePath = wt.Path, WorktreeId = wt.Id,
+            AgentId = "claude", AgentSessionId = "abc",
+        });
+        await store.SoftCloseSessionAsync(sid);
+
+        var removed = await store.RemoveWorktreeAsync(project.Id, wt.Id);
+        removed.IsSuccess.Should().BeTrue();
+
+        store.Projects.Single(p => p.Id == project.Id)
+            .Sessions.Should().BeEmpty();
+    }
 }

--- a/tests/CodeScope.Core.Tests/SessionStoreTests.cs
+++ b/tests/CodeScope.Core.Tests/SessionStoreTests.cs
@@ -21,7 +21,7 @@ public sealed class SessionStoreTests
         var git = Substitute.For<IGitService>();
         git.AddWorktreeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result<bool>.Ok(true)));
-        git.RemoveWorktreeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        git.RemoveWorktreeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result<bool>.Ok(true)));
         git.MoveWorktreeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result<bool>.Ok(true)));


### PR DESCRIPTION
## Summary

Bundled polish / bug-fix pass from daily v0.1.0 use. Nine commits across three themes:

### Bug fixes
- **Worktree delete** cascaded silently when a pwsh session held the cwd lock — now cascade-closes sessions first, waits for ConPTY teardown, offers `--force` retry, and toasts success/failure.
- **Terminal clipboard / URL open** — `Ctrl+C` (copy if selection, SIGINT otherwise), `Ctrl+V` / `Ctrl+Shift+V` paste with `\r\n → \r` normalization, `Ctrl+Shift+O` opens URL under selection. Routed through `PreviewKeyDown` tunneling because `Win32InputMode=True` swallows mouse/keyboard at the native layer.
- **Cross-group drag** started a fresh Claude instead of resuming — restored `ResumeByIdArgs=["--resume"]` on the Claude profile and preserved the telemetry tail across the move.
- **Status bar token count** — (a) stopped summing input+output+cache_creation across turns (each turn's input already carries the full prior conversation in the stateless API, so summing double-counts); (b) plain `claude-opus-4-*` model ids default to 1M context, not 200k; (c) `/clear` rotation is followed via a continuous adoption watch instead of a one-shot.
- **Sidebar chevron** needed a double-click to collapse — now single-click via a transparent hit-target Border.
- **DiffPanelViewModel crash** on `git worktree add` — the status poller raised `WorktreeStatusUpdated` on a threadpool thread and the panel mutated its `ObservableCollection` without marshaling. Now dispatches through `Application.Current.Dispatcher`.

### New: session persistence on close
`Ctrl+W` on a resume-capable agent tab (Claude et al — agents with `ResumeByIdArgs` + a persisted `AgentSessionId`) now soft-closes: the `Session` row stays on disk with `ClosedAt = UtcNow`, and the next **New session** on the same `(worktree, agent)` pair restores the row and launches with `--resume <id>`. **Restart** stays fresh-start (hard remove). Worktree delete still cascades over soft-closed rows.

### New: styled ConfirmDialog primitive
Replaces native Win32 MessageBox at six call sites (rebase, discard, remove, force-remove, init-failure, single-instance). Tracks `docs/design/html/CodeScope - Dialog System.html` 1:1 — surface `#0A0A0A`, footer `#070707`, accent `#0099FF`, danger `#FF5A5A`, radius 12, drop shadow 0/30/80 rgba(0,0,0,.55). Three flavors wired: `Confirm` (accent primary, Esc+Enter), `Destructive` (red primary, strict — no close X, no Esc/Enter), `Info` (OK-only, green check). Spec's `Form` / `Choice` flavors grow as call sites need them.

### Dev-mode
`CODESCOPE_DEV=1` redirects the single-instance mutex, projects.json, and local app state to `CodeScope.Dev` so the dev build runs side-by-side with the installed v0.1.0 without stealing mutexes or overwriting projects. Documented in CLAUDE.md.

## Test plan
- [x] `dotnet test` — 151 passed (4 new for soft-close)
- [x] Rebase / Discard / Remove-worktree dialogs — visually verified in dev build, match spec §02
- [x] Soft-close → New session resumes on same worktree (Claude)
- [x] Restart still spawns fresh conversation
- [x] Chevron single-click expand/collapse
- [x] `/clear` rotation: status bar follows the new session id
- [x] Status bar token % stays under 100% and matches Claude's own meter
- [ ] Worktree-delete cascade with live sessions (manual — not exercised on this branch)
- [ ] Ctrl+C/V/Shift+O in terminal (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)