### PR TITLE
Toast surface + workspace UX fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ appsettings.Local.json
 # tooling output that shouldn't ship. docs/screenshots/ is the tracked
 # home for README imagery — only that folder is published.
 scratch/
+.scratch/
 
 # Tool-state directories surfaced by AI / automation runners
 .claude/

--- a/docs/design/html/CodeScope - Errors and Toasts.html
+++ b/docs/design/html/CodeScope - Errors and Toasts.html
@@ -1,0 +1,1037 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>CodeScope — Errors &amp; Toasts</title>
+<meta name="viewport" content="width=1600" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg:#000; --panel:#0A0A0A; --elev:#141414; --elev-2:#1A1A1A;
+    --border:#1F1F1F; --border-2:#2A2A2A;
+    --text:#fff; --text-2:#A0A0A0; --text-3:#606060;
+    --accent:#0099FF; --ok:#4BD87B; --warn:#FFB23F; --err:#FF5A5A;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin:0; padding:0; min-height:100%;
+    background: radial-gradient(1100px 600px at 30% 15%, rgba(0,153,255,0.05), transparent 60%), #000;
+    color:#fff;
+    font-family:'Inter',-apple-system,system-ui,sans-serif;
+    -webkit-font-smoothing:antialiased;
+  }
+  .page { max-width:1520px; margin:0 auto; padding:56px 48px 80px; }
+
+  .doc-head { margin-bottom:40px; display:flex; align-items:flex-end; gap:20px; }
+  .eyebrow {
+    font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--accent);
+    letter-spacing:0.16em; text-transform:uppercase;
+    padding:4px 8px; border:1px solid rgba(0,153,255,0.3); border-radius:3px;
+    background:rgba(0,153,255,0.05); align-self:flex-start; margin-top:6px;
+  }
+  .doc-head h1 { font-size:36px; font-weight:600; letter-spacing:-0.02em; margin:0; line-height:1.1; }
+  .doc-head .sub { margin-left:auto; color:var(--text-2); font-size:13px; max-width:480px; line-height:1.5; text-align:right; }
+  .doc-head .sub b { color:#fff; font-weight:500; }
+  .doc-head .sub code { font-family:'JetBrains Mono',monospace; font-size:11.5px; color:var(--accent); background:rgba(0,153,255,0.08); padding:1px 5px; border-radius:3px; }
+
+  .sec { margin-bottom:56px; }
+  .sec-label {
+    font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--accent);
+    letter-spacing:0.16em; text-transform:uppercase; margin-bottom:16px;
+  }
+  .sec h2 { font-size:22px; font-weight:600; letter-spacing:-0.015em; margin:0 0 10px; }
+  .sec .sec-sub { color:var(--text-2); font-size:13px; line-height:1.55; max-width:820px; margin:0 0 24px; }
+  .sec .sec-sub b { color:#fff; font-weight:500; }
+  .sec .sec-sub code { font-family:'JetBrains Mono',monospace; font-size:11.5px; color:var(--accent); background:rgba(0,153,255,0.08); padding:1px 5px; border-radius:3px; }
+
+  .stage {
+    position:relative;
+    background:
+      linear-gradient(to right, rgba(255,255,255,0.025) 1px, transparent 1px) 0 0 / 80px 80px,
+      linear-gradient(to bottom, rgba(255,255,255,0.025) 1px, transparent 1px) 0 0 / 80px 80px,
+      #000;
+    border:1px solid var(--border); border-radius:10px;
+    padding: 60px;
+    min-height: 360px;
+  }
+
+  /* ============ TOAST PRIMITIVE ============ */
+  .toast {
+    position: relative;
+    background: var(--panel);
+    border: 1px solid var(--border-2);
+    border-radius: 10px;
+    box-shadow: 0 24px 60px rgba(0,0,0,0.5), 0 0 0 1px rgba(0,0,0,0.2);
+    width: 380px;
+    overflow: hidden;
+    color: #fff;
+  }
+  .toast .row { display:flex; align-items:flex-start; gap: 12px; padding: 14px 16px; }
+  .toast .icn {
+    width: 24px; height: 24px; flex: 0 0 24px; border-radius: 6px;
+    display:flex; align-items:center; justify-content:center;
+    background: rgba(0,153,255,0.1); color: var(--accent);
+    border: 1px solid rgba(0,153,255,0.25);
+  }
+  .toast .icn svg { width: 12px; height: 12px; }
+  .toast.info .icn { background: rgba(0,153,255,0.1); border-color: rgba(0,153,255,0.25); color: var(--accent); }
+  .toast.ok   .icn { background: rgba(75,216,123,0.08); border-color: rgba(75,216,123,0.25); color: var(--ok); }
+  .toast.warn .icn { background: rgba(255,178,63,0.1); border-color: rgba(255,178,63,0.3); color: var(--warn); }
+  .toast.err  .icn { background: rgba(255,90,90,0.1); border-color: rgba(255,90,90,0.3); color: var(--err); }
+
+  .toast .body { flex: 1 1 auto; min-width: 0; padding-top: 2px; }
+  .toast .ttl { font-size: 13px; font-weight: 600; line-height: 1.35; letter-spacing: -0.005em; }
+  .toast .msg { margin-top: 3px; font-size: 12px; color: var(--text-2); line-height: 1.5; }
+  .toast .msg code { font-family:'JetBrains Mono',monospace; font-size:11px; color:#E6E6E6; background:#000; border:1px solid var(--border); padding:1px 5px; border-radius:3px; }
+  .toast .msg b { color:#fff; font-weight: 500; }
+
+  .toast .actions { display:flex; gap: 8px; margin-top: 10px; }
+  .toast .actions button {
+    height: 24px; padding: 0 10px; border-radius: 4px;
+    font: 500 11.5px/1 'Inter', sans-serif; letter-spacing:-0.005em;
+    border: 1px solid var(--border-2); background: var(--elev); color: #fff;
+    cursor: pointer;
+  }
+  .toast .actions button.primary { border-color: rgba(0,153,255,0.3); color: var(--accent); background: rgba(0,153,255,0.05); }
+  .toast .actions button.danger  { border-color: rgba(255,90,90,0.3); color: var(--err);   background: rgba(255,90,90,0.05); }
+  .toast .actions button.ghost   { border-color: transparent; background: transparent; color: var(--text-2); }
+
+  .toast .x {
+    width: 18px; height: 18px; border-radius: 4px;
+    color: var(--text-3); background: transparent; border: 0; cursor: pointer;
+    display:flex; align-items:center; justify-content:center; flex: 0 0 18px;
+  }
+  .toast .x svg { width: 9px; height: 9px; }
+
+  .toast .meter {
+    height: 2px; background: var(--border);
+    position: relative;
+  }
+  .toast .meter::after {
+    content:""; position:absolute; left:0; top:0; bottom:0;
+    width: var(--p, 60%);
+    background: var(--accent);
+  }
+  .toast.ok   .meter::after { background: var(--ok); }
+  .toast.warn .meter::after { background: var(--warn); }
+  .toast.err  .meter::after { background: var(--err); }
+
+  .toast .accent {
+    position: absolute; left: 0; top: 0; bottom: 0; width: 2px;
+    background: var(--accent);
+  }
+  .toast.ok   .accent { background: var(--ok); }
+  .toast.warn .accent { background: var(--warn); }
+  .toast.err  .accent { background: var(--err); }
+
+  /* stack of toasts (bottom-right) */
+  .toast-stack {
+    position: absolute; right: 28px; bottom: 28px;
+    display: flex; flex-direction: column; gap: 10px;
+    align-items: flex-end;
+  }
+  .toast-stack .toast { transform-origin: bottom right; }
+  .toast-stack .toast.peek { transform: scale(0.97) translateY(-2px); opacity: 0.85; }
+  .toast-stack .toast.peek2 { transform: scale(0.94) translateY(-3px); opacity: 0.6; }
+
+  /* ============ ERROR PRIMITIVES ============ */
+
+  /* inline error under a field */
+  .field { display:flex; flex-direction:column; gap:6px; }
+  .field label { font-size:11px; font-weight:500; color:var(--text-2); letter-spacing:0.02em; text-transform:uppercase; }
+  .input {
+    width: 100%; height: 34px; background: #000;
+    border: 1px solid var(--border-2); border-radius: 6px;
+    color:#fff; font: 500 13px/1 'Inter', sans-serif; padding: 0 12px;
+    outline: none; font-family:'JetBrains Mono', monospace; font-size: 12.5px;
+  }
+  .input.has-err { border-color: var(--err); box-shadow: 0 0 0 3px rgba(255,90,90,0.15); }
+  .input.has-warn { border-color: var(--warn); box-shadow: 0 0 0 3px rgba(255,178,63,0.15); }
+
+  .helper {
+    display: flex; align-items: flex-start; gap: 6px;
+    font-size: 11.5px; color: var(--text-3); line-height: 1.4;
+  }
+  .helper.err { color: var(--err); }
+  .helper.warn { color: var(--warn); }
+  .helper svg { width: 11px; height: 11px; flex: 0 0 11px; margin-top: 2px; }
+
+  /* banner — page-level */
+  .banner {
+    display:flex; align-items:flex-start; gap: 12px;
+    padding: 12px 14px;
+    background: rgba(255,90,90,0.05);
+    border: 1px solid rgba(255,90,90,0.25);
+    border-left: 2px solid var(--err);
+    border-radius: 6px;
+    color: #fff;
+  }
+  .banner.warn { background: rgba(255,178,63,0.05); border-color: rgba(255,178,63,0.25); border-left-color: var(--warn); }
+  .banner.info { background: rgba(0,153,255,0.05); border-color: rgba(0,153,255,0.25); border-left-color: var(--accent); }
+  .banner .icn {
+    width: 16px; height: 16px; flex: 0 0 16px; margin-top: 2px;
+    color: var(--err);
+  }
+  .banner.warn .icn { color: var(--warn); }
+  .banner.info .icn { color: var(--accent); }
+  .banner .body { flex: 1 1 auto; min-width: 0; }
+  .banner .ttl { font-size: 12.5px; font-weight: 600; letter-spacing: -0.005em; }
+  .banner .msg { font-size: 12px; color: var(--text-2); margin-top: 2px; line-height: 1.5; }
+  .banner .msg code { font-family:'JetBrains Mono',monospace; font-size:11px; color:#E6E6E6; background:#000; border:1px solid var(--border); padding:1px 5px; border-radius:3px; }
+  .banner .actions { margin-top: 8px; display:flex; gap: 8px; }
+  .banner .actions a {
+    color: var(--err); font-size: 11.5px; font-weight: 500;
+    text-decoration: none; padding: 2px 0; border-bottom: 1px solid rgba(255,90,90,0.4);
+  }
+  .banner.warn .actions a { color: var(--warn); border-bottom-color: rgba(255,178,63,0.4); }
+  .banner.info .actions a { color: var(--accent); border-bottom-color: rgba(0,153,255,0.4); }
+  .banner .x {
+    width: 18px; height: 18px; border-radius: 4px;
+    color: var(--text-3); background: transparent; border: 0; cursor: pointer;
+    display:flex; align-items:center; justify-content:center; flex:0 0 18px;
+  }
+  .banner .x svg { width: 9px; height: 9px; }
+
+  /* terminal error panel */
+  .term-err {
+    background: #000; border: 1px solid var(--border); border-radius: 8px;
+    overflow: hidden; font-family:'JetBrains Mono', monospace; font-size: 12px;
+    color: #E6E6E6; line-height: 1.55;
+  }
+  .term-err .head {
+    padding: 10px 14px;
+    background: rgba(255,90,90,0.06);
+    border-bottom: 1px solid rgba(255,90,90,0.2);
+    display:flex; align-items:center; gap: 8px;
+    color: var(--err); font-weight: 600; font-size: 11.5px; letter-spacing: 0.04em;
+  }
+  .term-err .head svg { width: 12px; height: 12px; }
+  .term-err .head .code { color: var(--text-3); margin-left: auto; font-weight: 400; letter-spacing: 0; font-family:'JetBrains Mono',monospace; font-size: 11px; }
+  .term-err .body { padding: 14px; }
+  .term-err .body .err-line { color: var(--err); }
+  .term-err .body .ctx { color: var(--text-3); margin-top: 6px; }
+  .term-err .body .stk { margin-top: 10px; color: var(--text-2); font-size: 11.5px; }
+  .term-err .body .stk .at { color: var(--text-3); }
+  .term-err .body .hint {
+    margin-top: 14px; padding-top: 12px; border-top: 1px dashed var(--border);
+    color: var(--accent); font-family: 'Inter', sans-serif; font-size: 12px; line-height: 1.5;
+  }
+  .term-err .actions {
+    padding: 10px 14px; border-top: 1px solid var(--border);
+    display:flex; gap: 8px; background: #050505;
+  }
+  .term-err .actions button {
+    height: 26px; padding: 0 10px; border-radius: 4px;
+    font: 500 11.5px/1 'Inter', sans-serif;
+    border: 1px solid var(--border-2); background: var(--elev); color: #fff;
+    cursor: pointer;
+  }
+  .term-err .actions button.primary { border-color: rgba(0,153,255,0.3); color: var(--accent); background: rgba(0,153,255,0.05); }
+
+  /* full-screen catastrophic */
+  .blocker {
+    border: 1px solid var(--border); border-radius: 10px;
+    padding: 48px;
+    background:
+      radial-gradient(600px 300px at 50% 30%, rgba(255,90,90,0.08), transparent 70%),
+      #050505;
+    text-align: center;
+    color: #fff;
+  }
+  .blocker .glyph {
+    width: 56px; height: 56px; border-radius: 14px; margin: 0 auto 20px;
+    background: rgba(255,90,90,0.08); border: 1px solid rgba(255,90,90,0.25);
+    color: var(--err);
+    display:flex; align-items:center; justify-content:center;
+  }
+  .blocker .glyph svg { width: 24px; height: 24px; }
+  .blocker .ttl {
+    font-size: 22px; font-weight: 600; letter-spacing: -0.015em;
+  }
+  .blocker .sub { color: var(--text-2); font-size: 13px; margin-top: 8px; max-width: 480px; margin-left:auto; margin-right:auto; line-height: 1.55; }
+  .blocker .ref {
+    margin-top: 18px;
+    font-family:'JetBrains Mono',monospace; font-size: 11.5px; color: var(--text-3);
+    border-top: 1px solid var(--border); padding-top: 14px;
+  }
+  .blocker .ref code { color: var(--accent); }
+  .blocker .row {
+    margin-top: 20px; display:flex; gap: 8px; justify-content: center;
+  }
+  .blocker .row button {
+    height: 32px; padding: 0 14px; border-radius: 6px;
+    font: 500 12.5px/1 'Inter',sans-serif;
+    border: 0; cursor: pointer;
+  }
+  .blocker .row button.primary { background: var(--accent); color: #000; font-weight: 600; }
+  .blocker .row button.ghost { background: var(--elev); color: #fff; box-shadow: inset 0 0 0 1px var(--border-2); }
+
+  /* ============ VARIANT GRID ============ */
+  .vgrid { display:grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+  .vcard {
+    background: var(--panel); border:1px solid var(--border); border-radius:10px;
+    padding: 16px;
+  }
+  .vcard.full { grid-column: span 2; }
+  .vcard .vlabel {
+    display:flex; align-items:center; justify-content:space-between;
+    font-family:'JetBrains Mono',monospace; font-size:10px;
+    color: var(--text-3); letter-spacing:0.14em; text-transform:uppercase;
+    margin-bottom: 14px;
+  }
+  .vcard .vlabel .pill {
+    color:var(--accent); border:1px solid rgba(0,153,255,0.3);
+    padding:2px 6px; border-radius:3px; background:rgba(0,153,255,0.05);
+  }
+  .vcard .vlabel .pill.warn { color:var(--warn); border-color:rgba(255,178,63,0.3); background:rgba(255,178,63,0.05); }
+  .vcard .vlabel .pill.err { color:var(--err); border-color:rgba(255,90,90,0.3); background:rgba(255,90,90,0.05); }
+  .vcard .vlabel .pill.ok { color:var(--ok); border-color:rgba(75,216,123,0.3); background:rgba(75,216,123,0.05); }
+  .vcard .vstage {
+    background:
+      linear-gradient(to right, rgba(255,255,255,0.025) 1px, transparent 1px) 0 0 / 80px 80px,
+      linear-gradient(to bottom, rgba(255,255,255,0.025) 1px, transparent 1px) 0 0 / 80px 80px,
+      #000;
+    border-radius: 8px;
+    min-height: 220px;
+    display:flex; align-items:center; justify-content:center;
+    padding: 24px;
+    position: relative;
+  }
+  .vcard .vnote {
+    margin-top: 12px;
+    font-size: 12px; color: var(--text-2); line-height: 1.5;
+  }
+  .vcard .vnote b { color:#fff; font-weight: 500; }
+  .vcard .vnote code {
+    font-family:'JetBrains Mono',monospace; font-size:11.5px; color:var(--accent);
+    background:rgba(0,153,255,0.08); padding:1px 5px; border-radius:3px;
+  }
+
+  /* callouts */
+  .cx { position: absolute; inset: 0; z-index: 3; pointer-events: none; }
+  .cx .dot {
+    position: absolute; width: 8px; height: 8px; border-radius: 50%;
+    background: var(--accent); box-shadow: 0 0 0 3px rgba(0,153,255,0.18);
+    transform: translate(-50%, -50%);
+  }
+  .cx .line { position: absolute; background: rgba(0,153,255,0.45); }
+  .cx .line.h { height: 1px; }
+  .cx .line.v { width: 1px; }
+  .cx .label {
+    position: absolute;
+    background: #0A0A0A; border: 1px solid #1F1F1F; border-radius: 6px;
+    padding: 10px 12px; width: 220px;
+    color: #fff; font-size: 12px; line-height: 1.5;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+  }
+  .cx .label .num {
+    display: inline-block; width: 18px; height: 18px;
+    border-radius: 3px; background: var(--accent); color: #000;
+    font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 600;
+    text-align: center; line-height: 18px;
+    margin-right: 8px; vertical-align: 1px;
+  }
+  .cx .label b { font-weight: 600; }
+  .cx .label .hint { display: block; color: var(--text-2); margin-top: 4px; font-size: 11.5px; }
+  .cx .label code {
+    font-family: 'JetBrains Mono', monospace; font-size: 10.5px;
+    color: var(--accent); background: rgba(0,153,255,0.08);
+    padding: 1px 5px; border-radius: 3px;
+  }
+
+  /* tokens */
+  .spec-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:16px; }
+  .panel { background:var(--panel); border:1px solid var(--border); border-radius:8px; padding:20px; }
+  .panel h3 { font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--accent); letter-spacing:0.16em; text-transform:uppercase; margin:0 0 14px; }
+  .panel ul { list-style:none; padding:0; margin:0; }
+  .panel li { display:grid; grid-template-columns:120px 1fr; gap:10px; padding:8px 0; border-bottom:1px solid #141414; font-size:12px; line-height:1.4; }
+  .panel li:last-child { border-bottom:0; }
+  .panel li .k { font-family:'JetBrains Mono',monospace; color:var(--text-3); font-size:11px; }
+  .panel li .v { color:#E6E6E6; }
+  .swatch { display:inline-block; width:10px; height:10px; border-radius:2px; vertical-align:-1px; margin-right:6px; border:1px solid rgba(255,255,255,0.08); }
+
+  /* notes */
+  .notes { display:grid; grid-template-columns:repeat(2,1fr); gap:16px; }
+  .note {
+    background:var(--panel); border:1px solid var(--border);
+    border-left:2px solid var(--accent);
+    border-radius:6px; padding:14px 16px;
+    font-size:12.5px; line-height:1.5; color:#E6E6E6;
+  }
+  .note b { color:#fff; }
+  .note .t {
+    display:block; font-family:'JetBrains Mono',monospace; font-size:10px;
+    color:var(--accent); letter-spacing:0.14em; text-transform:uppercase; margin-bottom:6px;
+  }
+  .note code { font-family:'JetBrains Mono',monospace; font-size:11.5px; color:var(--accent); background:rgba(0,153,255,0.08); padding:1px 5px; border-radius:3px; }
+
+  /* decision matrix */
+  .matrix {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+    overflow: hidden;
+  }
+  .matrix table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+  .matrix th, .matrix td {
+    text-align: left; padding: 12px 16px; border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  .matrix th {
+    font-family:'JetBrains Mono',monospace; font-size: 10px;
+    color: var(--text-3); letter-spacing: 0.14em; text-transform: uppercase;
+    font-weight: 500; background: #050505;
+  }
+  .matrix td:first-child { color: #fff; font-weight: 500; }
+  .matrix td:nth-child(n+2) { color: var(--text-2); line-height: 1.5; }
+  .matrix tr:last-child td { border-bottom: 0; }
+  .matrix .pill {
+    display:inline-block; padding: 1px 6px; border-radius: 3px;
+    font-family:'JetBrains Mono',monospace; font-size: 10px;
+    letter-spacing: 0.04em;
+  }
+  .matrix .pill.toast { color: var(--accent); background: rgba(0,153,255,0.08); border: 1px solid rgba(0,153,255,0.25); }
+  .matrix .pill.banner { color: var(--warn); background: rgba(255,178,63,0.08); border: 1px solid rgba(255,178,63,0.25); }
+  .matrix .pill.inline { color: var(--text-2); background: var(--elev); border: 1px solid var(--border-2); }
+  .matrix .pill.term { color: var(--err); background: rgba(255,90,90,0.08); border: 1px solid rgba(255,90,90,0.25); }
+  .matrix .pill.block { color: #fff; background: #2A2A2A; border: 1px solid #333; }
+
+  /* impl */
+  .impl { background:#070707; border:1px solid var(--border); border-radius:8px; padding:28px 32px; }
+  .impl h3 { font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--accent); letter-spacing:0.16em; text-transform:uppercase; margin:0 0 16px; }
+  .impl pre { margin:0; font-family:'JetBrains Mono',monospace; font-size:12.5px; line-height:1.65; color:#E6E6E6; white-space:pre-wrap; }
+  .impl .c { color:var(--text-3); font-style:italic; }
+  .impl .k { color:var(--accent); }
+  .impl .s { color:#8FD679; }
+  .impl .t { color:#E8A857; }
+</style>
+</head>
+<body>
+<div class="page" data-screen-label="Errors and toasts — handoff">
+
+  <div class="doc-head">
+    <span class="eyebrow">Component spec</span>
+    <div><h1>Errors &amp; toasts</h1></div>
+    <div class="sub">
+      Five surfaces for surfacing async outcome &amp; failure: <b>toast</b>, <b>inline helper</b>, <b>banner</b>, <b>terminal error</b>, <b>blocker</b>. Each has a clear <code>when</code>; never use two for the same event. Handoff for Claude Code.
+    </div>
+  </div>
+
+  <!-- ============ DECISION MATRIX ============ -->
+  <div class="sec">
+    <div class="sec-label">01 · When to use what</div>
+    <h2>Pick the surface from the impact, not the severity</h2>
+    <p class="sec-sub">
+      Severity (info / ok / warn / err) is a <b>style</b> dimension. Surface (toast / banner / inline / terminal / blocker) is a <b>scope</b> dimension. They're independent — you can have a green toast or a red banner. Use this matrix to pick the surface.
+    </p>
+
+    <div class="matrix">
+      <table>
+        <thead>
+          <tr>
+            <th style="width:160px">Event</th>
+            <th style="width:120px">Surface</th>
+            <th>When · why</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Async action finished</td>
+            <td><span class="pill toast">toast</span></td>
+            <td>Worktree spawned · session committed · clipboard copied. <b>Out-of-flow confirmation</b>; user moved on. Auto-dismiss 4s.</td>
+          </tr>
+          <tr>
+            <td>Form field invalid</td>
+            <td><span class="pill inline">inline</span></td>
+            <td>Validation belongs <i>under the field</i> that caused it. Never as a toast — the user can't tie it back to a control.</td>
+          </tr>
+          <tr>
+            <td>Workspace-level state issue</td>
+            <td><span class="pill banner">banner</span></td>
+            <td>Repo behind origin · model API key invalid · update available. Persistent header bar — sticks until resolved or dismissed.</td>
+          </tr>
+          <tr>
+            <td>Tool call / agent failure</td>
+            <td><span class="pill term">terminal</span></td>
+            <td>Inline in the session log where the failure happened — full stack + suggested fix + retry. Never lifts out into a toast.</td>
+          </tr>
+          <tr>
+            <td>App can't start / data corrupt</td>
+            <td><span class="pill block">blocker</span></td>
+            <td>Catastrophic, recovery requires user action. Full-window. Always shows error code + &ldquo;Copy diagnostics&rdquo;.</td>
+          </tr>
+          <tr>
+            <td>Background sync conflict</td>
+            <td><span class="pill toast">toast</span> + <span class="pill banner">banner</span></td>
+            <td>Toast at the moment of the conflict, banner persists until resolved. Two surfaces, but one event — tag with the same <code>id</code> so the toast click opens the banner detail.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- ============ TOAST ANATOMY ============ -->
+  <div class="sec">
+    <div class="sec-label">02 · Toast anatomy</div>
+    <h2>The toast primitive</h2>
+    <p class="sec-sub">
+      Bottom-right anchored stack. 380px wide. 6 slots: accent rail · icon · title · message · actions · close. Optional progress meter for long-running.
+    </p>
+
+    <div class="stage" style="min-height: 720px; padding: 0; position: relative;">
+
+      <!-- Toast positioned in the right column. Toast at L380-760, T260-400 (approx). -->
+      <div style="position: absolute; left: 380px; top: 260px;">
+        <div class="toast info" id="anatomy-toast">
+          <div class="accent"></div>
+          <div class="row">
+            <div class="icn">
+              <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="4.5"/><path d="M6 4v3"/><circle cx="6" cy="8.4" r="0.5" fill="currentColor"/></svg>
+            </div>
+            <div class="body">
+              <div class="ttl">Worktree spawned</div>
+              <div class="msg"><code>feat/export-pdf</code> is checked out and a Claude session is warm.</div>
+              <div class="actions">
+                <button class="primary">Open</button>
+                <button class="ghost">Dismiss</button>
+              </div>
+            </div>
+            <button class="x"><svg viewBox="0 0 9 9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M1 1l7 7M8 1l-7 7"/></svg></button>
+          </div>
+          <div class="meter" style="--p: 60%"></div>
+        </div>
+      </div>
+
+      <!--
+        Toast geometry:
+          accent rail   L380-382, T260-T(260+H)
+          icon center   L408, T288
+          title         L432, T276
+          message       L432, T298
+          actions row   L432, T338-T362
+          close x       L728, T272
+          meter         L380-760, T(260+H-2)..  approx T398
+        Labels: 4 on the LEFT (220 wide, x=30..250), 3 on the RIGHT (x=805..1025).
+        All labels in vertical bands ≥ 16px gap apart; none overlap toast (toast L380+).
+      -->
+      <div class="cx">
+
+        <!-- 1 accent rail · LEFT, top band -->
+        <div class="dot" style="left:381px;top:330px"></div>
+        <div class="line h" style="left:251px;top:330px;width:130px"></div>
+        <div class="label" style="left:30px;top:295px">
+          <span class="num">1</span><b>Severity rail</b>
+          <span class="hint">2px left bar. The only structural color cue — accent (info), green (ok), amber (warn), red (err).</span>
+        </div>
+
+        <!-- 2 icon · LEFT, second band -->
+        <div class="dot" style="left:408px;top:288px"></div>
+        <div class="line v" style="left:408px;top:240px;height:48px"></div>
+        <div class="line h" style="left:251px;top:240px;width:157px"></div>
+        <div class="label" style="left:30px;top:185px">
+          <span class="num">2</span><b>Severity icon</b>
+          <span class="hint">24×24 tile, 12×12 line glyph. Tinted bg matches rail. Optional when stack shares severity.</span>
+        </div>
+
+        <!-- 3 title · RIGHT, top band -->
+        <div class="dot" style="left:480px;top:276px"></div>
+        <div class="line h" style="left:480px;top:276px;width:325px"></div>
+        <div class="label" style="left:805px;top:240px">
+          <span class="num">3</span><b>Title</b>
+          <span class="hint">13px Inter 600. Past-tense outcome — &ldquo;Spawned&rdquo;, not &ldquo;Spawning&rdquo;. Max 1 line.</span>
+        </div>
+
+        <!-- 4 message · RIGHT, mid band -->
+        <div class="dot" style="left:540px;top:300px"></div>
+        <div class="line h" style="left:540px;top:300px;width:0"></div>
+        <div class="line v" style="left:540px;top:300px;height:65px"></div>
+        <div class="line h" style="left:540px;top:365px;width:265px"></div>
+        <div class="label" style="left:805px;top:360px">
+          <span class="num">4</span><b>Message</b>
+          <span class="hint">12px · <code>#A0A0A0</code>. Fills in scope/context. Inline <code>code</code> for refs. Max 2 lines.</span>
+        </div>
+
+        <!-- 5 actions · LEFT, third band -->
+        <div class="dot" style="left:432px;top:350px"></div>
+        <div class="line h" style="left:432px;top:350px;width:0"></div>
+        <div class="line v" style="left:432px;top:350px;height:115px"></div>
+        <div class="line h" style="left:251px;top:465px;width:181px"></div>
+        <div class="label" style="left:30px;top:430px">
+          <span class="num">5</span><b>Actions</b>
+          <span class="hint">Max 2: <b>primary</b> (accent border) and <b>ghost</b>. Primary maps to a noun-verb (Open, Undo, Retry).</span>
+        </div>
+
+        <!-- 6 close x · RIGHT, bottom band -->
+        <div class="dot" style="left:728px;top:272px"></div>
+        <div class="line h" style="left:728px;top:272px;width:0"></div>
+        <div class="line v" style="left:728px;top:272px;height:210px"></div>
+        <div class="line h" style="left:728px;top:482px;width:77px"></div>
+        <div class="label" style="left:805px;top:480px">
+          <span class="num">6</span><b>Close</b>
+          <span class="hint">Always present. Hover-fades to 0.6 opacity. Click cancels auto-dismiss.</span>
+        </div>
+
+        <!-- 7 meter · LEFT, bottom band -->
+        <div class="dot" style="left:480px;top:399px"></div>
+        <div class="line h" style="left:480px;top:399px;width:0"></div>
+        <div class="line v" style="left:480px;top:399px;height:160px"></div>
+        <div class="line h" style="left:251px;top:559px;width:229px"></div>
+        <div class="label" style="left:30px;top:540px">
+          <span class="num">7</span><b>Auto-dismiss meter</b>
+          <span class="hint">2px progress strip. Drains in 4s (info/ok), 8s (warn), persists (err). Pauses on hover.</span>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ TOAST VARIANTS ============ -->
+  <div class="sec">
+    <div class="sec-label">03 · Toast severities</div>
+    <h2>Four flavors</h2>
+    <div class="vgrid">
+
+      <div class="vcard">
+        <div class="vlabel"><span>Info</span><span class="pill">accent</span></div>
+        <div class="vstage">
+          <div class="toast info" style="width: 360px">
+            <div class="accent"></div>
+            <div class="row">
+              <div class="icn"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="4.5"/><path d="M6 4v3"/><circle cx="6" cy="8.4" r="0.5" fill="currentColor"/></svg></div>
+              <div class="body">
+                <div class="ttl">Switching to claude-opus-4</div>
+                <div class="msg">Current turn finishes on <b>sonnet-4-5</b>, then swaps.</div>
+              </div>
+              <button class="x"><svg viewBox="0 0 9 9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M1 1l7 7M8 1l-7 7"/></svg></button>
+            </div>
+            <div class="meter" style="--p: 50%"></div>
+          </div>
+        </div>
+        <p class="vnote"><b>When.</b> Neutral state changes user initiated. 4s auto-dismiss.</p>
+      </div>
+
+      <div class="vcard">
+        <div class="vlabel"><span>Success</span><span class="pill ok">ok</span></div>
+        <div class="vstage">
+          <div class="toast ok" style="width: 360px">
+            <div class="accent"></div>
+            <div class="row">
+              <div class="icn"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 6.5 L5 9 L10 4"/></svg></div>
+              <div class="body">
+                <div class="ttl">Branch pushed</div>
+                <div class="msg"><code>feat/reporting</code> → <code>origin/feat/reporting</code> · 3 commits.</div>
+                <div class="actions">
+                  <button class="primary">Open PR</button>
+                </div>
+              </div>
+              <button class="x"><svg viewBox="0 0 9 9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M1 1l7 7M8 1l-7 7"/></svg></button>
+            </div>
+            <div class="meter" style="--p: 30%"></div>
+          </div>
+        </div>
+        <p class="vnote"><b>When.</b> Async finished as expected. 4s. Primary action surfaces the next obvious step.</p>
+      </div>
+
+      <div class="vcard">
+        <div class="vlabel"><span>Warning</span><span class="pill warn">warn</span></div>
+        <div class="vstage">
+          <div class="toast warn" style="width: 360px">
+            <div class="accent"></div>
+            <div class="row">
+              <div class="icn"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 1.5L11 10H1Z"/><path d="M6 5v3"/><circle cx="6" cy="9" r="0.5" fill="currentColor"/></svg></div>
+              <div class="body">
+                <div class="ttl">Context near cap</div>
+                <div class="msg"><b>186k / 200k</b> on <code>feat/reporting</code>. Compact or branch off the next message.</div>
+                <div class="actions">
+                  <button class="primary">Compact now</button>
+                </div>
+              </div>
+              <button class="x"><svg viewBox="0 0 9 9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M1 1l7 7M8 1l-7 7"/></svg></button>
+            </div>
+            <div class="meter" style="--p: 90%"></div>
+          </div>
+        </div>
+        <p class="vnote"><b>When.</b> Reversible degradation. <b>8s</b> auto-dismiss — longer because it's actionable.</p>
+      </div>
+
+      <div class="vcard">
+        <div class="vlabel"><span>Error</span><span class="pill err">err</span></div>
+        <div class="vstage">
+          <div class="toast err" style="width: 360px">
+            <div class="accent"></div>
+            <div class="row">
+              <div class="icn"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="4.5"/><path d="M3.5 3.5l5 5M8.5 3.5l-5 5"/></svg></div>
+              <div class="body">
+                <div class="ttl">Push failed</div>
+                <div class="msg"><code>origin</code> rejected: non-fast-forward. Pull <code>main</code> and rebase before pushing again.</div>
+                <div class="actions">
+                  <button class="primary">View output</button>
+                  <button>Retry</button>
+                </div>
+              </div>
+              <button class="x"><svg viewBox="0 0 9 9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M1 1l7 7M8 1l-7 7"/></svg></button>
+            </div>
+          </div>
+        </div>
+        <p class="vnote"><b>When.</b> Action failed but isn't catastrophic. <b>No auto-dismiss</b> — explicit close. No meter.</p>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ============ TOAST STACK ============ -->
+  <div class="sec">
+    <div class="sec-label">04 · Stack &amp; behavior</div>
+    <h2>Multiple toasts at once</h2>
+    <p class="sec-sub">
+      Bottom-right · 28px from window edge · 10px gap. Newest on top. Cap at <b>3 visible</b>; older toasts fold under with reduced scale + opacity. A &ldquo;<i>+N more</i>&rdquo; chip surfaces if more queue up. Hovering any toast in the stack pauses dismiss for <i>all</i> of them.
+    </p>
+
+    <div class="stage" style="min-height: 380px; padding: 0; position: relative;">
+      <div class="toast-stack">
+        <div class="toast peek2 warn">
+          <div class="accent"></div>
+          <div class="row">
+            <div class="icn"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 1.5L11 10H1Z"/></svg></div>
+            <div class="body"><div class="ttl">Context near cap</div></div>
+          </div>
+        </div>
+        <div class="toast peek ok">
+          <div class="accent"></div>
+          <div class="row">
+            <div class="icn"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 6.5 L5 9 L10 4"/></svg></div>
+            <div class="body">
+              <div class="ttl">Branch pushed</div>
+              <div class="msg"><code>feat/reporting</code> → origin · 3 commits.</div>
+            </div>
+          </div>
+          <div class="meter" style="--p: 70%"></div>
+        </div>
+        <div class="toast info">
+          <div class="accent"></div>
+          <div class="row">
+            <div class="icn"><svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="4.5"/><path d="M6 4v3"/><circle cx="6" cy="8.4" r="0.5" fill="currentColor"/></svg></div>
+            <div class="body">
+              <div class="ttl">Worktree spawned</div>
+              <div class="msg"><code>feat/export-pdf</code> · session warm.</div>
+              <div class="actions"><button class="primary">Open</button></div>
+            </div>
+            <button class="x"><svg viewBox="0 0 9 9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M1 1l7 7M8 1l-7 7"/></svg></button>
+          </div>
+          <div class="meter" style="--p: 30%"></div>
+        </div>
+      </div>
+
+      <div style="position:absolute; left:60px; top:60px; max-width: 340px; color: var(--text-2); font-size: 12.5px; line-height: 1.6;">
+        <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--accent); letter-spacing:0.14em; text-transform:uppercase; margin-bottom:8px">Stack rules</div>
+        <ul style="margin:0; padding-left: 18px;">
+          <li>Newest = bottom (front-of-stack), most prominent</li>
+          <li>Older toasts fold under with <code style="font-family:'JetBrains Mono',monospace;font-size:11px;color:#fff">scale(0.97)</code>, then <code style="font-family:'JetBrains Mono',monospace;font-size:11px;color:#fff">scale(0.94)</code></li>
+          <li>Cap at 3 visible; stash overflow behind a &ldquo;+N more&rdquo; chip</li>
+          <li>Hover anywhere = pause every meter in the stack</li>
+          <li>Errors never fold — they stay full-size until dismissed</li>
+          <li>De-dupe by <code style="font-family:'JetBrains Mono',monospace;font-size:11px;color:#fff">id</code> — same id replaces, doesn't add</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ INLINE & BANNER ============ -->
+  <div class="sec">
+    <div class="sec-label">05 · Inline &amp; banner errors</div>
+    <h2>For form fields and workspace state</h2>
+    <p class="sec-sub">
+      Inline errors live <b>under the field</b> that caused them. Banners live <b>at the top of the workspace</b> and persist across navigation. Both reuse the same severity colors as toasts.
+    </p>
+
+    <div class="vgrid">
+
+      <div class="vcard">
+        <div class="vlabel"><span>Inline · field error</span><span class="pill err">err</span></div>
+        <div class="vstage" style="display:block; padding: 32px 60px;">
+          <div class="field" style="margin-bottom: 18px;">
+            <label>Worktree name</label>
+            <input class="input has-err" value="feat/reporting" />
+            <div class="helper err">
+              <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="4.5"/><path d="M3.5 3.5l5 5M8.5 3.5l-5 5"/></svg>
+              <span>A worktree named <b>feat/reporting</b> already exists at <code style="font-family:'JetBrains Mono',monospace;font-size:11px;color:#fff;background:transparent;border:0;padding:0">~/code/cs/wt/reporting</code>.</span>
+            </div>
+          </div>
+          <div class="field">
+            <label>Path</label>
+            <input class="input has-warn" value="~/code/cs/wt/reporting" />
+            <div class="helper warn">
+              <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 1.5L11 10H1Z"/><path d="M6 5v3"/><circle cx="6" cy="9" r="0.5" fill="currentColor"/></svg>
+              <span>Directory exists but is empty. Will be reused.</span>
+            </div>
+          </div>
+        </div>
+        <p class="vnote"><b>When.</b> Form validation. Field gets <code>border + 3px ring</code> in severity color. Helper text replaces the neutral helper. Live-validate on blur, suppress on focus.</p>
+      </div>
+
+      <div class="vcard">
+        <div class="vlabel"><span>Banner · workspace state</span><span class="pill warn">warn</span></div>
+        <div class="vstage" style="display:block; padding: 32px;">
+          <div class="banner warn" style="margin-bottom: 12px">
+            <svg class="icn" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2L14 13H2Z"/><path d="M8 7v3"/><circle cx="8" cy="11.5" r="0.5" fill="currentColor"/></svg>
+            <div class="body">
+              <div class="ttl">Repo is 14 commits behind <code>origin/main</code></div>
+              <div class="msg">Pulled most recently <b>2h ago</b>. Worktrees may diverge from teammates.</div>
+              <div class="actions">
+                <a href="#">Pull now</a>
+                <a href="#">Review changes</a>
+              </div>
+            </div>
+            <button class="x"><svg viewBox="0 0 9 9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M1 1l7 7M8 1l-7 7"/></svg></button>
+          </div>
+          <div class="banner">
+            <svg class="icn" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="6"/><path d="M8 5v3.5"/><circle cx="8" cy="11" r="0.6" fill="currentColor"/></svg>
+            <div class="body">
+              <div class="ttl">Anthropic API key invalid</div>
+              <div class="msg">Sessions can't reach <code>claude-sonnet-4-5</code>. Configure a key in <b>Settings → Models</b>.</div>
+              <div class="actions">
+                <a href="#">Open settings</a>
+              </div>
+            </div>
+            <button class="x"><svg viewBox="0 0 9 9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M1 1l7 7M8 1l-7 7"/></svg></button>
+          </div>
+        </div>
+        <p class="vnote"><b>When.</b> Persistent state the user can resolve. Sticks at top of the workspace until dismissed or fixed. Stack max 2; oldest collapses to a chip.</p>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ============ TERMINAL ERROR ============ -->
+  <div class="sec">
+    <div class="sec-label">06 · Terminal errors</div>
+    <h2>Inline in the session log</h2>
+    <p class="sec-sub">
+      When a tool call or shell command fails, the error renders <b>in the terminal stream</b> — not as a toast. This keeps cause and effect adjacent and preserves scrollback.
+    </p>
+
+    <div class="vcard full" style="padding: 0; background: transparent; border: 0;">
+      <div class="vstage" style="min-height: 280px; padding: 32px 80px; display:block;">
+        <div class="term-err">
+          <div class="head">
+            <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="4.5"/><path d="M3.5 3.5l5 5M8.5 3.5l-5 5"/></svg>
+            <span>Tool call failed</span>
+            <span class="code">ENOENT · exit 1 · 04:12.7s</span>
+          </div>
+          <div class="body">
+            <div class="err-line">$ pnpm --filter @cs/api run test:integration</div>
+            <div class="ctx">  ↳ <span style="color:var(--err)">Error: Cannot find module '@cs/db/migrations/20240412_add_export.sql'</span></div>
+            <div class="stk">
+              <span class="at">at</span> Migrator.load (<span style="color:var(--accent)">packages/db/src/migrator.ts:48:11</span>)<br>
+              <span class="at">at</span> async runIntegration (<span style="color:var(--accent)">apps/api/test/integration.ts:12:3</span>)<br>
+              <span class="at">at</span> async <span style="color:var(--text-3)">node:internal/main/run_main_module:23:47</span>
+            </div>
+            <div class="hint">
+              <b style="color:#fff">Likely cause:</b> the migration file was deleted in <code style="font-family:'JetBrains Mono',monospace;color:var(--accent);background:rgba(0,153,255,0.08);padding:1px 5px;border-radius:3px">git pull</code> 4m ago and a worktree still references it. Try <code style="font-family:'JetBrains Mono',monospace;color:var(--accent);background:rgba(0,153,255,0.08);padding:1px 5px;border-radius:3px">pnpm install</code> or restart the dev server.
+            </div>
+          </div>
+          <div class="actions">
+            <button class="primary">Retry</button>
+            <button>Run pnpm install</button>
+            <button>Copy error</button>
+            <button>Ask Claude to fix</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p style="margin: 16px 24px 0; color: var(--text-2); font-size: 12.5px; line-height: 1.5;">
+      <b style="color:#fff">Anatomy.</b> <code style="font-family:'JetBrains Mono',monospace;color:var(--accent);background:rgba(0,153,255,0.08);padding:1px 5px;border-radius:3px">head</code> (severity bar + title + meta code) → <code style="font-family:'JetBrains Mono',monospace;color:var(--accent);background:rgba(0,153,255,0.08);padding:1px 5px;border-radius:3px">body</code> (command, error line, stack) → optional <code style="font-family:'JetBrains Mono',monospace;color:var(--accent);background:rgba(0,153,255,0.08);padding:1px 5px;border-radius:3px">hint</code> (Claude's diagnosis) → <code style="font-family:'JetBrains Mono',monospace;color:var(--accent);background:rgba(0,153,255,0.08);padding:1px 5px;border-radius:3px">actions</code>. The hint row is what makes this a CodeScope error, not a stock terminal one.
+    </p>
+  </div>
+
+  <!-- ============ BLOCKER ============ -->
+  <div class="sec">
+    <div class="sec-label">07 · Blocker</div>
+    <h2>The catastrophic full-window state</h2>
+    <p class="sec-sub">
+      Reserved for <b>can't continue</b>: corrupt project file, missing license, version-mismatch with daemon. Always shows an error code (for support) and a copyable diagnostics blob. No nav chrome, no sidebar.
+    </p>
+
+    <div class="stage" style="padding: 32px;">
+      <div class="blocker">
+        <div class="glyph">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M7 7l10 10M17 7l-10 10"/></svg>
+        </div>
+        <div class="ttl">CodeScope can't open this project</div>
+        <div class="sub">The project file at <code style="font-family:'JetBrains Mono',monospace;color:#fff;font-size:12px">~/code/pestscope/.codescope/state.json</code> is corrupt or was written by a newer version. CodeScope <b>2024.4</b> can't read it.</div>
+        <div class="ref">Error <code>E_STATE_VERSION_MISMATCH</code> · Expected schema ≤ 7 · got 9</div>
+        <div class="row">
+          <button class="primary">Update CodeScope</button>
+          <button class="ghost">Open another project</button>
+          <button class="ghost">Copy diagnostics</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ TOKENS ============ -->
+  <div class="sec">
+    <div class="sec-label">08 · Tokens</div>
+    <h2>Every measurable value</h2>
+    <div class="spec-grid">
+      <div class="panel">
+        <h3>Toast dimensions</h3>
+        <ul>
+          <li><span class="k">width</span><span class="v">380px</span></li>
+          <li><span class="k">radius</span><span class="v">10px</span></li>
+          <li><span class="k">accent rail</span><span class="v">2px · full height</span></li>
+          <li><span class="k">pad row</span><span class="v">14 · 16</span></li>
+          <li><span class="k">icon tile</span><span class="v">24 · radius 6</span></li>
+          <li><span class="k">icon glyph</span><span class="v">12 · stroke 1.5</span></li>
+          <li><span class="k">meter</span><span class="v">2px bottom strip</span></li>
+          <li><span class="k">action H</span><span class="v">24 · radius 4 · pad-x 10</span></li>
+          <li><span class="k">stack offset</span><span class="v">10px gap · scale 0.97/0.94</span></li>
+          <li><span class="k">anchor</span><span class="v">28px from bottom-right</span></li>
+        </ul>
+      </div>
+      <div class="panel">
+        <h3>Severity colors</h3>
+        <ul>
+          <li><span class="k"><span class="swatch" style="background:#0099FF"></span>info</span><span class="v">#0099FF · accent</span></li>
+          <li><span class="k"><span class="swatch" style="background:#4BD87B"></span>ok</span><span class="v">#4BD87B</span></li>
+          <li><span class="k"><span class="swatch" style="background:#FFB23F"></span>warn</span><span class="v">#FFB23F · amber</span></li>
+          <li><span class="k"><span class="swatch" style="background:#FF5A5A"></span>err</span><span class="v">#FF5A5A</span></li>
+          <li><span class="k">tint bg</span><span class="v">color/0.08–0.10</span></li>
+          <li><span class="k">tint border</span><span class="v">color/0.25–0.30</span></li>
+          <li><span class="k">ring (input)</span><span class="v">3px color/0.15</span></li>
+          <li><span class="k">message text</span><span class="v">#A0A0A0 (always)</span></li>
+        </ul>
+      </div>
+      <div class="panel">
+        <h3>Timing</h3>
+        <ul>
+          <li><span class="k">enter</span><span class="v">slide+fade · 200ms ease-out</span></li>
+          <li><span class="k">exit</span><span class="v">fade+collapse · 160ms ease-in</span></li>
+          <li><span class="k">stack reflow</span><span class="v">220ms cubic-bezier(.2,.8,.2,1)</span></li>
+          <li><span class="k">auto info</span><span class="v">4s</span></li>
+          <li><span class="k">auto ok</span><span class="v">4s</span></li>
+          <li><span class="k">auto warn</span><span class="v">8s</span></li>
+          <li><span class="k">auto err</span><span class="v">never</span></li>
+          <li><span class="k">hover pause</span><span class="v">all meters in stack</span></li>
+          <li><span class="k">de-dupe</span><span class="v">replace by id · reset meter</span></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ NOTES ============ -->
+  <div class="sec">
+    <div class="sec-label">09 · Build notes</div>
+    <h2>Rules that aren't obvious from the pixels</h2>
+    <div class="notes">
+      <div class="note">
+        <span class="t">Title is the outcome, message is the why</span>
+        Title: <b>past-tense, factual</b> — &ldquo;Branch pushed,&rdquo; &ldquo;Push failed.&rdquo; Message: scope and reason. If you can't say the title in 5 words, the surface is wrong (probably a banner or terminal error).
+      </div>
+      <div class="note">
+        <span class="t">Errors never auto-dismiss</span>
+        Info/ok/warn drain on a meter. Errors stay until clicked away. Don't skip the meter for non-errors — it's how the user judges &ldquo;is this safe to ignore?&rdquo;.
+      </div>
+      <div class="note">
+        <span class="t">Actions are noun-verbs of the toast</span>
+        &ldquo;Branch pushed&rdquo; → <b>Open PR</b>. &ldquo;Worktree spawned&rdquo; → <b>Open</b>. Never generic &ldquo;OK&rdquo; or &ldquo;Got it.&rdquo; If there's no obvious action, omit them — close handles it.
+      </div>
+      <div class="note">
+        <span class="t">Validation is inline, never toast</span>
+        A toast for &ldquo;name required&rdquo; is the worst kind of error UX — the user can't tie it back to the input. Every field has its own error slot. Toasts confirm <i>submission</i> outcomes, not validation.
+      </div>
+      <div class="note">
+        <span class="t">De-dupe aggressively</span>
+        Pass an <code>id</code> with every toast. Same id within 5s = replace, don't stack. The 4th &ldquo;Saved.&rdquo; in 200ms is a bug, not a feature.
+      </div>
+      <div class="note">
+        <span class="t">Banners are sticky, not modal</span>
+        They share row with the workspace, never block. If something must block, it's a dialog or blocker — never a banner.
+      </div>
+      <div class="note">
+        <span class="t">Terminal errors include a hint</span>
+        The dashed-divider hint row (Claude's diagnosis) is what differentiates this from a stock terminal. Always include — empty if Claude has nothing to say (rare).
+      </div>
+      <div class="note">
+        <span class="t">Blocker shows the code &amp; copy button</span>
+        Every blocker has an error code and a &ldquo;Copy diagnostics&rdquo; button. The diagnostics blob includes app version, OS, project state file path, and the last 50 log lines. Don't make support guess.
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ IMPLEMENTATION ============ -->
+  <div class="sec">
+    <div class="sec-label">10 · Implementation</div>
+    <h2>Suggested API</h2>
+    <div class="impl">
+<pre><span class="c">// One imperative API for toasts. Banner / blocker are components, not imperative.</span>
+
+<span class="k">type</span> <span class="t">Severity</span> = <span class="s">"info"</span> | <span class="s">"ok"</span> | <span class="s">"warn"</span> | <span class="s">"err"</span>;
+
+<span class="k">type</span> <span class="t">ToastAction</span> = {
+  <span class="t">label</span>: string;
+  <span class="t">intent</span>?: <span class="s">"primary"</span> | <span class="s">"ghost"</span> | <span class="s">"danger"</span>;
+  <span class="t">onClick</span>(): void | Promise&lt;void&gt;;     <span class="c">// resolves before dismiss</span>
+};
+
+<span class="k">type</span> <span class="t">ToastInput</span> = {
+  <span class="t">id</span>?: string;                          <span class="c">// for de-dupe + replace</span>
+  <span class="t">severity</span>: Severity;
+  <span class="t">title</span>: string;                         <span class="c">// past tense, ≤ 1 line</span>
+  <span class="t">message</span>?: ReactNode;
+  <span class="t">actions</span>?: ToastAction[];               <span class="c">// max 2</span>
+  <span class="t">duration</span>?: number | <span class="s">"persistent"</span>;     <span class="c">// override default</span>
+  <span class="t">icon</span>?: ReactNode;                       <span class="c">// override severity icon</span>
+};
+
+<span class="c">// Helpers wrap toast() so callers don't carry severity:</span>
+<span class="t">toast</span>.info(input)    <span class="c">// 4s</span>
+<span class="t">toast</span>.ok(input)      <span class="c">// 4s</span>
+<span class="t">toast</span>.warn(input)    <span class="c">// 8s</span>
+<span class="t">toast</span>.err(input)     <span class="c">// persistent, no meter</span>
+
+<span class="c">// Inline error — colocate with field. Don't ship a "FieldError" component;
+// expose the helper slot on your form primitives so it's harder to misuse:</span>
+
+&lt;<span class="t">Field</span>
+  <span class="t">label</span>=<span class="s">"Worktree name"</span>
+  <span class="t">value</span>={name}
+  <span class="t">onChange</span>={setName}
+  <span class="t">error</span>={nameError}            <span class="c">// string | null — drives ring + helper</span>
+  <span class="t">warn</span>={nameWarn}             <span class="c">// optional, lower priority than error</span>
+/&gt;
+
+<span class="c">// Banner — workspace-scoped state. Imperative + declarative:</span>
+
+useBanner(<span class="s">"repo-behind"</span>, {
+  severity: <span class="s">"warn"</span>,
+  title: <span class="s">"Repo is 14 commits behind origin/main"</span>,
+  message: …,
+  actions: [{ label: <span class="s">"Pull now"</span>, onClick: pullMain }],
+  while: state.commitsBehind &gt; 0,    <span class="c">// auto-clear when false</span>
+});
+
+<span class="c">// Terminal error — emit through the same stream as stdout:</span>
+
+session.emit({
+  kind: <span class="s">"tool-error"</span>,
+  command: <span class="s">"pnpm test:integration"</span>,
+  exitCode: 1, durationMs: 4127,
+  message: <span class="s">"Cannot find module '@cs/db/migrations/…'"</span>,
+  stack: […], hint: <span class="s">"Likely cause: …"</span>,
+  actions: [<span class="s">"retry"</span>, <span class="s">"pnpm install"</span>, <span class="s">"copy"</span>, <span class="s">"ask-claude"</span>],
+});
+
+<span class="c">// Blocker — single global slot. Setting it replaces the entire window UI.</span>
+setBlocker({
+  code: <span class="s">"E_STATE_VERSION_MISMATCH"</span>,
+  title: <span class="s">"CodeScope can't open this project"</span>,
+  message: …,
+  diagnostics: () =&gt; collectDiagnostics(),
+});</pre>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -84,7 +84,12 @@ public partial class App : Application
                     return AgentRegistry.FromConfig(cfg.IsSuccess ? cfg.Value : new ProjectsConfig());
                 });
                 services.AddSingleton<IGitService, GitService>();
-                services.AddSingleton<Wpf.Ui.ISnackbarService, Wpf.Ui.SnackbarService>();
+                // Custom toast service — hosted in a top-level Popup HWND inside MainWindow
+                // so toasts render above the Microsoft.Terminal.Wpf HwndHost children that
+                // fill the workspace. See CodeScope.App/Toasts/ToastHostView.xaml.cs.
+                services.AddSingleton<NoScope.CodeScope.App.Toasts.ToastService>();
+                services.AddSingleton<NoScope.CodeScope.Ui.Services.IToastService>(
+                    sp => sp.GetRequiredService<NoScope.CodeScope.App.Toasts.ToastService>());
                 services.AddSingleton<IGitHubPullRequestService, GitHubPullRequestService>();
                 services.AddSingleton<IGiteaPullRequestService, GiteaPullRequestService>();
                 services.AddSingleton<IPullRequestService, PullRequestService>();
@@ -105,7 +110,7 @@ public partial class App : Application
                     PickFolder,
                     PickNewWorktree,
                     sp.GetRequiredService<IPullRequestService>(),
-                    sp.GetRequiredService<Wpf.Ui.ISnackbarService>(),
+                    sp.GetRequiredService<NoScope.CodeScope.Ui.Services.IToastService>(),
                     sp.GetRequiredService<IAgentRegistry>(),
                     sp.GetRequiredService<IGitService>()));
                 services.AddSingleton<DiffPanelViewModel>();

--- a/src/CodeScope.App/MainWindow.xaml
+++ b/src/CodeScope.App/MainWindow.xaml
@@ -9,6 +9,7 @@
     xmlns:conv="clr-namespace:NoScope.CodeScope.Ui.Converters;assembly=CodeScope.Ui"
     xmlns:views="clr-namespace:NoScope.CodeScope.Ui.Views;assembly=CodeScope.Ui"
     xmlns:app="clr-namespace:NoScope.CodeScope.App"
+    xmlns:toasts="clr-namespace:NoScope.CodeScope.App.Toasts"
     mc:Ignorable="d"
     Title="{Binding WindowTitle}"
     Icon="pack://application:,,,/assets/codescope.ico"
@@ -361,15 +362,17 @@
             Grid.Row="2"
             Grid.ColumnSpan="3" />
 
-        <!-- Overlay: non-blocking when empty; draws over every row+col. -->
-        <ui:SnackbarPresenter
-            x:Name="SnackbarHost"
-            Grid.Row="0"
-            Grid.RowSpan="3"
-            Grid.Column="0"
-            Grid.ColumnSpan="3"
-            HorizontalAlignment="Right"
-            VerticalAlignment="Bottom"
-            Margin="0,0,16,28" />
+        <!-- Toast host: a hidden 0×0 anchor that owns a top-level Popup. The Popup is
+             a separate HWND so toasts render above the Microsoft.Terminal.Wpf HwndHost
+             children that fill the workspace. A WPF SnackbarPresenter sits on the WPF
+             visual tree and gets clipped behind those native HWNDs (airspace bug). -->
+        <toasts:ToastHostView x:Name="ToastHost"
+                              Grid.Row="0"
+                              Grid.RowSpan="3"
+                              Grid.Column="0"
+                              Grid.ColumnSpan="3"
+                              Width="0" Height="0"
+                              HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom" />
     </Grid>
 </ui:FluentWindow>

--- a/src/CodeScope.App/MainWindow.xaml.cs
+++ b/src/CodeScope.App/MainWindow.xaml.cs
@@ -2,9 +2,9 @@ using System.Collections.Specialized;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using NoScope.CodeScope.App.Toasts;
 using NoScope.CodeScope.Ui.ViewModels;
 using NoScope.CodeScope.Ui.Views;
-using Wpf.Ui;
 using Wpf.Ui.Controls;
 
 namespace NoScope.CodeScope.App;
@@ -13,7 +13,7 @@ namespace NoScope.CodeScope.App;
 public partial class MainWindow : FluentWindow
 {
     private readonly MainViewModel _viewModel;
-    private readonly ISnackbarService _snackbar;
+    private readonly ToastService _toasts;
 
     // Cached per-VM view instances. Re-created EditorGroupViews would force the hosted
     // EasyTerminalControl HWND to tear down and respawn pwsh, so we hold on to them for
@@ -31,16 +31,17 @@ public partial class MainWindow : FluentWindow
     // CaptionButton style in MainWindow.xaml.
     private const double CaptionClusterWidth = 4 * 46.0;
 
-    public MainWindow(MainViewModel viewModel, ISnackbarService snackbar)
+    public MainWindow(MainViewModel viewModel, ToastService toasts)
     {
         _viewModel = viewModel;
-        _snackbar = snackbar;
+        _toasts = toasts;
         DataContext = viewModel;
 
         InitializeComponent();
 
-        // Presenter only exists after InitializeComponent; hook it up now.
-        _snackbar.SetSnackbarPresenter(SnackbarHost);
+        // The toast host binds Items off the service; the service is the single
+        // dispatcher-marshalled owner of the visible-toast collection.
+        ToastHost.DataContext = _toasts;
 
         // Apply persisted geometry (size, position, maximised state) before the window renders.
         WindowGeometryStore.Apply(this, WindowGeometryStore.Load());
@@ -76,6 +77,16 @@ public partial class MainWindow : FluentWindow
             // Regardless, a rebuild now gives a single authoritative layout.
             RebuildGroupLayout();
             await _viewModel.InitializeAsync();
+
+            // Opt-in toast sampler — surfaces one of each severity ~600ms after the
+            // first render so the design QA workflow (wpf-cli screenshot vs. Playwright
+            // screenshot of the spec HTML) doesn't need to drive a git operation to see
+            // a toast. Set CODESCOPE_TOAST_SAMPLE=1 alongside CODESCOPE_DEV=1 to fire it.
+            if (NoScope.CodeScope.Core.AppPaths.IsDevMode
+                && Environment.GetEnvironmentVariable("CODESCOPE_TOAST_SAMPLE") == "1")
+            {
+                _ = SeedDevToastsAsync();
+            }
         }
         catch (Exception ex)
         {
@@ -296,4 +307,35 @@ public partial class MainWindow : FluentWindow
         => WindowState = WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
 
     private void OnCaptionClose(object sender, System.Windows.RoutedEventArgs e) => Close();
+
+    private async Task SeedDevToastsAsync()
+    {
+        await Task.Delay(600).ConfigureAwait(true);
+        _toasts.Show(new NoScope.CodeScope.Ui.Services.ToastRequest(
+            NoScope.CodeScope.Ui.Services.ToastSeverity.Info,
+            "Switching to claude-opus-4",
+            "Current turn finishes on sonnet-4-5, then swaps."));
+        await Task.Delay(150).ConfigureAwait(true);
+        _toasts.Show(new NoScope.CodeScope.Ui.Services.ToastRequest(
+            NoScope.CodeScope.Ui.Services.ToastSeverity.Ok,
+            "Branch pushed",
+            "feat/reporting → origin/feat/reporting · 3 commits.",
+            Actions: [new NoScope.CodeScope.Ui.Services.ToastAction("Open PR", () => { }, IsPrimary: true)]));
+        await Task.Delay(150).ConfigureAwait(true);
+        _toasts.Show(new NoScope.CodeScope.Ui.Services.ToastRequest(
+            NoScope.CodeScope.Ui.Services.ToastSeverity.Warn,
+            "Context near cap",
+            "186k / 200k on feat/reporting. Compact or branch off the next message.",
+            Actions: [new NoScope.CodeScope.Ui.Services.ToastAction("Compact now", () => { }, IsPrimary: true)]));
+        await Task.Delay(150).ConfigureAwait(true);
+        _toasts.Show(new NoScope.CodeScope.Ui.Services.ToastRequest(
+            NoScope.CodeScope.Ui.Services.ToastSeverity.Err,
+            "Push failed",
+            "origin rejected: non-fast-forward. Pull main and rebase before pushing again.",
+            Actions:
+            [
+                new NoScope.CodeScope.Ui.Services.ToastAction("View output", () => { }, IsPrimary: true),
+                new NoScope.CodeScope.Ui.Services.ToastAction("Retry", () => { }),
+            ]));
+    }
 }

--- a/src/CodeScope.App/Styles/DesignTokens.xaml
+++ b/src/CodeScope.App/Styles/DesignTokens.xaml
@@ -96,6 +96,41 @@
     <SolidColorBrush x:Key="Accent.Soft"          Color="{StaticResource Accent.Color.Soft}" />
     <SolidColorBrush x:Key="Accent.Glow"          Color="{StaticResource Accent.Color.Glow}" />
 
+    <!-- Toast / errors palette — sourced from "CodeScope - Errors and Toasts" spec.
+         Five severities × three roles (foreground / tint bg / tint border) so the same
+         Toast template can render any flavor by binding three brushes off the VM.
+         Note: existing `Signal.Warn` is historically red; we leave it for callers that
+         depend on it and introduce dedicated `Severity.*` keys here so toast/banner
+         consumers don't get tangled with the older naming. -->
+    <Color x:Key="Severity.Color.Info">#FF0099FF</Color>
+    <Color x:Key="Severity.Color.Ok">#FF4BD87B</Color>
+    <Color x:Key="Severity.Color.Warn">#FFFFB23F</Color>
+    <Color x:Key="Severity.Color.Err">#FFFF5A5A</Color>
+
+    <SolidColorBrush x:Key="Severity.Info"        Color="{StaticResource Severity.Color.Info}" />
+    <SolidColorBrush x:Key="Severity.Ok"          Color="{StaticResource Severity.Color.Ok}" />
+    <SolidColorBrush x:Key="Severity.Warn"        Color="{StaticResource Severity.Color.Warn}" />
+    <SolidColorBrush x:Key="Severity.Err"         Color="{StaticResource Severity.Color.Err}" />
+
+    <!-- Tint bg ≈ color/0.10 · tint border ≈ color/0.25–0.30. Pre-baked because WPF
+         doesn't let you compose alpha into a static SolidColorBrush at the call site. -->
+    <SolidColorBrush x:Key="Severity.Info.Bg"     Color="#1A0099FF" />
+    <SolidColorBrush x:Key="Severity.Info.Border" Color="#400099FF" />
+    <SolidColorBrush x:Key="Severity.Ok.Bg"       Color="#144BD87B" />
+    <SolidColorBrush x:Key="Severity.Ok.Border"   Color="#404BD87B" />
+    <SolidColorBrush x:Key="Severity.Warn.Bg"     Color="#1AFFB23F" />
+    <SolidColorBrush x:Key="Severity.Warn.Border" Color="#4DFFB23F" />
+    <SolidColorBrush x:Key="Severity.Err.Bg"      Color="#1AFF5A5A" />
+    <SolidColorBrush x:Key="Severity.Err.Border"  Color="#4DFF5A5A" />
+
+    <!-- Toast surface — slightly lighter than the panel black used elsewhere so the
+         toast pops a touch off the workspace background. Matches the spec's #0A0A0A. -->
+    <Color x:Key="Toast.Color.Bg">#FF0A0A0A</Color>
+    <Color x:Key="Toast.Color.Border">#FF2A2A2A</Color>
+    <SolidColorBrush x:Key="Toast.Bg"             Color="{StaticResource Toast.Color.Bg}" />
+    <SolidColorBrush x:Key="Toast.Border"         Color="{StaticResource Toast.Color.Border}" />
+    <SolidColorBrush x:Key="Toast.Meter.Track"    Color="{StaticResource Surface.Color.Border}" />
+
     <!-- ========================================================================= -->
     <!-- §5 SPACING SCALE — base 8, full Framer ladder                              -->
     <!-- ========================================================================= -->

--- a/src/CodeScope.App/Styles/DesignTokens.xaml
+++ b/src/CodeScope.App/Styles/DesignTokens.xaml
@@ -16,7 +16,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+    xmlns:sys="clr-namespace:System;assembly=mscorlib"
+    xmlns:toasts="clr-namespace:NoScope.CodeScope.App.Toasts">
 
     <!-- ========================================================================= -->
     <!-- §2 COLOR PALETTE                                                           -->
@@ -501,6 +502,62 @@
     <Style x:Key="Fig.Style.Pill" TargetType="Border">
         <Setter Property="CornerRadius" Value="{StaticResource Fig.Radius.Pill}" />
         <Setter Property="Padding"      Value="10,4" />
+    </Style>
+
+    <!-- ========================================================================= -->
+    <!-- TOAST ACTION BUTTON — small chip-style action used inside toasts.          -->
+    <!-- Distinct from Fig.Style.Button.* (those are 100/40px-radius CTAs); spec   -->
+    <!-- §02 wants a 24px-tall radius-4 chip. Severity-aware primary swap lives    -->
+    <!-- in the consuming template (DataContext = ToastActionViewModel).           -->
+    <!-- ========================================================================= -->
+    <toasts:SeverityBrushConverter x:Key="ToastSeverityBrush" />
+
+    <Style x:Key="Fig.Style.Button.ToastAction" TargetType="Button">
+        <Setter Property="Foreground"      Value="{StaticResource Text.Primary}" />
+        <Setter Property="BorderBrush"     Value="{StaticResource Toast.Border}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Background"      Value="{StaticResource Surface.Elev}" />
+        <Setter Property="Height"          Value="24" />
+        <Setter Property="MinWidth"        Value="0" />
+        <Setter Property="Padding"         Value="10,0" />
+        <Setter Property="FontFamily"      Value="{StaticResource Fig.Font.Sans}" />
+        <Setter Property="FontSize"        Value="11.5" />
+        <Setter Property="FontWeight"      Value="Medium" />
+        <Setter Property="Cursor"          Value="Hand" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Bd"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="4">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          Margin="{TemplateBinding Padding}"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"
+                                          TextElement.FontFamily="{TemplateBinding FontFamily}"
+                                          TextElement.FontSize="{TemplateBinding FontSize}"
+                                          TextElement.FontWeight="{TemplateBinding FontWeight}" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource Fig.Brush.GlassLight}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <!-- Primary action: accent border/text/fill driven by the toast's severity
+                 (DataContext = ToastActionViewModel exposes Severity + IsPrimary). -->
+            <DataTrigger Binding="{Binding IsPrimary}" Value="True">
+                <Setter Property="BorderBrush" Value="{Binding Severity, Converter={StaticResource ToastSeverityBrush}, ConverterParameter=Border}" />
+                <Setter Property="Foreground" Value="{Binding Severity, Converter={StaticResource ToastSeverityBrush}, ConverterParameter=Fg}" />
+                <Setter Property="Background" Value="{Binding Severity, Converter={StaticResource ToastSeverityBrush}, ConverterParameter=Bg}" />
+            </DataTrigger>
+        </Style.Triggers>
     </Style>
 
 </ResourceDictionary>

--- a/src/CodeScope.App/Toasts/ToastConverters.cs
+++ b/src/CodeScope.App/Toasts/ToastConverters.cs
@@ -52,23 +52,30 @@ public sealed class SeverityIconConverter : IValueConverter
     // Icons are drawn into a 12×12 viewbox so a single Path Data string fits inside
     // the 24×24 tinted tile without further scaling. Strokes ride on the parent Path's
     // Stroke + StrokeThickness so the color flows from the severity converter above.
-    private const string Info = "M 6 1.5 A 4.5 4.5 0 1 1 5.999 1.5 Z M 6 4 L 6 7";
-    private const string Ok = "M 2.5 6.5 L 5 9 L 10 4";
-    private const string Warn = "M 6 1.5 L 11 10 L 1 10 Z M 6 5 L 6 8";
-    private const string Err = "M 6 1.5 A 4.5 4.5 0 1 1 5.999 1.5 Z M 3.5 3.5 L 8.5 8.5 M 8.5 3.5 L 3.5 8.5";
+    // Cached + Frozen so every toast in the stack shares the same Geometry instance —
+    // Geometry.Parse is non-trivial and the WPF render thread plays nicer with frozen
+    // freezables, so this is a "free" win.
+    private static readonly Geometry InfoIcon = FreezeParse("M 6 1.5 A 4.5 4.5 0 1 1 5.999 1.5 Z M 6 4 L 6 7");
+    private static readonly Geometry OkIcon = FreezeParse("M 2.5 6.5 L 5 9 L 10 4");
+    private static readonly Geometry WarnIcon = FreezeParse("M 6 1.5 L 11 10 L 1 10 Z M 6 5 L 6 8");
+    private static readonly Geometry ErrIcon = FreezeParse("M 6 1.5 A 4.5 4.5 0 1 1 5.999 1.5 Z M 3.5 3.5 L 8.5 8.5 M 8.5 3.5 L 3.5 8.5");
+
+    private static Geometry FreezeParse(string data)
+    {
+        var g = Geometry.Parse(data);
+        if (g.CanFreeze) { g.Freeze(); }
+        return g;
+    }
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        var data = value switch
+        => value switch
         {
-            ToastSeverity.Info => Info,
-            ToastSeverity.Ok => Ok,
-            ToastSeverity.Warn => Warn,
-            ToastSeverity.Err => Err,
-            _ => Info,
+            ToastSeverity.Info => InfoIcon,
+            ToastSeverity.Ok => OkIcon,
+            ToastSeverity.Warn => WarnIcon,
+            ToastSeverity.Err => ErrIcon,
+            _ => InfoIcon,
         };
-        return Geometry.Parse(data);
-    }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotSupportedException();

--- a/src/CodeScope.App/Toasts/ToastConverters.cs
+++ b/src/CodeScope.App/Toasts/ToastConverters.cs
@@ -1,0 +1,100 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+using NoScope.CodeScope.Ui.Services;
+
+namespace NoScope.CodeScope.App.Toasts;
+
+/// <summary>
+/// Resolves the per-severity foreground brush from the static resource dictionary.
+/// Each severity owns three brushes (foreground / tint bg / tint border) — using a
+/// shared converter with a parameter (<c>Fg</c>, <c>Bg</c>, <c>Border</c>) keeps the
+/// XAML compact instead of repeating four <c>DataTrigger</c> blocks per visual slot.
+/// </summary>
+[ValueConversion(typeof(ToastSeverity), typeof(Brush))]
+public sealed class SeverityBrushConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not ToastSeverity severity) { return Brushes.Transparent; }
+        var role = parameter as string ?? "Fg";
+        var key = (severity, role) switch
+        {
+            (ToastSeverity.Info, "Fg") => "Severity.Info",
+            (ToastSeverity.Info, "Bg") => "Severity.Info.Bg",
+            (ToastSeverity.Info, "Border") => "Severity.Info.Border",
+            (ToastSeverity.Ok, "Fg") => "Severity.Ok",
+            (ToastSeverity.Ok, "Bg") => "Severity.Ok.Bg",
+            (ToastSeverity.Ok, "Border") => "Severity.Ok.Border",
+            (ToastSeverity.Warn, "Fg") => "Severity.Warn",
+            (ToastSeverity.Warn, "Bg") => "Severity.Warn.Bg",
+            (ToastSeverity.Warn, "Border") => "Severity.Warn.Border",
+            (ToastSeverity.Err, "Fg") => "Severity.Err",
+            (ToastSeverity.Err, "Bg") => "Severity.Err.Bg",
+            (ToastSeverity.Err, "Border") => "Severity.Err.Border",
+            _ => "Severity.Info",
+        };
+        return Application.Current.TryFindResource(key) as Brush ?? Brushes.Transparent;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Picks the right <see cref="Geometry"/> path for the severity icon. The four
+/// glyphs match the SVGs in spec §03 (info dot, ok check, warn triangle, err cross).
+/// </summary>
+[ValueConversion(typeof(ToastSeverity), typeof(Geometry))]
+public sealed class SeverityIconConverter : IValueConverter
+{
+    // Icons are drawn into a 12×12 viewbox so a single Path Data string fits inside
+    // the 24×24 tinted tile without further scaling. Strokes ride on the parent Path's
+    // Stroke + StrokeThickness so the color flows from the severity converter above.
+    private const string Info = "M 6 1.5 A 4.5 4.5 0 1 1 5.999 1.5 Z M 6 4 L 6 7";
+    private const string Ok = "M 2.5 6.5 L 5 9 L 10 4";
+    private const string Warn = "M 6 1.5 L 11 10 L 1 10 Z M 6 5 L 6 8";
+    private const string Err = "M 6 1.5 A 4.5 4.5 0 1 1 5.999 1.5 Z M 3.5 3.5 L 8.5 8.5 M 8.5 3.5 L 3.5 8.5";
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var data = value switch
+        {
+            ToastSeverity.Info => Info,
+            ToastSeverity.Ok => Ok,
+            ToastSeverity.Warn => Warn,
+            ToastSeverity.Err => Err,
+            _ => Info,
+        };
+        return Geometry.Parse(data);
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Multiplies a 0..1 progress fraction by a target width (passed as <c>parameter</c>
+/// so the same converter handles meters of any width). Used by the meter strip so its
+/// inner fill drains right-to-left as <see cref="ToastItemViewModel.Progress"/> ticks
+/// down. Returns 0 for non-positive inputs to avoid layout warnings.
+/// </summary>
+[ValueConversion(typeof(double), typeof(double))]
+public sealed class ProgressToWidthConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var progress = value as double? ?? 0;
+        var max = parameter switch
+        {
+            double d => d,
+            string s when double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var sd) => sd,
+            _ => 380.0,
+        };
+        return Math.Max(0, Math.Min(1, progress)) * max;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/CodeScope.App/Toasts/ToastHostView.xaml
+++ b/src/CodeScope.App/Toasts/ToastHostView.xaml
@@ -1,0 +1,45 @@
+<!--
+    Bottom-right anchored toast stack. Hosted inside a Popup so it gets its own
+    top-level HWND — that's the only way WPF content can render above the native
+    Microsoft.Terminal.Wpf HwndHost children. Without the popup, anything overlapping
+    the terminal area silently disappears behind it (classic WPF airspace).
+
+    Placement is computed by ToastHostView.xaml.cs so the popup's bottom-right
+    corner aligns with the parent window's bottom-right inside a 28px margin
+    (matches spec §08 "anchor: 28px from bottom-right").
+-->
+<UserControl x:Class="NoScope.CodeScope.App.Toasts.ToastHostView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:t="clr-namespace:NoScope.CodeScope.App.Toasts"
+             Background="Transparent"
+             IsHitTestVisible="False">
+    <Popup x:Name="Popup"
+           AllowsTransparency="True"
+           StaysOpen="True"
+           IsHitTestVisible="True"
+           Placement="Custom"
+           PopupAnimation="Fade"
+           AllowDrop="False">
+        <ItemsControl x:Name="ItemsHost"
+                      ItemsSource="{Binding Items}"
+                      Background="Transparent"
+                      Focusable="False">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <!-- 10px gap between toasts (spec §04). Newest at the bottom — append
+                         to bottom because the ItemsControl renders top-down and the service
+                         appends new items to the end of the collection. -->
+                    <StackPanel Orientation="Vertical"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Bottom" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate DataType="{x:Type t:ToastItemViewModel}">
+                    <t:ToastView Margin="0,0,0,10" />
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </Popup>
+</UserControl>

--- a/src/CodeScope.App/Toasts/ToastHostView.xaml.cs
+++ b/src/CodeScope.App/Toasts/ToastHostView.xaml.cs
@@ -1,0 +1,80 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+
+namespace NoScope.CodeScope.App.Toasts;
+
+/// <summary>
+/// Host that owns the toast <see cref="Popup"/> and computes its bottom-right
+/// placement relative to the parent window. The placement callback fires once per
+/// open; we re-trigger it on every parent SizeChanged / LocationChanged so the popup
+/// tracks window resizes and screen-space moves.
+/// </summary>
+public partial class ToastHostView : UserControl
+{
+    /// <summary>Inset from the parent window's bottom-right (spec §08 "anchor 28px").</summary>
+    private const double Inset = 28.0;
+
+    private Window? _parent;
+
+    public ToastHostView()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+        Popup.CustomPopupPlacementCallback = PlaceBottomRight;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        _parent = Window.GetWindow(this);
+        if (_parent is null) { return; }
+        // The popup's PlacementTarget needs a WPF FrameworkElement that the popup's
+        // size-tracking code can measure. The window itself works because Custom
+        // placement gets its targetSize from the placement target's render size.
+        Popup.PlacementTarget = _parent;
+        _parent.SizeChanged += OnParentChanged;
+        _parent.LocationChanged += OnParentChanged;
+        _parent.StateChanged += OnParentChanged;
+        Popup.IsOpen = true;
+        ReplacePopup();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (_parent is not null)
+        {
+            _parent.SizeChanged -= OnParentChanged;
+            _parent.LocationChanged -= OnParentChanged;
+            _parent.StateChanged -= OnParentChanged;
+            _parent = null;
+        }
+        Popup.IsOpen = false;
+    }
+
+    private void OnParentChanged(object? sender, EventArgs e) => ReplacePopup();
+
+    /// <summary>
+    /// WPF popups don't reposition automatically when their PlacementTarget moves or
+    /// resizes. Toggling <see cref="Popup.HorizontalOffset"/> forces a layout pass
+    /// without flickering. Cheap, no visible re-open animation.
+    /// </summary>
+    private void ReplacePopup()
+    {
+        var horizontal = Popup.HorizontalOffset;
+        Popup.HorizontalOffset = horizontal + 1;
+        Popup.HorizontalOffset = horizontal;
+    }
+
+    /// <summary>
+    /// Position the popup so its bottom-right corner sits at the window's bottom-right
+    /// minus a 28px gutter. <paramref name="targetSize"/> is the parent window's
+    /// render size; <paramref name="popupSize"/> is the measured popup contents.
+    /// </summary>
+    private static CustomPopupPlacement[] PlaceBottomRight(Size popupSize, Size targetSize, Point offset)
+    {
+        var x = targetSize.Width - popupSize.Width - Inset;
+        var y = targetSize.Height - popupSize.Height - Inset;
+        return [new CustomPopupPlacement(new Point(x, y), PopupPrimaryAxis.None)];
+    }
+}

--- a/src/CodeScope.App/Toasts/ToastHostView.xaml.cs
+++ b/src/CodeScope.App/Toasts/ToastHostView.xaml.cs
@@ -92,8 +92,8 @@ public partial class ToastHostView : UserControl
     /// </summary>
     private static CustomPopupPlacement[] PlaceBottomRight(Size popupSize, Size targetSize, Point offset)
     {
-        var x = targetSize.Width - popupSize.Width - Inset;
-        var y = targetSize.Height - popupSize.Height - Inset;
+        var x = Math.Max(0, targetSize.Width - popupSize.Width - Inset);
+        var y = Math.Max(0, targetSize.Height - popupSize.Height - Inset);
         return [new CustomPopupPlacement(new Point(x, y), PopupPrimaryAxis.None)];
     }
 }

--- a/src/CodeScope.App/Toasts/ToastHostView.xaml.cs
+++ b/src/CodeScope.App/Toasts/ToastHostView.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Input;
 
 namespace NoScope.CodeScope.App.Toasts;
 
@@ -23,6 +24,12 @@ public partial class ToastHostView : UserControl
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
         Popup.CustomPopupPlacementCallback = PlaceBottomRight;
+        // Stack-level hover: a single enter/leave on the items host pauses every
+        // visible toast at once (spec §04). Subscribing here — instead of on each
+        // ToastView — guarantees the gap between two toasts also counts as "hover"
+        // because the StackPanel itself is the listening element.
+        ItemsHost.MouseEnter += OnStackEnter;
+        ItemsHost.MouseLeave += OnStackLeave;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -53,6 +60,18 @@ public partial class ToastHostView : UserControl
     }
 
     private void OnParentChanged(object? sender, EventArgs e) => ReplacePopup();
+
+    private void OnStackEnter(object sender, MouseEventArgs e)
+    {
+        if (DataContext is not ToastService svc) { return; }
+        foreach (var item in svc.Items) { item.Pause(); }
+    }
+
+    private void OnStackLeave(object sender, MouseEventArgs e)
+    {
+        if (DataContext is not ToastService svc) { return; }
+        foreach (var item in svc.Items) { item.Resume(); }
+    }
 
     /// <summary>
     /// WPF popups don't reposition automatically when their PlacementTarget moves or

--- a/src/CodeScope.App/Toasts/ToastItemViewModel.cs
+++ b/src/CodeScope.App/Toasts/ToastItemViewModel.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using NoScope.CodeScope.Ui.Services;
+
+namespace NoScope.CodeScope.App.Toasts;
+
+/// <summary>
+/// One row in <see cref="ToastService"/>'s observable collection. Owns the auto-dismiss
+/// <see cref="DispatcherTimer"/> and the meter progress (0..1, drives the 2px strip
+/// at the bottom of the toast). Hover pauses the timer for the entire stack — the
+/// host wires <see cref="Pause"/> / <see cref="Resume"/> from a single MouseEnter /
+/// MouseLeave on the popup, so this VM doesn't need to know about its siblings.
+/// </summary>
+public sealed partial class ToastItemViewModel : ObservableObject
+{
+    private readonly Action<ToastItemViewModel> _onDismiss;
+    private readonly DispatcherTimer? _ticker;
+    private readonly DateTime _start;
+    private readonly TimeSpan _duration;
+    private TimeSpan _elapsed;
+    private bool _paused;
+
+    public ToastItemViewModel(
+        ToastRequest request,
+        TimeSpan duration,
+        Action<ToastItemViewModel> onDismiss)
+    {
+        _onDismiss = onDismiss;
+        _duration = duration;
+        _start = DateTime.UtcNow;
+
+        Id = request.Id ?? Guid.NewGuid().ToString("N");
+        Severity = request.Severity;
+        Title = request.Title;
+        Message = request.Message;
+        Actions = new ObservableCollection<ToastActionViewModel>(
+            (request.Actions ?? []).Select(a => new ToastActionViewModel(a, this)));
+        Progress = 1.0;
+
+        // Persistent toasts (errors by default) draw no meter and don't tick.
+        if (duration == Timeout.InfiniteTimeSpan || duration == TimeSpan.Zero)
+        {
+            HasMeter = false;
+            Progress = 1.0;
+            return;
+        }
+
+        HasMeter = true;
+        // 60ms ≈ 16fps — smooth enough for a 4–8s drain without burning the dispatcher.
+        _ticker = new DispatcherTimer(DispatcherPriority.Background) { Interval = TimeSpan.FromMilliseconds(60) };
+        _ticker.Tick += OnTick;
+        _ticker.Start();
+    }
+
+    public string Id { get; }
+    public ToastSeverity Severity { get; }
+    public string Title { get; }
+    public string? Message { get; }
+    public ObservableCollection<ToastActionViewModel> Actions { get; }
+
+    /// <summary>
+    /// 1.0 → 0.0 over <see cref="_duration"/>. The meter strip uses this via a width
+    /// converter so the bar drains right-to-left in unison with the auto-dismiss.
+    /// </summary>
+    [ObservableProperty]
+    private double _progress;
+
+    public bool HasMeter { get; }
+    public bool HasMessage => !string.IsNullOrEmpty(Message);
+    public bool HasActions => Actions.Count > 0;
+
+    private void OnTick(object? sender, EventArgs e)
+    {
+        if (_paused) { return; }
+        _elapsed = DateTime.UtcNow - _start;
+        var p = 1.0 - (_elapsed.TotalMilliseconds / _duration.TotalMilliseconds);
+        if (p <= 0)
+        {
+            Progress = 0;
+            DismissCommand.Execute(null);
+            return;
+        }
+        Progress = p;
+    }
+
+    public void Pause()
+    {
+        if (!HasMeter) { return; }
+        _paused = true;
+    }
+
+    public void Resume()
+    {
+        if (!HasMeter) { return; }
+        // Reset the start anchor so the remaining time uses the current Progress.
+        _paused = false;
+    }
+
+    [RelayCommand]
+    private void Dismiss()
+    {
+        _ticker?.Stop();
+        _onDismiss(this);
+    }
+}
+
+/// <summary>
+/// Per-action wrapper so the toast template can bind to a button command. Click
+/// invokes the user-supplied <see cref="ToastAction.Invoke"/> handler then dismisses
+/// the toast — actions are noun-verbs of the toast (spec §09 "Actions are noun-verbs"),
+/// they're never neutral "OK" so leaving the toast up after a click would be redundant.
+/// </summary>
+public sealed partial class ToastActionViewModel : ObservableObject
+{
+    private readonly ToastAction _model;
+    private readonly ToastItemViewModel _owner;
+
+    public ToastActionViewModel(ToastAction model, ToastItemViewModel owner)
+    {
+        _model = model;
+        _owner = owner;
+    }
+
+    public string Label => _model.Label;
+    public bool IsPrimary => _model.IsPrimary;
+
+    [RelayCommand]
+    private void Invoke()
+    {
+        try { _model.Invoke(); }
+        finally { _owner.DismissCommand.Execute(null); }
+    }
+}

--- a/src/CodeScope.App/Toasts/ToastItemViewModel.cs
+++ b/src/CodeScope.App/Toasts/ToastItemViewModel.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -18,9 +17,13 @@ public sealed partial class ToastItemViewModel : ObservableObject
 {
     private readonly Action<ToastItemViewModel> _onDismiss;
     private readonly DispatcherTimer? _ticker;
-    private readonly DateTime _start;
     private readonly TimeSpan _duration;
-    private TimeSpan _elapsed;
+    // Mutable start anchor: shifts forward by the paused span on each Resume so OnTick
+    // can keep the simple `elapsed = now - start` formula without tracking a separate
+    // accumulator. Pausing 2s on a 4s toast → start moves +2s → meter resumes at the
+    // exact same Progress it paused at.
+    private DateTime _start;
+    private DateTime _pausedAt;
     private bool _paused;
 
     public ToastItemViewModel(
@@ -75,8 +78,8 @@ public sealed partial class ToastItemViewModel : ObservableObject
     private void OnTick(object? sender, EventArgs e)
     {
         if (_paused) { return; }
-        _elapsed = DateTime.UtcNow - _start;
-        var p = 1.0 - (_elapsed.TotalMilliseconds / _duration.TotalMilliseconds);
+        var elapsed = DateTime.UtcNow - _start;
+        var p = 1.0 - (elapsed.TotalMilliseconds / _duration.TotalMilliseconds);
         if (p <= 0)
         {
             Progress = 0;
@@ -88,16 +91,26 @@ public sealed partial class ToastItemViewModel : ObservableObject
 
     public void Pause()
     {
-        if (!HasMeter) { return; }
+        if (!HasMeter || _paused) { return; }
         _paused = true;
+        _pausedAt = DateTime.UtcNow;
     }
 
     public void Resume()
     {
-        if (!HasMeter) { return; }
-        // Reset the start anchor so the remaining time uses the current Progress.
+        if (!HasMeter || !_paused) { return; }
+        // Shift start forward by however long we were paused — the elapsed-since-start
+        // formula in OnTick then naturally resumes at the exact pre-pause Progress.
+        _start = _start + (DateTime.UtcNow - _pausedAt);
         _paused = false;
     }
+
+    /// <summary>
+    /// Stops the timer without invoking <see cref="DismissCommand"/>. Used by
+    /// <see cref="ToastService.Dismiss(string)"/> and the cap eviction so externally-
+    /// removed toasts don't keep ticking and re-firing dismissal on a detached VM.
+    /// </summary>
+    internal void StopTimer() => _ticker?.Stop();
 
     [RelayCommand]
     private void Dismiss()
@@ -126,6 +139,8 @@ public sealed partial class ToastActionViewModel : ObservableObject
 
     public string Label => _model.Label;
     public bool IsPrimary => _model.IsPrimary;
+    /// <summary>Forwarded so the action button's accent can follow the toast severity.</summary>
+    public ToastSeverity Severity => _owner.Severity;
 
     [RelayCommand]
     private void Invoke()

--- a/src/CodeScope.App/Toasts/ToastItemViewModel.cs
+++ b/src/CodeScope.App/Toasts/ToastItemViewModel.cs
@@ -44,7 +44,10 @@ public sealed partial class ToastItemViewModel : ObservableObject
         Progress = 1.0;
 
         // Persistent toasts (errors by default) draw no meter and don't tick.
-        if (duration == Timeout.InfiniteTimeSpan || duration == TimeSpan.Zero)
+        // Only InfiniteTimeSpan is the documented persistent sentinel — TimeSpan.Zero
+        // means "dismiss immediately" and falls through to the ticker path below
+        // (which fires on the first 60ms tick and auto-dismisses).
+        if (duration == Timeout.InfiniteTimeSpan)
         {
             HasMeter = false;
             Progress = 1.0;
@@ -141,6 +144,16 @@ public sealed partial class ToastActionViewModel : ObservableObject
     public bool IsPrimary => _model.IsPrimary;
     /// <summary>Forwarded so the action button's accent can follow the toast severity.</summary>
     public ToastSeverity Severity => _owner.Severity;
+    /// <summary>Stable, sanitized UIA id — includes the owning toast's id so "Retry" buttons
+    /// on two different error toasts don't collide in the automation tree.</summary>
+    public string AutomationId => $"ToastAction_{Sanitize(_model.Label)}_{_owner.Id}";
+
+    private static string Sanitize(string s)
+    {
+        if (string.IsNullOrWhiteSpace(s)) { return "unknown"; }
+        var token = new string([.. s.Select(c => char.IsLetterOrDigit(c) ? c : '_')]).Trim('_');
+        return string.IsNullOrEmpty(token) ? "unknown" : token;
+    }
 
     [RelayCommand]
     private void Invoke()

--- a/src/CodeScope.App/Toasts/ToastService.cs
+++ b/src/CodeScope.App/Toasts/ToastService.cs
@@ -37,6 +37,7 @@ public sealed class ToastService : IToastService
             var existing = Items.FirstOrDefault(i => i.Id == id);
             if (existing is not null)
             {
+                existing.StopTimer();
                 Items.Remove(existing);
             }
         }
@@ -44,11 +45,16 @@ public sealed class ToastService : IToastService
         var vm = new ToastItemViewModel(request, duration, OnDismiss);
         Items.Add(vm);
 
-        // Cap at MaxVisible. Drop the oldest non-error first so error toasts stay until
-        // the user dismisses them (spec §04 "errors never fold").
-        while (Items.Count > MaxVisible)
+        // Cap at MaxVisible BUT errors never auto-fold (spec §04 "errors never fold")
+        // — count only non-error toasts against the cap and only evict from that pool.
+        // If everything visible is an error and the user keeps stacking errors, we let
+        // the stack grow past MaxVisible so the user sees them all rather than silently
+        // dropping the oldest critical message on the floor.
+        while (Items.Count(i => i.Severity != ToastSeverity.Err) > MaxVisible)
         {
-            var victim = Items.FirstOrDefault(i => i.Severity != ToastSeverity.Err) ?? Items[0];
+            var victim = Items.FirstOrDefault(i => i.Severity != ToastSeverity.Err);
+            if (victim is null) { break; }
+            victim.StopTimer();
             Items.Remove(victim);
         }
     }
@@ -64,7 +70,9 @@ public sealed class ToastService : IToastService
         }
 
         var match = Items.FirstOrDefault(i => i.Id == id);
-        if (match is not null) { Items.Remove(match); }
+        if (match is null) { return; }
+        match.StopTimer();
+        Items.Remove(match);
     }
 
     private void OnDismiss(ToastItemViewModel item)

--- a/src/CodeScope.App/Toasts/ToastService.cs
+++ b/src/CodeScope.App/Toasts/ToastService.cs
@@ -1,0 +1,88 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using NoScope.CodeScope.Ui.Services;
+
+namespace NoScope.CodeScope.App.Toasts;
+
+/// <summary>
+/// WPF implementation of <see cref="IToastService"/>. Owns the
+/// <see cref="ObservableCollection{T}"/> the popup binds to. Marshals every mutation
+/// onto the dispatcher because <see cref="UpdateService"/> calls in from the threadpool
+/// and SidebarViewModel calls in from RelayCommand handlers — both paths need to
+/// resolve safely without the caller knowing the threading model.
+/// </summary>
+public sealed class ToastService : IToastService
+{
+    /// <summary>Bottom-up, newest-first stack. Cap matches spec §04 "max 3 visible".</summary>
+    private const int MaxVisible = 3;
+
+    public ObservableCollection<ToastItemViewModel> Items { get; } = [];
+
+    public void Show(ToastRequest request)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null) { return; }
+        if (!dispatcher.CheckAccess())
+        {
+            dispatcher.BeginInvoke(() => Show(request));
+            return;
+        }
+
+        var duration = request.Duration ?? DefaultDuration(request.Severity);
+
+        // De-dupe by id — same id within visible lifetime replaces in place. Kills the
+        // "4× Saved." stack flicker that's noted as a bug, not a feature in spec §09.
+        if (request.Id is { } id)
+        {
+            var existing = Items.FirstOrDefault(i => i.Id == id);
+            if (existing is not null)
+            {
+                Items.Remove(existing);
+            }
+        }
+
+        var vm = new ToastItemViewModel(request, duration, OnDismiss);
+        Items.Add(vm);
+
+        // Cap at MaxVisible. Drop the oldest non-error first so error toasts stay until
+        // the user dismisses them (spec §04 "errors never fold").
+        while (Items.Count > MaxVisible)
+        {
+            var victim = Items.FirstOrDefault(i => i.Severity != ToastSeverity.Err) ?? Items[0];
+            Items.Remove(victim);
+        }
+    }
+
+    public void Dismiss(string id)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null) { return; }
+        if (!dispatcher.CheckAccess())
+        {
+            dispatcher.BeginInvoke(() => Dismiss(id));
+            return;
+        }
+
+        var match = Items.FirstOrDefault(i => i.Id == id);
+        if (match is not null) { Items.Remove(match); }
+    }
+
+    private void OnDismiss(ToastItemViewModel item)
+    {
+        if (Items.Contains(item)) { Items.Remove(item); }
+    }
+
+    /// <summary>
+    /// Spec §08 timing table: info/ok 4s · warn 8s · err persistent. Errors are
+    /// non-negotiable persistent — failures the user needs to see; meter would imply
+    /// "safe to ignore," which is the opposite of what an error means.
+    /// </summary>
+    private static TimeSpan DefaultDuration(ToastSeverity severity) => severity switch
+    {
+        ToastSeverity.Info => TimeSpan.FromSeconds(4),
+        ToastSeverity.Ok => TimeSpan.FromSeconds(4),
+        ToastSeverity.Warn => TimeSpan.FromSeconds(8),
+        ToastSeverity.Err => Timeout.InfiniteTimeSpan,
+        _ => TimeSpan.FromSeconds(4),
+    };
+}

--- a/src/CodeScope.App/Toasts/ToastView.xaml
+++ b/src/CodeScope.App/Toasts/ToastView.xaml
@@ -104,7 +104,7 @@
                                 <Button Command="{Binding InvokeCommand}"
                                         Style="{StaticResource Fig.Style.Button.ToastAction}"
                                         Margin="0,0,8,0"
-                                        AutomationProperties.AutomationId="{Binding Label, StringFormat='ToastAction_{0}'}"
+                                        AutomationProperties.AutomationId="{Binding AutomationId}"
                                         AutomationProperties.Name="{Binding Label}">
                                     <TextBlock Text="{Binding Label}" />
                                 </Button>

--- a/src/CodeScope.App/Toasts/ToastView.xaml
+++ b/src/CodeScope.App/Toasts/ToastView.xaml
@@ -102,61 +102,10 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Button Command="{Binding InvokeCommand}"
+                                        Style="{StaticResource Fig.Style.Button.ToastAction}"
                                         Margin="0,0,8,0"
-                                        Padding="10,0"
-                                        Height="24"
-                                        MinWidth="0"
-                                        FontFamily="Inter, Segoe UI"
-                                        FontSize="11.5"
-                                        FontWeight="Medium"
-                                        Cursor="Hand"
-                                        SnapsToDevicePixels="True"
                                         AutomationProperties.AutomationId="{Binding Label, StringFormat='ToastAction_{0}'}"
                                         AutomationProperties.Name="{Binding Label}">
-                                    <Button.Style>
-                                        <Style TargetType="Button">
-                                            <!-- Default: ghost / secondary. Primary swaps to accent via DataTrigger. -->
-                                            <Setter Property="Foreground" Value="{StaticResource Text.Primary}" />
-                                            <Setter Property="BorderBrush" Value="{StaticResource Toast.Border}" />
-                                            <Setter Property="BorderThickness" Value="1" />
-                                            <Setter Property="Background" Value="{StaticResource Surface.Elev}" />
-                                            <Setter Property="Template">
-                                                <Setter.Value>
-                                                    <ControlTemplate TargetType="Button">
-                                                        <Border x:Name="Bd"
-                                                                Background="{TemplateBinding Background}"
-                                                                BorderBrush="{TemplateBinding BorderBrush}"
-                                                                BorderThickness="{TemplateBinding BorderThickness}"
-                                                                CornerRadius="4">
-                                                            <ContentPresenter HorizontalAlignment="Center"
-                                                                              VerticalAlignment="Center"
-                                                                              Margin="{TemplateBinding Padding}"
-                                                                              TextElement.Foreground="{TemplateBinding Foreground}"
-                                                                              TextElement.FontFamily="{TemplateBinding FontFamily}"
-                                                                              TextElement.FontSize="{TemplateBinding FontSize}"
-                                                                              TextElement.FontWeight="{TemplateBinding FontWeight}" />
-                                                        </Border>
-                                                        <ControlTemplate.Triggers>
-                                                            <Trigger Property="IsMouseOver" Value="True">
-                                                                <Setter TargetName="Bd" Property="Background" Value="{StaticResource Fig.Brush.GlassLight}" />
-                                                            </Trigger>
-                                                        </ControlTemplate.Triggers>
-                                                    </ControlTemplate>
-                                                </Setter.Value>
-                                            </Setter>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsPrimary}" Value="True">
-                                                    <!-- Primary action: accent border + accent text + soft accent fill.
-                                                         Colors flow from the toast's severity so an Err's "Retry" reads
-                                                         red, a Warn's primary action reads orange, etc — keeps the
-                                                         action visually anchored to the message it acts on. -->
-                                                    <Setter Property="BorderBrush" Value="{Binding Severity, Converter={StaticResource SevBrush}, ConverterParameter=Border}" />
-                                                    <Setter Property="Foreground" Value="{Binding Severity, Converter={StaticResource SevBrush}, ConverterParameter=Fg}" />
-                                                    <Setter Property="Background" Value="{Binding Severity, Converter={StaticResource SevBrush}, ConverterParameter=Bg}" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Button.Style>
                                     <TextBlock Text="{Binding Label}" />
                                 </Button>
                             </DataTemplate>

--- a/src/CodeScope.App/Toasts/ToastView.xaml
+++ b/src/CodeScope.App/Toasts/ToastView.xaml
@@ -1,0 +1,202 @@
+<!--
+    Single toast — DataContext = ToastItemViewModel. Geometry follows the spec
+    (380×auto · radius 10 · 1px Toast.Border · accent rail 2px left · row pad 14/16).
+    Severity colors are pulled by SeverityBrushConverter so the same template handles
+    info/ok/warn/err without four DataTrigger blocks per slot.
+-->
+<UserControl x:Class="NoScope.CodeScope.App.Toasts.ToastView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:t="clr-namespace:NoScope.CodeScope.App.Toasts"
+             Width="380"
+             Background="Transparent"
+             SnapsToDevicePixels="True"
+             UseLayoutRounding="True">
+    <UserControl.Resources>
+        <t:SeverityBrushConverter x:Key="SevBrush" />
+        <t:SeverityIconConverter x:Key="SevIcon" />
+        <t:ProgressToWidthConverter x:Key="ProgressToWidth" />
+        <BooleanToVisibilityConverter x:Key="BoolVis" />
+    </UserControl.Resources>
+
+    <Border Background="{StaticResource Toast.Bg}"
+            BorderBrush="{StaticResource Toast.Border}"
+            BorderThickness="1"
+            CornerRadius="10"
+            ClipToBounds="True">
+        <Border.Effect>
+            <DropShadowEffect BlurRadius="48" ShadowDepth="14" Opacity="0.5" Color="#000000" />
+        </Border.Effect>
+
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <!-- Severity rail · 2px full height, color flows from severity. -->
+            <Border Grid.Row="0"
+                    Width="2"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Stretch"
+                    Background="{Binding Severity, Converter={StaticResource SevBrush}, ConverterParameter=Fg}" />
+
+            <!-- Main row: icon · body · close. Padding 14/16 per spec. -->
+            <Grid Grid.Row="0" Margin="16,14,16,14">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="12" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="8" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <!-- Icon tile · 24×24 · radius 6 · tinted bg + 1px tinted border + severity glyph. -->
+                <Border Grid.Column="0"
+                        Width="24" Height="24"
+                        CornerRadius="6"
+                        VerticalAlignment="Top"
+                        Background="{Binding Severity, Converter={StaticResource SevBrush}, ConverterParameter=Bg}"
+                        BorderBrush="{Binding Severity, Converter={StaticResource SevBrush}, ConverterParameter=Border}"
+                        BorderThickness="1">
+                    <Path Width="12" Height="12"
+                          Stretch="None"
+                          StrokeThickness="1.5"
+                          StrokeStartLineCap="Round"
+                          StrokeEndLineCap="Round"
+                          StrokeLineJoin="Round"
+                          Stroke="{Binding Severity, Converter={StaticResource SevBrush}, ConverterParameter=Fg}"
+                          Data="{Binding Severity, Converter={StaticResource SevIcon}}" />
+                </Border>
+
+                <!-- Body: title · message · actions. -->
+                <StackPanel Grid.Column="2" Margin="0,2,0,0">
+                    <TextBlock Text="{Binding Title}"
+                               Foreground="{StaticResource Text.Primary}"
+                               FontFamily="Inter, Segoe UI"
+                               FontSize="13"
+                               FontWeight="SemiBold"
+                               TextWrapping="NoWrap"
+                               TextTrimming="CharacterEllipsis" />
+                    <TextBlock Text="{Binding Message}"
+                               Margin="0,3,0,0"
+                               Foreground="{StaticResource Text.Secondary}"
+                               FontFamily="Inter, Segoe UI"
+                               FontSize="12"
+                               LineHeight="18"
+                               LineStackingStrategy="BlockLineHeight"
+                               TextWrapping="Wrap"
+                               Visibility="{Binding HasMessage, Converter={StaticResource BoolVis}}" />
+
+                    <ItemsControl ItemsSource="{Binding Actions}"
+                                  Margin="0,10,0,0"
+                                  Visibility="{Binding HasActions, Converter={StaticResource BoolVis}}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Button Command="{Binding InvokeCommand}"
+                                        Margin="0,0,8,0"
+                                        Padding="10,0"
+                                        Height="24"
+                                        MinWidth="0"
+                                        FontFamily="Inter, Segoe UI"
+                                        FontSize="11.5"
+                                        FontWeight="Medium"
+                                        Cursor="Hand"
+                                        SnapsToDevicePixels="True">
+                                    <Button.Style>
+                                        <Style TargetType="Button">
+                                            <!-- Default: ghost / secondary. Primary swaps to accent via DataTrigger. -->
+                                            <Setter Property="Foreground" Value="{StaticResource Text.Primary}" />
+                                            <Setter Property="BorderBrush" Value="{StaticResource Toast.Border}" />
+                                            <Setter Property="BorderThickness" Value="1" />
+                                            <Setter Property="Background" Value="{StaticResource Surface.Elev}" />
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="Button">
+                                                        <Border x:Name="Bd"
+                                                                Background="{TemplateBinding Background}"
+                                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                                BorderThickness="{TemplateBinding BorderThickness}"
+                                                                CornerRadius="4">
+                                                            <ContentPresenter HorizontalAlignment="Center"
+                                                                              VerticalAlignment="Center"
+                                                                              Margin="{TemplateBinding Padding}"
+                                                                              TextElement.Foreground="{TemplateBinding Foreground}"
+                                                                              TextElement.FontFamily="{TemplateBinding FontFamily}"
+                                                                              TextElement.FontSize="{TemplateBinding FontSize}"
+                                                                              TextElement.FontWeight="{TemplateBinding FontWeight}" />
+                                                        </Border>
+                                                        <ControlTemplate.Triggers>
+                                                            <Trigger Property="IsMouseOver" Value="True">
+                                                                <Setter TargetName="Bd" Property="Background" Value="{StaticResource Fig.Brush.GlassLight}" />
+                                                            </Trigger>
+                                                        </ControlTemplate.Triggers>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsPrimary}" Value="True">
+                                                    <!-- Primary action: accent border + accent text + soft accent fill. -->
+                                                    <Setter Property="BorderBrush" Value="{StaticResource Severity.Info.Border}" />
+                                                    <Setter Property="Foreground" Value="{StaticResource Severity.Info}" />
+                                                    <Setter Property="Background" Value="{StaticResource Severity.Info.Bg}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                    <TextBlock Text="{Binding Label}" />
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Close x · 18×18 · ghost glyph. -->
+                <Button Grid.Column="4"
+                        Command="{Binding DismissCommand}"
+                        Width="18" Height="18"
+                        VerticalAlignment="Top"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        ToolTip="Dismiss">
+                    <Button.Template>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="Bd" Background="{TemplateBinding Background}" CornerRadius="4">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource Fig.Brush.GlassDark}" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Button.Template>
+                    <Path Width="9" Height="9"
+                          Stretch="None"
+                          Stroke="{StaticResource Text.Faint}"
+                          StrokeThickness="1.4"
+                          StrokeStartLineCap="Round"
+                          StrokeEndLineCap="Round"
+                          Data="M 1 1 L 8 8 M 8 1 L 1 8" />
+                </Button>
+            </Grid>
+
+            <!-- Auto-dismiss meter · 2px strip across the bottom · drains right-to-left.
+                 Hidden for persistent toasts (errors). Width is 380 minus the 2px rail. -->
+            <Grid Grid.Row="1"
+                  Height="2"
+                  Visibility="{Binding HasMeter, Converter={StaticResource BoolVis}}">
+                <Rectangle Fill="{StaticResource Toast.Meter.Track}" />
+                <Rectangle HorizontalAlignment="Left"
+                           Fill="{Binding Severity, Converter={StaticResource SevBrush}, ConverterParameter=Fg}"
+                           Width="{Binding Progress, Converter={StaticResource ProgressToWidth}, ConverterParameter=378}" />
+            </Grid>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/CodeScope.App/Toasts/ToastView.xaml
+++ b/src/CodeScope.App/Toasts/ToastView.xaml
@@ -11,7 +11,10 @@
              Width="380"
              Background="Transparent"
              SnapsToDevicePixels="True"
-             UseLayoutRounding="True">
+             UseLayoutRounding="True"
+             AutomationProperties.AutomationId="{Binding Id, StringFormat='Toast_{0}'}"
+             AutomationProperties.Name="{Binding Title}"
+             AutomationProperties.HelpText="{Binding Message}">
     <UserControl.Resources>
         <t:SeverityBrushConverter x:Key="SevBrush" />
         <t:SeverityIconConverter x:Key="SevIcon" />
@@ -107,7 +110,9 @@
                                         FontSize="11.5"
                                         FontWeight="Medium"
                                         Cursor="Hand"
-                                        SnapsToDevicePixels="True">
+                                        SnapsToDevicePixels="True"
+                                        AutomationProperties.AutomationId="{Binding Label, StringFormat='ToastAction_{0}'}"
+                                        AutomationProperties.Name="{Binding Label}">
                                     <Button.Style>
                                         <Style TargetType="Button">
                                             <!-- Default: ghost / secondary. Primary swaps to accent via DataTrigger. -->
@@ -141,10 +146,13 @@
                                             </Setter>
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsPrimary}" Value="True">
-                                                    <!-- Primary action: accent border + accent text + soft accent fill. -->
-                                                    <Setter Property="BorderBrush" Value="{StaticResource Severity.Info.Border}" />
-                                                    <Setter Property="Foreground" Value="{StaticResource Severity.Info}" />
-                                                    <Setter Property="Background" Value="{StaticResource Severity.Info.Bg}" />
+                                                    <!-- Primary action: accent border + accent text + soft accent fill.
+                                                         Colors flow from the toast's severity so an Err's "Retry" reads
+                                                         red, a Warn's primary action reads orange, etc — keeps the
+                                                         action visually anchored to the message it acts on. -->
+                                                    <Setter Property="BorderBrush" Value="{Binding Severity, Converter={StaticResource SevBrush}, ConverterParameter=Border}" />
+                                                    <Setter Property="Foreground" Value="{Binding Severity, Converter={StaticResource SevBrush}, ConverterParameter=Fg}" />
+                                                    <Setter Property="Background" Value="{Binding Severity, Converter={StaticResource SevBrush}, ConverterParameter=Bg}" />
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -164,7 +172,9 @@
                         Background="Transparent"
                         BorderThickness="0"
                         Cursor="Hand"
-                        ToolTip="Dismiss">
+                        ToolTip="Dismiss"
+                        AutomationProperties.AutomationId="{Binding Id, StringFormat='ToastDismiss_{0}'}"
+                        AutomationProperties.Name="Dismiss">
                     <Button.Template>
                         <ControlTemplate TargetType="Button">
                             <Border x:Name="Bd" Background="{TemplateBinding Background}" CornerRadius="4">

--- a/src/CodeScope.App/Toasts/ToastView.xaml.cs
+++ b/src/CodeScope.App/Toasts/ToastView.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace NoScope.CodeScope.App.Toasts;
+
+/// <summary>
+/// Single-toast surface. The host's MouseEnter / MouseLeave handles pause-on-hover for
+/// every toast in the stack at once (spec §04 "hover anywhere = pause every meter").
+/// </summary>
+public partial class ToastView : UserControl
+{
+    public ToastView()
+    {
+        InitializeComponent();
+        MouseEnter += (_, _) => (DataContext as ToastItemViewModel)?.Pause();
+        MouseLeave += (_, _) => (DataContext as ToastItemViewModel)?.Resume();
+    }
+}

--- a/src/CodeScope.App/Toasts/ToastView.xaml.cs
+++ b/src/CodeScope.App/Toasts/ToastView.xaml.cs
@@ -1,18 +1,16 @@
 using System.Windows.Controls;
-using System.Windows.Input;
 
 namespace NoScope.CodeScope.App.Toasts;
 
 /// <summary>
-/// Single-toast surface. The host's MouseEnter / MouseLeave handles pause-on-hover for
-/// every toast in the stack at once (spec §04 "hover anywhere = pause every meter").
+/// Single-toast surface. Hover-to-pause is handled at the <see cref="ToastHostView"/>
+/// level so a single MouseEnter pauses the meters of every visible toast (spec §04
+/// "hover anywhere = pause every meter") — see <see cref="ToastHostView"/>.
 /// </summary>
 public partial class ToastView : UserControl
 {
     public ToastView()
     {
         InitializeComponent();
-        MouseEnter += (_, _) => (DataContext as ToastItemViewModel)?.Pause();
-        MouseLeave += (_, _) => (DataContext as ToastItemViewModel)?.Resume();
     }
 }

--- a/src/CodeScope.App/UpdateService.cs
+++ b/src/CodeScope.App/UpdateService.cs
@@ -1,15 +1,14 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using NoScope.CodeScope.Ui.Services;
 using Velopack;
 using Velopack.Sources;
-using Wpf.Ui;
-using Wpf.Ui.Controls;
 
 namespace NoScope.CodeScope.App;
 
 /// <summary>
 /// Background updater backed by Velopack + GitHub releases (the same channel the release.yml
-/// workflow publishes to). On success it surfaces a non-blocking <see cref="ISnackbarService"/>
+/// workflow publishes to). On success it surfaces a non-blocking <see cref="IToastService"/>
 /// toast to signal that the update finished downloading, then later offers restart via a
 /// confirmation dialog. The check is best-effort — any exception (offline, rate-limited, not
 /// an installed build) is swallowed with a warning log.
@@ -21,12 +20,12 @@ public sealed class UpdateService
     private const string Channel = "win";
 
     private readonly ILogger<UpdateService> _logger;
-    private readonly ISnackbarService _snackbar;
+    private readonly IToastService _toasts;
 
-    public UpdateService(ILogger<UpdateService> logger, ISnackbarService snackbar)
+    public UpdateService(ILogger<UpdateService> logger, IToastService toasts)
     {
         _logger = logger;
-        _snackbar = snackbar;
+        _toasts = toasts;
     }
 
     /// <summary>
@@ -90,12 +89,12 @@ public sealed class UpdateService
             return;
         }
 
-        _snackbar.Show(
-            title: $"CodeScope {version} ready",
-            message: "Update downloaded — restart to install.",
-            appearance: ControlAppearance.Success,
-            icon: null,
-            timeout: System.TimeSpan.FromSeconds(10));
+        _toasts.Show(new ToastRequest(
+            ToastSeverity.Ok,
+            Title: $"CodeScope {version} ready",
+            Message: "Update downloaded — restart to install.",
+            Duration: System.TimeSpan.FromSeconds(10),
+            Id: "update-ready"));
 
         _ = System.Threading.Tasks.Task.Run(async () =>
         {

--- a/src/CodeScope.App/WorktreeStatusPoller.cs
+++ b/src/CodeScope.App/WorktreeStatusPoller.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using NoScope.CodeScope.Core.Models;
 using NoScope.CodeScope.Core.Services;
+using NoScope.CodeScope.Ui.Services;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -30,13 +31,19 @@ public sealed class WorktreeStatusPoller : BackgroundService
 
     private readonly ISessionStore _store;
     private readonly IGitService _git;
+    private readonly IToastService? _toasts;
     private readonly ILogger<WorktreeStatusPoller> _logger;
 
-    public WorktreeStatusPoller(ISessionStore store, IGitService git, ILogger<WorktreeStatusPoller> logger)
+    public WorktreeStatusPoller(
+        ISessionStore store,
+        IGitService git,
+        ILogger<WorktreeStatusPoller> logger,
+        IToastService? toasts = null)
     {
         _store = store;
         _git = git;
         _logger = logger;
+        _toasts = toasts;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -107,6 +114,15 @@ public sealed class WorktreeStatusPoller : BackgroundService
                             {
                                 _missingTicks.TryRemove(worktree.Id, out _);
                                 _states.TryRemove(worktree.Id, out _);
+                                // User-visible heads-up that the entry vanished — silent removal
+                                // is confusing when the sidebar count just changes by one without
+                                // any acknowledgment that "the folder you deleted is also gone here".
+                                var branchLabel = worktree.Branch ?? System.IO.Path.GetFileName(worktree.Path.TrimEnd('\\', '/'));
+                                _toasts?.Show(new ToastRequest(
+                                    ToastSeverity.Warn,
+                                    "Worktree removed",
+                                    $"'{branchLabel}' was pruned because its folder no longer exists.",
+                                    Id: $"prune-{worktree.Id}"));
                             }
                         }
                         catch (Exception ex)

--- a/src/CodeScope.App/WorktreeStatusPoller.cs
+++ b/src/CodeScope.App/WorktreeStatusPoller.cs
@@ -18,7 +18,15 @@ public sealed class WorktreeStatusPoller : BackgroundService
     private static readonly TimeSpan Cadence = TimeSpan.FromSeconds(3);
     private const int MaxSkipTicks = 15; // 3 s tick * (MaxSkipTicks + 1) ≈ 48 s cap
 
+    /// <summary>
+    /// Poll-tick threshold for treating a missing path as "user intentionally deleted
+    /// it" rather than a transient filesystem hiccup (network drive going away briefly,
+    /// AV moving a file). Two consecutive misses ≈ 6 s before the entry is dropped.
+    /// </summary>
+    private const int MissingPathTicksBeforePrune = 2;
+
     private readonly ConcurrentDictionary<string, PollBackoff<WorktreeStatus>> _states = new();
+    private readonly ConcurrentDictionary<string, int> _missingTicks = new();
 
     private readonly ISessionStore _store;
     private readonly IGitService _git;
@@ -74,8 +82,44 @@ public sealed class WorktreeStatusPoller : BackgroundService
                 if (ct.IsCancellationRequested) { return; }
                 if (string.IsNullOrWhiteSpace(worktree.Path) || !Directory.Exists(worktree.Path))
                 {
+                    // Path missing — likely deleted by the user outside the app. Wait
+                    // MissingPathTicksBeforePrune consecutive misses before removing
+                    // (Directory.Exists is reliable on Windows, but we still want a
+                    // small buffer for transient filesystem oddities). Primary worktrees
+                    // never auto-prune — their absence means the project itself is broken
+                    // and the user has to remove the project.
+                    if (worktree.IsPrimary) { continue; }
+
+                    var misses = _missingTicks.AddOrUpdate(worktree.Id, 1, (_, n) => n + 1);
+                    if (misses >= MissingPathTicksBeforePrune)
+                    {
+                        _logger.LogInformation(
+                            "Pruning worktree {Worktree} — path {Path} no longer exists ({Misses} misses)",
+                            worktree.Id, worktree.Path, misses);
+                        try
+                        {
+                            var pruned = await _store.PruneMissingWorktreeAsync(project.Id, worktree.Id, ct).ConfigureAwait(false);
+                            if (pruned.IsFailure)
+                            {
+                                _logger.LogWarning("Prune failed for {Worktree}: {Error}", worktree.Id, pruned.Error);
+                            }
+                            else
+                            {
+                                _missingTicks.TryRemove(worktree.Id, out _);
+                                _states.TryRemove(worktree.Id, out _);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, "Prune threw for {Worktree}", worktree.Id);
+                        }
+                    }
                     continue;
                 }
+
+                // Reset the miss counter once a poll sees the path again — covers the
+                // user re-creating the directory before we decide to prune.
+                _missingTicks.TryRemove(worktree.Id, out _);
 
                 var state = _states.GetOrAdd(worktree.Id, _ => new PollBackoff<WorktreeStatus>());
                 if (state.TicksUntilNextPoll > 0)

--- a/src/CodeScope.Core/Services/ISessionStore.cs
+++ b/src/CodeScope.Core/Services/ISessionStore.cs
@@ -59,6 +59,17 @@ public interface ISessionStore
     Task<Result<bool>> RemoveWorktreeAsync(string projectId, string worktreeId, bool force = false, CancellationToken ct = default);
 
     /// <summary>
+    /// Drops a worktree entry whose working directory is gone (user ran <c>rm -rf</c>
+    /// outside the app). Skips git's <c>worktree remove</c> entirely — git can't operate
+    /// on a path that no longer exists, and the .git/worktrees/&lt;name&gt; metadata is
+    /// harmless ghost data that <c>git worktree prune</c> sweeps the next time the user
+    /// runs anything under the project. Primary worktrees are rejected (their absence
+    /// means the whole project is broken; the user has to remove the project itself).
+    /// Cascades through <see cref="Session.WorktreeId"/> so orphaned sessions disappear too.
+    /// </summary>
+    Task<Result<bool>> PruneMissingWorktreeAsync(string projectId, string worktreeId, CancellationToken ct = default);
+
+    /// <summary>
     /// Runs <c>git worktree move</c> to relocate the worktree folder, then cascades the new path
     /// into every <see cref="Session.WorktreePath"/> referencing the moved worktree and persists.
     /// The worktree id is preserved. Primary worktrees are rejected.

--- a/src/CodeScope.Core/Services/SessionStore.cs
+++ b/src/CodeScope.Core/Services/SessionStore.cs
@@ -400,6 +400,44 @@ public sealed class SessionStore : ISessionStore
         return Result<bool>.Ok(true);
     }
 
+    public async Task<Result<bool>> PruneMissingWorktreeAsync(string projectId, string worktreeId, CancellationToken ct = default)
+    {
+        Project? project;
+        Worktree? worktree;
+        lock (_lock)
+        {
+            project = _projects.FirstOrDefault(p => p.Id == projectId);
+            worktree = project?.Worktrees.FirstOrDefault(w => w.Id == worktreeId);
+        }
+
+        if (project is null || worktree is null)
+        {
+            return Result<bool>.Fail("Project or worktree not found");
+        }
+        if (worktree.IsPrimary)
+        {
+            return Result<bool>.Fail("Primary worktrees cannot be pruned");
+        }
+
+        // Skip the git step intentionally — see XML doc on PruneMissingWorktreeAsync.
+        lock (_lock)
+        {
+            var idx = _projects.FindIndex(p => p.Id == projectId);
+            var p = _projects[idx];
+            _projects[idx] = p with
+            {
+                Worktrees = p.Worktrees.Where(w => w.Id != worktreeId).ToList(),
+                Sessions = p.Sessions.Where(s => s.WorktreeId != worktreeId).ToList(),
+            };
+        }
+
+        var saved = await SaveSnapshotAsync(ct).ConfigureAwait(false);
+        if (saved.IsFailure) { return saved; }
+
+        Raise(new SessionStoreChange.WorktreeRemoved(projectId, worktreeId));
+        return Result<bool>.Ok(true);
+    }
+
     public async Task<Result<Worktree>> RenameWorktreeAsync(string projectId, string worktreeId, string newWorktreePath, CancellationToken ct = default)
     {
         Project? project;

--- a/src/CodeScope.Core/Services/SessionStore.cs
+++ b/src/CodeScope.Core/Services/SessionStore.cs
@@ -420,19 +420,36 @@ public sealed class SessionStore : ISessionStore
         }
 
         // Skip the git step intentionally — see XML doc on PruneMissingWorktreeAsync.
+        // Mutate-then-persist with explicit rollback: keep a snapshot of the original
+        // Project record so a failed SaveSnapshotAsync (disk full, AV lock, anything
+        // weird) can put the in-memory store back exactly where it was. Without this,
+        // a save failure left the store inconsistent — UI would show the worktree as
+        // removed but the next reload would resurrect it from disk.
+        Project? rollbackProject = null;
+        int rollbackIndex = -1;
         lock (_lock)
         {
-            var idx = _projects.FindIndex(p => p.Id == projectId);
-            var p = _projects[idx];
-            _projects[idx] = p with
+            rollbackIndex = _projects.FindIndex(p => p.Id == projectId);
+            rollbackProject = _projects[rollbackIndex];
+            _projects[rollbackIndex] = rollbackProject with
             {
-                Worktrees = p.Worktrees.Where(w => w.Id != worktreeId).ToList(),
-                Sessions = p.Sessions.Where(s => s.WorktreeId != worktreeId).ToList(),
+                Worktrees = rollbackProject.Worktrees.Where(w => w.Id != worktreeId).ToList(),
+                Sessions = rollbackProject.Sessions.Where(s => s.WorktreeId != worktreeId).ToList(),
             };
         }
 
         var saved = await SaveSnapshotAsync(ct).ConfigureAwait(false);
-        if (saved.IsFailure) { return saved; }
+        if (saved.IsFailure)
+        {
+            lock (_lock)
+            {
+                if (rollbackIndex >= 0 && rollbackIndex < _projects.Count && rollbackProject is not null)
+                {
+                    _projects[rollbackIndex] = rollbackProject;
+                }
+            }
+            return saved;
+        }
 
         Raise(new SessionStoreChange.WorktreeRemoved(projectId, worktreeId));
         return Result<bool>.Ok(true);

--- a/src/CodeScope.Core/Services/SessionStore.cs
+++ b/src/CodeScope.Core/Services/SessionStore.cs
@@ -420,21 +420,23 @@ public sealed class SessionStore : ISessionStore
         }
 
         // Skip the git step intentionally — see XML doc on PruneMissingWorktreeAsync.
-        // Mutate-then-persist with explicit rollback: keep a snapshot of the original
-        // Project record so a failed SaveSnapshotAsync (disk full, AV lock, anything
-        // weird) can put the in-memory store back exactly where it was. Without this,
-        // a save failure left the store inconsistent — UI would show the worktree as
-        // removed but the next reload would resurrect it from disk.
-        Project? rollbackProject = null;
-        int rollbackIndex = -1;
+        // Mutate-then-persist with explicit *narrow* rollback: only re-add the pruned
+        // worktree + its sessions on failure, instead of restoring the entire Project
+        // record. Restoring the whole project would clobber any concurrent mutation
+        // (e.g. AddWorktreeAsync running in parallel) that landed during the await.
+        Worktree? rollbackWorktree = null;
+        List<Session> rollbackSessions = [];
         lock (_lock)
         {
-            rollbackIndex = _projects.FindIndex(p => p.Id == projectId);
-            rollbackProject = _projects[rollbackIndex];
-            _projects[rollbackIndex] = rollbackProject with
+            var idx = _projects.FindIndex(p => p.Id == projectId);
+            if (idx < 0) { return Result<bool>.Fail("Project disappeared mid-flight"); }
+            var p = _projects[idx];
+            rollbackWorktree = p.Worktrees.FirstOrDefault(w => w.Id == worktreeId);
+            rollbackSessions = [.. p.Sessions.Where(s => s.WorktreeId == worktreeId)];
+            _projects[idx] = p with
             {
-                Worktrees = rollbackProject.Worktrees.Where(w => w.Id != worktreeId).ToList(),
-                Sessions = rollbackProject.Sessions.Where(s => s.WorktreeId != worktreeId).ToList(),
+                Worktrees = p.Worktrees.Where(w => w.Id != worktreeId).ToList(),
+                Sessions = p.Sessions.Where(s => s.WorktreeId != worktreeId).ToList(),
             };
         }
 
@@ -443,9 +445,19 @@ public sealed class SessionStore : ISessionStore
         {
             lock (_lock)
             {
-                if (rollbackIndex >= 0 && rollbackIndex < _projects.Count && rollbackProject is not null)
+                var idx = _projects.FindIndex(p => p.Id == projectId);
+                if (idx >= 0 && rollbackWorktree is not null)
                 {
-                    _projects[rollbackIndex] = rollbackProject;
+                    var p = _projects[idx];
+                    // Re-attach iff still missing — a concurrent re-add would have
+                    // replaced it under a different reference; don't double-insert.
+                    var wts = p.Worktrees.Any(w => w.Id == worktreeId)
+                        ? p.Worktrees
+                        : [.. p.Worktrees, rollbackWorktree];
+                    var existingSessionIds = new HashSet<string>(p.Sessions.Select(s => s.Id));
+                    var sessions = p.Sessions.Concat(
+                        rollbackSessions.Where(s => !existingSessionIds.Contains(s.Id))).ToList();
+                    _projects[idx] = p with { Worktrees = wts, Sessions = sessions };
                 }
             }
             return saved;

--- a/src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml.cs
+++ b/src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml.cs
@@ -123,10 +123,22 @@ public partial class ConfirmDialog : Window
         Size size,
         Window? owner)
     {
-        var dlg = new ConfirmDialog(flavor, size, title, body, confirmLabel, cancelLabel, hint)
+        var dlg = new ConfirmDialog(flavor, size, title, body, confirmLabel, cancelLabel, hint);
+
+        // Resolve the owner *after* construction, never inside the object initializer:
+        //   a) WPF promotes the first shown Window to Application.Current.MainWindow.
+        //      During very-early-startup scenarios (e.g. the single-instance branch in
+        //      App.OnStartup, before the real MainWindow is shown) the only candidate
+        //      MainWindow becomes the dialog itself once ShowDialog runs — assigning
+        //      Owner = dlg throws "Cannot set Owner property to itself" and the app
+        //      exits silently with no user-visible message.
+        //   b) Setting Owner=null is invalid; keep it unassigned in that case.
+        var candidate = owner ?? Application.Current?.MainWindow;
+        if (candidate is not null && !ReferenceEquals(candidate, dlg))
         {
-            Owner = owner ?? Application.Current?.MainWindow,
-        };
+            dlg.Owner = candidate;
+        }
+
         return dlg.ShowDialog() == true;
     }
 

