### PR TITLE
Sidebar: track active worktree per editor group

### DIFF
--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -122,18 +122,28 @@ public sealed partial class MainViewModel : ObservableObject
                 break;
         }
         RaiseGroupWidthsReset();
+        // Group structure changed — the active set might shrink (close-group) or grow
+        // (split-right inheriting a tab); push the new flags into the sidebar.
+        RecomputeActiveWorktreesAcrossGroups();
     }
 
     /// <summary>
     /// Forwards a group's SelectedTab changes into MainViewModel.SelectedTab when the
     /// group is focused — keeps WindowTitle, per-tab IsActive bookkeeping, and the
-    /// diff panel in sync regardless of which group the user clicked.
+    /// diff panel in sync regardless of which group the user clicked. Also recomputes
+    /// the sidebar's per-worktree active flags for *every* group, so a tab change in
+    /// an unfocused group still updates that group's worktree row in the sidebar.
     /// </summary>
     private void HookGroupSelection(EditorGroupViewModel group)
     {
         group.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName != nameof(EditorGroupViewModel.SelectedTab)) { return; }
+            // Every group's selection contributes to the sidebar's active set, even
+            // if the change happened in an unfocused group (drag-between-groups,
+            // close-tab cascading, hydrate). Recompute first so the row state is
+            // correct before any downstream sync touches the sidebar.
+            RecomputeActiveWorktreesAcrossGroups();
             if (!ReferenceEquals(group, FocusedGroup)) { return; }
             if (ReferenceEquals(SelectedTab, group.SelectedTab)) { return; }
             SelectedTab = group.SelectedTab;
@@ -514,6 +524,13 @@ public sealed partial class MainViewModel : ObservableObject
     {
         Sidebar = sidebar;
         OnPropertyChanged(nameof(Sidebar));
+
+        // Sidebar tree structure mutates from store events (Loaded clears + rebuilds, projects/
+        // worktrees added/removed). Each rebuild produces fresh WorktreeViewModel instances with
+        // IsActiveInAnyGroup=false; reapply the multi-group active flags after every structural
+        // change so the bold/rail visuals don't lose state on hydrate or worktree CRUD.
+        sidebar.Projects.CollectionChanged += OnSidebarProjectsChanged;
+        foreach (var p in sidebar.Projects) { HookProjectWorktrees(p); }
 
         Overview = new OverviewViewModel(sidebar, Groups, _agents);
         Overview.FocusSessionRequested += (_, session) =>
@@ -1122,46 +1139,108 @@ public sealed partial class MainViewModel : ObservableObject
     private void SyncSidebarToTab(SessionTabViewModel? tab)
     {
         if (tab is null || Sidebar is null) { return; }
+        var match = ResolveWorktreeForTab(tab);
+        if (match is not null && !ReferenceEquals(Sidebar.SelectedWorktree, match))
+        {
+            Sidebar.SelectedWorktree = match;
+        }
+    }
 
-        WorktreeViewModel? match = null;
+    private void OnSidebarProjectsChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+        {
+            foreach (var p in e.OldItems.OfType<ProjectViewModel>()) { UnhookProjectWorktrees(p); }
+        }
+        if (e.NewItems is not null)
+        {
+            foreach (var p in e.NewItems.OfType<ProjectViewModel>()) { HookProjectWorktrees(p); }
+        }
+        if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset && Sidebar is not null)
+        {
+            // Reset gives no Old/New items — re-hook from current state.
+            foreach (var p in Sidebar.Projects) { HookProjectWorktrees(p); }
+        }
+        RecomputeActiveWorktreesAcrossGroups();
+    }
 
