### PR TITLE
Re-check for Velopack updates every 3 hours

### DIFF
--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -150,12 +150,13 @@ public partial class App : Application
         MainWindow = window;
         window.Show();
 
-        // Kick off the auto-update check 10s after the window is visible. The delay keeps it
-        // off the startup-critical path (no network blocking first paint) and gives the host
-        // loggers a moment to wire up so we see any check failures in the console. Fire-and-
-        // forget by design: UpdateService swallows its own exceptions. The CancellationToken
-        // is cancelled in OnExit so the check is aborted if the user closes the app within
-        // the 10s delay — prevents hitting disposed services.
+        // Kick off the auto-update check 10s after the window is visible, then re-check every
+        // 3 hours so long-running sessions still pick up newly published releases without a
+        // restart. The 10s initial delay keeps the first check off the startup-critical path
+        // (no network blocking first paint) and gives the host loggers a moment to wire up.
+        // Fire-and-forget by design: UpdateService swallows its own exceptions. The
+        // CancellationToken is cancelled in OnExit so any in-flight check or pending delay
+        // is aborted on shutdown — prevents hitting disposed services.
         _updateCts = new CancellationTokenSource();
         var updateToken = _updateCts.Token;
         var updater = _host.Services.GetRequiredService<UpdateService>();
@@ -165,6 +166,11 @@ public partial class App : Application
             {
                 await System.Threading.Tasks.Task.Delay(System.TimeSpan.FromSeconds(10), updateToken).ConfigureAwait(false);
                 await updater.CheckAsync().ConfigureAwait(false);
+                while (!updateToken.IsCancellationRequested)
+                {
+                    await System.Threading.Tasks.Task.Delay(System.TimeSpan.FromHours(3), updateToken).ConfigureAwait(false);
+                    await updater.CheckAsync().ConfigureAwait(false);
+                }
             }
             catch (System.OperationCanceledException) { }
         });

--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -165,10 +165,12 @@ public partial class App : Application
             try
             {
                 await System.Threading.Tasks.Task.Delay(System.TimeSpan.FromSeconds(10), updateToken).ConfigureAwait(false);
+                updateToken.ThrowIfCancellationRequested();
                 await updater.CheckAsync().ConfigureAwait(false);
                 while (!updateToken.IsCancellationRequested)
                 {
                     await System.Threading.Tasks.Task.Delay(System.TimeSpan.FromHours(3), updateToken).ConfigureAwait(false);
+                    updateToken.ThrowIfCancellationRequested();
                     await updater.CheckAsync().ConfigureAwait(false);
                 }
             }

--- a/src/CodeScope.App/UpdateService.cs
+++ b/src/CodeScope.App/UpdateService.cs
@@ -74,9 +74,9 @@ public sealed class UpdateService
 
             _logger.LogInformation("UpdateService: downloading update {Version}", version);
             await mgr.DownloadUpdatesAsync(info).ConfigureAwait(false);
-            _stagedVersion = version;
 
             ShowUpdateReadyToast(mgr, info, version);
+            _stagedVersion = version;
         }
         catch (System.Exception ex)
         {

--- a/src/CodeScope.App/UpdateService.cs
+++ b/src/CodeScope.App/UpdateService.cs
@@ -21,6 +21,9 @@ public sealed class UpdateService
 
     private readonly ILogger<UpdateService> _logger;
     private readonly IToastService _toasts;
+    // Tracks the version we've already staged + announced this process lifetime so the
+    // periodic 3-hour re-check doesn't re-download or re-toast the same release.
+    private string? _stagedVersion;
 
     public UpdateService(ILogger<UpdateService> logger, IToastService toasts)
     {
@@ -62,10 +65,17 @@ public sealed class UpdateService
                 return;
             }
 
-            _logger.LogInformation("UpdateService: downloading update {Version}", info.TargetFullRelease.Version);
-            await mgr.DownloadUpdatesAsync(info).ConfigureAwait(false);
-
             var version = info.TargetFullRelease.Version.ToString();
+            if (string.Equals(_stagedVersion, version, System.StringComparison.Ordinal))
+            {
+                _logger.LogDebug("UpdateService: {Version} already staged this session, skipping", version);
+                return;
+            }
+
+            _logger.LogInformation("UpdateService: downloading update {Version}", version);
+            await mgr.DownloadUpdatesAsync(info).ConfigureAwait(false);
+            _stagedVersion = version;
+
             ShowUpdateReadyToast(mgr, info, version);
         }
         catch (System.Exception ex)


### PR DESCRIPTION
## Summary
- The auto-updater previously ran once 10s after window-show and never again, so long-running sessions never picked up new Velopack releases without a manual restart.
- Wrap the post-launch check in a `while (!cancelled)` loop with a 3-hour delay so subsequent releases are detected while the app stays open. Existing `CancellationToken` from `OnExit` already aborts the pending delay.
- Add a `_stagedVersion` guard in `UpdateService` so the periodic re-check skips re-downloading and re-toasting a version that's already been staged this process lifetime.

## Test plan
- [x] `dotnet build src/CodeScope.App` clean (0 errors)
- [ ] Smoke test: launch installed build, leave running >3h, confirm no duplicate "Update ready" toast when no new release exists.
- [ ] When a new release ships: confirm the periodic tick downloads it and surfaces the toast + restart dialog exactly once.
- [x] `CODESCOPE_DEV=1` still skips all checks (existing guard in `UpdateService.CheckAsync`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)