--- a/src/CodeScope.Ui/Services/IToastService.cs
+++ b/src/CodeScope.Ui/Services/IToastService.cs
@@ -1,0 +1,68 @@
+namespace NoScope.CodeScope.Ui.Services;
+
+/// <summary>
+/// Severity drives the toast's accent rail, icon, tinted backgrounds and
+/// auto-dismiss policy. Mirrors the four flavors in
+/// <c>docs/design/html/CodeScope - Errors and Toasts.html</c> (§03).
+/// </summary>
+public enum ToastSeverity
+{
+    Info = 0,
+    Ok = 1,
+    Warn = 2,
+    Err = 3,
+}
+
+/// <summary>
+/// One inline action button on a toast. Maximum two per toast (spec §02 callout 5).
+/// Click resolves before the toast auto-dismisses, so an async handler can finish its
+/// work before the row disappears.
+/// </summary>
+public sealed record ToastAction(string Label, Action Invoke, bool IsPrimary = false);
+
+/// <summary>
+/// One toast request. <see cref="Id"/> drives de-dupe — re-pushing the same id within
+/// the lifetime of a visible toast replaces it in place (spec §04 stack rules).
+/// <see cref="Duration"/> overrides the severity default (info/ok 4s · warn 8s ·
+/// err persistent); pass <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> for
+/// "never auto-dismiss".
+/// </summary>
+public sealed record ToastRequest(
+    ToastSeverity Severity,
+    string Title,
+    string? Message = null,
+    IReadOnlyList<ToastAction>? Actions = null,
+    string? Id = null,
+    TimeSpan? Duration = null);
+
+/// <summary>
+/// App-wide toast surface. Implementation lives in CodeScope.App and is hosted inside
+/// a <c>Popup</c> so it gets its own top-level HWND — that's the only way to render
+/// above the <c>Microsoft.Terminal.Wpf</c> HwndHost children that fill the workspace.
+/// Without the popup, toasts that overlap a terminal silently disappear behind it
+/// (classic WPF airspace).
+/// </summary>
+public interface IToastService
+{
+    /// <summary>Show a toast (or replace the existing one with the same id).</summary>
+    void Show(ToastRequest request);
+
+    /// <summary>Dismiss a toast by id. No-op if no toast with that id is visible.</summary>
+    void Dismiss(string id);
+}
+
+/// <summary>Convenience helpers so callers don't carry severity in every call.</summary>
+public static class ToastServiceExtensions
+{
+    public static void Info(this IToastService svc, string title, string? message = null, string? id = null)
+        => svc.Show(new ToastRequest(ToastSeverity.Info, title, message, Id: id));
+
+    public static void Ok(this IToastService svc, string title, string? message = null, string? id = null)
+        => svc.Show(new ToastRequest(ToastSeverity.Ok, title, message, Id: id));
+
+    public static void Warn(this IToastService svc, string title, string? message = null, string? id = null)
+        => svc.Show(new ToastRequest(ToastSeverity.Warn, title, message, Id: id));
+
+    public static void Err(this IToastService svc, string title, string? message = null, string? id = null)
+        => svc.Show(new ToastRequest(ToastSeverity.Err, title, message, Id: id));
+}

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -486,6 +486,12 @@ public sealed partial class MainViewModel : ObservableObject
             var stored = FindStoredSession(value);
             if (stored?.AgentSessionId is { Length: > 0 } sid) { _notifications.MarkSessionRead(sid); }
         }
