### PR TITLE
Auto-update check via Velopack GithubSource

### DIFF
--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -134,6 +134,7 @@ public partial class App : Application
                     return vm;
                 });
                 services.AddSingleton<MainWindow>();
+                services.AddSingleton<UpdateService>();
             })
             .Build();
 
@@ -142,6 +143,17 @@ public partial class App : Application
         var window = _host.Services.GetRequiredService<MainWindow>();
         MainWindow = window;
         window.Show();
+
+        // Kick off the auto-update check 10s after the window is visible. The delay keeps it
+        // off the startup-critical path (no network blocking first paint) and gives the host
+        // loggers a moment to wire up so we see any check failures in the console. Fire-and-
+        // forget by design: UpdateService swallows its own exceptions.
+        var updater = _host.Services.GetRequiredService<UpdateService>();
+        _ = System.Threading.Tasks.Task.Run(async () =>
+        {
+            await System.Threading.Tasks.Task.Delay(System.TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+            await updater.CheckAsync().ConfigureAwait(false);
+        });
     }
 
     protected override void OnExit(ExitEventArgs e)

--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -23,6 +23,7 @@ public partial class App : Application
     private IHost? _host;
     private Mutex? _singleInstanceMutex;
     private ProcessTreeKiller? _appKiller;
+    private CancellationTokenSource? _updateCts;
 
     public App()
     {
@@ -147,17 +148,29 @@ public partial class App : Application
         // Kick off the auto-update check 10s after the window is visible. The delay keeps it
         // off the startup-critical path (no network blocking first paint) and gives the host
         // loggers a moment to wire up so we see any check failures in the console. Fire-and-
-        // forget by design: UpdateService swallows its own exceptions.
+        // forget by design: UpdateService swallows its own exceptions. The CancellationToken
+        // is cancelled in OnExit so the check is aborted if the user closes the app within
+        // the 10s delay — prevents hitting disposed services.
+        _updateCts = new CancellationTokenSource();
+        var updateToken = _updateCts.Token;
         var updater = _host.Services.GetRequiredService<UpdateService>();
         _ = System.Threading.Tasks.Task.Run(async () =>
         {
-            await System.Threading.Tasks.Task.Delay(System.TimeSpan.FromSeconds(10)).ConfigureAwait(false);
-            await updater.CheckAsync().ConfigureAwait(false);
+            try
+            {
+                await System.Threading.Tasks.Task.Delay(System.TimeSpan.FromSeconds(10), updateToken).ConfigureAwait(false);
+                await updater.CheckAsync().ConfigureAwait(false);
+            }
+            catch (System.OperationCanceledException) { }
         });
     }
 
     protected override void OnExit(ExitEventArgs e)
     {
+        try { _updateCts?.Cancel(); } catch { }
+        _updateCts?.Dispose();
+        _updateCts = null;
+
         _host?.StopAsync().GetAwaiter().GetResult();
         _host?.Dispose();
         _host = null;

--- a/src/CodeScope.App/UpdateService.cs
+++ b/src/CodeScope.App/UpdateService.cs
@@ -1,0 +1,115 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Velopack;
+using Velopack.Sources;
+using Wpf.Ui;
+using Wpf.Ui.Controls;
+
+namespace NoScope.CodeScope.App;
+
+/// <summary>
+/// Background updater backed by Velopack + GitHub releases (the same channel the release.yml
+/// workflow publishes to). On success it fires a non-blocking <see cref="ISnackbarService"/>
+/// toast the user can click to restart into the new version. The check is best-effort — any
+/// exception (offline, rate-limited, not an installed build) is swallowed with a warning log.
+/// </summary>
+public sealed class UpdateService
+{
+    // Public GitHub releases channel — `vpk upload github --channel win` from release.yml.
+    private const string RepoUrl = "https://github.com/maui1911/CodeScope";
+    private const string Channel = "win";
+
+    private readonly ILogger<UpdateService> _logger;
+    private readonly ISnackbarService _snackbar;
+
+    public UpdateService(ILogger<UpdateService> logger, ISnackbarService snackbar)
+    {
+        _logger = logger;
+        _snackbar = snackbar;
+    }
+
+    /// <summary>
+    /// Fire-and-forget entry point. Checks once, downloads if newer, surfaces the toast.
+    /// No-op under <c>CODESCOPE_DEV=1</c> (the dev build runs from <c>dotnet run</c> and has no
+    /// Velopack manifest — <see cref="UpdateManager"/> would throw on CheckForUpdatesAsync).
+    /// </summary>
+    public async Task CheckAsync()
+    {
+        if (NoScope.CodeScope.Core.AppPaths.IsDevMode)
+        {
+            _logger.LogDebug("UpdateService: skipped (CODESCOPE_DEV=1)");
+            return;
+        }
+
+        try
+        {
+            var source = new GithubSource(RepoUrl, accessToken: null, prerelease: false);
+            var mgr = new UpdateManager(source, new UpdateOptions { ExplicitChannel = Channel });
+
+            // IsInstalled flips false when running loose from a publish folder (CI smoke test,
+            // local `dotnet run --configuration Release`, Velopack's squirrel bootstrap hasn't
+            // staged a Current\ yet). Skip — nothing we can `ApplyUpdatesAndRestart` onto.
+            if (!mgr.IsInstalled)
+            {
+                _logger.LogDebug("UpdateService: not an installed build, skipping update check");
+                return;
+            }
+
+            var info = await mgr.CheckForUpdatesAsync().ConfigureAwait(false);
+            if (info is null)
+            {
+                _logger.LogDebug("UpdateService: up to date");
+                return;
+            }
+
+            _logger.LogInformation("UpdateService: downloading update {Version}", info.TargetFullRelease.Version);
+            await mgr.DownloadUpdatesAsync(info).ConfigureAwait(false);
+
+            var version = info.TargetFullRelease.Version.ToString();
+            ShowUpdateReadyToast(mgr, info, version);
+        }
+        catch (System.Exception ex)
+        {
+            _logger.LogWarning(ex, "UpdateService: check failed");
+        }
+    }
+
+    private void ShowUpdateReadyToast(UpdateManager mgr, UpdateInfo info, string version)
+    {
+        // Two-step prompt so the user isn't yanked into a modal the moment they launch the
+        // app: (1) a Success snackbar as the quiet signal that an update finished downloading,
+        // then (2) a non-blocking ConfirmDialog a few seconds later asking whether to restart.
+        // The snackbar is fire-and-forget; the dialog is the actual decision point. Users can
+        // defer by clicking Later — the update stays staged and Velopack applies it on the
+        // next clean exit regardless, so a "skip" never loses the download.
+        var app = System.Windows.Application.Current;
+        if (app?.Dispatcher is { } d && !d.CheckAccess())
+        {
+            d.Invoke(() => ShowUpdateReadyToast(mgr, info, version));
+            return;
+        }
+
+        _snackbar.Show(
+            title: $"CodeScope {version} ready",
+            message: "Update downloaded — restart to install.",
+            appearance: ControlAppearance.Success,
+            icon: null,
+            timeout: System.TimeSpan.FromSeconds(10));
+
+        _ = System.Threading.Tasks.Task.Run(async () =>
+        {
+            await System.Threading.Tasks.Task.Delay(System.TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+            app?.Dispatcher.Invoke(() =>
+            {
+                var restart = NoScope.CodeScope.Ui.Dialogs.ConfirmDialog.Confirm(
+                    title: $"CodeScope {version} is ready",
+                    body: "Restart now to finish installing. Open sessions will be closed and their transcripts resumed automatically on the next launch.",
+                    confirmLabel: "Restart",
+                    cancelLabel: "Later");
+                if (!restart) { return; }
+                try { mgr.ApplyUpdatesAndRestart(info); }
+                catch (System.Exception ex) { _logger.LogWarning(ex, "ApplyUpdatesAndRestart failed"); }
+            });
+        });
+    }
+}

--- a/src/CodeScope.App/UpdateService.cs
+++ b/src/CodeScope.App/UpdateService.cs
@@ -9,9 +9,10 @@ namespace NoScope.CodeScope.App;
 
 /// <summary>
 /// Background updater backed by Velopack + GitHub releases (the same channel the release.yml
-/// workflow publishes to). On success it fires a non-blocking <see cref="ISnackbarService"/>
-/// toast the user can click to restart into the new version. The check is best-effort — any
-/// exception (offline, rate-limited, not an installed build) is swallowed with a warning log.
+/// workflow publishes to). On success it surfaces a non-blocking <see cref="ISnackbarService"/>
+/// toast to signal that the update finished downloading, then later offers restart via a
+/// confirmation dialog. The check is best-effort — any exception (offline, rate-limited, not
+/// an installed build) is swallowed with a warning log.
 /// </summary>
 public sealed class UpdateService
 {
@@ -98,18 +99,32 @@ public sealed class UpdateService
 
         _ = System.Threading.Tasks.Task.Run(async () =>
         {
-            await System.Threading.Tasks.Task.Delay(System.TimeSpan.FromSeconds(3)).ConfigureAwait(false);
-            app?.Dispatcher.Invoke(() =>
+            try
             {
-                var restart = NoScope.CodeScope.Ui.Dialogs.ConfirmDialog.Confirm(
-                    title: $"CodeScope {version} is ready",
-                    body: "Restart now to finish installing. Open sessions will be closed and their transcripts resumed automatically on the next launch.",
-                    confirmLabel: "Restart",
-                    cancelLabel: "Later");
-                if (!restart) { return; }
-                try { mgr.ApplyUpdatesAndRestart(info); }
-                catch (System.Exception ex) { _logger.LogWarning(ex, "ApplyUpdatesAndRestart failed"); }
-            });
+                await System.Threading.Tasks.Task.Delay(System.TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+
+                var dispatcher = app?.Dispatcher;
+                if (dispatcher is null || dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
+                {
+                    return;
+                }
+
+                await dispatcher.InvokeAsync(() =>
+                {
+                    var restart = NoScope.CodeScope.Ui.Dialogs.ConfirmDialog.Confirm(
+                        title: $"CodeScope {version} is ready",
+                        body: "Restart now to finish installing. Open sessions will be closed and their transcripts resumed automatically on the next launch.",
+                        confirmLabel: "Restart",
+                        cancelLabel: "Later");
+                    if (!restart) { return; }
+                    try { mgr.ApplyUpdatesAndRestart(info); }
+                    catch (System.Exception ex) { _logger.LogWarning(ex, "ApplyUpdatesAndRestart failed"); }
+                });
+            }
+            catch (System.Exception ex)
+            {
+                _logger.LogWarning(ex, "Unable to show update ready prompt");
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary

Adds a background auto-updater so users on v0.1.0+ pick up new releases without manually redownloading. Check fires 10s after window show (off the startup-critical path) and hits the same GitHub releases channel the \`release.yml\` workflow publishes to.

Behavior:
- Downloads the delta silently via Velopack's \`UpdateManager\`
- Shows a Success snackbar when ready
- 3s later opens a \`ConfirmDialog\` with Restart / Later
- Restart calls \`ApplyUpdatesAndRestart\`; Later keeps the update staged (Velopack applies it on next clean exit regardless — no download is lost)

Skipped when:
- \`CODESCOPE_DEV=1\` (dev build has no Velopack manifest)
- \`UpdateManager.IsInstalled\` is false (loose publish / CI smoke)
- GitHub is unreachable (exception logged as warning, swallowed)

## Test plan
- [x] \`dotnet test\` — 151 passed
- [ ] Install v0.1.0 release, tag v0.1.1 via this branch merged to main, observe snackbar + dialog on v0.1.0 after 10s
- [ ] CODESCOPE_DEV=1 dev build: no check fires (console log shows skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)