-        // Authoritative path: find the project whose Sessions list owns this tab,
-        // then resolve the worktree inside that project's WorktreeViewModels.
+    private void HookProjectWorktrees(ProjectViewModel p)
+    {
+        // Idempotent: detach first so re-hooking on Reset doesn't double-subscribe.
+        p.Worktrees.CollectionChanged -= OnProjectWorktreesChanged;
+        p.Worktrees.CollectionChanged += OnProjectWorktreesChanged;
+    }
+
+    private void UnhookProjectWorktrees(ProjectViewModel p)
+    {
+        p.Worktrees.CollectionChanged -= OnProjectWorktreesChanged;
+    }
+
+    private void OnProjectWorktreesChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        RecomputeActiveWorktreesAcrossGroups();
+    }
+
+    /// <summary>
+    /// Recomputes <see cref="WorktreeViewModel.IsActiveInAnyGroup"/> for every worktree in
+    /// the sidebar by walking <see cref="Groups"/> and resolving each group's
+    /// <c>SelectedTab</c> to its owning worktree. The TreeView's single-selection model
+    /// can only mark one row as <c>IsSelected</c>, so this bool is the multi-group
+    /// counterpart that drives the bold/accent-rail/active-dot styling.
+    /// </summary>
+    private void RecomputeActiveWorktreesAcrossGroups()
+    {
+        if (Sidebar is null) { return; }
+
+        var active = new HashSet<WorktreeViewModel>();
+        foreach (var g in Groups)
+        {
+            var t = g.SelectedTab;
+            if (t is null) { continue; }
+            var wt = ResolveWorktreeForTab(t);
+            if (wt is not null) { active.Add(wt); }
+        }
+
+        foreach (var p in Sidebar.Projects)
+        {
+            foreach (var w in p.Worktrees)
+            {
+                var should = active.Contains(w);
+                if (w.IsActiveInAnyGroup != should) { w.IsActiveInAnyGroup = should; }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Maps <paramref name="tab"/> to the worktree row that owns it. Same lookup logic
+    /// as <see cref="SyncSidebarToTab"/> — store-authoritative first (project whose
+    /// <c>Sessions</c> list contains the descriptor id), then a working-directory
+    /// fallback for transient tabs that haven't been persisted yet.
+    /// </summary>
+    private WorktreeViewModel? ResolveWorktreeForTab(SessionTabViewModel tab)
+    {
+        if (Sidebar is null) { return null; }
+
         foreach (var p in _store.Projects)
         {
             var session = p.Sessions.FirstOrDefault(s => s.Id == tab.Descriptor.Id);
             if (session is null) { continue; }
             var projVm = Sidebar.Projects.FirstOrDefault(pv => pv.Id == p.Id);
-            if (projVm is null) { break; }
+            if (projVm is null) { return null; }
             if (session.WorktreeId is { Length: > 0 } wid)
             {
-                match = projVm.Worktrees.FirstOrDefault(w => w.Id == wid);
+                var byId = projVm.Worktrees.FirstOrDefault(w => w.Id == wid);
+                if (byId is not null) { return byId; }
             }
-            if (match is null)
-            {
-                match = projVm.Worktrees.FirstOrDefault(w =>
-                    string.Equals(w.Path, session.WorktreePath, StringComparison.OrdinalIgnoreCase));
-            }
-            break;
+            return projVm.Worktrees.FirstOrDefault(w =>
+                string.Equals(w.Path, session.WorktreePath, StringComparison.OrdinalIgnoreCase));
         }
 
-        // Transient-tab fallback: no persisted Session yet, so match purely by the
-        // tab's working directory across every project's worktrees.
-        if (match is null)
-        {
-            var path = tab.Descriptor.WorkingDirectory;
-            if (!string.IsNullOrWhiteSpace(path))
-            {
-                match = Sidebar.Projects
-                    .SelectMany(p => p.Worktrees)
-                    .FirstOrDefault(w => string.Equals(w.Path, path, StringComparison.OrdinalIgnoreCase));
-            }
-        }
-
-        if (match is not null && !ReferenceEquals(Sidebar.SelectedWorktree, match))
-        {
-            Sidebar.SelectedWorktree = match;
-        }
+        var path = tab.Descriptor.WorkingDirectory;
+        if (string.IsNullOrWhiteSpace(path)) { return null; }
+        return Sidebar.Projects
+            .SelectMany(p => p.Worktrees)
+            .FirstOrDefault(w => string.Equals(w.Path, path, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -528,7 +528,9 @@ public sealed partial class MainViewModel : ObservableObject
         // Sidebar tree structure mutates from store events (Loaded clears + rebuilds, projects/
         // worktrees added/removed). Each rebuild produces fresh WorktreeViewModel instances with
         // IsActiveInAnyGroup=false; reapply the multi-group active flags after every structural
-        // change so the bold/rail visuals don't lose state on hydrate or worktree CRUD.
+        // change so the bold/rail visuals don't lose state on hydrate or worktree CRUD. Detach
+        // first so a re-attach (tests, theoretical hot-swap) doesn't double-subscribe.
+        sidebar.Projects.CollectionChanged -= OnSidebarProjectsChanged;
         sidebar.Projects.CollectionChanged += OnSidebarProjectsChanged;
         foreach (var p in sidebar.Projects) { HookProjectWorktrees(p); }
 
@@ -1322,8 +1324,16 @@ public sealed partial class MainViewModel : ObservableObject
         }
 
         // Fix up selections: source falls back to its last remaining tab, target
-        // adopts the moved one + takes window focus.
-        if (sourceGroup.SelectedTab is null && sourceGroup.Tabs.Count > 0)
+        // adopts the moved one + takes window focus. ObservableCollection.Remove does
+        // not null SelectedTab when the removed item was selected, so we re-check
+        // explicitly — otherwise the source group keeps a dangling reference to the
+        // moved tab and RecomputeActiveWorktreesAcrossGroups would mark the source's
+        // old worktree active forever.
+        if (ReferenceEquals(sourceGroup.SelectedTab, tab))
+        {
+            sourceGroup.SelectedTab = sourceGroup.Tabs.Count > 0 ? sourceGroup.Tabs[^1] : null;
+        }
+        else if (sourceGroup.SelectedTab is null && sourceGroup.Tabs.Count > 0)
         {
             sourceGroup.SelectedTab = sourceGroup.Tabs[^1];
         }

--- a/src/CodeScope.Ui/ViewModels/WorktreeViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/WorktreeViewModel.cs
@@ -91,6 +91,17 @@ public sealed partial class WorktreeViewModel : ObservableObject
     [ObservableProperty]
     private bool _isVisible = true;
 
+    /// <summary>
+    /// True when at least one editor group's <c>SelectedTab</c> belongs to this worktree.
+    /// Drives the sidebar's bold/accent-rail/active-dot styling. Independent of
+    /// <see cref="System.Windows.Controls.TreeViewItem.IsSelected"/>: a TreeView only
+    /// supports a single selected item, but with multi-group splits the user can have
+    /// one focused tab per group on different worktrees, and every one of those rows
+    /// should look "active" in the sidebar. Recomputed by <c>MainViewModel</c>.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isActiveInAnyGroup;
+
     /// <summary>Called by the sidebar filter: hides the row when <paramref name="filter"/> misses.</summary>
     public void ApplyFilter(string filter)
     {

--- a/src/CodeScope.Ui/Views/SidebarView.xaml
+++ b/src/CodeScope.Ui/Views/SidebarView.xaml
@@ -283,6 +283,10 @@
                                         <DataTrigger Binding="{Binding HasActiveSession}" Value="True">
                                             <Setter Property="Opacity" Value="1" />
                                         </DataTrigger>
+                                        <!-- Per-group active worktree (any group's focused tab → row reads "active"). -->
+                                        <DataTrigger Binding="{Binding IsActiveInAnyGroup}" Value="True">
+                                            <Setter Property="Opacity" Value="1" />
+                                        </DataTrigger>
                                         <DataTrigger Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
                                             <Setter Property="Opacity" Value="1" />
                                         </DataTrigger>
@@ -352,7 +356,13 @@
                                             <DataTrigger Binding="{Binding DotState}" Value="wait">
                                                 <Setter Property="Fill" Value="{DynamicResource Signal.Warn}" />
                                             </DataTrigger>
-                                            <!-- Selected row supersedes idle/rest with the accent "active" state. -->
+                                            <!-- Active in any group supersedes idle/rest with the accent "active" state.
+                                                 Multi-group splits can have one focused tab per group on different
+                                                 worktrees; each row should advertise that independently of which
+                                                 single TreeViewItem is currently IsSelected. -->
+                                            <DataTrigger Binding="{Binding IsActiveInAnyGroup}" Value="True">
+                                                <Setter Property="Fill" Value="{DynamicResource Accent.Primary}" />
+                                            </DataTrigger>
                                             <DataTrigger Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
                                                 <Setter Property="Fill" Value="{DynamicResource Accent.Primary}" />
                                             </DataTrigger>
@@ -371,10 +381,16 @@
                             TextTrimming="CharacterEllipsis">
                             <TextBlock.Style>
                                 <Style TargetType="TextBlock">
-                                    <!-- Rest: muted. Selected row: white + Medium weight (spec §6). -->
+                                    <!-- Rest: muted. Active row (focused tab in any group): white + Medium weight (spec §6).
+                                         IsActiveInAnyGroup is a multi-row capable signal; IsSelected is the single
+                                         TreeView selection (keyboard nav / right-click target) — both bold the row. -->
                                     <Setter Property="Foreground" Value="{DynamicResource Text.Secondary}" />
                                     <Setter Property="FontWeight" Value="Normal" />
                                     <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsActiveInAnyGroup}" Value="True">
+                                            <Setter Property="Foreground" Value="{DynamicResource Text.Primary}" />
+                                            <Setter Property="FontWeight" Value="Medium" />
+                                        </DataTrigger>
                                         <DataTrigger Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
                                             <Setter Property="Foreground" Value="{DynamicResource Text.Primary}" />
                                             <Setter Property="FontWeight" Value="Medium" />


### PR DESCRIPTION
## Summary

The sidebar's active-worktree highlight (bold branch label, accent left rail, accent dot fill) was hard-wired to `TreeViewItem.IsSelected`. WPF's `TreeView` only allows one selected item, so with multi-group editor splits — one focused tab per group on different worktrees — only the most recently focused row stayed bold; the other group's worktree row dropped its accent rail and bold label even though its tab was still hosting work. The visual jumped between rows on every focus change instead of advertising every group's active worktree in parallel.

This PR introduces a multi-row capable signal on top of the existing single-selection model:

- `WorktreeViewModel.IsActiveInAnyGroup` (new `ObservableProperty`) — true when at least one editor group's `SelectedTab` belongs to that worktree.
- `MainViewModel.RecomputeActiveWorktreesAcrossGroups` walks every group's `SelectedTab`, resolves to the owning `WorktreeViewModel` via the new `ResolveWorktreeForTab` helper (extracted from `SyncSidebarToTab`'s duplicate logic), and pushes the bool into every worktree in the sidebar.
- Recompute triggers: any group's `SelectedTab` change (`HookGroupSelection`), `Groups` mutations (split-right, close-group), `Sidebar.Projects` mutations + per-project `Worktrees` mutations (so freshly-rebuilt VMs after a `Loaded` event get the correct flags reapplied).
- XAML: the left accent rail's `Opacity`, the branch-text `Foreground`+`FontWeight`, and the dot `Fill` trigger off `IsActiveInAnyGroup` in addition to `IsSelected`. Row background fill stays on `IsSelected` so keyboard nav / right-click still has its single-row indicator — they're now two distinct concepts.

## Codex review fixes folded into the same branch

- `MoveTabToGroup`: `ObservableCollection.Remove` doesn't null `SelectedTab` when the removed item was selected, so the source group could keep a dangling reference to the moved tab and the recompute would mark its old worktree active forever. Reassign explicitly to the last remaining tab (or null) when the moved tab was the source's selection.
- `AttachSidebar`: detach `OnSidebarProjectsChanged` before re-subscribing, so a hypothetical re-attach can't double-fire. Matches the pattern `HookProjectWorktrees` already uses.

## Test plan

- [x] `dotnet build` clean — 0 errors
- [x] `dotnet test` — 151/151 green
- [ ] Manual: open one tab in workspace A, `Ctrl+\` split, open another tab in workspace B → both worktree rows in sidebar are bold + have accent rail simultaneously
- [ ] Manual: drag tab from group A → group B; source group's old worktree drops `IsActiveInAnyGroup` if no other tab in source still pins it
- [ ] Manual: close-group cascades; remaining groups' active flags stay correct
- [ ] Manual: cold-start hydrate of a multi-group layout; both selected tabs' worktrees render active immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)