+        // Sidebar selection follows the focused tab — when the user clicks a terminal
+        // in another split-group, the blue rail in the sidebar should jump to the
+        // worktree that owns that tab. Without this, sidebar selection got "stuck"
+        // on whatever the user last clicked in the tree even though their attention
+        // had moved to a tab in a different worktree.
+        SyncSidebarToTab(value);
         // Status dot is window-global: only the focused-group's selected tab gets Active;
         // every other tab (including selected tabs in other groups) drops to Idle unless
         // it's still waiting (Wait survives focus changes per top-bar spec §3).
@@ -1104,6 +1110,42 @@ public sealed partial class MainViewModel : ObservableObject
     /// </summary>
     private static bool AgentSupportsSessionId(AgentProfile? agent)
         => !string.IsNullOrEmpty(agent?.SessionIdFlag);
+
+    /// <summary>
+    /// Maps the focused tab back to the worktree row that owns it and updates the
+    /// sidebar's <see cref="SidebarViewModel.SelectedWorktree"/>. Prefers the stored
+    /// Session's <c>WorktreeId</c>; falls back to matching by <c>WorktreePath</c> for
+    /// pre-Phase 3 sessions and for transient tabs that haven't persisted yet (their
+    /// descriptor's <c>WorkingDirectory</c> is the same path).
+    /// </summary>
+    private void SyncSidebarToTab(SessionTabViewModel? tab)
+    {
+        if (tab is null || Sidebar is null) { return; }
+
+        WorktreeViewModel? match = null;
+        var stored = FindStoredSession(tab);
+        if (stored?.WorktreeId is { Length: > 0 } wid)
+        {
+            match = Sidebar.Projects
+                .SelectMany(p => p.Worktrees)
+                .FirstOrDefault(w => w.Id == wid);
+        }
+        if (match is null)
+        {
+            var path = stored?.WorktreePath ?? tab.Descriptor.WorkingDirectory;
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                match = Sidebar.Projects
+                    .SelectMany(p => p.Worktrees)
+                    .FirstOrDefault(w => string.Equals(w.Path, path, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        if (match is not null && !ReferenceEquals(Sidebar.SelectedWorktree, match))
+        {
+            Sidebar.SelectedWorktree = match;
+        }
+    }
 
     /// <summary>
     /// Walks the store for the persisted <see cref="Session"/> backing <paramref name="tab"/>.

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -1113,26 +1113,43 @@ public sealed partial class MainViewModel : ObservableObject
 
     /// <summary>
     /// Maps the focused tab back to the worktree row that owns it and updates the
-    /// sidebar's <see cref="SidebarViewModel.SelectedWorktree"/>. Prefers the stored
-    /// Session's <c>WorktreeId</c>; falls back to matching by <c>WorktreePath</c> for
-    /// pre-Phase 3 sessions and for transient tabs that haven't persisted yet (their
-    /// descriptor's <c>WorkingDirectory</c> is the same path).
+    /// sidebar's <see cref="SidebarViewModel.SelectedWorktree"/>. Worktree ids are NOT
+    /// globally unique (every project has a worktree literally called "primary"), so
+    /// we scope every lookup by the owning project — first by walking the store for
+    /// the project whose <c>Sessions</c> contains the tab's descriptor, then by the
+    /// worktree-path fallback for transient/pre-Phase 3 tabs.
     /// </summary>
     private void SyncSidebarToTab(SessionTabViewModel? tab)
     {
         if (tab is null || Sidebar is null) { return; }
 
         WorktreeViewModel? match = null;
-        var stored = FindStoredSession(tab);
-        if (stored?.WorktreeId is { Length: > 0 } wid)
+
+        // Authoritative path: find the project whose Sessions list owns this tab,
+        // then resolve the worktree inside that project's WorktreeViewModels.
+        foreach (var p in _store.Projects)
         {
-            match = Sidebar.Projects
-                .SelectMany(p => p.Worktrees)
-                .FirstOrDefault(w => w.Id == wid);
+            var session = p.Sessions.FirstOrDefault(s => s.Id == tab.Descriptor.Id);
+            if (session is null) { continue; }
+            var projVm = Sidebar.Projects.FirstOrDefault(pv => pv.Id == p.Id);
+            if (projVm is null) { break; }
+            if (session.WorktreeId is { Length: > 0 } wid)
+            {
+                match = projVm.Worktrees.FirstOrDefault(w => w.Id == wid);
+            }
+            if (match is null)
+            {
+                match = projVm.Worktrees.FirstOrDefault(w =>
+                    string.Equals(w.Path, session.WorktreePath, StringComparison.OrdinalIgnoreCase));
+            }
+            break;
         }
+
+        // Transient-tab fallback: no persisted Session yet, so match purely by the
+        // tab's working directory across every project's worktrees.
         if (match is null)
         {
-            var path = stored?.WorktreePath ?? tab.Descriptor.WorkingDirectory;
+            var path = tab.Descriptor.WorkingDirectory;
             if (!string.IsNullOrWhiteSpace(path))
             {
                 match = Sidebar.Projects

--- a/src/CodeScope.Ui/ViewModels/ProjectViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/ProjectViewModel.cs
@@ -55,10 +55,12 @@ public sealed partial class ProjectViewModel : ObservableObject
     /// </summary>
     public string AutomationId => $"Project_{SafeToken(Name)}";
 
-    private static string SafeToken(string s)
-        => string.IsNullOrWhiteSpace(s)
-            ? "unknown"
-            : new string([.. s.Select(c => char.IsLetterOrDigit(c) ? c : '_')]).Trim('_');
+    private static string SafeToken(string? s)
+    {
+        if (string.IsNullOrWhiteSpace(s)) { return "unknown"; }
+        var token = new string([.. s.Select(c => char.IsLetterOrDigit(c) ? c : '_')]).Trim('_');
+        return string.IsNullOrEmpty(token) ? "unknown" : token;
+    }
 
     public string? DefaultAgentId => Project.DefaultAgentId;
 

--- a/src/CodeScope.Ui/ViewModels/ProjectViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/ProjectViewModel.cs
@@ -47,6 +47,19 @@ public sealed partial class ProjectViewModel : ObservableObject
 
     public string Path => Project.Path;
 
+    /// <summary>
+    /// Stable, human-readable id for UIA automation. Composed off <see cref="Name"/>
+    /// rather than the project guid so wpf-cli snapshots show e.g. <c>a:Project_codescope</c>
+    /// instead of an opaque hash. Whitespace/punctuation collapse to underscores so
+    /// the value is safe to use as a ref token.
+    /// </summary>
+    public string AutomationId => $"Project_{SafeToken(Name)}";
+
+    private static string SafeToken(string s)
+        => string.IsNullOrWhiteSpace(s)
+            ? "unknown"
+            : new string([.. s.Select(c => char.IsLetterOrDigit(c) ? c : '_')]).Trim('_');
+
     public string? DefaultAgentId => Project.DefaultAgentId;
 
     public string DefaultBranch => string.IsNullOrWhiteSpace(Project.DefaultBranch) ? "main" : Project.DefaultBranch;

--- a/src/CodeScope.Ui/ViewModels/SessionTabViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/SessionTabViewModel.cs
@@ -83,6 +83,23 @@ public sealed partial class SessionTabViewModel : ObservableObject
     /// <summary>Alias kept for XAML bindings that reference Title (e.g. window chrome).</summary>
     public string Title => DisplayName;
 
-    partial void OnDisplayNameChanged(string value) => OnPropertyChanged(nameof(Title));
+    /// <summary>
+    /// Stable, human-readable id for UIA automation. Falls back to the descriptor's
+    /// session id when DisplayName is empty so a:Tab_* always resolves. Wpf-cli
+    /// snapshots will show e.g. <c>a:Tab_main</c> instead of the VM type name.
+    /// </summary>
+    public string AutomationId
+        => $"Tab_{(string.IsNullOrWhiteSpace(DisplayName) ? Descriptor.Id : SafeToken(DisplayName))}";
+
+    private static string SafeToken(string s)
+        => string.IsNullOrWhiteSpace(s)
+            ? "unknown"
+            : new string([.. s.Select(c => char.IsLetterOrDigit(c) ? c : '_')]).Trim('_');
+
+    partial void OnDisplayNameChanged(string value)
+    {
+        OnPropertyChanged(nameof(Title));
+        OnPropertyChanged(nameof(AutomationId));
+    }
 }
 

--- a/src/CodeScope.Ui/ViewModels/SessionTabViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/SessionTabViewModel.cs
@@ -89,12 +89,14 @@ public sealed partial class SessionTabViewModel : ObservableObject
     /// snapshots will show e.g. <c>a:Tab_main</c> instead of the VM type name.
     /// </summary>
     public string AutomationId
-        => $"Tab_{(string.IsNullOrWhiteSpace(DisplayName) ? Descriptor.Id : SafeToken(DisplayName))}";
+        => $"Tab_{SafeToken(string.IsNullOrWhiteSpace(DisplayName) ? Descriptor.Id : DisplayName)}";
 
-    private static string SafeToken(string s)
-        => string.IsNullOrWhiteSpace(s)
-            ? "unknown"
-            : new string([.. s.Select(c => char.IsLetterOrDigit(c) ? c : '_')]).Trim('_');
+    private static string SafeToken(string? s)
+    {
+        if (string.IsNullOrWhiteSpace(s)) { return "unknown"; }
+        var token = new string([.. s.Select(c => char.IsLetterOrDigit(c) ? c : '_')]).Trim('_');
+        return string.IsNullOrEmpty(token) ? "unknown" : token;
+    }
 
     partial void OnDisplayNameChanged(string value)
     {

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
@@ -120,7 +120,7 @@ public sealed partial class SidebarViewModel
         else
         {
             _logger.LogDebug("Fetch failed: {Error}", r.Error);
-            ErrToast("Fetch failed", r.Error, retry: () => _ = FetchAllAsync(project));
+            ErrToast("Fetch failed", r.Error, retry: () => FetchAllAsync(project));
         }
     }
 
@@ -136,7 +136,7 @@ public sealed partial class SidebarViewModel
         else
         {
             _logger.LogDebug("Pull failed: {Error}", r.Error);
-            ErrToast("Pull failed", r.Error, retry: () => _ = PullAsync(worktree));
+            ErrToast("Pull failed", r.Error, retry: () => PullAsync(worktree));
         }
     }
 
@@ -314,7 +314,7 @@ public sealed partial class SidebarViewModel
         {
             _logger.LogWarning("CreatePR failed: {Error}", result.Error);
             ErrToast("Create pull request failed", result.Error,
-                retry: () => _ = CreatePullRequestAsync(worktree));
+                retry: () => CreatePullRequestAsync(worktree));
             return;
         }
 

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
@@ -120,7 +120,7 @@ public sealed partial class SidebarViewModel
         else
         {
             _logger.LogDebug("Fetch failed: {Error}", r.Error);
-            Toast("Fetch failed", r.Error, ToastSeverity.Err);
+            ErrToast("Fetch failed", r.Error, retry: () => _ = FetchAllAsync(project));
         }
     }
 
@@ -136,7 +136,7 @@ public sealed partial class SidebarViewModel
         else
         {
             _logger.LogDebug("Pull failed: {Error}", r.Error);
-            Toast("Pull failed", r.Error, ToastSeverity.Err);
+            ErrToast("Pull failed", r.Error, retry: () => _ = PullAsync(worktree));
         }
     }
 
@@ -162,7 +162,9 @@ public sealed partial class SidebarViewModel
         else
         {
             _logger.LogWarning("Rebase failed: {Error}", r.Error);
-            Toast("Rebase failed or has conflicts", r.Error, ToastSeverity.Err);
+            // Rebase failure usually means conflicts the user has to resolve manually,
+            // so a blind retry would re-fail. Copy-only is the right affordance here.
+            ErrToast("Rebase failed or has conflicts", r.Error);
         }
     }
 
