### PR TITLE
Remove sidebar-follows-focused-tab selection sync

### DIFF
--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -486,12 +486,6 @@ public sealed partial class MainViewModel : ObservableObject
             var stored = FindStoredSession(value);
             if (stored?.AgentSessionId is { Length: > 0 } sid) { _notifications.MarkSessionRead(sid); }
         }
-        // Sidebar selection follows the focused tab — when the user clicks a terminal
-        // in another split-group, the blue rail in the sidebar should jump to the
-        // worktree that owns that tab. Without this, sidebar selection got "stuck"
-        // on whatever the user last clicked in the tree even though their attention
-        // had moved to a tab in a different worktree.
-        SyncSidebarToTab(value);
         // Status dot is window-global: only the focused-group's selected tab gets Active;
         // every other tab (including selected tabs in other groups) drops to Idle unless
         // it's still waiting (Wait survives focus changes per top-bar spec §3).
@@ -1110,59 +1104,6 @@ public sealed partial class MainViewModel : ObservableObject
     /// </summary>
     private static bool AgentSupportsSessionId(AgentProfile? agent)
         => !string.IsNullOrEmpty(agent?.SessionIdFlag);
-
-    /// <summary>
-    /// Maps the focused tab back to the worktree row that owns it and updates the
-    /// sidebar's <see cref="SidebarViewModel.SelectedWorktree"/>. Worktree ids are NOT
-    /// globally unique (every project has a worktree literally called "primary"), so
-    /// we scope every lookup by the owning project — first by walking the store for
-    /// the project whose <c>Sessions</c> contains the tab's descriptor, then by the
-    /// worktree-path fallback for transient/pre-Phase 3 tabs.
-    /// </summary>
-    private void SyncSidebarToTab(SessionTabViewModel? tab)
-    {
-        if (tab is null || Sidebar is null) { return; }
-
-        WorktreeViewModel? match = null;
-
-        // Authoritative path: find the project whose Sessions list owns this tab,
-        // then resolve the worktree inside that project's WorktreeViewModels.
-        foreach (var p in _store.Projects)
-        {
-            var session = p.Sessions.FirstOrDefault(s => s.Id == tab.Descriptor.Id);
-            if (session is null) { continue; }
-            var projVm = Sidebar.Projects.FirstOrDefault(pv => pv.Id == p.Id);
-            if (projVm is null) { break; }
-            if (session.WorktreeId is { Length: > 0 } wid)
-            {
-                match = projVm.Worktrees.FirstOrDefault(w => w.Id == wid);
-            }
-            if (match is null)
-            {
-                match = projVm.Worktrees.FirstOrDefault(w =>
-                    string.Equals(w.Path, session.WorktreePath, StringComparison.OrdinalIgnoreCase));
-            }
-            break;
-        }
-
-        // Transient-tab fallback: no persisted Session yet, so match purely by the
-        // tab's working directory across every project's worktrees.
-        if (match is null)
-        {
-            var path = tab.Descriptor.WorkingDirectory;
-            if (!string.IsNullOrWhiteSpace(path))
-            {
-                match = Sidebar.Projects
-                    .SelectMany(p => p.Worktrees)
-                    .FirstOrDefault(w => string.Equals(w.Path, path, StringComparison.OrdinalIgnoreCase));
-            }
-        }
-
-        if (match is not null && !ReferenceEquals(Sidebar.SelectedWorktree, match))
-        {
-            Sidebar.SelectedWorktree = match;
-        }
-    }
 
     /// <summary>
     /// Walks the store for the persisted <see cref="Session"/> backing <paramref name="tab"/>.

--- a/src/CodeScope.Ui/Views/SidebarView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SidebarView.xaml.cs
@@ -11,73 +11,9 @@ namespace NoScope.CodeScope.Ui.Views;
 
 public partial class SidebarView : UserControl
 {
-    private SidebarViewModel? _wiredVm;
-
     public SidebarView()
     {
         InitializeComponent();
-        DataContextChanged += OnDataContextChanged;
-        Unloaded += (_, _) =>
-        {
-            if (_wiredVm is not null)
-            {
-                _wiredVm.WorktreeSelected -= OnWorktreeSelectedFromVm;
-                _wiredVm = null;
-            }
-        };
-    }
-
-    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
-    {
-        // Subscribe to the active VM's selection event so external callers (MainViewModel
-        // syncing sidebar to the focused tab) can drive the visual tree selection. The
-        // SidebarViewModel only wires the *visual → VM* direction via OnTreeSelectionChanged;
-        // the reverse used to be a no-op, which is why programmatic SelectedWorktree
-        // changes never moved the blue rail.
-        if (_wiredVm is not null)
-        {
-            _wiredVm.WorktreeSelected -= OnWorktreeSelectedFromVm;
-        }
-        _wiredVm = e.NewValue as SidebarViewModel;
-        if (_wiredVm is not null)
-        {
-            _wiredVm.WorktreeSelected += OnWorktreeSelectedFromVm;
-        }
-    }
-
-    private void OnWorktreeSelectedFromVm(object? sender, WorktreeViewModel? wt)
-    {
-        if (wt is null) { return; }
-        // Defer to the dispatcher's ContextIdle so containers generated lazily by the
-        // TreeView (e.g. on first reveal of a project's children) have time to materialize
-        // before we look them up.
-        Dispatcher.BeginInvoke(new Action(() => SelectTreeItemForWorktree(wt)),
-            System.Windows.Threading.DispatcherPriority.ContextIdle);
-    }
-
-    private void SelectTreeItemForWorktree(WorktreeViewModel wt)
-    {
-        if (Tree is null) { return; }
-        // The owning project must be expanded for the worktree's TreeViewItem to exist.
-        // Walk projects → matching project → expand if needed → then resolve the worktree
-        // container and toggle IsSelected.
-        foreach (var pObj in Tree.Items)
-        {
-            if (pObj is not ProjectViewModel proj) { continue; }
-            if (proj.Worktrees.All(w => !ReferenceEquals(w, wt))) { continue; }
-            if (Tree.ItemContainerGenerator.ContainerFromItem(proj) is not TreeViewItem projTvi) { return; }
-            if (!projTvi.IsExpanded)
-            {
-                projTvi.IsExpanded = true;
-                projTvi.UpdateLayout();
-            }
-            if (projTvi.ItemContainerGenerator.ContainerFromItem(wt) is TreeViewItem wtTvi)
-            {
-                if (!wtTvi.IsSelected) { wtTvi.IsSelected = true; }
-                wtTvi.BringIntoView();
-            }
-            return;
-        }
     }
 
     /// <summary>No-op now that the inline filter is gone — kept so MainViewModel's Ctrl+F


### PR DESCRIPTION
## Summary
- The sidebar's blue rail tried to follow the focused tab across split-groups (introduced in c7e72d4 / 523d23a), but the behavior was unreliable — the rail would land on stale rows or fail to move depending on TreeView container materialization timing.
- Roll the feature out entirely: drop `SyncSidebarToTab` from `MainViewModel` and the VM→tree reverse-binding plumbing from `SidebarView.xaml.cs`.
- `SidebarViewModel.WorktreeSelected` is kept; `App.xaml.cs` still uses it to attach the diff panel to the user-clicked worktree.

## Test plan
- [x] `dotnet build src/CodeScope.Ui` clean (0 errors)
- [x] Smoke test in dev build: clicking between tabs in different worktrees no longer moves the sidebar selection rail; clicking a worktree row still selects it and updates the diff panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)