@@ -184,7 +186,7 @@ public sealed partial class SidebarViewModel
         else
         {
             _logger.LogWarning("DiscardChanges failed: {Error}", r.Error);
-            Toast("Discard failed", r.Error, ToastSeverity.Err);
+            ErrToast("Discard failed", r.Error);
         }
     }
 
@@ -311,7 +313,8 @@ public sealed partial class SidebarViewModel
         if (result.IsFailure)
         {
             _logger.LogWarning("CreatePR failed: {Error}", result.Error);
-            Toast("Create pull request failed", result.Error, ToastSeverity.Err);
+            ErrToast("Create pull request failed", result.Error,
+                retry: () => _ = CreatePullRequestAsync(worktree));
             return;
         }
 
@@ -338,7 +341,7 @@ public sealed partial class SidebarViewModel
         var parent = System.IO.Path.GetDirectoryName(worktree.Path.TrimEnd('\\', '/'));
         if (string.IsNullOrWhiteSpace(parent))
         {
-            Toast("Rename failed", "Could not determine parent folder", ToastSeverity.Err);
+            ErrToast("Rename failed", "Could not determine parent folder");
             return;
         }
         var newPath = System.IO.Path.Combine(parent, newLeaf);
@@ -351,7 +354,7 @@ public sealed partial class SidebarViewModel
         else
         {
             _logger.LogWarning("RenameWorktree failed: {Error}", r.Error);
-            Toast("Rename failed", r.Error, ToastSeverity.Err);
+            ErrToast("Rename failed", r.Error);
         }
     }
 
@@ -400,7 +403,7 @@ public sealed partial class SidebarViewModel
         if (!retry)
         {
             await InvokeRollbackAsync(rollback).ConfigureAwait(true);
-            Toast("Remove failed", r.Error, ToastSeverity.Err);
+            ErrToast("Remove failed", r.Error);
             return;
         }
 
@@ -413,7 +416,7 @@ public sealed partial class SidebarViewModel
         {
             _logger.LogWarning("Force RemoveWorktree failed: {Error}", forced.Error);
             await InvokeRollbackAsync(rollback).ConfigureAwait(true);
-            Toast("Remove failed", forced.Error, ToastSeverity.Err);
+            ErrToast("Remove failed", forced.Error);
         }
     }
 

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
@@ -1,7 +1,7 @@
 using NoScope.CodeScope.Core.Models;
+using NoScope.CodeScope.Ui.Services;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
-using Wpf.Ui.Controls;
 
 namespace NoScope.CodeScope.Ui.ViewModels;
 
@@ -30,7 +30,7 @@ public sealed partial class SidebarViewModel
         var r = await _store.AddProjectAsync(folder, displayName: null).ConfigureAwait(true);
         if (r.IsSuccess)
         {
-            Toast("Project added", r.Value.Name, ControlAppearance.Success);
+            Toast("Project added", r.Value.Name, ToastSeverity.Ok);
         }
         else
         {
@@ -105,7 +105,7 @@ public sealed partial class SidebarViewModel
         var label = string.IsNullOrEmpty(request.AgentId)
             ? "(global default)"
             : request.AgentId;
-        Toast("Default agent updated", $"{request.Project.Name} → {label}", ControlAppearance.Info);
+        Toast("Default agent updated", $"{request.Project.Name} → {label}", ToastSeverity.Info);
     }
 
     [RelayCommand]
@@ -115,12 +115,12 @@ public sealed partial class SidebarViewModel
         var r = await _git.FetchAllAsync(project.Path).ConfigureAwait(true);
         if (r.IsSuccess)
         {
-            Toast("Fetch complete", project.Name, ControlAppearance.Success);
+            Toast("Fetch complete", project.Name, ToastSeverity.Ok);
         }
         else
         {
             _logger.LogDebug("Fetch failed: {Error}", r.Error);
-            Toast("Fetch failed", r.Error, ControlAppearance.Danger);
+            Toast("Fetch failed", r.Error, ToastSeverity.Err);
         }
     }
 
@@ -131,12 +131,12 @@ public sealed partial class SidebarViewModel
         var r = await _git.PullAsync(worktree.Path).ConfigureAwait(true);
         if (r.IsSuccess)
         {
-            Toast("Pull complete", $"{worktree.DisplayBranch} fast-forwarded", ControlAppearance.Success);
+            Toast("Pull complete", $"{worktree.DisplayBranch} fast-forwarded", ToastSeverity.Ok);
         }
         else
         {
             _logger.LogDebug("Pull failed: {Error}", r.Error);
-            Toast("Pull failed", r.Error, ControlAppearance.Danger);
+            Toast("Pull failed", r.Error, ToastSeverity.Err);
         }
     }
 
@@ -157,12 +157,12 @@ public sealed partial class SidebarViewModel
         var r = await _git.RebaseOntoAsync(worktree.Path, baseRef).ConfigureAwait(true);
         if (r.IsSuccess)
         {
-            Toast("Rebase complete", $"{worktree.DisplayBranch} ↻ {baseRef}", ControlAppearance.Success);
+            Toast("Rebase complete", $"{worktree.DisplayBranch} ↻ {baseRef}", ToastSeverity.Ok);
         }
         else
         {
             _logger.LogWarning("Rebase failed: {Error}", r.Error);
-            Toast("Rebase failed or has conflicts", r.Error, ControlAppearance.Danger);
+            Toast("Rebase failed or has conflicts", r.Error, ToastSeverity.Err);
         }
     }
 
@@ -179,12 +179,12 @@ public sealed partial class SidebarViewModel
         var r = await _git.DiscardChangesAsync(worktree.Path).ConfigureAwait(true);
         if (r.IsSuccess)
         {
-            Toast("Changes discarded", worktree.DisplayBranch, ControlAppearance.Success);
+            Toast("Changes discarded", worktree.DisplayBranch, ToastSeverity.Ok);
         }
         else
         {
             _logger.LogWarning("DiscardChanges failed: {Error}", r.Error);
-            Toast("Discard failed", r.Error, ControlAppearance.Danger);
+            Toast("Discard failed", r.Error, ToastSeverity.Err);
         }
     }
 
@@ -214,7 +214,7 @@ public sealed partial class SidebarViewModel
         try
         {
             System.Windows.Clipboard.SetText(path);
-            Toast("Path copied", path, ControlAppearance.Info);
+            Toast("Path copied", path, ToastSeverity.Info);
         }
         catch (Exception ex)
         {
@@ -262,7 +262,7 @@ public sealed partial class SidebarViewModel
         try
         {
             System.Windows.Clipboard.SetText(branch);
-            Toast("Branch copied", branch, ControlAppearance.Info);
+            Toast("Branch copied", branch, ToastSeverity.Info);
         }
         catch (Exception ex)
         {
@@ -278,7 +278,7 @@ public sealed partial class SidebarViewModel
         try
         {
             System.Windows.Clipboard.SetText(url);
-            Toast("PR URL copied", url, ControlAppearance.Info);
+            Toast("PR URL copied", url, ToastSeverity.Info);
         }
         catch (Exception ex)
         {
@@ -311,7 +311,7 @@ public sealed partial class SidebarViewModel
         if (result.IsFailure)
         {
             _logger.LogWarning("CreatePR failed: {Error}", result.Error);
-            Toast("Create pull request failed", result.Error, ControlAppearance.Danger);
+            Toast("Create pull request failed", result.Error, ToastSeverity.Err);
             return;
         }
 
@@ -320,7 +320,7 @@ public sealed partial class SidebarViewModel
         Toast(
             pr.Number > 0 ? $"Pull request #{pr.Number} created" : "Pull request created",
             $"{project.Name} · {worktree.DisplayBranch}",
-            ControlAppearance.Success);
+            ToastSeverity.Ok);
     }
 
     [RelayCommand]
@@ -338,7 +338,7 @@ public sealed partial class SidebarViewModel
         var parent = System.IO.Path.GetDirectoryName(worktree.Path.TrimEnd('\\', '/'));
         if (string.IsNullOrWhiteSpace(parent))
         {
-            Toast("Rename failed", "Could not determine parent folder", ControlAppearance.Danger);
+            Toast("Rename failed", "Could not determine parent folder", ToastSeverity.Err);
             return;
         }
         var newPath = System.IO.Path.Combine(parent, newLeaf);
@@ -346,12 +346,12 @@ public sealed partial class SidebarViewModel
         var r = await _store.RenameWorktreeAsync(worktree.ProjectId, worktree.Id, newPath).ConfigureAwait(true);
         if (r.IsSuccess)
         {
-            Toast("Worktree renamed", $"{currentLeaf} → {newLeaf}", ControlAppearance.Success);
+            Toast("Worktree renamed", $"{currentLeaf} → {newLeaf}", ToastSeverity.Ok);
         }
         else
         {
             _logger.LogWarning("RenameWorktree failed: {Error}", r.Error);
-            Toast("Rename failed", r.Error, ControlAppearance.Danger);
+            Toast("Rename failed", r.Error, ToastSeverity.Err);
         }
     }
 
@@ -384,7 +384,7 @@ public sealed partial class SidebarViewModel
         var r = await _store.RemoveWorktreeAsync(worktree.ProjectId, worktree.Id).ConfigureAwait(true);
         if (r.IsSuccess)
         {
-            Toast("Worktree removed", worktree.DisplayBranch, ControlAppearance.Success);
+            Toast("Worktree removed", worktree.DisplayBranch, ToastSeverity.Ok);
             return;
         }
 
@@ -400,20 +400,20 @@ public sealed partial class SidebarViewModel
         if (!retry)
         {
             await InvokeRollbackAsync(rollback).ConfigureAwait(true);
-            Toast("Remove failed", r.Error, ControlAppearance.Danger);
+            Toast("Remove failed", r.Error, ToastSeverity.Err);
             return;
         }
 
         var forced = await _store.RemoveWorktreeAsync(worktree.ProjectId, worktree.Id, force: true).ConfigureAwait(true);
         if (forced.IsSuccess)
         {
-            Toast("Worktree force-removed", worktree.DisplayBranch, ControlAppearance.Success);
+            Toast("Worktree force-removed", worktree.DisplayBranch, ToastSeverity.Ok);
         }
         else
         {
             _logger.LogWarning("Force RemoveWorktree failed: {Error}", forced.Error);
             await InvokeRollbackAsync(rollback).ConfigureAwait(true);
-            Toast("Remove failed", forced.Error, ControlAppearance.Danger);
+            Toast("Remove failed", forced.Error, ToastSeverity.Err);
         }
     }
 

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.StoreSync.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.StoreSync.cs
@@ -1,7 +1,7 @@
 using System.Windows;
 using NoScope.CodeScope.Core.Models;
 using NoScope.CodeScope.Core.Services;
-using Wpf.Ui.Controls;
+using NoScope.CodeScope.Ui.Services;
 
 namespace NoScope.CodeScope.Ui.ViewModels;
 
@@ -171,10 +171,10 @@ public sealed partial class SidebarViewModel
         switch (pr.CiStatus)
         {
             case CiStatus.Success:
-                Toast($"CI passed on #{pr.Number}", label, ControlAppearance.Success);
+                Toast($"CI passed on #{pr.Number}", label, ToastSeverity.Ok);
                 break;
             case CiStatus.Failure:
-                Toast($"CI failed on #{pr.Number}", label, ControlAppearance.Danger);
+                Toast($"CI failed on #{pr.Number}", label, ToastSeverity.Err);
                 break;
         }
     }

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
@@ -3,9 +3,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using NoScope.CodeScope.Core.Models;
 using NoScope.CodeScope.Core.Services;
 using NoScope.CodeScope.Ui.Dialogs;
+using NoScope.CodeScope.Ui.Services;
 using Microsoft.Extensions.Logging;
-using Wpf.Ui;
-using Wpf.Ui.Controls;
 
 namespace NoScope.CodeScope.Ui.ViewModels;
 
@@ -21,7 +20,7 @@ public sealed partial class SidebarViewModel : ObservableObject
 {
     private readonly ISessionStore _store;
     private readonly IPullRequestService? _pullRequests;
-    private readonly ISnackbarService? _snackbar;
+    private readonly IToastService? _toasts;
     private readonly IAgentRegistry? _agents;
     private readonly IGitService? _git;
     private readonly ILogger<SidebarViewModel> _logger;
@@ -34,13 +33,13 @@ public sealed partial class SidebarViewModel : ObservableObject
         Func<string?>? pickFolder = null,
         Func<NewWorktreeRequest, NewWorktreeResult?>? pickNewWorktree = null,
         IPullRequestService? pullRequests = null,
-        ISnackbarService? snackbar = null,
+        IToastService? toasts = null,
         IAgentRegistry? agents = null,
         IGitService? git = null)
     {
         _store = store;
         _pullRequests = pullRequests;
-        _snackbar = snackbar;
+        _toasts = toasts;
         _agents = agents;
         _git = git;
         _logger = logger;
@@ -109,9 +108,9 @@ public sealed partial class SidebarViewModel : ObservableObject
     /// </summary>
     public Func<string, string, Task<Func<Task>>>? CloseWorktreeSessionsAsync { get; set; }
 
-    private void Toast(string title, string message, ControlAppearance appearance)
+    private void Toast(string title, string message, ToastSeverity severity)
     {
-        if (_snackbar is null) { return; }
-        _snackbar.Show(title, message, appearance, icon: null, TimeSpan.FromSeconds(4));
+        if (_toasts is null) { return; }
+        _toasts.Show(new ToastRequest(severity, title, message));
     }
 }

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
@@ -113,4 +113,26 @@ public sealed partial class SidebarViewModel : ObservableObject
         if (_toasts is null) { return; }
         _toasts.Show(new ToastRequest(severity, title, message));
     }
+
+    /// <summary>
+    /// Variant that accepts inline actions (e.g. Retry / Copy). Errors get a Copy
+    /// action by default — the message is usually the raw stderr from git/gh which
+    /// the user wants to paste into a bug report or chat. Pass <paramref name="retry"/>
+    /// to add a primary "Retry" button that re-runs the failed command.
+    /// </summary>
+    private void ErrToast(string title, string message, Action? retry = null)
+    {
+        if (_toasts is null) { return; }
+        var actions = new List<ToastAction>(2);
+        if (retry is not null)
+        {
+            actions.Add(new ToastAction("Retry", retry, IsPrimary: true));
+        }
+        actions.Add(new ToastAction("Copy", () =>
+        {
+            try { System.Windows.Clipboard.SetText(message); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Toast copy failed"); }
+        }));
+        _toasts.Show(new ToastRequest(ToastSeverity.Err, title, message, Actions: actions));
+    }
 }

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
@@ -118,15 +118,21 @@ public sealed partial class SidebarViewModel : ObservableObject
     /// Variant that accepts inline actions (e.g. Retry / Copy). Errors get a Copy
     /// action by default — the message is usually the raw stderr from git/gh which
     /// the user wants to paste into a bug report or chat. Pass <paramref name="retry"/>
-    /// to add a primary "Retry" button that re-runs the failed command.
+    /// to add a primary "Retry" button that re-runs the failed command. The retry
+    /// task is awaited inside a try/catch so a thrown retry doesn't disappear into a
+    /// fire-and-forget — without this wrapper, callers had to remember to do
+    /// <c>_ = SomeAsync()</c> and any thrown exception was lost on the floor.
     /// </summary>
-    private void ErrToast(string title, string message, Action? retry = null)
+    private void ErrToast(string title, string message, Func<Task>? retry = null)
     {
         if (_toasts is null) { return; }
         var actions = new List<ToastAction>(2);
         if (retry is not null)
         {
-            actions.Add(new ToastAction("Retry", retry, IsPrimary: true));
+            actions.Add(new ToastAction("Retry", () =>
+            {
+                _ = RunRetryAsync(retry, title);
+            }, IsPrimary: true));
         }
         actions.Add(new ToastAction("Copy", () =>
         {
@@ -134,5 +140,20 @@ public sealed partial class SidebarViewModel : ObservableObject
             catch (Exception ex) { _logger.LogDebug(ex, "Toast copy failed"); }
         }));
         _toasts.Show(new ToastRequest(ToastSeverity.Err, title, message, Actions: actions));
+    }
+
+    private async Task RunRetryAsync(Func<Task> retry, string label)
+    {
+        try { await retry().ConfigureAwait(true); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Retry of {Label} threw", label);
+            // Surface the failure so the user knows the retry itself died — silent
+            // task faults inside a "Retry" button are the worst kind of UX bug.
+            _toasts?.Show(new ToastRequest(
+                ToastSeverity.Err,
+                $"{label}: retry failed",
+                ex.Message));
+        }
     }
 }

--- a/src/CodeScope.Ui/ViewModels/WorktreeViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/WorktreeViewModel.cs
@@ -198,6 +198,10 @@ public sealed partial class WorktreeViewModel : ObservableObject
         Worktree = worktree;
         OnPropertyChanged(nameof(DisplayBranch));
         OnPropertyChanged(nameof(Path));
+        // AutomationId is derived from DisplayBranch — a rename invalidates any wpf-cli
+        // ref that resolved to the old token, so notify or the test layer keeps pointing
+        // at a stale slug until something else triggers a snapshot.
+        OnPropertyChanged(nameof(AutomationId));
     }
 
     /// <summary>Applies a refreshed <see cref="NoScope.CodeScope.Core.Models.WorktreeStatus"/> from the poller.</summary>
@@ -213,6 +217,7 @@ public sealed partial class WorktreeViewModel : ObservableObject
         {
             Worktree = Worktree with { Branch = b };
             OnPropertyChanged(nameof(DisplayBranch));
+            OnPropertyChanged(nameof(AutomationId));
         }
         OnPropertyChanged(nameof(DirtyGlyph));
         OnPropertyChanged(nameof(AheadBehindText));

--- a/src/CodeScope.Ui/ViewModels/WorktreeViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/WorktreeViewModel.cs
@@ -56,9 +56,11 @@ public sealed partial class WorktreeViewModel : ObservableObject
         => $"Worktree_{SafeToken(ProjectId)}__{SafeToken(DisplayBranch)}";
 
     private static string SafeToken(string? s)
-        => string.IsNullOrWhiteSpace(s)
-            ? "unknown"
-            : new string([.. s.Select(c => char.IsLetterOrDigit(c) ? c : '_')]).Trim('_');
+    {
+        if (string.IsNullOrWhiteSpace(s)) { return "unknown"; }
+        var token = new string([.. s.Select(c => char.IsLetterOrDigit(c) ? c : '_')]).Trim('_');
+        return string.IsNullOrEmpty(token) ? "unknown" : token;
+    }
 
     public ObservableCollection<SessionTabViewModel> Sessions { get; }
 

--- a/src/CodeScope.Ui/ViewModels/WorktreeViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/WorktreeViewModel.cs
@@ -47,6 +47,19 @@ public sealed partial class WorktreeViewModel : ObservableObject
 
     public string DisplayBranch => Worktree.Branch ?? (Worktree.IsPrimary ? "main" : "(no branch)");
 
+    /// <summary>
+    /// Stable, human-readable id for UIA automation. Combines project id with the
+    /// branch name so two worktrees in different projects on the same branch don't
+    /// collide. Wpf-cli snapshots will show e.g. <c>a:Worktree_codescope__main</c>.
+    /// </summary>
+    public string AutomationId
+        => $"Worktree_{SafeToken(ProjectId)}__{SafeToken(DisplayBranch)}";
+
+    private static string SafeToken(string? s)
+        => string.IsNullOrWhiteSpace(s)
+            ? "unknown"
+            : new string([.. s.Select(c => char.IsLetterOrDigit(c) ? c : '_')]).Trim('_');
+
     public ObservableCollection<SessionTabViewModel> Sessions { get; }
 
     [ObservableProperty]

--- a/src/CodeScope.Ui/Views/EditorGroupView.xaml
+++ b/src/CodeScope.Ui/Views/EditorGroupView.xaml
@@ -24,7 +24,8 @@
         AllowDrop="True"
         DragOver="OnStripDragOver"
         Drop="OnStripDrop"
-        PreviewMouseDown="OnGroupPreviewMouseDown">
+        PreviewMouseDown="OnGroupPreviewMouseDown"
+        GotKeyboardFocus="OnGroupGotKeyboardFocus">
         <Grid>
             <!-- Top accent rail, visible only when this group is focused — a subtle cue
                  since the window-global strip already shows the focused group's tabs. -->
@@ -49,6 +50,9 @@
                 <ItemsControl.ItemContainerStyle>
                     <Style TargetType="ContentPresenter">
                         <Setter Property="Visibility" Value="Collapsed" />
+                        <!-- Mirrors the tab strip's item id so a tab and its workspace pane
+                             resolve to the same a:Tab_* ref under different parents. -->
+                        <Setter Property="AutomationProperties.AutomationId" Value="{Binding AutomationId}" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsActive}" Value="True">
                                 <Setter Property="Visibility" Value="Visible" />

--- a/src/CodeScope.Ui/Views/EditorGroupView.xaml.cs
+++ b/src/CodeScope.Ui/Views/EditorGroupView.xaml.cs
@@ -44,6 +44,24 @@ public partial class EditorGroupView : UserControl
     /// <summary>Any mouse-down in this group transfers focus to it so the global strip flips.</summary>
     private void OnGroupPreviewMouseDown(object sender, MouseButtonEventArgs e)
     {
+        FocusOwningGroup();
+    }
+
+    /// <summary>
+    /// Backstop for clicks that land inside the terminal's <c>HwndHost</c> child — those
+    /// clicks never reach <see cref="OnGroupPreviewMouseDown"/> because the native window
+    /// captures the mouse message before WPF's input system sees it. They DO move keyboard
+    /// focus into the HwndHost, however, and WPF raises <c>GotKeyboardFocus</c> on every
+    /// ancestor up the visual tree — including this UserControl. So whenever any element
+    /// inside this group acquires keyboard focus, flip the focused group.
+    /// </summary>
+    private void OnGroupGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+    {
+        FocusOwningGroup();
+    }
+
+    private void FocusOwningGroup()
+    {
         if (DataContext is not EditorGroupViewModel group) { return; }
         if (Application.Current?.MainWindow?.DataContext is not MainViewModel main) { return; }
         if (ReferenceEquals(main.FocusedGroup, group)) { return; }

--- a/src/CodeScope.Ui/Views/GroupStripView.xaml
+++ b/src/CodeScope.Ui/Views/GroupStripView.xaml
@@ -62,6 +62,9 @@
                                 <Setter Property="MinWidth" Value="140" />
                                 <Setter Property="MaxWidth" Value="280" />
                                 <Setter Property="VerticalContentAlignment" Value="Stretch" />
+                                <!-- SessionTabViewModel.AutomationId — wpf-cli snapshots
+                                     resolve to a:Tab_<displayName> instead of the VM type. -->
+                                <Setter Property="AutomationProperties.AutomationId" Value="{Binding AutomationId}" />
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="ListBoxItem">

--- a/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
@@ -89,10 +89,7 @@ public partial class SessionTabView : UserControl
             e.Handled = true;
             var text = TryGetClipboardText();
             if (string.IsNullOrEmpty(text)) { return; }
-            // Each CR is one Enter to the shell. \r\n would emit a blank line between
-            // every pasted line; collapse to a single \r per line.
-            var normalised = text.Replace("\r\n", "\r").Replace("\n", "\r");
-            Terminal.ConPTYTerm?.WriteToTerm(normalised.AsSpan());
+            BracketedPaste(text);
         }
         else if (e.Key == Key.O && shift)
         {
@@ -125,6 +122,41 @@ public partial class SessionTabView : UserControl
         }
     }
 
+
+    /// <summary>
+    /// Emit a bracketed-paste sequence (xterm DEC: <c>ESC[200~ … ESC[201~</c>) so the
+    /// receiving program can recognise the chunk as a single paste event instead of
+    /// per-line keystrokes.
+    ///
+    /// <para>Why bracketed paste instead of normalising newlines to a single <c>\r</c>:
+    /// the older approach (collapse <c>\r\n</c> → <c>\r</c>) makes multi-line pastes work
+    /// for plain pwsh/bash by emitting one Enter per line — but every Enter submits the
+    /// current line. That's the right thing for a shell building a multi-line command,
+    /// but the wrong thing for full-screen TUIs like Claude Code or Codex where the
+    /// user wants the paste to land in the editor as a single multi-line message and
+    /// hit "send" only when they explicitly press Enter. Bracketed paste mode is the
+    /// xterm-standard way to express "this is one paste event, please don't treat
+    /// embedded newlines as Enter": modern PSReadLine, GNU readline, fish, claude
+    /// code, codex, etc. all enable it (they send <c>ESC[?2004h</c> on init) and route
+    /// bracketed text into their input buffer rather than the line-submit path.</para>
+    ///
+    /// <para>Newlines inside the bracket are kept as <c>\r</c> (a paste-mode-aware
+    /// receiver normalises this internally; raw cmd.exe — which does NOT enable
+    /// bracketed paste — would see the literal <c>200~…201~</c> as junk, but raw
+    /// cmd.exe is a vanishingly rare paste target in this app).</para>
+    /// </summary>
+    private void BracketedPaste(string text)
+    {
+        // Normalise to \r so any TUI that doesn't strip \r\n itself doesn't see
+        // double line breaks. Bracketed-paste-aware programs do their own
+        // normalisation; this is just a defensive prep.
+        var normalised = text.Replace("\r\n", "\r").Replace("\n", "\r");
+        var pty = Terminal.ConPTYTerm;
+        if (pty is null) { return; }
+        pty.WriteToTerm("\x1b[200~".AsSpan());
+        pty.WriteToTerm(normalised.AsSpan());
+        pty.WriteToTerm("\x1b[201~".AsSpan());
+    }
 
     private static void TrySetClipboard(string text)
     {

--- a/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
@@ -78,11 +78,21 @@ public partial class SessionTabView : UserControl
         }
         else if (e.Key == Key.V)
         {
+            // ALWAYS mark the key handled — even when our paste finds no text. With
+            // Win32InputMode=True, the inner terminal still processes WM_KEYDOWN via the
+            // native message pump after WPF, which triggers its OWN paste path against a
+            // separate, often stale buffer (terminal's right-click-to-paste shares the
+            // same internal stack). Letting that double-fire is what makes pastes look
+            // like "something else weird" — the user sees whatever the terminal cached
+            // last, not what they just copied. Swallowing the event here keeps the WPF
+            // path authoritative.
+            e.Handled = true;
             var text = TryGetClipboardText();
             if (string.IsNullOrEmpty(text)) { return; }
+            // Each CR is one Enter to the shell. \r\n would emit a blank line between
+            // every pasted line; collapse to a single \r per line.
             var normalised = text.Replace("\r\n", "\r").Replace("\n", "\r");
             Terminal.ConPTYTerm?.WriteToTerm(normalised.AsSpan());
-            e.Handled = true;
         }
         else if (e.Key == Key.O && shift)
         {

--- a/src/CodeScope.Ui/Views/SidebarView.xaml
+++ b/src/CodeScope.Ui/Views/SidebarView.xaml
@@ -193,6 +193,10 @@
                     <Setter Property="Padding" Value="0" />
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                     <Setter Property="Background" Value="Transparent" />
+                    <!-- Bound off the data item: ProjectViewModel.AutomationId or
+                         WorktreeViewModel.AutomationId (both expose the property). Wpf-cli
+                         snapshots resolve to a:Project_<name> / a:Worktree_<id>__<branch>. -->
+                    <Setter Property="AutomationProperties.AutomationId" Value="{Binding AutomationId}" />
                     <Setter Property="Template">
                         <Setter.Value>
                             <ControlTemplate TargetType="TreeViewItem">

--- a/src/CodeScope.Ui/Views/SidebarView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SidebarView.xaml.cs
@@ -11,9 +11,65 @@ namespace NoScope.CodeScope.Ui.Views;
 
 public partial class SidebarView : UserControl
 {
+    private SidebarViewModel? _wiredVm;
+
     public SidebarView()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        // Subscribe to the active VM's selection event so external callers (MainViewModel
+        // syncing sidebar to the focused tab) can drive the visual tree selection. The
+        // SidebarViewModel only wires the *visual → VM* direction via OnTreeSelectionChanged;
+        // the reverse used to be a no-op, which is why programmatic SelectedWorktree
+        // changes never moved the blue rail.
+        if (_wiredVm is not null)
+        {
+            _wiredVm.WorktreeSelected -= OnWorktreeSelectedFromVm;
+        }
+        _wiredVm = e.NewValue as SidebarViewModel;
+        if (_wiredVm is not null)
+        {
+            _wiredVm.WorktreeSelected += OnWorktreeSelectedFromVm;
+        }
+    }
+
+    private void OnWorktreeSelectedFromVm(object? sender, WorktreeViewModel? wt)
+    {
+        if (wt is null) { return; }
+        // Defer to the dispatcher's ContextIdle so containers generated lazily by the
+        // TreeView (e.g. on first reveal of a project's children) have time to materialize
+        // before we look them up.
+        Dispatcher.BeginInvoke(new Action(() => SelectTreeItemForWorktree(wt)),
+            System.Windows.Threading.DispatcherPriority.ContextIdle);
+    }
+
+    private void SelectTreeItemForWorktree(WorktreeViewModel wt)
+    {
+        if (Tree is null) { return; }
+        // The owning project must be expanded for the worktree's TreeViewItem to exist.
+        // Walk projects → matching project → expand if needed → then resolve the worktree
+        // container and toggle IsSelected.
+        foreach (var pObj in Tree.Items)
+        {
+            if (pObj is not ProjectViewModel proj) { continue; }
+            if (proj.Worktrees.All(w => !ReferenceEquals(w, wt))) { continue; }
+            if (Tree.ItemContainerGenerator.ContainerFromItem(proj) is not TreeViewItem projTvi) { return; }
+            if (!projTvi.IsExpanded)
+            {
+                projTvi.IsExpanded = true;
+                projTvi.UpdateLayout();
+            }
+            if (projTvi.ItemContainerGenerator.ContainerFromItem(wt) is TreeViewItem wtTvi)
+            {
+                if (!wtTvi.IsSelected) { wtTvi.IsSelected = true; }
+                wtTvi.BringIntoView();
+            }
+            return;
+        }
     }
 
     /// <summary>No-op now that the inline filter is gone — kept so MainViewModel's Ctrl+F

--- a/src/CodeScope.Ui/Views/SidebarView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SidebarView.xaml.cs
@@ -17,6 +17,14 @@ public partial class SidebarView : UserControl
     {
         InitializeComponent();
         DataContextChanged += OnDataContextChanged;
+        Unloaded += (_, _) =>
+        {
+            if (_wiredVm is not null)
+            {
+                _wiredVm.WorktreeSelected -= OnWorktreeSelectedFromVm;
+                _wiredVm = null;
+            }
+        };
     }
 
     private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)

--- a/src/CodeScope.Ui/Views/StatusBarView.xaml
+++ b/src/CodeScope.Ui/Views/StatusBarView.xaml
@@ -243,6 +243,7 @@
                 <Rectangle Style="{StaticResource SbSep}" Margin="10,0,10,0"
                            Visibility="{Binding Notifications, Converter={StaticResource NullToVisibility}}" />
                 <Button x:Name="BellButton"
+                        AutomationProperties.AutomationId="BellButton"
                         Background="Transparent"
                         BorderThickness="0"
                         Padding="4,4"
@@ -314,7 +315,8 @@
                                            FontSize="12" FontWeight="Medium"
                                            Foreground="#FFFFFFFF"
                                            VerticalAlignment="Center" />
-                                <Button HorizontalAlignment="Right"
+                                <Button AutomationProperties.AutomationId="NotificationsClearAllBtn"
+                                        HorizontalAlignment="Right"
                                         VerticalAlignment="Center"
                                         Background="Transparent"
                                         BorderThickness="0"
@@ -357,7 +359,8 @@
                                 <ItemsControl ItemsSource="{Binding Notifications.Entries}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
-                                            <Button Background="Transparent"
+                                            <Button AutomationProperties.AutomationId="{Binding Id, StringFormat='Notification_{0}'}"
+                                                    Background="Transparent"
                                                     BorderThickness="0,1,0,0"
                                                     BorderBrush="{DynamicResource Surface.Border}"
                                                     HorizontalContentAlignment="Stretch"


### PR DESCRIPTION
## Summary

A bundle of UX fixes around the workspace + a full redesign of the notification surface.

### Toast surface (popup-hosted)
- New `IToastService` + popup-hosted `ToastHostView` that defeats the WPF airspace bug — toasts now render above the terminal HwndHost children. Previously errors fell *behind* terminals.
- Visual spec follows `docs/design/html/CodeScope - Errors and Toasts.html` exactly: 380×auto, severity rail, 24×24 icon tile, 2px meter, 28px anchor.
- Severity-aware behavior: info/ok 4s, warn 8s, **err persistent**. Hover anywhere on the stack pauses every meter; resume preserves remaining time. MaxVisible=3 cap on non-errors only — errors never auto-fold.
- `ErrToast` helper gives error sites Copy + optional Retry actions. Retry is awaited inside try/catch with a follow-up err toast on failure (no silent task faults).
- New `Fig.Style.Button.ToastAction` chip-style button in `DesignTokens.xaml`, severity-aware primary swap.

### Workspace + sidebar
- **Click on terminal area inside a split group focuses that group** (HwndHost was eating mouse events; backstopped via `GotKeyboardFocus` on the EditorGroupView).
- **Sidebar's blue rail follows the focused tab** across split-groups. `MainViewModel.SyncSidebarToTab` resolves the tab → owning project → owning worktree (project-scoped lookup; worktree ids are not globally unique). `SidebarView` now drives the visual TreeView selection from the VM via `WorktreeSelected` + `ItemContainerGenerator`.
- **Auto-prune worktrees whose folder was deleted outside the app**. `WorktreeStatusPoller` counts ~6s of consecutive misses, then prunes; emits a Warn toast (no more silent removal). `SessionStore.PruneMissingWorktreeAsync` does mutate-then-persist with a *narrow* rollback that doesn't clobber concurrent worktree mutations on save failure.

### Terminal paste
- Bracketed paste mode (`ESC[200~…ESC[201~`) instead of CRLF normalization — multi-line pastes now land as one paste event in Claude Code/Codex/modern shells. Raw cmd.exe loses paste support but that was an explicit trade-off ("fuck raw cmd.exe").
- `Ctrl+V` `e.Handled = true` set before clipboard read so the native paste path can't race.

### Infra
- `AutomationProperties.AutomationId` on dynamic tree/list items, status-bar widgets, toast root + actions + close button. Wpf-cli refs resolve in O(depth) instead of full-tree walks.
- `WorktreeViewModel` raises `OnPropertyChanged(nameof(AutomationId))` on branch rename so refs don't go stale.
- `ConfirmDialog.Show` no longer assigns Owner=self when called before MainWindow exists (caused a startup crash on a single-instance race).
- Cached + Frozen severity-icon `Geometry` instances.
- `.scratch/` added to `.gitignore`.

## Codex review

Three rounds of multi-agent code review (correctness/bugs, WPF idioms, UX/spec fidelity) plus a fix-verification round. Findings addressed inline; final round confirmed ready to ship. Only minor non-blocking notes remain (SidebarView event subscription doesn't unsubscribe on Unloaded — but VM is a DI singleton, view is permanent, no real leak).

## Test plan

- [x] Build clean: 0 errors
- [x] Tests: 150/151 pass (1 pre-existing FSWatcher flake, unrelated)
- [x] Smoke tested via wpf-cli: tabs in two different worktrees, clicking between them moves both the editor-group rail and the sidebar selection in both directions
- [x] Toast sample (`CODESCOPE_TOAST_SAMPLE=1`) renders all four severities to spec, popup overlays the terminal correctly
- [ ] Manual exercise of Retry actions (Fetch/Pull/CreatePR) on real network failures
- [ ] Manual exercise of worktree auto-prune (delete folder outside app, watch for warn toast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)