### PR TITLE
Add pi.dev + opencode-cli agents with status-bar telemetry

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -13,7 +13,7 @@
 **Uncommitted work:** none beyond this HANDOFF update.
 **Unpushed commits:** entire `feature/pi-and-opencode-agents` branch (1 implementation commit + this HANDOFF commit) — no PR opened yet.
 
-### Session 23 — pi.dev agent support (uncommitted)
+### Session 23 — pi.dev agent support (committed in `26586d0`)
 
 User-visible: a fourth agent ("π  Pi") in the new-session menu that launches
 `@mariozechner/pi-coding-agent`, with the same busy/idle status dot, token
@@ -69,10 +69,10 @@ Open follow-ups:
 - `ContextWindowTokens` for Pi is left at 0 (model-agnostic CLI). The status
   bar's percent indicator stays blank for Pi until we surface a per-tab cap
   override, which is its own design problem.
-- No `git commit` taken — user asked for full implementation, not the merge
-  plan. Diff is `git status -s` clean except for these new + modified files.
+- Committed in `26586d0` together with session 23b (shared files in
+  AgentRegistry/MainViewModel/App.xaml.cs couldn't be split cleanly).
 
-### Session 23b — opencode-cli telemetry parity (uncommitted)
+### Session 23b — opencode-cli telemetry parity (committed in `26586d0`)
 
 User-visible: the OpenCode tab now gets the same status-dot + token + turn
 read-out the Claude / Pi tabs have. Resume-by-id wired through the existing

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -5,13 +5,125 @@
 > **Intent:** cursor + last 1–2 sessions in depth, everything else a one-liner.
 > Old detail lives in `git log` — don't duplicate it here.
 
-**Last updated:** 2026-04-26 (session 22)
-**Branch:** `feature/session-history-per-worktree` — adds the cross-group drag pool on top of session 21's history work; PR pending.
-**Head:** see session 22 below (cross-group terminal drag pool)
+**Last updated:** 2026-04-27 (session 23)
+**Branch:** `feature/pi-and-opencode-agents` (off `main`); pi.dev + opencode-cli telemetry committed as `26586d0`.
+**Head:** `26586d0` — see sessions 23 + 23b below.
 **Release:** `v0.1.0` shipped via GitHub Actions — https://github.com/maui1911/CodeScope/releases/tag/v0.1.0
-**Build status:** ✅ `dotnet build` clean. `dotnet test` 280/281 green; 1 pre-existing FSWatcher flake (`Callback_Fires_For_Each_New_Jsonl_So_Clear_Rotations_Are_Adopted`) — confirmed flaky on `main` too, not a regression.
-**Uncommitted work:** none.
-**Unpushed commits:** entire `feature/session-history-per-worktree` branch (9 feature commits + this HANDOFF commit) — no PR opened yet.
+**Build status:** ✅ `dotnet build` clean. Full solution `dotnet test` 334/334 green (Core 202, Ui 115, App 17).
+**Uncommitted work:** none beyond this HANDOFF update.
+**Unpushed commits:** entire `feature/pi-and-opencode-agents` branch (1 implementation commit + this HANDOFF commit) — no PR opened yet.
+
+### Session 23 — pi.dev agent support (uncommitted)
+
+User-visible: a fourth agent ("π  Pi") in the new-session menu that launches
+`@mariozechner/pi-coding-agent`, with the same busy/idle status dot, token
+progress, and turn-duration read-out the Claude tab gets. Resume-by-id wires
+through the existing `--resume`-style plumbing (Pi flag is `--session <uuid>`,
+fallback `pi -c` for "continue most recent").
+
+How: Pi's on-disk session-jsonl format is structurally similar to Claude's but
+under `~/.pi/agent/sessions/--<encoded-cwd>--/<timestamp>_<uuid>.jsonl` and
+with different field names (`message.usage.{input,output,cacheRead,cacheWrite}`,
+`stopReason ∈ {stop, tool_use}`, `role ∈ {user, assistant, toolResult}`). Each
+file's first line is a `session` header carrying the canonical `cwd`, so
+discovery matches by header (canonicalised path comparison) instead of trying
+to predict Pi's directory-naming scheme on Windows.
+
+Files added:
+- `src/CodeScope.Core/Services/PiTranscriptParser.cs` — pure parser; mirrors
+  ClaudeTranscriptParser's contract. Includes `ExtractSessionIdFromFileName`
+  that pulls the trailing UUID out of `<ts>_<uuid>.jsonl` names.
+- `src/CodeScope.Core/Services/IPiTelemetryService.cs` + `PiTelemetryService.cs`
+  — single recursive `FileSystemWatcher` over the entire sessions root so a
+  fresh-launch race (Register before pi has written its first line) still
+  picks up the file. Token + activity FSM identical to Claude's.
+- `src/CodeScope.Core/Services/IPiSessionDiscovery.cs` + `PiSessionDiscovery.cs`
+  — header-cwd matching with cross-platform path canonicalisation so
+  `C:\dev\x` and `/c/dev/x` collapse to the same key. `since` filter, poll
+  fallback, dispose semantics — all mirror `ClaudeSessionDiscovery`.
+- 3 test files: `PiTranscriptParserTests` (10), `PiTelemetryServiceTests` (7),
+  `PiSessionDiscoveryTests` (7) — all green.
+
+Files touched:
+- `src/CodeScope.Core/Services/AgentRegistry.cs` — Pi profile in `BuildDefaults`:
+  `Command="pi"`, `ResumeArgs=["-c"]`, `ResumeByIdArgs=["--session"]`,
+  `SessionIdFlag=null`, `Icon="π"`. Default agent stays Claude.
+- `src/CodeScope.App/App.xaml.cs` — register `IPiTelemetryService` +
+  `IPiSessionDiscovery`; pass to `MainViewModel`.
+- `src/CodeScope.Ui/ViewModels/MainViewModel.cs`:
+  - Optional `IPiTelemetryService` / `IPiSessionDiscovery` ctor params; both
+    services emit `ClaudeSessionTelemetry` so `OnTelemetryUpdated` doesn't care.
+  - `BeginClaudeAdoption` now branches on agent id (claude vs pi) and uses the
+    appropriate discovery service. Same handle-management as before.
+  - `ApplyAdoption` is the shared callback that persists the new id + (re-)
+    registers the right telemetry tail.
+  - `RegisterAgentTelemetry` / `UnregisterAgentTelemetry` route by agent id;
+    callers (`HydrateFromLoaded`, `RestoreClosedWorktreeSessionsAsync`,
+    `TryRestoreSessionAsync`, `CloseTabAsync`) no longer hard-code Claude.
+- `tests/CodeScope.Core.Tests/AgentRegistryTests.cs` — Pi assertions added.
+
+Open follow-ups:
+- Pi's path-encoding on Windows is genuinely undocumented; we sidestep the
+  problem by content-matching the header. If Pi ever drops the header line,
+  this whole approach falls over — file an issue at that point, not before.
+- `ContextWindowTokens` for Pi is left at 0 (model-agnostic CLI). The status
+  bar's percent indicator stays blank for Pi until we surface a per-tab cap
+  override, which is its own design problem.
+- No `git commit` taken — user asked for full implementation, not the merge
+  plan. Diff is `git status -s` clean except for these new + modified files.
+
+### Session 23b — opencode-cli telemetry parity (uncommitted)
+
+User-visible: the OpenCode tab now gets the same status-dot + token + turn
+read-out the Claude / Pi tabs have. Resume-by-id wired through the existing
+descriptor plumbing (`opencode --session <id>`).
+
+Why per-message JSON instead of JSONL: OpenCode persists each message as its
+own file under `%USERPROFILE%\.local\share\opencode\project\<slug>\storage\
+message\<sessionId>\msg_<id>.json`. The schema is upstream-defined in
+`packages/opencode/src/session/message.ts` (Effect Schema.Struct):
+`metadata.assistant.{tokens.{input,output,reasoning,cache.{read,write}}, modelID,
+providerID, path.{cwd,root}, cost}` + `metadata.time.{created,completed?}`.
+Tool-pending state flows from a part with `type:"tool-invocation"` whose
+`toolInvocation.state` is `call` or `partial-call`.
+
+Files added:
+- `src/CodeScope.Core/Services/OpenCodeMessageParser.cs` — pure parser with
+  `ExtractMessageIdFromFileName` for `msg_*.json` names and pending-tool
+  detection on the `parts` array.
+- `src/CodeScope.Core/Services/IOpenCodeTelemetryService.cs` +
+  `OpenCodeTelemetryService.cs` — recursive root watcher; locates the right
+  `message/<sessionId>/` dir via path-segment match (parent must be `message`),
+  re-aggregates every Recompute by sorting in-memory entries on
+  `metadata.time.created`. Activity FSM: latest message role/state drives
+  Composing / PendingToolUse / Idle.
+- `src/CodeScope.Core/Services/IOpenCodeSessionDiscovery.cs` +
+  `OpenCodeSessionDiscovery.cs` — header-cwd matching reuses
+  `PiSessionDiscovery.CanonicalizePath` (same cross-platform path problem).
+  Adoption fires once per session id, on the first assistant message because
+  that's where `metadata.assistant.path.cwd` first appears.
+- 3 test files: `OpenCodeMessageParserTests` (8), `OpenCodeTelemetryServiceTests`
+  (6), `OpenCodeSessionDiscoveryTests` (6) — all green.
+
+Files touched:
+- `AgentRegistry.cs` — opencode profile gains `ResumeByIdArgs=["--session"]`
+  (was missing); Command/Icon/ResumeArgs unchanged.
+- `App.xaml.cs` — register `IOpenCodeTelemetryService` +
+  `IOpenCodeSessionDiscovery`; pass to `MainViewModel`.
+- `MainViewModel.cs` — `BeginClaudeAdoption` gains an `opencode` branch;
+  `RegisterAgentTelemetry` / `UnregisterAgentTelemetry` route opencode too.
+  Same `ApplyAdoption` shared-callback shape as Claude/Pi.
+- `AgentRegistryTests.cs` — opencode profile assertion added.
+
+Open follow-ups:
+- The Effect Schema upstream uses Unix-ms numbers for `time.created/completed`;
+  the parser handles those as `DateTimeOffset.FromUnixTimeMilliseconds`. If
+  OpenCode ever switches to ISO strings, parser returns null timestamps but
+  the rest still works.
+- OpenCode session-list browser (`opencode session list`) isn't surfaced in
+  CodeScope — the user can still hit it from inside the tab via `/sessions`.
+- Same `ContextWindowTokens` caveat as Pi (model-agnostic CLI), unless a
+  Claude/known model lights up `ClaudeModelCatalog`.
 
 ---
 

--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -108,6 +108,10 @@ public partial class App : Application
                 services.AddSingleton<ISessionStore, SessionStore>();
                 services.AddSingleton<IClaudeTelemetryService, ClaudeTelemetryService>();
                 services.AddSingleton<IClaudeSessionDiscovery, ClaudeSessionDiscovery>();
+                services.AddSingleton<IPiTelemetryService, PiTelemetryService>();
+                services.AddSingleton<IPiSessionDiscovery, PiSessionDiscovery>();
+                services.AddSingleton<IOpenCodeTelemetryService, OpenCodeTelemetryService>();
+                services.AddSingleton<IOpenCodeSessionDiscovery, OpenCodeSessionDiscovery>();
                 services.AddSingleton<INotificationService, NotificationService>();
                 // Owns SessionTabView lifecycle so the inner HwndHost survives reparent on
                 // drag-between-groups. See spec
@@ -148,7 +152,11 @@ public partial class App : Application
                         sp.GetRequiredService<INotificationService>(),
                         sp.GetRequiredService<IClaudeSessionDiscovery>(),
                         sp.GetRequiredService<NoScope.CodeScope.Ui.Services.IToastService>(),
-                        sp.GetRequiredService<NoScope.CodeScope.Ui.Services.ISessionViewHostPool>());
+                        sp.GetRequiredService<NoScope.CodeScope.Ui.Services.ISessionViewHostPool>(),
+                        sp.GetRequiredService<IPiTelemetryService>(),
+                        sp.GetRequiredService<IPiSessionDiscovery>(),
+                        sp.GetRequiredService<IOpenCodeTelemetryService>(),
+                        sp.GetRequiredService<IOpenCodeSessionDiscovery>());
                     var sidebar = sp.GetRequiredService<SidebarViewModel>();
                     vm.AttachSidebar(sidebar);
                     var diff = sp.GetRequiredService<DiffPanelViewModel>();

--- a/src/CodeScope.Core/Services/AgentRegistry.cs
+++ b/src/CodeScope.Core/Services/AgentRegistry.cs
@@ -65,10 +65,37 @@ public sealed class AgentRegistry : IAgentRegistry
         {
             Id = "opencode",
             DisplayName = "OpenCode",
-            Command = "opencode",
+            // Windows ships the binary as `opencode-cli.exe` (npm `opencode-ai` package
+            // installs that name on Win to dodge a Windows reserved/conflicting name).
+            // macOS/Linux use `opencode`; flip this default if we ever cross-compile.
+            Command = "opencode-cli",
+            // `opencode -c` (= `--continue`) resumes the most recent session in the cwd.
+            // `opencode --session <id>` (= `-s <id>`) resumes a specific id; we adopt that
+            // id from the message-file watcher once OpenCode has written its first assistant
+            // turn (the message JSON's metadata.assistant.path.cwd is the canonical record).
+            // SessionIdFlag stays null — OpenCode mints its own ids, doesn't accept caller-minted.
             ResumeArgs = ["--continue"],
             NewSessionArgs = [],
+            SessionIdFlag = null,
+            ResumeByIdArgs = ["--session"],
             Icon = "◈",
+        },
+        new AgentProfile
+        {
+            Id = "pi",
+            DisplayName = "Pi",
+            Command = "pi",
+            // Fresh launches: bare `pi`. Pi mints its own UUID + writes a session-jsonl whose
+            // header carries the cwd, which `IPiSessionDiscovery` matches to adopt the id.
+            // Resume-by-id: `pi --session <uuid>` — Pi resolves the latest session file with
+            // that UUID suffix anywhere under `~/.pi/agent/sessions/`. Continue-most-recent:
+            // `pi -c` (used as the bare ResumeArgs fallback when we don't have a stored id).
+            // SessionIdFlag stays null because Pi doesn't accept caller-minted ids on launch.
+            ResumeArgs = ["-c"],
+            NewSessionArgs = [],
+            SessionIdFlag = null,
+            ResumeByIdArgs = ["--session"],
+            Icon = "π",
         },
     ];
 }

--- a/src/CodeScope.Core/Services/IOpenCodeSessionDiscovery.cs
+++ b/src/CodeScope.Core/Services/IOpenCodeSessionDiscovery.cs
@@ -1,0 +1,20 @@
+namespace NoScope.CodeScope.Core.Services;
+
+/// <summary>
+/// Watches the OpenCode data root for new <c>message/&lt;sessionId&gt;/msg_*.json</c> files whose
+/// embedded <c>metadata.assistant.path.cwd</c> matches the launched session's working directory,
+/// and reports back the session id OpenCode chose.
+///
+/// <para>Adoption requires at least one assistant message because that's where the cwd is
+/// recorded — sessions created but never run won't fire the callback. In practice the first
+/// assistant turn lands within seconds of launch.</para>
+/// </summary>
+public interface IOpenCodeSessionDiscovery
+{
+    /// <summary>
+    /// Watch for new OpenCode session files in <paramref name="workingDirectory"/>.
+    /// <paramref name="onDiscovered"/> is invoked with <c>(sessionId, messageFilePath)</c>
+    /// on the watcher thread; dispose the returned handle to stop.
+    /// </summary>
+    IDisposable Watch(string workingDirectory, DateTimeOffset since, Action<string, string> onDiscovered);
+}

--- a/src/CodeScope.Core/Services/IOpenCodeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/IOpenCodeTelemetryService.cs
@@ -1,0 +1,31 @@
+namespace NoScope.CodeScope.Core.Services;
+
+/// <summary>
+/// Tails OpenCode message-JSON directories and projects per-session token totals + activity for
+/// the status bar. Mirrors <see cref="IClaudeTelemetryService"/> / <see cref="IPiTelemetryService"/>;
+/// emits <see cref="ClaudeSessionTelemetry"/> records so the UI consumer stays agent-agnostic.
+///
+/// <para>OpenCode persists each message as its own JSON file under
+/// <c>%USERPROFILE%\.local\share\opencode\project\&lt;slug&gt;\storage\message\&lt;sessionId&gt;\msg_*.json</c>.
+/// The slug is derived from the project path (git slug or <c>global</c> for non-git), so the
+/// service searches recursively for the matching <c>message/&lt;sessionId&gt;</c> directory rather
+/// than predicting the slug.</para>
+/// </summary>
+public interface IOpenCodeTelemetryService : IDisposable
+{
+    /// <summary>Raised on the service's own thread — consumers must marshal to the UI dispatcher.</summary>
+    event EventHandler<ClaudeSessionTelemetry>? Updated;
+
+    /// <summary>
+    /// Begin watching the message directory for <paramref name="sessionId"/>. <paramref name="workingDirectory"/>
+    /// is currently a hint and unused — we resolve the directory by recursive scan from the
+    /// OpenCode data root. Safe to call repeatedly.
+    /// </summary>
+    void Register(string sessionId, string workingDirectory);
+
+    /// <summary>Stop watching the session.</summary>
+    void Unregister(string sessionId);
+
+    /// <summary>Latest snapshot, or <c>null</c> if the session was never registered or has no entries yet.</summary>
+    ClaudeSessionTelemetry? GetSnapshot(string sessionId);
+}

--- a/src/CodeScope.Core/Services/IPiSessionDiscovery.cs
+++ b/src/CodeScope.Core/Services/IPiSessionDiscovery.cs
@@ -1,0 +1,24 @@
+namespace NoScope.CodeScope.Core.Services;
+
+/// <summary>
+/// Watches <c>~/.pi/agent/sessions/</c> for new session-jsonl files whose <c>session</c> header
+/// references the launched session's working directory, and reports back the UUID Pi adopted.
+///
+/// <para>Why peek the header instead of trusting the directory name: Pi normalizes the cwd into
+/// its directory name with platform-dependent rules that we don't model exactly (and that change
+/// across Pi versions). The <c>session</c> header's <c>cwd</c> field is the canonical record of
+/// "what cwd did Pi launch in", so matching by header content is encoding-agnostic.</para>
+///
+/// <para>Mirrors <see cref="IClaudeSessionDiscovery"/>'s contract: the <c>since</c> argument
+/// filters out pre-existing files, the callback fires once per matching file, and disposing
+/// the handle stops the watch.</para>
+/// </summary>
+public interface IPiSessionDiscovery
+{
+    /// <summary>
+    /// Watch for new Pi session files in <paramref name="workingDirectory"/>. <paramref name="onDiscovered"/>
+    /// is invoked with <c>(sessionId, filePath)</c> on the watcher thread; dispose the returned
+    /// handle to stop.
+    /// </summary>
+    IDisposable Watch(string workingDirectory, DateTimeOffset since, Action<string, string> onDiscovered);
+}

--- a/src/CodeScope.Core/Services/IPiTelemetryService.cs
+++ b/src/CodeScope.Core/Services/IPiTelemetryService.cs
@@ -1,0 +1,31 @@
+namespace NoScope.CodeScope.Core.Services;
+
+/// <summary>
+/// Tails pi-coding-agent <c>session.jsonl</c> transcripts and projects per-session token totals
+/// + activity state for the status bar. Mirrors <see cref="IClaudeTelemetryService"/>; emits
+/// <see cref="ClaudeSessionTelemetry"/> records so the UI consumer can stay agent-agnostic.
+///
+/// <para>Pi names files <c>&lt;timestamp&gt;_&lt;uuid&gt;.jsonl</c> under
+/// <c>~/.pi/agent/sessions/--&lt;encoded-cwd&gt;--/</c>. Because the timestamp prefix isn't
+/// recoverable from the session id alone, <see cref="Register"/> scans the configured root for
+/// any subdirectory containing a file whose stem ends with the requested id.</para>
+/// </summary>
+public interface IPiTelemetryService : IDisposable
+{
+    /// <summary>Raised on the service's own thread — consumers must marshal to the UI dispatcher.</summary>
+    event EventHandler<ClaudeSessionTelemetry>? Updated;
+
+    /// <summary>
+    /// Begin watching the transcript for <paramref name="sessionId"/>. <paramref name="workingDirectory"/>
+    /// is currently a hint and unused — Pi's encoding scheme isn't documented for Windows, so
+    /// the service searches every subdirectory of the sessions root for a matching file.
+    /// Safe to call repeatedly with the same id (replaces the prior watch).
+    /// </summary>
+    void Register(string sessionId, string workingDirectory);
+
+    /// <summary>Stop tailing the transcript for <paramref name="sessionId"/>.</summary>
+    void Unregister(string sessionId);
+
+    /// <summary>Latest snapshot, or <c>null</c> if the session was never registered or has no entries yet.</summary>
+    ClaudeSessionTelemetry? GetSnapshot(string sessionId);
+}

--- a/src/CodeScope.Core/Services/OpenCodeMessageParser.cs
+++ b/src/CodeScope.Core/Services/OpenCodeMessageParser.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+
+namespace NoScope.CodeScope.Core.Services;
+
+/// <summary>
+/// One parsed OpenCode message file. Unlike Claude/Pi (append-only JSONL), OpenCode persists each
+/// message as its own JSON file under
+/// <c>~/.local/share/opencode/project/&lt;slug&gt;/storage/message/&lt;sessionId&gt;/msg_&lt;id&gt;.json</c>,
+/// so the unit of parse is one whole file.
+/// </summary>
+public sealed record OpenCodeMessageEntry(
+    string? Id,
+    string? SessionId,
+    string? Role,
+    DateTimeOffset? CreatedAt,
+    DateTimeOffset? CompletedAt,
+    int InputTokens,
+    int OutputTokens,
+    int ReasoningTokens,
+    int CacheReadTokens,
+    int CacheWriteTokens,
+    string? ModelId,
+    string? ProviderId,
+    string? Cwd,
+    bool HasPendingToolCall)
+{
+    /// <summary>True when this entry is an assistant turn carrying token usage.</summary>
+    public bool HasUsage => Role == "assistant"
+        && (InputTokens > 0 || OutputTokens > 0 || ReasoningTokens > 0 || CacheReadTokens > 0 || CacheWriteTokens > 0);
+
+    /// <summary>Status-bar billable count — input + output + reasoning + cache-write. Cache-read excluded (already billed previously).</summary>
+    public int BillableTokens => InputTokens + OutputTokens + ReasoningTokens + CacheWriteTokens;
+
+    /// <summary>Total in-context tokens (mirrors Claude's ContextTokens calc): input + output + reasoning + cache.read + cache.write.</summary>
+    public int ContextTokens => InputTokens + OutputTokens + ReasoningTokens + CacheReadTokens + CacheWriteTokens;
+}
+
+/// <summary>
+/// Pure static parser for OpenCode message JSON. Each file is a single JSON object — the schema
+/// is defined upstream in <c>packages/opencode/src/session/message.ts</c>:
+/// <list type="bullet">
+///   <item>top-level <c>id</c>, <c>role</c> ("user"|"assistant"), <c>parts</c></item>
+///   <item><c>metadata.time.{created, completed?}</c> as Unix-ms numbers</item>
+///   <item><c>metadata.sessionID</c></item>
+///   <item><c>metadata.assistant</c> (assistant only) — <c>tokens.{input,output,reasoning,cache.{read,write}}</c>, <c>cost</c>, <c>modelID</c>, <c>providerID</c>, <c>path.{cwd,root}</c></item>
+///   <item><c>parts[]</c> may contain a <c>ToolInvocationPart</c> with <c>state ∈ {"call","partial-call","result"}</c> — pre-result states mark a pending tool call</item>
+/// </list>
+/// Returns <c>null</c> for blank input or unparseable JSON.
+/// </summary>
+public static class OpenCodeMessageParser
+{
+    /// <summary>Parse a single OpenCode <c>msg_*.json</c> file content. Returns <c>null</c> for blank/garbage input.</summary>
+    public static OpenCodeMessageEntry? ParseContent(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content)) { return null; }
+        try
+        {
+            using var doc = JsonDocument.Parse(content);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) { return null; }
+
+            var id = GetString(root, "id");
+            var role = GetString(root, "role");
+
+            DateTimeOffset? created = null;
+            DateTimeOffset? completed = null;
+            string? sessionId = null;
+            int input = 0, output = 0, reasoning = 0, cacheRead = 0, cacheWrite = 0;
+            string? modelId = null;
+            string? providerId = null;
+            string? cwd = null;
+            var pendingTool = false;
+
+            if (root.TryGetProperty("metadata", out var meta) && meta.ValueKind == JsonValueKind.Object)
+            {
+                sessionId = GetString(meta, "sessionID");
+
+                if (meta.TryGetProperty("time", out var time) && time.ValueKind == JsonValueKind.Object)
+                {
+                    created = ReadUnixMs(time, "created");
+                    completed = ReadUnixMs(time, "completed");
+                }
+
+                if (meta.TryGetProperty("assistant", out var assistant) && assistant.ValueKind == JsonValueKind.Object)
+                {
+                    modelId = GetString(assistant, "modelID");
+                    providerId = GetString(assistant, "providerID");
+                    if (assistant.TryGetProperty("path", out var path) && path.ValueKind == JsonValueKind.Object)
+                    {
+                        cwd = GetString(path, "cwd");
+                    }
+                    if (assistant.TryGetProperty("tokens", out var tokens) && tokens.ValueKind == JsonValueKind.Object)
+                    {
+                        input = GetInt(tokens, "input");
+                        output = GetInt(tokens, "output");
+                        reasoning = GetInt(tokens, "reasoning");
+                        if (tokens.TryGetProperty("cache", out var cache) && cache.ValueKind == JsonValueKind.Object)
+                        {
+                            cacheRead = GetInt(cache, "read");
+                            cacheWrite = GetInt(cache, "write");
+                        }
+                    }
+                }
+            }
+
+            // Pending tool detection: any ToolInvocationPart whose toolInvocation.state is not
+            // "result" means the agent is mid-call — typically waiting on a permission prompt
+            // in interactive mode. Conservative: only flag pending if assistant role; user
+            // messages can carry tool parts too in some shapes but never wait.
+            if (role == "assistant"
+                && root.TryGetProperty("parts", out var parts)
+                && parts.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var part in parts.EnumerateArray())
+                {
+                    if (part.ValueKind != JsonValueKind.Object) { continue; }
+                    if (GetString(part, "type") != "tool-invocation") { continue; }
+                    if (!part.TryGetProperty("toolInvocation", out var inv) || inv.ValueKind != JsonValueKind.Object) { continue; }
+                    var state = GetString(inv, "state");
+                    if (state is "call" or "partial-call")
+                    {
+                        pendingTool = true;
+                        break;
+                    }
+                }
+            }
+
+            return new OpenCodeMessageEntry(
+                Id: id,
+                SessionId: sessionId,
+                Role: role,
+                CreatedAt: created,
+                CompletedAt: completed,
+                InputTokens: input,
+                OutputTokens: output,
+                ReasoningTokens: reasoning,
+                CacheReadTokens: cacheRead,
+                CacheWriteTokens: cacheWrite,
+                ModelId: modelId,
+                ProviderId: providerId,
+                Cwd: cwd,
+                HasPendingToolCall: pendingTool);
+        }
+        catch (JsonException ex)
+        {
+            // OpenCode writes whole files atomically (rename-into-place), so partial reads are
+            // rare but still possible during a save race.
+            System.Diagnostics.Debug.WriteLine($"[OpenCodeMessageParser] Skipping malformed JSON: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Pulls the message id out of an OpenCode message file name like <c>msg_&lt;id&gt;.json</c>.
+    /// Returns <c>null</c> for non-conforming names.
+    /// </summary>
+    public static string? ExtractMessageIdFromFileName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName)) { return null; }
+        var stem = Path.GetFileNameWithoutExtension(fileName);
+        return stem.StartsWith("msg_", StringComparison.Ordinal) && stem.Length > 4
+            ? stem[4..]
+            : null;
+    }
+
+    private static string? GetString(JsonElement obj, string prop) =>
+        obj.TryGetProperty(prop, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private static int GetInt(JsonElement obj, string prop) =>
+        obj.TryGetProperty(prop, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var n) ? n : 0;
+
+    private static DateTimeOffset? ReadUnixMs(JsonElement obj, string prop)
+    {
+        if (!obj.TryGetProperty(prop, out var v) || v.ValueKind != JsonValueKind.Number) { return null; }
+        return v.TryGetInt64(out var ms)
+            ? DateTimeOffset.FromUnixTimeMilliseconds(ms)
+            : null;
+    }
+}

--- a/src/CodeScope.Core/Services/OpenCodeSessionDiscovery.cs
+++ b/src/CodeScope.Core/Services/OpenCodeSessionDiscovery.cs
@@ -1,0 +1,163 @@
+using Microsoft.Extensions.Logging;
+
+namespace NoScope.CodeScope.Core.Services;
+
+/// <inheritdoc />
+public sealed class OpenCodeSessionDiscovery : IOpenCodeSessionDiscovery
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(400);
+
+    private readonly ILogger<OpenCodeSessionDiscovery> _logger;
+    private readonly string _dataRoot;
+
+    public OpenCodeSessionDiscovery(ILogger<OpenCodeSessionDiscovery> logger)
+        : this(logger, DefaultDataRoot()) { }
+
+    /// <summary>Test-seam: point at a throwaway opencode data root.</summary>
+    public OpenCodeSessionDiscovery(ILogger<OpenCodeSessionDiscovery> logger, string dataRoot)
+    {
+        _logger = logger;
+        _dataRoot = dataRoot;
+    }
+
+    public IDisposable Watch(string workingDirectory, DateTimeOffset since, Action<string, string> onDiscovered)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+        ArgumentNullException.ThrowIfNull(onDiscovered);
+
+        try { Directory.CreateDirectory(_dataRoot); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "OpenCode discovery: cannot ensure {Dir}", _dataRoot);
+            return NoopDisposable.Instance;
+        }
+
+        // Reuse the canonical-path helper from the Pi service — same cross-platform comparison
+        // problem (slash direction, drive-letter colon, case) and same fix.
+        var canonCwd = PiSessionDiscovery.CanonicalizePath(workingDirectory);
+        var handle = new WatchHandle(since.UtcDateTime, canonCwd, onDiscovered, _logger);
+
+        try
+        {
+            handle.Watcher = new FileSystemWatcher(_dataRoot, "msg_*.json")
+            {
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.Size,
+                EnableRaisingEvents = true,
+            };
+            handle.Watcher.Created += (_, e) => handle.TryConsider(e.FullPath);
+            handle.Watcher.Changed += (_, e) => handle.TryConsider(e.FullPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "OpenCode discovery: failed to watch {Dir}", _dataRoot);
+        }
+
+        handle.PollTimer = new Timer(_ =>
+        {
+            try
+            {
+                if (!Directory.Exists(_dataRoot)) { return; }
+                foreach (var path in Directory.EnumerateFiles(_dataRoot, "msg_*.json", SearchOption.AllDirectories))
+                {
+                    handle.TryConsider(path);
+                }
+            }
+            catch (Exception ex) { _logger.LogTrace(ex, "OpenCode discovery poll failed"); }
+        }, null, TimeSpan.Zero, PollInterval);
+
+        return handle;
+    }
+
+    private static string DefaultDataRoot() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "opencode");
+
+    private sealed class WatchHandle(
+        DateTime sinceUtc,
+        string canonCwd,
+        Action<string, string> onDiscovered,
+        ILogger logger) : IDisposable
+    {
+        private readonly HashSet<string> _firedSessions = new(StringComparer.OrdinalIgnoreCase);
+        private readonly object _firedLock = new();
+        private int _disposed;
+
+        public FileSystemWatcher? Watcher;
+        public Timer? PollTimer;
+
+        public void TryConsider(string path)
+        {
+            if (Volatile.Read(ref _disposed) != 0) { return; }
+            try
+            {
+                var info = new FileInfo(path);
+                if (!info.Exists) { return; }
+                if (info.CreationTimeUtc < sinceUtc && info.LastWriteTimeUtc < sinceUtc) { return; }
+
+                // Path layout: <root>/project/<slug>/storage/message/<sessionId>/msg_*.json
+                // The sessionId is the parent directory name; verify by checking the
+                // grandparent is "message" so we don't fire on stray msg_*.json files.
+                var dir = Path.GetDirectoryName(path);
+                if (dir is null) { return; }
+                var sessionId = Path.GetFileName(dir);
+                if (string.IsNullOrEmpty(sessionId)) { return; }
+                var grandparent = Path.GetFileName(Path.GetDirectoryName(dir) ?? string.Empty);
+                if (!string.Equals(grandparent, "message", StringComparison.OrdinalIgnoreCase)) { return; }
+
+                lock (_firedLock)
+                {
+                    if (_firedSessions.Contains(sessionId)) { return; }
+                }
+
+                if (!HeaderMatches(path)) { return; }
+
+                lock (_firedLock)
+                {
+                    if (!_firedSessions.Add(sessionId)) { return; }
+                }
+
+                try { onDiscovered(sessionId, path); }
+                catch (Exception ex) { logger.LogWarning(ex, "OpenCode discovery: subscriber threw"); }
+            }
+            catch (Exception ex) { logger.LogTrace(ex, "OpenCode discovery: consider failed for {Path}", path); }
+        }
+
+        private bool HeaderMatches(string path)
+        {
+            try
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+                using var reader = new StreamReader(fs);
+                var content = reader.ReadToEnd();
+                var entry = OpenCodeMessageParser.ParseContent(content);
+                if (entry?.Cwd is null) { return false; }
+                var theirs = PiSessionDiscovery.CanonicalizePath(entry.Cwd);
+                return string.Equals(theirs, canonCwd, StringComparison.Ordinal);
+            }
+            catch (IOException) { return false; }
+            catch (Exception ex)
+            {
+                logger.LogTrace(ex, "OpenCode discovery: header peek failed for {Path}", path);
+                return false;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) { return; }
+            try { Watcher?.Dispose(); }
+            catch (Exception ex) { logger.LogTrace(ex, "OpenCode discovery: watcher dispose threw"); }
+            try { PollTimer?.Dispose(); }
+            catch (Exception ex) { logger.LogTrace(ex, "OpenCode discovery: poll timer dispose threw"); }
+            Watcher = null;
+            PollTimer = null;
+        }
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static readonly NoopDisposable Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
@@ -85,14 +85,18 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
     private void OnFileEvent(object? _, FileSystemEventArgs e)
     {
         // Path layout: <root>/project/<slug>/storage/message/<sessionId>/<file>.json
-        // Pull the parent directory name as the candidate session id.
-        var sid = Path.GetFileName(Path.GetDirectoryName(e.FullPath) ?? string.Empty);
+        // Validate the grandparent dir is `message` so a stray `msg_*.json` outside the
+        // canonical layout (manual test file, future extensions) can't accidentally bind
+        // to a registered session id and corrupt its telemetry.
+        var messageDir = Path.GetDirectoryName(e.FullPath);
+        if (string.IsNullOrEmpty(messageDir)) { return; }
+        var grandparent = Path.GetFileName(Path.GetDirectoryName(messageDir) ?? string.Empty);
+        if (!string.Equals(grandparent, "message", StringComparison.OrdinalIgnoreCase)) { return; }
+
+        var sid = Path.GetFileName(messageDir);
         if (string.IsNullOrEmpty(sid)) { return; }
         if (!_watches.TryGetValue(sid, out var watch)) { return; }
-        if (watch.MessageDir is null)
-        {
-            watch.MessageDir = Path.GetDirectoryName(e.FullPath);
-        }
+        if (watch.MessageDir is null) { watch.MessageDir = messageDir; }
         Recompute(watch);
     }
 

--- a/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
@@ -1,0 +1,238 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace NoScope.CodeScope.Core.Services;
+
+/// <inheritdoc />
+public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(350);
+
+    private readonly ILogger<OpenCodeTelemetryService> _logger;
+    private readonly string _dataRoot;
+    private readonly ConcurrentDictionary<string, Watch> _watches = new();
+    private readonly Timer? _pollTimer;
+    private FileSystemWatcher? _rootWatcher;
+
+    public OpenCodeTelemetryService(ILogger<OpenCodeTelemetryService> logger)
+        : this(logger, DefaultDataRoot(), enablePolling: true) { }
+
+    /// <summary>Test-seam: point at a throwaway opencode data root, no polling unless requested.</summary>
+    public OpenCodeTelemetryService(ILogger<OpenCodeTelemetryService> logger, string dataRoot)
+        : this(logger, dataRoot, enablePolling: false) { }
+
+    /// <summary>Full test-seam constructor.</summary>
+    public OpenCodeTelemetryService(ILogger<OpenCodeTelemetryService> logger, string dataRoot, bool enablePolling)
+    {
+        _logger = logger;
+        _dataRoot = dataRoot;
+        if (enablePolling)
+        {
+            _pollTimer = new Timer(_ => PollAll(), null, PollInterval, PollInterval);
+        }
+
+        try
+        {
+            Directory.CreateDirectory(_dataRoot);
+            _rootWatcher = new FileSystemWatcher(_dataRoot, "msg_*.json")
+            {
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName | NotifyFilters.CreationTime,
+                EnableRaisingEvents = true,
+            };
+            _rootWatcher.Created += OnFileEvent;
+            _rootWatcher.Changed += OnFileEvent;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "OpenCode telemetry: failed to attach root watcher at {Root}", _dataRoot);
+        }
+    }
+
+    public event EventHandler<ClaudeSessionTelemetry>? Updated;
+
+    public void Register(string sessionId, string workingDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) { return; }
+
+        Unregister(sessionId);
+
+        var watch = new Watch(sessionId);
+        _watches[sessionId] = watch;
+
+        watch.MessageDir = TryLocateMessageDir(sessionId);
+        Recompute(watch);
+    }
+
+    public void Unregister(string sessionId)
+    {
+        if (_watches.TryRemove(sessionId, out var watch)) { watch.Dispose(); }
+    }
+
+    public ClaudeSessionTelemetry? GetSnapshot(string sessionId) =>
+        _watches.TryGetValue(sessionId, out var w) ? w.Snapshot : null;
+
+    public void Dispose()
+    {
+        try { _pollTimer?.Dispose(); }
+        catch (Exception ex) { _logger.LogTrace(ex, "OpenCode telemetry: poll timer dispose threw"); }
+        try { _rootWatcher?.Dispose(); }
+        catch (Exception ex) { _logger.LogTrace(ex, "OpenCode telemetry: root watcher dispose threw"); }
+        foreach (var w in _watches.Values) { w.Dispose(); }
+        _watches.Clear();
+    }
+
+    private void OnFileEvent(object? _, FileSystemEventArgs e)
+    {
+        // Path layout: <root>/project/<slug>/storage/message/<sessionId>/<file>.json
+        // Pull the parent directory name as the candidate session id.
+        var sid = Path.GetFileName(Path.GetDirectoryName(e.FullPath) ?? string.Empty);
+        if (string.IsNullOrEmpty(sid)) { return; }
+        if (!_watches.TryGetValue(sid, out var watch)) { return; }
+        if (watch.MessageDir is null)
+        {
+            watch.MessageDir = Path.GetDirectoryName(e.FullPath);
+        }
+        Recompute(watch);
+    }
+
+    private void PollAll()
+    {
+        foreach (var watch in _watches.Values)
+        {
+            try
+            {
+                if (watch.MessageDir is null)
+                {
+                    watch.MessageDir = TryLocateMessageDir(watch.SessionId);
+                    if (watch.MessageDir is null) { continue; }
+                }
+                Recompute(watch);
+            }
+            catch (Exception ex) { _logger.LogTrace(ex, "OpenCode telemetry poll failed for {Sid}", watch.SessionId); }
+        }
+    }
+
+    private string? TryLocateMessageDir(string sessionId)
+    {
+        if (!Directory.Exists(_dataRoot)) { return null; }
+        try
+        {
+            // Match the trailing path segment so we don't pick up a sibling project's directory
+            // that happens to embed the session id.
+            return Directory.EnumerateDirectories(_dataRoot, sessionId, SearchOption.AllDirectories)
+                .FirstOrDefault(d =>
+                {
+                    var parent = Path.GetFileName(Path.GetDirectoryName(d) ?? string.Empty);
+                    return string.Equals(parent, "message", StringComparison.OrdinalIgnoreCase);
+                });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogTrace(ex, "OpenCode telemetry locate failed for {Sid}", sessionId);
+            return null;
+        }
+    }
+
+    private void Recompute(Watch watch)
+    {
+        if (watch.MessageDir is null || !Directory.Exists(watch.MessageDir)) { return; }
+        lock (watch.ReadLock)
+        {
+            try
+            {
+                // OpenCode never modifies a message file once written — files are appended to the
+                // directory only. So we only parse files we haven't seen yet, then re-aggregate
+                // the in-memory entry list to derive the snapshot.
+                foreach (var file in Directory.EnumerateFiles(watch.MessageDir, "msg_*.json"))
+                {
+                    if (watch.SeenFiles.Contains(file)) { continue; }
+                    string content;
+                    try { content = File.ReadAllText(file); }
+                    catch (IOException) { continue; } // mid-write race — pick it up next poll
+                    var entry = OpenCodeMessageParser.ParseContent(content);
+                    if (entry is null) { continue; }
+                    watch.SeenFiles.Add(file);
+                    watch.Entries.Add(entry);
+                }
+
+                if (watch.Entries.Count == 0) { return; }
+
+                // Order canonically by metadata.time.created so file-system enumeration order
+                // doesn't skew the activity FSM.
+                watch.Entries.Sort((a, b) =>
+                    Nullable.Compare(a.CreatedAt, b.CreatedAt));
+
+                var lastAssistantWithUsage = watch.Entries.LastOrDefault(e => e.HasUsage);
+                var lastEntry = watch.Entries[^1];
+                var lastUser = watch.Entries.LastOrDefault(e => e.Role == "user");
+
+                var contextTokens = lastAssistantWithUsage?.ContextTokens ?? 0;
+                var turns = watch.Entries.Count(e => e.HasUsage);
+                var lastTurnAt = lastAssistantWithUsage?.CompletedAt ?? lastAssistantWithUsage?.CreatedAt;
+                TimeSpan? lastDuration = null;
+                if (lastAssistantWithUsage is not null && lastUser?.CreatedAt is { } userCreated
+                    && lastAssistantWithUsage.CreatedAt is { } assistantCreated
+                    && assistantCreated > userCreated)
+                {
+                    lastDuration = (lastAssistantWithUsage.CompletedAt ?? assistantCreated) - userCreated;
+                }
+
+                // Activity FSM:
+                //   user is most recent                      → Composing
+                //   assistant + pending tool call            → PendingToolUse
+                //   assistant + completed (no pending tools) → Idle
+                //   assistant + not yet completed            → Composing (streaming)
+                ClaudeActivityState activity;
+                if (lastEntry.Role == "user")
+                {
+                    activity = ClaudeActivityState.Composing;
+                }
+                else if (lastEntry.Role == "assistant" && lastEntry.HasPendingToolCall)
+                {
+                    activity = ClaudeActivityState.PendingToolUse;
+                }
+                else if (lastEntry.Role == "assistant" && lastEntry.CompletedAt is not null)
+                {
+                    activity = ClaudeActivityState.Idle;
+                }
+                else
+                {
+                    activity = ClaudeActivityState.Composing;
+                }
+
+                var modelId = lastAssistantWithUsage?.ModelId;
+                var contextCap = string.IsNullOrEmpty(modelId)
+                    ? watch.Snapshot?.ContextWindowTokens ?? 0
+                    : Math.Max(ClaudeModelCatalog.GetContextWindow(modelId!), watch.Snapshot?.ContextWindowTokens ?? 0);
+
+                var snap = new ClaudeSessionTelemetry(
+                    watch.SessionId, contextTokens, turns, lastTurnAt, lastDuration, activity, modelId, contextCap);
+
+                if (snap.Equals(watch.Snapshot)) { return; }
+                watch.Snapshot = snap;
+                try { Updated?.Invoke(this, snap); }
+                catch (Exception ex) { _logger.LogWarning(ex, "OpenCode telemetry subscriber threw"); }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "OpenCode telemetry: recompute failed for {Sid}", watch.SessionId);
+            }
+        }
+    }
+
+    private static string DefaultDataRoot() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "opencode");
+
+    private sealed class Watch(string sessionId) : IDisposable
+    {
+        public string SessionId { get; } = sessionId;
+        public string? MessageDir { get; set; }
+        public readonly HashSet<string> SeenFiles = new(StringComparer.OrdinalIgnoreCase);
+        public readonly List<OpenCodeMessageEntry> Entries = [];
+        public ClaudeSessionTelemetry? Snapshot;
+        public readonly object ReadLock = new();
+
+        public void Dispose() { }
+    }
+}

--- a/src/CodeScope.Core/Services/PiSessionDiscovery.cs
+++ b/src/CodeScope.Core/Services/PiSessionDiscovery.cs
@@ -1,0 +1,178 @@
+using Microsoft.Extensions.Logging;
+
+namespace NoScope.CodeScope.Core.Services;
+
+/// <inheritdoc />
+public sealed class PiSessionDiscovery : IPiSessionDiscovery
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(350);
+
+    private readonly ILogger<PiSessionDiscovery> _logger;
+    private readonly string _sessionsRoot;
+
+    public PiSessionDiscovery(ILogger<PiSessionDiscovery> logger)
+        : this(logger, DefaultSessionsRoot()) { }
+
+    /// <summary>Test-seam: point at a throwaway sessions root.</summary>
+    public PiSessionDiscovery(ILogger<PiSessionDiscovery> logger, string sessionsRoot)
+    {
+        _logger = logger;
+        _sessionsRoot = sessionsRoot;
+    }
+
+    public IDisposable Watch(string workingDirectory, DateTimeOffset since, Action<string, string> onDiscovered)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+        ArgumentNullException.ThrowIfNull(onDiscovered);
+
+        try { Directory.CreateDirectory(_sessionsRoot); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Pi discovery: cannot ensure {Dir}", _sessionsRoot);
+            return NoopDisposable.Instance;
+        }
+
+        var canonCwd = CanonicalizePath(workingDirectory);
+        var handle = new WatchHandle(since.UtcDateTime, canonCwd, onDiscovered, _logger);
+
+        try
+        {
+            handle.Watcher = new FileSystemWatcher(_sessionsRoot, "*.jsonl")
+            {
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.Size,
+                EnableRaisingEvents = true,
+            };
+            handle.Watcher.Created += (_, e) => handle.TryConsider(e.FullPath);
+            handle.Watcher.Changed += (_, e) => handle.TryConsider(e.FullPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Pi discovery: failed to watch {Dir}", _sessionsRoot);
+        }
+
+        // Poll fallback handles the same races Claude's discovery does: file pre-existed,
+        // FSWatcher buffer overflow, header line not yet flushed at Created event time.
+        handle.PollTimer = new Timer(_ =>
+        {
+            try
+            {
+                if (!Directory.Exists(_sessionsRoot)) { return; }
+                foreach (var path in Directory.EnumerateFiles(_sessionsRoot, "*.jsonl", SearchOption.AllDirectories))
+                {
+                    handle.TryConsider(path);
+                }
+            }
+            catch (Exception ex) { _logger.LogTrace(ex, "Pi discovery poll failed"); }
+        }, null, TimeSpan.Zero, PollInterval);
+
+        return handle;
+    }
+
+    /// <summary>
+    /// Canonicalize a path for cross-platform comparison: lowercase, forward-slashes, drive
+    /// colon stripped, trimmed leading slashes. So <c>C:\dev\codescope</c> and <c>/c/dev/codescope</c>
+    /// and <c>c:/dev/codescope</c> all collapse to <c>c/dev/codescope</c>.
+    /// </summary>
+    internal static string CanonicalizePath(string path)
+    {
+        if (string.IsNullOrEmpty(path)) { return string.Empty; }
+        return path
+            .Replace('\\', '/')
+            .Replace(":", string.Empty)
+            .TrimStart('/')
+            .TrimEnd('/')
+            .ToLowerInvariant();
+    }
+
+    private static string DefaultSessionsRoot() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".pi", "agent", "sessions");
+
+    private sealed class WatchHandle(
+        DateTime sinceUtc,
+        string canonCwd,
+        Action<string, string> onDiscovered,
+        ILogger logger) : IDisposable
+    {
+        private readonly HashSet<string> _fired = new(StringComparer.OrdinalIgnoreCase);
+        private readonly object _firedLock = new();
+        private int _disposed;
+
+        public FileSystemWatcher? Watcher;
+        public Timer? PollTimer;
+
+        public void TryConsider(string path)
+        {
+            if (Volatile.Read(ref _disposed) != 0) { return; }
+            try
+            {
+                var info = new FileInfo(path);
+                if (!info.Exists) { return; }
+                if (info.CreationTimeUtc < sinceUtc && info.LastWriteTimeUtc < sinceUtc) { return; }
+
+                var sid = PiTranscriptParser.ExtractSessionIdFromFileName(info.Name);
+                if (sid is null) { return; }
+
+                lock (_firedLock)
+                {
+                    if (_fired.Contains(path)) { return; }
+                }
+
+                // Peek the header (first non-empty line) — match by cwd to avoid adopting an
+                // unrelated session that landed in the watch root from another workspace.
+                if (!HeaderMatches(path)) { return; }
+
+                lock (_firedLock)
+                {
+                    if (!_fired.Add(path)) { return; }
+                }
+
+                try { onDiscovered(sid, path); }
+                catch (Exception ex) { logger.LogWarning(ex, "Pi discovery: subscriber threw"); }
+            }
+            catch (Exception ex) { logger.LogTrace(ex, "Pi discovery: consider failed for {Path}", path); }
+        }
+
+        private bool HeaderMatches(string path)
+        {
+            try
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+                using var reader = new StreamReader(fs);
+                while (reader.ReadLine() is { } line)
+                {
+                    if (string.IsNullOrWhiteSpace(line)) { continue; }
+                    var entry = PiTranscriptParser.ParseLine(line);
+                    if (entry?.Type != "session") { return false; }
+                    var theirs = CanonicalizePath(entry.Cwd ?? string.Empty);
+                    return string.Equals(theirs, canonCwd, StringComparison.Ordinal);
+                }
+                return false;
+            }
+            catch (IOException) { return false; }
+            catch (Exception ex)
+            {
+                logger.LogTrace(ex, "Pi discovery: header peek failed for {Path}", path);
+                return false;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) { return; }
+            try { Watcher?.Dispose(); }
+            catch (Exception ex) { logger.LogTrace(ex, "Pi discovery: watcher dispose threw"); }
+            try { PollTimer?.Dispose(); }
+            catch (Exception ex) { logger.LogTrace(ex, "Pi discovery: poll timer dispose threw"); }
+            Watcher = null;
+            PollTimer = null;
+        }
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static readonly NoopDisposable Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/src/CodeScope.Core/Services/PiTelemetryService.cs
+++ b/src/CodeScope.Core/Services/PiTelemetryService.cs
@@ -1,0 +1,263 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace NoScope.CodeScope.Core.Services;
+
+/// <inheritdoc />
+public sealed class PiTelemetryService : IPiTelemetryService
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(250);
+
+    private readonly ILogger<PiTelemetryService> _logger;
+    private readonly string _sessionsRoot;
+    private readonly ConcurrentDictionary<string, Watch> _watches = new();
+    private readonly Timer? _pollTimer;
+    private FileSystemWatcher? _rootWatcher;
+
+    public PiTelemetryService(ILogger<PiTelemetryService> logger)
+        : this(logger, DefaultSessionsRoot(), enablePolling: true) { }
+
+    /// <summary>Test-seam: point at a throwaway sessions root, no polling unless requested.</summary>
+    public PiTelemetryService(ILogger<PiTelemetryService> logger, string sessionsRoot)
+        : this(logger, sessionsRoot, enablePolling: false) { }
+
+    /// <summary>Full test-seam constructor.</summary>
+    public PiTelemetryService(ILogger<PiTelemetryService> logger, string sessionsRoot, bool enablePolling)
+    {
+        _logger = logger;
+        _sessionsRoot = sessionsRoot;
+        if (enablePolling)
+        {
+            _pollTimer = new Timer(_ => PollAll(), null, PollInterval, PollInterval);
+        }
+
+        // Single recursive watcher across the whole sessions root: cheaper than one per
+        // registration AND covers files that don't exist yet at Register time (fresh launch
+        // where pi hasn't written its header line).
+        try
+        {
+            Directory.CreateDirectory(_sessionsRoot);
+            _rootWatcher = new FileSystemWatcher(_sessionsRoot, "*.jsonl")
+            {
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName | NotifyFilters.CreationTime,
+                EnableRaisingEvents = true,
+            };
+            _rootWatcher.Created += OnFileEvent;
+            _rootWatcher.Changed += OnFileEvent;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Pi telemetry: failed to attach root watcher at {Root}", _sessionsRoot);
+        }
+    }
+
+    public event EventHandler<ClaudeSessionTelemetry>? Updated;
+
+    public void Register(string sessionId, string workingDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) { return; }
+
+        Unregister(sessionId);
+
+        // workingDirectory hint is ignored: Pi's cwd→dir encoding isn't reliably recoverable
+        // on Windows, so we resolve the file path by scanning for "*_<sessionId>.jsonl" anywhere
+        // under the sessions root. When the file doesn't exist yet (fresh launch race), the
+        // root watcher will route the Created event back through OnFileEvent → Adopt.
+        var watch = new Watch(sessionId);
+        _watches[sessionId] = watch;
+
+        var existing = TryLocate(sessionId);
+        if (existing is not null)
+        {
+            watch.FilePath = existing;
+            TryRead(watch);
+        }
+    }
+
+    public void Unregister(string sessionId)
+    {
+        if (_watches.TryRemove(sessionId, out var watch)) { watch.Dispose(); }
+    }
+
+    public ClaudeSessionTelemetry? GetSnapshot(string sessionId) =>
+        _watches.TryGetValue(sessionId, out var w) ? w.Snapshot : null;
+
+    public void Dispose()
+    {
+        try { _pollTimer?.Dispose(); }
+        catch (Exception ex) { _logger.LogTrace(ex, "Pi telemetry: poll timer dispose threw"); }
+        try { _rootWatcher?.Dispose(); }
+        catch (Exception ex) { _logger.LogTrace(ex, "Pi telemetry: root watcher dispose threw"); }
+        foreach (var w in _watches.Values) { w.Dispose(); }
+        _watches.Clear();
+    }
+
+    private void OnFileEvent(object? _, FileSystemEventArgs e)
+    {
+        // The path matches "*_<sid>.jsonl" — extract the trailing UUID and route to the
+        // registered watch (if any).
+        var sid = PiTranscriptParser.ExtractSessionIdFromFileName(e.Name ?? string.Empty);
+        if (sid is null) { return; }
+        if (!_watches.TryGetValue(sid, out var watch)) { return; }
+        if (watch.FilePath is null) { watch.FilePath = e.FullPath; }
+        TryRead(watch);
+    }
+
+    private void PollAll()
+    {
+        foreach (var watch in _watches.Values)
+        {
+            try
+            {
+                if (watch.FilePath is null)
+                {
+                    var found = TryLocate(watch.SessionId);
+                    if (found is null) { continue; }
+                    watch.FilePath = found;
+                }
+                var info = new FileInfo(watch.FilePath);
+                if (!info.Exists) { continue; }
+                if (info.Length == watch.Offset) { continue; }
+                TryRead(watch);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogTrace(ex, "Pi telemetry poll failed for {Sid}", watch.SessionId);
+            }
+        }
+    }
+
+    private string? TryLocate(string sessionId)
+    {
+        // Pi pads session-files as "<timestamp>_<uuid>.jsonl"; the suffix pattern uniquely
+        // identifies the file across the entire sessions root (UUIDs are unique).
+        if (!Directory.Exists(_sessionsRoot)) { return null; }
+        try
+        {
+            return Directory.EnumerateFiles(_sessionsRoot, $"*_{sessionId}.jsonl",
+                SearchOption.AllDirectories).FirstOrDefault();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogTrace(ex, "Pi telemetry locate failed for {Sid}", sessionId);
+            return null;
+        }
+    }
+
+    private void TryRead(Watch watch)
+    {
+        if (watch.FilePath is null) { return; }
+        lock (watch.ReadLock)
+        {
+            if (!File.Exists(watch.FilePath)) { return; }
+            try
+            {
+                using var fs = new FileStream(watch.FilePath, FileMode.Open, FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+                if (watch.Offset > fs.Length) { watch.Offset = 0; }
+                fs.Seek(watch.Offset, SeekOrigin.Begin);
+                using var reader = new StreamReader(fs);
+
+                var contextTokens = watch.Snapshot?.ContextTokens ?? 0;
+                var turns = watch.Snapshot?.TurnCount ?? 0;
+                var lastAt = watch.Snapshot?.LastTurnAt;
+                var lastDuration = watch.Snapshot?.LastTurnDuration;
+                var activity = watch.Snapshot?.Activity ?? ClaudeActivityState.Unknown;
+                var modelId = watch.Snapshot?.ModelId;
+                var contextCap = watch.Snapshot?.ContextWindowTokens ?? 0;
+                var changed = false;
+
+                while (reader.ReadLine() is { } line)
+                {
+                    var entry = PiTranscriptParser.ParseLine(line);
+                    if (entry is null) { continue; }
+
+                    // Pi has dedicated `model_change` events; latch the model + cap as they arrive.
+                    if (entry.Type == "model_change" && !string.IsNullOrWhiteSpace(entry.Model))
+                    {
+                        modelId = entry.Model;
+                        var cap = ClaudeModelCatalog.GetContextWindow(entry.Model);
+                        if (cap > 0) { contextCap = cap; }
+                        changed = true;
+                        continue;
+                    }
+
+                    if (entry.Type != "message") { continue; }
+
+                    // Activity FSM:
+                    //   user / toolResult        → Composing (agent is now responding)
+                    //   assistant + stop         → Idle
+                    //   assistant + tool_use     → PendingToolUse
+                    if (entry.Role is "user" or "toolResult")
+                    {
+                        activity = ClaudeActivityState.Composing;
+                        if (entry.Timestamp is { } userTs) { watch.LastUserTurnAt = userTs; }
+                        changed = true;
+                        continue;
+                    }
+
+                    if (entry.Role == "assistant")
+                    {
+                        activity = entry.StopReason switch
+                        {
+                            "tool_use" => ClaudeActivityState.PendingToolUse,
+                            "stop" => ClaudeActivityState.Idle,
+                            "end_turn" => ClaudeActivityState.Idle, // anthropic-style alias
+                            _ => activity,
+                        };
+                        changed = true;
+                    }
+
+                    if (!entry.HasUsage) { continue; }
+
+                    if (!string.IsNullOrWhiteSpace(entry.Model) && entry.Model != modelId)
+                    {
+                        modelId = entry.Model;
+                        var detected = ClaudeModelCatalog.GetContextWindow(entry.Model);
+                        if (detected > 0) { contextCap = detected; }
+                    }
+
+                    contextTokens = entry.InputTokens + entry.CacheReadTokens + entry.CacheCreationTokens + entry.OutputTokens;
+                    turns += 1;
+                    if (entry.Timestamp is { } ts)
+                    {
+                        if (watch.LastUserTurnAt is { } userAt && ts > userAt)
+                        {
+                            lastDuration = ts - userAt;
+                        }
+                        lastAt = ts;
+                    }
+                }
+
+                watch.Offset = fs.Position;
+
+                if (changed)
+                {
+                    var snap = new ClaudeSessionTelemetry(
+                        watch.SessionId, contextTokens, turns, lastAt, lastDuration, activity, modelId, contextCap);
+                    watch.Snapshot = snap;
+                    try { Updated?.Invoke(this, snap); }
+                    catch (Exception ex) { _logger.LogWarning(ex, "Pi telemetry subscriber threw"); }
+                }
+            }
+            catch (IOException ex) { _logger.LogTrace(ex, "Pi telemetry: mid-flush race for {Path}", watch.FilePath); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Pi telemetry: read failed for {Path}", watch.FilePath); }
+        }
+    }
+
+    private static string DefaultSessionsRoot() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".pi", "agent", "sessions");
+
+    private sealed class Watch(string sessionId) : IDisposable
+    {
+        public string SessionId { get; } = sessionId;
+        public string? FilePath { get; set; }
+        public long Offset;
+        public ClaudeSessionTelemetry? Snapshot;
+        public DateTimeOffset? LastUserTurnAt;
+        public readonly object ReadLock = new();
+
+        public void Dispose() { }
+    }
+}

--- a/src/CodeScope.Core/Services/PiTelemetryService.cs
+++ b/src/CodeScope.Core/Services/PiTelemetryService.cs
@@ -192,7 +192,14 @@ public sealed class PiTelemetryService : IPiTelemetryService
                     if (entry.Role is "user" or "toolResult")
                     {
                         activity = ClaudeActivityState.Composing;
-                        if (entry.Timestamp is { } userTs) { watch.LastUserTurnAt = userTs; }
+                        // Only a fresh user turn anchors LastUserTurnAt — toolResult marks the
+                        // mid-turn return of a tool call, so resetting here would cut the
+                        // measured turn-duration short. Mirrors ClaudeTelemetryService's
+                        // `!entry.UserCarriesToolResult` guard.
+                        if (entry.Role == "user" && entry.Timestamp is { } userTs)
+                        {
+                            watch.LastUserTurnAt = userTs;
+                        }
                         changed = true;
                         continue;
                     }

--- a/src/CodeScope.Core/Services/PiTranscriptParser.cs
+++ b/src/CodeScope.Core/Services/PiTranscriptParser.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+
+namespace NoScope.CodeScope.Core.Services;
+
+/// <summary>
+/// One parsed line from a pi-coding-agent <c>~/.pi/agent/sessions/--&lt;cwd&gt;--/&lt;ts&gt;_&lt;uuid&gt;.jsonl</c>
+/// transcript. Pi's on-disk schema is richer than its <c>--mode json</c> stdout stream — top-level
+/// types include <c>session</c> (header), <c>message</c> (with role + usage + stopReason),
+/// <c>compaction</c>, <c>model_change</c>, <c>thinking_level_change</c>, <c>branch_summary</c>,
+/// <c>label</c>, <c>custom</c>, <c>custom_message</c>. Fields outside what the status bar
+/// consumes are intentionally dropped.
+/// </summary>
+public sealed record PiTranscriptEntry(
+    string? SessionId,
+    string? Type,
+    string? Role,
+    DateTimeOffset? Timestamp,
+    int InputTokens,
+    int OutputTokens,
+    int CacheCreationTokens,
+    int CacheReadTokens,
+    string? StopReason = null,
+    string? Model = null,
+    string? Provider = null,
+    string? Cwd = null)
+{
+    /// <summary>True when this entry carries assistant token usage.</summary>
+    public bool HasUsage => Type == "message"
+        && Role == "assistant"
+        && (InputTokens > 0 || OutputTokens > 0 || CacheCreationTokens > 0 || CacheReadTokens > 0);
+
+    /// <summary>Status-bar billable count — input + output + cache-write. Mirrors Claude semantics.</summary>
+    public int BillableTokens => InputTokens + OutputTokens + CacheCreationTokens;
+}
+
+/// <summary>
+/// Pure static parser for Pi session.jsonl entries. No IO. <c>null</c> on unparseable lines
+/// (trailing partial flush, extension-emitted custom types we don't model, etc.).
+/// </summary>
+public static class PiTranscriptParser
+{
+    /// <summary>Parse a single Pi <c>session.jsonl</c> line. Returns <c>null</c> for blank lines or malformed JSON.</summary>
+    public static PiTranscriptEntry? ParseLine(string line)
+    {
+        if (string.IsNullOrWhiteSpace(line)) { return null; }
+        try
+        {
+            using var doc = JsonDocument.Parse(line);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) { return null; }
+
+            var type = GetString(root, "type");
+            var timestamp = ParseTimestamp(GetString(root, "timestamp"));
+
+            // session header carries the canonical session id + cwd; all other entries' top-level
+            // `id` is the line id, not the session id (we recover the session id from the file
+            // name via ExtractSessionIdFromFileName).
+            if (type == "session")
+            {
+                return new PiTranscriptEntry(
+                    SessionId: GetString(root, "id"),
+                    Type: type,
+                    Role: null,
+                    Timestamp: timestamp,
+                    InputTokens: 0, OutputTokens: 0,
+                    CacheCreationTokens: 0, CacheReadTokens: 0,
+                    Cwd: GetString(root, "cwd"));
+            }
+
+            // model_change events carry the model id at root, not under message.
+            if (type == "model_change")
+            {
+                return new PiTranscriptEntry(
+                    SessionId: null,
+                    Type: type,
+                    Role: null,
+                    Timestamp: timestamp,
+                    InputTokens: 0, OutputTokens: 0,
+                    CacheCreationTokens: 0, CacheReadTokens: 0,
+                    Model: GetString(root, "modelId"),
+                    Provider: GetString(root, "provider"));
+            }
+
+            string? role = null;
+            int input = 0, output = 0, cacheCreate = 0, cacheRead = 0;
+            string? stopReason = null;
+            string? model = null;
+            string? provider = null;
+
+            if (type == "message"
+                && root.TryGetProperty("message", out var msg)
+                && msg.ValueKind == JsonValueKind.Object)
+            {
+                role = GetString(msg, "role");
+                stopReason = GetString(msg, "stopReason");
+                model = GetString(msg, "model");
+                provider = GetString(msg, "provider");
+
+                if (msg.TryGetProperty("usage", out var usage) && usage.ValueKind == JsonValueKind.Object)
+                {
+                    input = GetInt(usage, "input");
+                    output = GetInt(usage, "output");
+                    cacheRead = GetInt(usage, "cacheRead");
+                    cacheCreate = GetInt(usage, "cacheWrite");
+                }
+            }
+
+            return new PiTranscriptEntry(
+                SessionId: null,
+                Type: type,
+                Role: role,
+                Timestamp: timestamp,
+                InputTokens: input, OutputTokens: output,
+                CacheCreationTokens: cacheCreate, CacheReadTokens: cacheRead,
+                StopReason: stopReason,
+                Model: model,
+                Provider: provider);
+        }
+        catch (JsonException ex)
+        {
+            // Mid-flush partial line — Pi flushes per event but a process exit can leave a
+            // half-written tail. Trace and skip; the next read picks up the rest.
+            System.Diagnostics.Debug.WriteLine($"[PiTranscriptParser] Skipping malformed JSONL line: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Pulls the trailing UUID out of a Pi session-file name like
+    /// <c>2026-04-22T08-00-00-000Z_f1e2d3c4-aaaa-bbbb-cccc-1234567890ab.jsonl</c>. Pi names every
+    /// session file with a timestamp prefix and an underscore separator before the UUID, so the
+    /// portion after the last <c>_</c> minus the extension IS the session id. Returns
+    /// <c>null</c> when the file name doesn't match the convention or the trailing token isn't
+    /// a valid UUID — that lets the discovery layer skip extension-created sidecar files
+    /// without picking up false positives.
+    /// </summary>
+    public static string? ExtractSessionIdFromFileName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName)) { return null; }
+        var stem = Path.GetFileNameWithoutExtension(fileName);
+        var underscore = stem.LastIndexOf('_');
+        if (underscore < 0 || underscore == stem.Length - 1) { return null; }
+        var id = stem[(underscore + 1)..];
+        return Guid.TryParseExact(id, "D", out _) ? id : null;
+    }
+
+    private static string? GetString(JsonElement obj, string prop) =>
+        obj.TryGetProperty(prop, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private static int GetInt(JsonElement obj, string prop) =>
+        obj.TryGetProperty(prop, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var n) ? n : 0;
+
+    private static DateTimeOffset? ParseTimestamp(string? raw) =>
+        DateTimeOffset.TryParse(raw, out var dt) ? dt : null;
+}

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -436,7 +436,7 @@ public sealed partial class MainViewModel : ObservableObject
         var vm = new SessionTabViewModel(descriptor, project.Id, session.AgentId, session.DisplayName, agent?.Icon);
         FocusedGroup.Tabs.Add(vm);
         SelectedTab = vm;
-        BeginClaudeAdoption(descriptor.Id, agent?.Id, targetFolder, DateTimeOffset.UtcNow);
+        BeginAgentAdoption(descriptor.Id, agent?.Id, targetFolder, DateTimeOffset.UtcNow);
         OnPropertyChanged(nameof(CanCloseGroup));
         CloseGroupCommand.NotifyCanExecuteChanged();
     }
@@ -554,7 +554,7 @@ public sealed partial class MainViewModel : ObservableObject
             {
                 RegisterAgentTelemetry(stored.AgentId, sid, stored.WorktreePath);
             }
-            BeginClaudeAdoption(descriptor.Id, stored.AgentId, stored.WorktreePath, DateTimeOffset.UtcNow);
+            BeginAgentAdoption(descriptor.Id, stored.AgentId, stored.WorktreePath, DateTimeOffset.UtcNow);
         }
         CloseGroupCommand.NotifyCanExecuteChanged();
         OnPropertyChanged(nameof(CanCloseGroup));
@@ -628,7 +628,7 @@ public sealed partial class MainViewModel : ObservableObject
         {
             RegisterAgentTelemetry(closed.AgentId, sid, worktree.Path);
         }
-        BeginClaudeAdoption(descriptor.Id, closed.AgentId, worktree.Path, DateTimeOffset.UtcNow);
+        BeginAgentAdoption(descriptor.Id, closed.AgentId, worktree.Path, DateTimeOffset.UtcNow);
         OnPropertyChanged(nameof(CanCloseGroup));
         CloseGroupCommand.NotifyCanExecuteChanged();
         return true;
@@ -762,7 +762,7 @@ public sealed partial class MainViewModel : ObservableObject
         var vm = new SessionTabViewModel(descriptor, project.Id, session.AgentId, session.DisplayName, agent?.Icon);
         FocusedGroup.Tabs.Add(vm);
         SelectedTab = vm;
-        BeginClaudeAdoption(descriptor.Id, agent?.Id, folder, DateTimeOffset.UtcNow);
+        BeginAgentAdoption(descriptor.Id, agent?.Id, folder, DateTimeOffset.UtcNow);
         CloseGroupCommand.NotifyCanExecuteChanged();
     }
 
@@ -798,7 +798,7 @@ public sealed partial class MainViewModel : ObservableObject
         {
             UnregisterAgentTelemetry(storedForTab.AgentId, tsid);
         }
-        StopClaudeAdoption(tab.Descriptor.Id);
+        StopAgentAdoption(tab.Descriptor.Id);
         // The pool owns the SessionTabView; release here so ConPTY teardown actually runs.
         // (Removed Unloaded teardown on the view itself — see SessionTabView ctor.)
         SessionViewPool?.Release(tab.Descriptor.Id);
@@ -1041,7 +1041,7 @@ public sealed partial class MainViewModel : ObservableObject
                     // this handler fires; the external-only path (store removes without
                     // CloseTabAsync) is a fire-and-forget edge case that can't recover the
                     // AgentSessionId without an extra lookup.
-                    StopClaudeAdoption(removed.SessionId);
+                    StopAgentAdoption(removed.SessionId);
                     CloseGroupCommand.NotifyCanExecuteChanged();
                     break;
             }
@@ -1153,19 +1153,19 @@ public sealed partial class MainViewModel : ObservableObject
                 {
                     RegisterAgentTelemetry(s.AgentId, sid, s.WorktreePath);
                 }
-                BeginClaudeAdoption(s.Id, s.AgentId, s.WorktreePath, now);
+                BeginAgentAdoption(s.Id, s.AgentId, s.WorktreePath, now);
             }
         }
     }
 
     /// <summary>
-    /// Starts a discovery watch on <paramref name="workingDir"/> and, on first new jsonl,
-    /// persists the adopted id onto <paramref name="storedSessionId"/> and registers the
-    /// matching telemetry tail. Routes by <paramref name="agentId"/> to either Claude or
-    /// Pi backends; no-op for other agents or when the relevant services aren't wired
-    /// (tests / headless).
+    /// Starts a discovery watch on <paramref name="workingDir"/> and, on first adoption-worthy
+    /// transcript event, persists the adopted id onto <paramref name="storedSessionId"/> and
+    /// registers the matching telemetry tail. Routes by <paramref name="agentId"/> to the
+    /// Claude, Pi, or OpenCode backend; no-op for other agents or when the relevant services
+    /// aren't wired (tests / headless).
     /// </summary>
-    private void BeginClaudeAdoption(string storedSessionId, string? agentId, string workingDir, DateTimeOffset since)
+    private void BeginAgentAdoption(string storedSessionId, string? agentId, string workingDir, DateTimeOffset since)
     {
         if (string.IsNullOrWhiteSpace(workingDir)) { return; }
 
@@ -1196,14 +1196,15 @@ public sealed partial class MainViewModel : ObservableObject
         }
 
         if (handle is null) { return; }
-        StopClaudeAdoption(storedSessionId);
+        StopAgentAdoption(storedSessionId);
         _discoveryWatches[storedSessionId] = handle;
     }
 
     /// <summary>
-    /// Adoption callback shared by Claude + Pi: persist the new id onto the store row and
-    /// (re-)register the matching telemetry tail. Marshals onto the dispatcher because the
-    /// discovery callback fires on a watcher thread.
+    /// Adoption callback shared by every supported agent backend (Claude, Pi, OpenCode):
+    /// persist the new id onto the store row and (re-)register the matching telemetry
+    /// tail. Marshals onto the dispatcher because the discovery callback fires on a
+    /// watcher thread.
     /// </summary>
     private void ApplyAdoption(string storedSessionId, string adoptedId, string? agentId, string workingDir)
     {
@@ -1293,12 +1294,12 @@ public sealed partial class MainViewModel : ObservableObject
         return null;
     }
 
-    private void StopClaudeAdoption(string storedSessionId)
+    private void StopAgentAdoption(string storedSessionId)
     {
         if (_discoveryWatches.Remove(storedSessionId, out var handle))
         {
             try { handle.Dispose(); }
-            catch (Exception ex) { _logger.LogTrace(ex, "StopClaudeAdoption: dispose threw for {SessionId}", storedSessionId); }
+            catch (Exception ex) { _logger.LogTrace(ex, "StopAgentAdoption: dispose threw for {SessionId}", storedSessionId); }
         }
     }
 

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -28,6 +28,10 @@ public sealed partial class MainViewModel : ObservableObject
     private readonly INotificationService? _notifications;
     private readonly IClaudeSessionDiscovery? _discovery;
     private readonly IToastService? _toasts;
+    private readonly IPiTelemetryService? _piTelemetry;
+    private readonly IPiSessionDiscovery? _piDiscovery;
+    private readonly IOpenCodeTelemetryService? _opencodeTelemetry;
+    private readonly IOpenCodeSessionDiscovery? _opencodeDiscovery;
     private readonly Dictionary<string, ClaudeActivityState> _lastActivity = [];
     // Per-tab discovery watcher — disposed on adoption or tab close.
     private readonly Dictionary<string, IDisposable> _discoveryWatches = [];
@@ -43,7 +47,11 @@ public sealed partial class MainViewModel : ObservableObject
         INotificationService? notifications = null,
         IClaudeSessionDiscovery? discovery = null,
         IToastService? toasts = null,
-        ISessionViewHostPool? sessionViewPool = null)
+        ISessionViewHostPool? sessionViewPool = null,
+        IPiTelemetryService? piTelemetry = null,
+        IPiSessionDiscovery? piDiscovery = null,
+        IOpenCodeTelemetryService? opencodeTelemetry = null,
+        IOpenCodeSessionDiscovery? opencodeDiscovery = null)
     {
         _sessionManager = sessionManager;
         _store = store;
@@ -55,8 +63,16 @@ public sealed partial class MainViewModel : ObservableObject
         _notifications = notifications;
         _discovery = discovery;
         _toasts = toasts;
+        _piTelemetry = piTelemetry;
+        _piDiscovery = piDiscovery;
+        _opencodeTelemetry = opencodeTelemetry;
+        _opencodeDiscovery = opencodeDiscovery;
         SessionViewPool = sessionViewPool;
         if (_telemetry is not null) { _telemetry.Updated += OnTelemetryUpdated; }
+        // All telemetry backends emit ClaudeSessionTelemetry — same handler routes any source
+        // through ApplyTelemetry, which keys by AgentSessionId so backend identity doesn't matter.
+        if (_piTelemetry is not null) { _piTelemetry.Updated += OnTelemetryUpdated; }
+        if (_opencodeTelemetry is not null) { _opencodeTelemetry.Updated += OnTelemetryUpdated; }
         if (_notifications is not null)
         {
             Notifications = new NotificationsViewModel(_notifications);
@@ -534,10 +550,9 @@ public sealed partial class MainViewModel : ObservableObject
             var insertAt = Math.Clamp(indexInGroup, 0, group.Tabs.Count);
             group.Tabs.Insert(insertAt, vm);
 
-            if (string.Equals(stored.AgentId, "claude", StringComparison.OrdinalIgnoreCase)
-                && stored.AgentSessionId is { Length: > 0 } sid)
+            if (stored.AgentSessionId is { Length: > 0 } sid)
             {
-                _telemetry?.Register(sid, stored.WorktreePath);
+                RegisterAgentTelemetry(stored.AgentId, sid, stored.WorktreePath);
             }
             BeginClaudeAdoption(descriptor.Id, stored.AgentId, stored.WorktreePath, DateTimeOffset.UtcNow);
         }
@@ -609,10 +624,9 @@ public sealed partial class MainViewModel : ObservableObject
         FocusedGroup.Tabs.Add(vm);
         SelectedTab = vm;
 
-        if (string.Equals(closed.AgentId, "claude", StringComparison.OrdinalIgnoreCase)
-            && closed.AgentSessionId is { Length: > 0 } sid)
+        if (closed.AgentSessionId is { Length: > 0 } sid)
         {
-            _telemetry?.Register(sid, worktree.Path);
+            RegisterAgentTelemetry(closed.AgentId, sid, worktree.Path);
         }
         BeginClaudeAdoption(descriptor.Id, closed.AgentId, worktree.Path, DateTimeOffset.UtcNow);
         OnPropertyChanged(nameof(CanCloseGroup));
@@ -780,7 +794,10 @@ public sealed partial class MainViewModel : ObservableObject
         var index = group.Tabs.IndexOf(tab);
         if (index >= 0) { group.Tabs.RemoveAt(index); }
         var storedForTab = FindStoredSession(tab);
-        if (storedForTab?.AgentSessionId is { Length: > 0 } tsid) { _telemetry?.Unregister(tsid); }
+        if (storedForTab?.AgentSessionId is { Length: > 0 } tsid)
+        {
+            UnregisterAgentTelemetry(storedForTab.AgentId, tsid);
+        }
         StopClaudeAdoption(tab.Descriptor.Id);
         // The pool owns the SessionTabView; release here so ConPTY teardown actually runs.
         // (Removed Unloaded teardown on the view itself — see SessionTabView ctor.)
@@ -1132,10 +1149,9 @@ public sealed partial class MainViewModel : ObservableObject
                 // frozen until the user fires the next turn. Registering here synchronously
                 // replays the persisted transcript and seeds the snapshot immediately; the
                 // adoption watch still runs in parallel to catch `/clear` rotations.
-                if (string.Equals(s.AgentId, "claude", StringComparison.OrdinalIgnoreCase)
-                    && s.AgentSessionId is { Length: > 0 } sid)
+                if (s.AgentSessionId is { Length: > 0 } sid)
                 {
-                    _telemetry?.Register(sid, s.WorktreePath);
+                    RegisterAgentTelemetry(s.AgentId, sid, s.WorktreePath);
                 }
                 BeginClaudeAdoption(s.Id, s.AgentId, s.WorktreePath, now);
             }
@@ -1145,55 +1161,124 @@ public sealed partial class MainViewModel : ObservableObject
     /// <summary>
     /// Starts a discovery watch on <paramref name="workingDir"/> and, on first new jsonl,
     /// persists the adopted id onto <paramref name="storedSessionId"/> and registers the
-    /// Claude telemetry tail. No-op for non-Claude agents or when discovery isn't wired
+    /// matching telemetry tail. Routes by <paramref name="agentId"/> to either Claude or
+    /// Pi backends; no-op for other agents or when the relevant services aren't wired
     /// (tests / headless).
     /// </summary>
     private void BeginClaudeAdoption(string storedSessionId, string? agentId, string workingDir, DateTimeOffset since)
     {
-        if (_discovery is null) { return; }
-        if (!string.Equals(agentId, "claude", StringComparison.OrdinalIgnoreCase)) { return; }
         if (string.IsNullOrWhiteSpace(workingDir)) { return; }
 
-        StopClaudeAdoption(storedSessionId);
-
-        // Watch stays alive for the tab's lifetime: Claude Code rotates its session id on
-        // `/clear` by writing a fresh jsonl in the same cwd dir. Each rotation fires the
-        // callback with the new id; we unregister the old telemetry tail, persist the new
-        // id, and register the new tail so the status bar keeps tracking. Disposed on
-        // tab close / cross-group drop via StopClaudeAdoption.
-        var handle = _discovery.Watch(workingDir, since, (adoptedId, _path) =>
+        IDisposable? handle = null;
+        if (string.Equals(agentId, "claude", StringComparison.OrdinalIgnoreCase) && _discovery is not null)
         {
-            var app = Application.Current;
-            async Task ApplyAsync()
-            {
-                // Skip if this id is already the one we're persisting — the initial launch
-                // adoption fires on startup and the poll fallback can re-fire on a live file.
-                var currentId = FindStoredSessionById(storedSessionId)?.AgentSessionId;
-                if (string.Equals(currentId, adoptedId, StringComparison.OrdinalIgnoreCase))
-                {
-                    // Still make sure telemetry is registered — a just-loaded hydrate may need it.
-                    _telemetry?.Register(adoptedId, workingDir);
-                    return;
-                }
+            // Claude Code rotates its session id on `/clear` by writing a fresh jsonl in the
+            // same cwd dir; the watch stays alive for the tab's lifetime to catch each rotation.
+            handle = _discovery.Watch(workingDir, since, (adoptedId, _path) =>
+                ApplyAdoption(storedSessionId, adoptedId, agentId, workingDir));
+        }
+        else if (string.Equals(agentId, "pi", StringComparison.OrdinalIgnoreCase) && _piDiscovery is not null)
+        {
+            // Pi doesn't rotate ids on /clear (each `pi` invocation = its own session file),
+            // but a long-running tab can still see fresh files when the user manually starts
+            // a new conversation in the same cwd, so the same long-lived watch model applies.
+            handle = _piDiscovery.Watch(workingDir, since, (adoptedId, _path) =>
+                ApplyAdoption(storedSessionId, adoptedId, agentId, workingDir));
+        }
+        else if (string.Equals(agentId, "opencode", StringComparison.OrdinalIgnoreCase) && _opencodeDiscovery is not null)
+        {
+            // OpenCode mints its own session id and stores per-message JSON files. Adoption
+            // fires once per session id (the first assistant message exposes the cwd we match
+            // against). The watch stays alive for the tab's lifetime so a `/sessions` switch
+            // inside OpenCode that creates a new session is also picked up.
+            handle = _opencodeDiscovery.Watch(workingDir, since, (adoptedId, _path) =>
+                ApplyAdoption(storedSessionId, adoptedId, agentId, workingDir));
+        }
 
-                if (!string.IsNullOrEmpty(currentId)) { _telemetry?.Unregister(currentId!); }
-                _telemetry?.Register(adoptedId, workingDir);
-                var result = await _store.UpdateAgentSessionIdAsync(storedSessionId, adoptedId).ConfigureAwait(true);
-                if (result.IsFailure)
-                {
-                    _logger.LogDebug("Adoption persist failed for {Sid}: {Error}", storedSessionId, result.Error);
-                }
-            }
-            if (app?.Dispatcher is { } d && !d.CheckAccess())
-            {
-                d.BeginInvoke(new Action(() => { _ = ApplyAsync(); }));
-            }
-            else
-            {
-                _ = ApplyAsync();
-            }
-        });
+        if (handle is null) { return; }
+        StopClaudeAdoption(storedSessionId);
         _discoveryWatches[storedSessionId] = handle;
+    }
+
+    /// <summary>
+    /// Adoption callback shared by Claude + Pi: persist the new id onto the store row and
+    /// (re-)register the matching telemetry tail. Marshals onto the dispatcher because the
+    /// discovery callback fires on a watcher thread.
+    /// </summary>
+    private void ApplyAdoption(string storedSessionId, string adoptedId, string? agentId, string workingDir)
+    {
+        var app = Application.Current;
+        async Task ApplyAsync()
+        {
+            var currentId = FindStoredSessionById(storedSessionId)?.AgentSessionId;
+            if (string.Equals(currentId, adoptedId, StringComparison.OrdinalIgnoreCase))
+            {
+                // Already persisted — initial launch adoption + poll fallback can both fire.
+                // Re-register defensively for the hydrate-on-startup case.
+                RegisterAgentTelemetry(agentId, adoptedId, workingDir);
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(currentId)) { UnregisterAgentTelemetry(agentId, currentId!); }
+            RegisterAgentTelemetry(agentId, adoptedId, workingDir);
+            var result = await _store.UpdateAgentSessionIdAsync(storedSessionId, adoptedId).ConfigureAwait(true);
+            if (result.IsFailure)
+            {
+                _logger.LogDebug("Adoption persist failed for {Sid}: {Error}", storedSessionId, result.Error);
+            }
+        }
+        if (app?.Dispatcher is { } d && !d.CheckAccess())
+        {
+            d.BeginInvoke(new Action(() => { _ = ApplyAsync(); }));
+        }
+        else
+        {
+            _ = ApplyAsync();
+        }
+    }
+
+    /// <summary>Routes telemetry registration to the right backend by agent id.</summary>
+    private void RegisterAgentTelemetry(string? agentId, string sessionId, string workingDir)
+    {
+        if (string.IsNullOrEmpty(sessionId)) { return; }
+        if (string.Equals(agentId, "claude", StringComparison.OrdinalIgnoreCase))
+        {
+            _telemetry?.Register(sessionId, workingDir);
+        }
+        else if (string.Equals(agentId, "pi", StringComparison.OrdinalIgnoreCase))
+        {
+            _piTelemetry?.Register(sessionId, workingDir);
+        }
+        else if (string.Equals(agentId, "opencode", StringComparison.OrdinalIgnoreCase))
+        {
+            _opencodeTelemetry?.Register(sessionId, workingDir);
+        }
+    }
+
+    /// <summary>Routes telemetry unregister to the right backend. Idempotent — calls all when agent unknown.</summary>
+    private void UnregisterAgentTelemetry(string? agentId, string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) { return; }
+        if (string.IsNullOrEmpty(agentId))
+        {
+            // Unknown source (cleanup path) — best-effort kick all backends.
+            _telemetry?.Unregister(sessionId);
+            _piTelemetry?.Unregister(sessionId);
+            _opencodeTelemetry?.Unregister(sessionId);
+            return;
+        }
+        if (string.Equals(agentId, "claude", StringComparison.OrdinalIgnoreCase))
+        {
+            _telemetry?.Unregister(sessionId);
+        }
+        else if (string.Equals(agentId, "pi", StringComparison.OrdinalIgnoreCase))
+        {
+            _piTelemetry?.Unregister(sessionId);
+        }
+        else if (string.Equals(agentId, "opencode", StringComparison.OrdinalIgnoreCase))
+        {
+            _opencodeTelemetry?.Unregister(sessionId);
+        }
     }
 
     private Session? FindStoredSessionById(string storedSessionId)

--- a/tests/CodeScope.Core.Tests/AgentRegistryTests.cs
+++ b/tests/CodeScope.Core.Tests/AgentRegistryTests.cs
@@ -6,12 +6,34 @@ namespace NoScope.CodeScope.Core.Tests;
 public sealed class AgentRegistryTests
 {
     [Fact]
-    public void Default_Set_Includes_Claude_Codex_Opencode()
+    public void Default_Set_Includes_Claude_Codex_Opencode_Pi()
     {
         var registry = new AgentRegistry();
 
         var ids = registry.GetAll().Select(a => a.Id).ToList();
-        ids.Should().Contain(["claude", "codex", "opencode"]);
+        ids.Should().Contain(["claude", "codex", "opencode", "pi"]);
+    }
+
+    [Fact]
+    public void Pi_Profile_Has_Resume_Continue_And_SessionFlag()
+    {
+        var pi = new AgentRegistry().GetById("pi")!;
+        pi.Command.Should().Be("pi");
+        pi.ResumeArgs.Should().BeEquivalentTo(["-c"]);
+        pi.ResumeByIdArgs.Should().BeEquivalentTo(["--session"]);
+        pi.SessionIdFlag.Should().BeNull();
+        pi.IsDefault.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OpenCode_Profile_Has_Resume_Continue_And_SessionFlag()
+    {
+        var oc = new AgentRegistry().GetById("opencode")!;
+        oc.Command.Should().Be("opencode-cli");
+        oc.ResumeArgs.Should().BeEquivalentTo(["--continue"]);
+        oc.ResumeByIdArgs.Should().BeEquivalentTo(["--session"]);
+        oc.SessionIdFlag.Should().BeNull();
+        oc.IsDefault.Should().BeFalse();
     }
 
     [Fact]
@@ -54,7 +76,7 @@ public sealed class AgentRegistryTests
     public void FromConfig_Empty_Falls_Back_To_Defaults()
     {
         var registry = AgentRegistry.FromConfig(new ProjectsConfig());
-        registry.GetAll().Select(a => a.Id).Should().Contain(["claude", "codex", "opencode"]);
+        registry.GetAll().Select(a => a.Id).Should().Contain(["claude", "codex", "opencode", "pi"]);
     }
 
     [Fact]

--- a/tests/CodeScope.Core.Tests/OpenCodeMessageParserTests.cs
+++ b/tests/CodeScope.Core.Tests/OpenCodeMessageParserTests.cs
@@ -1,0 +1,170 @@
+using NoScope.CodeScope.Core.Services;
+
+namespace NoScope.CodeScope.Core.Tests;
+
+public sealed class OpenCodeMessageParserTests
+{
+    [Fact]
+    public void ParseContent_Assistant_Message_Extracts_Tokens_And_Path()
+    {
+        const string json = """
+        {
+          "id": "msg_1",
+          "role": "assistant",
+          "parts": [{"type":"text","text":"Hello"}],
+          "metadata": {
+            "time": {"created": 1733234567890, "completed": 1733234570000},
+            "sessionID": "ses-abc",
+            "tool": {},
+            "assistant": {
+              "system": [],
+              "modelID": "claude-sonnet-4-5",
+              "providerID": "anthropic",
+              "path": {"cwd": "/c/dev/myrepo", "root": "/c/dev/myrepo"},
+              "cost": 0.001,
+              "tokens": {"input": 100, "output": 50, "reasoning": 0, "cache": {"read": 200, "write": 0}}
+            }
+          }
+        }
+        """;
+
+        var entry = OpenCodeMessageParser.ParseContent(json);
+
+        entry.Should().NotBeNull();
+        entry!.Id.Should().Be("msg_1");
+        entry.Role.Should().Be("assistant");
+        entry.SessionId.Should().Be("ses-abc");
+        entry.InputTokens.Should().Be(100);
+        entry.OutputTokens.Should().Be(50);
+        entry.CacheReadTokens.Should().Be(200);
+        entry.CacheWriteTokens.Should().Be(0);
+        entry.ReasoningTokens.Should().Be(0);
+        entry.ModelId.Should().Be("claude-sonnet-4-5");
+        entry.ProviderId.Should().Be("anthropic");
+        entry.Cwd.Should().Be("/c/dev/myrepo");
+        entry.CompletedAt.Should().NotBeNull();
+        entry.CreatedAt.Should().NotBeNull();
+        entry.HasUsage.Should().BeTrue();
+        entry.HasPendingToolCall.Should().BeFalse();
+        entry.ContextTokens.Should().Be(100 + 50 + 0 + 200 + 0);
+    }
+
+    [Fact]
+    public void ParseContent_User_Message_Has_No_Usage()
+    {
+        const string json = """
+        {
+          "id": "msg_u1",
+          "role": "user",
+          "parts": [{"type":"text","text":"hi"}],
+          "metadata": {
+            "time": {"created": 1733234567000},
+            "sessionID": "ses-abc",
+            "tool": {}
+          }
+        }
+        """;
+
+        var entry = OpenCodeMessageParser.ParseContent(json);
+
+        entry.Should().NotBeNull();
+        entry!.Role.Should().Be("user");
+        entry.HasUsage.Should().BeFalse();
+        entry.CompletedAt.Should().BeNull();
+        entry.CreatedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ParseContent_Assistant_Without_Completed_Marks_In_Flight()
+    {
+        const string json = """
+        {
+          "id": "msg_2",
+          "role": "assistant",
+          "parts": [],
+          "metadata": {
+            "time": {"created": 1733234567000},
+            "sessionID": "s",
+            "tool": {},
+            "assistant": {
+              "system": [], "modelID":"x","providerID":"a",
+              "path": {"cwd":"/c/x","root":"/c/x"}, "cost": 0,
+              "tokens": {"input": 1, "output": 0, "reasoning": 0, "cache":{"read":0,"write":0}}
+            }
+          }
+        }
+        """;
+
+        var entry = OpenCodeMessageParser.ParseContent(json);
+        entry!.CompletedAt.Should().BeNull();
+        entry.CreatedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ParseContent_Detects_Pending_Tool_Call()
+    {
+        const string json = """
+        {
+          "id":"msg_3","role":"assistant",
+          "parts":[
+            {"type":"text","text":"running it"},
+            {"type":"tool-invocation","toolInvocation":{"state":"call","toolName":"bash","args":{}}}
+          ],
+          "metadata":{
+            "time":{"created":1},
+            "sessionID":"s","tool":{},
+            "assistant":{"system":[],"modelID":"x","providerID":"a","path":{"cwd":"/c","root":"/c"},"cost":0,
+                         "tokens":{"input":1,"output":1,"reasoning":0,"cache":{"read":0,"write":0}}}
+          }
+        }
+        """;
+
+        var entry = OpenCodeMessageParser.ParseContent(json);
+        entry!.HasPendingToolCall.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseContent_Resolved_Tool_Call_Is_Not_Pending()
+    {
+        const string json = """
+        {
+          "id":"msg_4","role":"assistant",
+          "parts":[
+            {"type":"tool-invocation","toolInvocation":{"state":"result","toolName":"bash","args":{},"result":"ok"}}
+          ],
+          "metadata":{
+            "time":{"created":1,"completed":2},
+            "sessionID":"s","tool":{},
+            "assistant":{"system":[],"modelID":"x","providerID":"a","path":{"cwd":"/c","root":"/c"},"cost":0,
+                         "tokens":{"input":1,"output":1,"reasoning":0,"cache":{"read":0,"write":0}}}
+          }
+        }
+        """;
+
+        var entry = OpenCodeMessageParser.ParseContent(json);
+        entry!.HasPendingToolCall.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseContent_Garbage_Returns_Null()
+    {
+        OpenCodeMessageParser.ParseContent("{not json").Should().BeNull();
+        OpenCodeMessageParser.ParseContent("").Should().BeNull();
+        OpenCodeMessageParser.ParseContent("   ").Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractMessageIdFromFileName_Pulls_Suffix()
+    {
+        OpenCodeMessageParser.ExtractMessageIdFromFileName("msg_abc123.json").Should().Be("abc123");
+        OpenCodeMessageParser.ExtractMessageIdFromFileName("msg_01HXY9Z.json").Should().Be("01HXY9Z");
+    }
+
+    [Fact]
+    public void ExtractMessageIdFromFileName_Rejects_Non_Conforming()
+    {
+        OpenCodeMessageParser.ExtractMessageIdFromFileName("session.json").Should().BeNull();
+        OpenCodeMessageParser.ExtractMessageIdFromFileName("msg_.json").Should().BeNull();
+        OpenCodeMessageParser.ExtractMessageIdFromFileName("").Should().BeNull();
+    }
+}

--- a/tests/CodeScope.Core.Tests/OpenCodeSessionDiscoveryTests.cs
+++ b/tests/CodeScope.Core.Tests/OpenCodeSessionDiscoveryTests.cs
@@ -1,0 +1,138 @@
+using NoScope.CodeScope.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace NoScope.CodeScope.Core.Tests;
+
+public sealed class OpenCodeSessionDiscoveryTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _cwd;
+
+    public OpenCodeSessionDiscoveryTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "codescope-oc-disc-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _cwd = @"C:\dev\fake-oc-project";
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private OpenCodeSessionDiscovery NewSut() =>
+        new(NullLogger<OpenCodeSessionDiscovery>.Instance, _root);
+
+    private string WriteAssistantMessage(string slug, string sessionId, string cwd)
+    {
+        var dir = Path.Combine(_root, "project", slug, "storage", "message", sessionId);
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "msg_1.json");
+        // Build the JSON via concatenation — embedded { } trip up raw-string interpolation.
+        var json = "{\"id\":\"msg_1\",\"role\":\"assistant\",\"parts\":[{\"type\":\"text\",\"text\":\"hi\"}],"
+            + "\"metadata\":{\"time\":{\"created\":1,\"completed\":2},\"sessionID\":\"" + sessionId + "\",\"tool\":{},"
+            + "\"assistant\":{\"system\":[],\"modelID\":\"x\",\"providerID\":\"a\","
+            + "\"path\":{\"cwd\":\"" + cwd.Replace("\\", "\\\\") + "\",\"root\":\"" + cwd.Replace("\\", "\\\\") + "\"},"
+            + "\"cost\":0,\"tokens\":{\"input\":1,\"output\":1,\"reasoning\":0,\"cache\":{\"read\":0,\"write\":0}}}}}";
+        File.WriteAllText(file, json);
+        return file;
+    }
+
+    [Fact]
+    public async Task Discovers_New_Session_With_Matching_Cwd()
+    {
+        var sut = NewSut();
+        var tcs = new TaskCompletionSource<(string id, string path)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (id, path) => tcs.TrySetResult((id, path)));
+
+        var sessionId = "ses-" + Guid.NewGuid().ToString("N")[..10];
+        var file = WriteAssistantMessage("fake-oc-project", sessionId, _cwd);
+
+        var completed = await Task.WhenAny(tcs.Task, Task.Delay(3000));
+        completed.Should().Be(tcs.Task);
+        var (id, path) = await tcs.Task;
+        id.Should().Be(sessionId);
+        path.Should().Be(file);
+    }
+
+    [Fact]
+    public async Task Ignores_Different_Cwd()
+    {
+        var sut = NewSut();
+        var fired = false;
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (_, _) => fired = true);
+
+        var sessionId = "ses-other";
+        WriteAssistantMessage("other-project", sessionId, @"C:\some\other\repo");
+
+        await Task.Delay(800);
+        fired.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Matches_Cwd_Across_Slash_Variants()
+    {
+        var sut = NewSut();
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (id, _) => tcs.TrySetResult(id));
+
+        var sessionId = "ses-xform";
+        WriteAssistantMessage("variant-slug", sessionId, "/c/dev/fake-oc-project");
+
+        var completed = await Task.WhenAny(tcs.Task, Task.Delay(3000));
+        completed.Should().Be(tcs.Task);
+        (await tcs.Task).Should().Be(sessionId);
+    }
+
+    [Fact]
+    public async Task Ignores_Files_Older_Than_Since()
+    {
+        var sessionId = "ses-old";
+        var file = WriteAssistantMessage("fake-oc-project", sessionId, _cwd);
+        var ancient = DateTime.UtcNow.AddDays(-30);
+        File.SetCreationTimeUtc(file, ancient);
+        File.SetLastWriteTimeUtc(file, ancient);
+
+        var sut = NewSut();
+        var fired = false;
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (_, _) => fired = true);
+
+        await Task.Delay(800);
+        fired.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Callback_Fires_Once_Per_Session_Even_With_Multiple_Messages()
+    {
+        var sut = NewSut();
+        var count = 0;
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (_, _) => Interlocked.Increment(ref count));
+
+        var sessionId = "ses-multi";
+        WriteAssistantMessage("fake-oc-project", sessionId, _cwd);
+
+        await Task.Delay(500);
+
+        // Append a second message — should NOT re-fire for the same session id.
+        var dir = Path.Combine(_root, "project", "fake-oc-project", "storage", "message", sessionId);
+        var json2 = "{\"id\":\"msg_2\",\"role\":\"user\",\"parts\":[],\"metadata\":{\"time\":{\"created\":3},\"sessionID\":\"" + sessionId + "\",\"tool\":{}}}";
+        await File.WriteAllTextAsync(Path.Combine(dir, "msg_2.json"), json2);
+        await Task.Delay(800);
+
+        count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Dispose_Suppresses_Future_Callbacks()
+    {
+        var sut = NewSut();
+        var fired = false;
+        var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (_, _) => fired = true);
+        handle.Dispose();
+
+        WriteAssistantMessage("fake-oc-project", "ses-late", _cwd);
+        await Task.Delay(600);
+
+        fired.Should().BeFalse();
+    }
+}

--- a/tests/CodeScope.Core.Tests/OpenCodeTelemetryServiceTests.cs
+++ b/tests/CodeScope.Core.Tests/OpenCodeTelemetryServiceTests.cs
@@ -1,0 +1,143 @@
+using NoScope.CodeScope.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace NoScope.CodeScope.Core.Tests;
+
+public sealed class OpenCodeTelemetryServiceTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "cs-oc-telemetry-" + Guid.NewGuid().ToString("n"));
+
+    public OpenCodeTelemetryServiceTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private string MessageDirFor(string slug, string sessionId)
+    {
+        var dir = Path.Combine(_root, "project", slug, "storage", "message", sessionId);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string AssistantJson(string id, string sessionId, long created, long? completed,
+        int input, int output, int cacheRead, int cacheWrite, string model, bool pendingTool = false)
+    {
+        var toolPart = pendingTool
+            ? "{\"type\":\"tool-invocation\",\"toolInvocation\":{\"state\":\"call\",\"toolName\":\"bash\",\"args\":{}}}"
+            : "{\"type\":\"text\",\"text\":\"ok\"}";
+        var completedField = completed is long c ? ",\"completed\":" + c : "";
+        return "{\"id\":\"" + id + "\",\"role\":\"assistant\",\"parts\":[" + toolPart + "],"
+            + "\"metadata\":{\"time\":{\"created\":" + created + completedField + "},"
+            + "\"sessionID\":\"" + sessionId + "\",\"tool\":{},"
+            + "\"assistant\":{\"system\":[],\"modelID\":\"" + model + "\",\"providerID\":\"anthropic\","
+            + "\"path\":{\"cwd\":\"/c/x\",\"root\":\"/c/x\"},\"cost\":0,"
+            + "\"tokens\":{\"input\":" + input + ",\"output\":" + output + ",\"reasoning\":0,"
+            + "\"cache\":{\"read\":" + cacheRead + ",\"write\":" + cacheWrite + "}}}}}";
+    }
+
+    private static string UserJson(string id, string sessionId, long created)
+        => "{\"id\":\"" + id + "\",\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"hi\"}],"
+            + "\"metadata\":{\"time\":{\"created\":" + created + "},\"sessionID\":\"" + sessionId + "\",\"tool\":{}}}";
+
+    [Fact]
+    public void Register_Reads_Existing_Messages_And_Computes_Snapshot()
+    {
+        var sid = "ses-" + Guid.NewGuid().ToString("N")[..8];
+        var dir = MessageDirFor("my-repo", sid);
+        File.WriteAllText(Path.Combine(dir, "msg_1.json"), UserJson("msg_1", sid, 1_000_000));
+        File.WriteAllText(Path.Combine(dir, "msg_2.json"),
+            AssistantJson("msg_2", sid, 1_001_000, 1_002_000, input: 100, output: 50, cacheRead: 200, cacheWrite: 0, model: "claude-sonnet-4-5"));
+
+        using var svc = new OpenCodeTelemetryService(NullLogger<OpenCodeTelemetryService>.Instance, _root);
+
+        ClaudeSessionTelemetry? last = null;
+        svc.Updated += (_, t) => last = t;
+        svc.Register(sid, @"C:\x");
+
+        last.Should().NotBeNull();
+        last!.SessionId.Should().Be(sid);
+        last.TurnCount.Should().Be(1);
+        last.ContextTokens.Should().Be(100 + 50 + 200);
+        last.Activity.Should().Be(ClaudeActivityState.Idle);
+        last.LastTurnDuration.Should().NotBeNull();
+        last.ModelId.Should().Be("claude-sonnet-4-5");
+    }
+
+    [Fact]
+    public void Register_With_Missing_Dir_Yields_Null_Snapshot()
+    {
+        using var svc = new OpenCodeTelemetryService(NullLogger<OpenCodeTelemetryService>.Instance, _root);
+        svc.Register("ghost", @"C:\nope");
+        svc.GetSnapshot("ghost").Should().BeNull();
+    }
+
+    [Fact]
+    public void Activity_Is_PendingToolUse_When_Latest_Assistant_Has_Open_Tool_Call()
+    {
+        var sid = "ses-pend";
+        var dir = MessageDirFor("repo", sid);
+        File.WriteAllText(Path.Combine(dir, "msg_u.json"), UserJson("msg_u", sid, 1));
+        File.WriteAllText(Path.Combine(dir, "msg_a.json"),
+            AssistantJson("msg_a", sid, 2, completed: null, input: 1, output: 1, cacheRead: 0, cacheWrite: 0, model: "x", pendingTool: true));
+
+        using var svc = new OpenCodeTelemetryService(NullLogger<OpenCodeTelemetryService>.Instance, _root);
+        svc.Register(sid, @"C:\repo");
+
+        svc.GetSnapshot(sid)!.Activity.Should().Be(ClaudeActivityState.PendingToolUse);
+    }
+
+    [Fact]
+    public void Activity_Is_Composing_When_Latest_Is_User()
+    {
+        var sid = "ses-comp";
+        var dir = MessageDirFor("repo", sid);
+        File.WriteAllText(Path.Combine(dir, "msg_a.json"),
+            AssistantJson("msg_a", sid, 1, completed: 2, input: 1, output: 1, cacheRead: 0, cacheWrite: 0, model: "x"));
+        File.WriteAllText(Path.Combine(dir, "msg_u.json"), UserJson("msg_u", sid, 3));
+
+        using var svc = new OpenCodeTelemetryService(NullLogger<OpenCodeTelemetryService>.Instance, _root);
+        svc.Register(sid, @"C:\repo");
+
+        svc.GetSnapshot(sid)!.Activity.Should().Be(ClaudeActivityState.Composing);
+    }
+
+    [Fact]
+    public async Task File_Created_After_Register_Is_Picked_Up()
+    {
+        var sid = "ses-late";
+        using var svc = new OpenCodeTelemetryService(NullLogger<OpenCodeTelemetryService>.Instance, _root, enablePolling: true);
+        svc.Register(sid, @"C:\later");
+        svc.GetSnapshot(sid).Should().BeNull();
+
+        var dir = MessageDirFor("later-repo", sid);
+        await File.WriteAllTextAsync(Path.Combine(dir, "msg_1.json"),
+            AssistantJson("msg_1", sid, 100, completed: 200, input: 5, output: 5, cacheRead: 0, cacheWrite: 0, model: "x"));
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline && svc.GetSnapshot(sid) is null)
+        {
+            await Task.Delay(100);
+        }
+
+        svc.GetSnapshot(sid).Should().NotBeNull();
+        svc.GetSnapshot(sid)!.Activity.Should().Be(ClaudeActivityState.Idle);
+    }
+
+    [Fact]
+    public void Unregister_Drops_Snapshot()
+    {
+        var sid = "ses-drop";
+        var dir = MessageDirFor("repo", sid);
+        File.WriteAllText(Path.Combine(dir, "msg_1.json"),
+            AssistantJson("msg_1", sid, 1, completed: 2, input: 1, output: 1, cacheRead: 0, cacheWrite: 0, model: "x"));
+
+        using var svc = new OpenCodeTelemetryService(NullLogger<OpenCodeTelemetryService>.Instance, _root);
+        svc.Register(sid, @"C:\drop");
+        svc.GetSnapshot(sid).Should().NotBeNull();
+
+        svc.Unregister(sid);
+        svc.GetSnapshot(sid).Should().BeNull();
+    }
+}

--- a/tests/CodeScope.Core.Tests/PiSessionDiscoveryTests.cs
+++ b/tests/CodeScope.Core.Tests/PiSessionDiscoveryTests.cs
@@ -1,0 +1,148 @@
+using NoScope.CodeScope.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace NoScope.CodeScope.Core.Tests;
+
+public sealed class PiSessionDiscoveryTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _cwd;
+
+    public PiSessionDiscoveryTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "codescope-pi-disc-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _cwd = @"C:\dev\fake-pi-project";
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private PiSessionDiscovery NewSut() =>
+        new(NullLogger<PiSessionDiscovery>.Instance, _root);
+
+    private string WriteSession(string subdir, string sessionId, string cwd)
+    {
+        var dir = Path.Combine(_root, subdir);
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, $"2026-04-22T08-00-00-000Z_{sessionId}.jsonl");
+        File.WriteAllText(file,
+            $$"""{"type":"session","version":3,"id":"{{sessionId}}","timestamp":"2026-04-22T08:00:00Z","cwd":"{{cwd.Replace("\\", "\\\\")}}"}""" + "\n");
+        return file;
+    }
+
+    [Fact]
+    public async Task Discovers_New_Session_File_With_Matching_Cwd()
+    {
+        var sut = NewSut();
+        var tcs = new TaskCompletionSource<(string id, string path)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (id, path) => tcs.TrySetResult((id, path)));
+
+        var sessionId = Guid.NewGuid().ToString("D");
+        var file = WriteSession("--C--dev-fake-pi-project--", sessionId, _cwd);
+
+        var completed = await Task.WhenAny(tcs.Task, Task.Delay(3000));
+        completed.Should().Be(tcs.Task, "discovery should fire within 3s");
+        var (id, path) = await tcs.Task;
+        id.Should().Be(sessionId);
+        path.Should().Be(file);
+    }
+
+    [Fact]
+    public async Task Ignores_Session_File_With_Different_Cwd()
+    {
+        var sut = NewSut();
+        var fired = false;
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (_, _) => fired = true);
+
+        var sessionId = Guid.NewGuid().ToString("D");
+        WriteSession("--unrelated--", sessionId, @"C:\some\other\path");
+
+        await Task.Delay(800);
+        fired.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Matches_Cwd_With_Forward_Slashes_And_Drive_Letter_Variants()
+    {
+        // Pi's header may write "/c/dev/fake-pi-project" or "C:/dev/..." depending on platform.
+        // Canonicalisation should make any of those equivalent.
+        var sut = NewSut();
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (id, _) => tcs.TrySetResult(id));
+
+        var sessionId = Guid.NewGuid().ToString("D");
+        WriteSession("--c-dev-fake-pi-project--", sessionId, "/c/dev/fake-pi-project");
+
+        var completed = await Task.WhenAny(tcs.Task, Task.Delay(3000));
+        completed.Should().Be(tcs.Task);
+        (await tcs.Task).Should().Be(sessionId);
+    }
+
+    [Fact]
+    public async Task Ignores_Files_Older_Than_Since()
+    {
+        var sessionId = Guid.NewGuid().ToString("D");
+        var file = WriteSession("--C--dev-fake-pi-project--", sessionId, _cwd);
+        var ancient = DateTime.UtcNow.AddDays(-30);
+        File.SetCreationTimeUtc(file, ancient);
+        File.SetLastWriteTimeUtc(file, ancient);
+
+        var sut = NewSut();
+        var fired = false;
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (_, _) => fired = true);
+
+        await Task.Delay(800);
+        fired.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Ignores_Non_Pi_Filenames()
+    {
+        var sut = NewSut();
+        var fired = false;
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (_, _) => fired = true);
+
+        var dir = Path.Combine(_root, "--C--dev-fake-pi-project--");
+        Directory.CreateDirectory(dir);
+        await File.WriteAllTextAsync(Path.Combine(dir, "garbage.jsonl"),
+            $$"""{"type":"session","id":"x","cwd":"{{_cwd.Replace("\\", "\\\\")}}"}""");
+        await Task.Delay(800);
+
+        fired.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Callback_Fires_At_Most_Once_Per_File()
+    {
+        var sut = NewSut();
+        var count = 0;
+        using var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (_, _) => Interlocked.Increment(ref count));
+
+        var sessionId = Guid.NewGuid().ToString("D");
+        var file = WriteSession("--C--dev-fake-pi-project--", sessionId, _cwd);
+
+        await Task.Delay(500);
+        await File.AppendAllTextAsync(file, "{\"type\":\"message\"}\n");
+        await Task.Delay(800);
+
+        count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Dispose_Suppresses_Future_Callbacks()
+    {
+        var sut = NewSut();
+        var fired = false;
+        var handle = sut.Watch(_cwd, DateTimeOffset.UtcNow, (_, _) => fired = true);
+        handle.Dispose();
+
+        var sessionId = Guid.NewGuid().ToString("D");
+        WriteSession("--C--dev-fake-pi-project--", sessionId, _cwd);
+        await Task.Delay(600);
+
+        fired.Should().BeFalse();
+    }
+}

--- a/tests/CodeScope.Core.Tests/PiTelemetryServiceTests.cs
+++ b/tests/CodeScope.Core.Tests/PiTelemetryServiceTests.cs
@@ -1,0 +1,165 @@
+using NoScope.CodeScope.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace NoScope.CodeScope.Core.Tests;
+
+public sealed class PiTelemetryServiceTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "cs-pi-telemetry-" + Guid.NewGuid().ToString("n"));
+
+    public PiTelemetryServiceTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private string WriteSession(string sessionId, string subdirEncoded, IEnumerable<string> lines)
+    {
+        var dir = Path.Combine(_root, subdirEncoded);
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, $"2026-04-22T08-00-00-000Z_{sessionId}.jsonl");
+        File.WriteAllLines(file, lines);
+        return file;
+    }
+
+    [Fact]
+    public void Register_Reads_Existing_Transcript_And_Raises_Updated()
+    {
+        var sessionId = Guid.NewGuid().ToString("D");
+        WriteSession(sessionId, "--C--dev-myrepo--",
+        [
+            $$"""{"type":"session","version":3,"id":"{{sessionId}}","timestamp":"2026-04-22T08:00:00Z","cwd":"/c/dev/myrepo"}""",
+            """{"type":"message","id":"u1","timestamp":"2026-04-22T08:00:01Z","message":{"role":"user","content":"hi"}}""",
+            """{"type":"message","id":"a1","timestamp":"2026-04-22T08:01:00Z","message":{"role":"assistant","provider":"anthropic","model":"x","usage":{"input":10,"output":20,"cacheRead":50,"cacheWrite":100},"stopReason":"tool_use"}}""",
+            """{"type":"message","id":"a2","timestamp":"2026-04-22T08:02:00Z","message":{"role":"assistant","provider":"anthropic","model":"x","usage":{"input":5,"output":15,"cacheRead":200,"cacheWrite":0},"stopReason":"stop"}}""",
+        ]);
+
+        using var svc = new PiTelemetryService(NullLogger<PiTelemetryService>.Instance, _root);
+
+        ClaudeSessionTelemetry? last = null;
+        svc.Updated += (_, t) => last = t;
+
+        svc.Register(sessionId, @"C:\dev\myrepo");
+
+        last.Should().NotBeNull();
+        last!.SessionId.Should().Be(sessionId);
+        last.TurnCount.Should().Be(2);
+        // Latest assistant turn: 5 + 15 + 0 + 200 = 220.
+        last.ContextTokens.Should().Be(220);
+        last.Activity.Should().Be(ClaudeActivityState.Idle);
+        svc.GetSnapshot(sessionId).Should().BeEquivalentTo(last);
+    }
+
+    [Fact]
+    public void Register_Tolerates_Missing_Transcript()
+    {
+        using var svc = new PiTelemetryService(NullLogger<PiTelemetryService>.Instance, _root);
+        svc.Register(Guid.NewGuid().ToString("D"), @"C:\nope");
+        // No file → no snapshot yet, but no exception.
+        svc.GetSnapshot("ghost").Should().BeNull();
+    }
+
+    [Fact]
+    public void ActivityState_Is_PendingToolUse_When_Last_Assistant_Stop_Is_Tool_Use()
+    {
+        var sid = Guid.NewGuid().ToString("D");
+        WriteSession(sid, "--pend--",
+        [
+            """{"type":"message","id":"u","timestamp":"2026-04-22T08:00:00Z","message":{"role":"user","content":"go"}}""",
+            """{"type":"message","id":"a","timestamp":"2026-04-22T08:01:00Z","message":{"role":"assistant","model":"x","usage":{"input":1,"output":2,"cacheRead":0,"cacheWrite":0},"stopReason":"tool_use"}}""",
+        ]);
+
+        using var svc = new PiTelemetryService(NullLogger<PiTelemetryService>.Instance, _root);
+        svc.Register(sid, @"C:\pend");
+
+        svc.GetSnapshot(sid)!.Activity.Should().Be(ClaudeActivityState.PendingToolUse);
+    }
+
+    [Fact]
+    public void ActivityState_Is_Composing_After_ToolResult_Even_With_Pending_Before()
+    {
+        var sid = Guid.NewGuid().ToString("D");
+        WriteSession(sid, "--comp--",
+        [
+            """{"type":"message","id":"u","timestamp":"2026-04-22T08:00:00Z","message":{"role":"user","content":"go"}}""",
+            """{"type":"message","id":"a","timestamp":"2026-04-22T08:01:00Z","message":{"role":"assistant","usage":{"input":1,"output":2,"cacheRead":0,"cacheWrite":0},"stopReason":"tool_use"}}""",
+            """{"type":"message","id":"tr","timestamp":"2026-04-22T08:02:00Z","message":{"role":"toolResult","toolCallId":"c","toolName":"bash","content":[]}}""",
+        ]);
+
+        using var svc = new PiTelemetryService(NullLogger<PiTelemetryService>.Instance, _root);
+        svc.Register(sid, @"C:\comp");
+
+        svc.GetSnapshot(sid)!.Activity.Should().Be(ClaudeActivityState.Composing);
+    }
+
+    [Fact]
+    public async Task Polling_Picks_Up_Appended_Lines()
+    {
+        var sid = Guid.NewGuid().ToString("D");
+        var file = WriteSession(sid, "--poll--",
+        [
+            """{"type":"message","id":"a","timestamp":"2026-04-22T08:00:00Z","message":{"role":"assistant","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0},"stopReason":"stop"}}""",
+        ]);
+
+        using var svc = new PiTelemetryService(NullLogger<PiTelemetryService>.Instance, _root, enablePolling: true);
+        svc.Register(sid, @"C:\poll");
+        svc.GetSnapshot(sid)!.Activity.Should().Be(ClaudeActivityState.Idle);
+
+        await File.AppendAllTextAsync(file,
+            """{"type":"message","id":"u","timestamp":"2026-04-22T08:01:00Z","message":{"role":"user","content":"go"}}""" + "\n" +
+            """{"type":"message","id":"a2","timestamp":"2026-04-22T08:02:00Z","message":{"role":"assistant","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0},"stopReason":"tool_use"}}""" + "\n");
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline &&
+               svc.GetSnapshot(sid)?.Activity != ClaudeActivityState.PendingToolUse)
+        {
+            await Task.Delay(100);
+        }
+
+        svc.GetSnapshot(sid)!.Activity.Should().Be(ClaudeActivityState.PendingToolUse);
+    }
+
+    [Fact]
+    public async Task File_Created_After_Register_Is_Picked_Up_By_Watcher()
+    {
+        // Fresh-launch race: Register fires before pi has written its first line.
+        var sid = Guid.NewGuid().ToString("D");
+        using var svc = new PiTelemetryService(NullLogger<PiTelemetryService>.Instance, _root, enablePolling: true);
+        svc.Register(sid, @"C:\later");
+        svc.GetSnapshot(sid).Should().BeNull();
+
+        var dir = Path.Combine(_root, "--C--later--");
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, $"2026-04-22T09-00-00-000Z_{sid}.jsonl");
+        await File.WriteAllTextAsync(file,
+            $$"""{"type":"session","version":3,"id":"{{sid}}","timestamp":"2026-04-22T09:00:00Z","cwd":"/c/later"}""" + "\n" +
+            """{"type":"message","id":"a","timestamp":"2026-04-22T09:00:01Z","message":{"role":"assistant","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0},"stopReason":"stop"}}""" + "\n");
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline && svc.GetSnapshot(sid) is null)
+        {
+            await Task.Delay(100);
+        }
+
+        svc.GetSnapshot(sid).Should().NotBeNull();
+        svc.GetSnapshot(sid)!.Activity.Should().Be(ClaudeActivityState.Idle);
+    }
+
+    [Fact]
+    public void Unregister_Drops_Snapshot()
+    {
+        var sid = Guid.NewGuid().ToString("D");
+        WriteSession(sid, "--drop--",
+        [
+            """{"type":"message","id":"a","timestamp":"2026-04-22T08:00:00Z","message":{"role":"assistant","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0},"stopReason":"stop"}}""",
+        ]);
+
+        using var svc = new PiTelemetryService(NullLogger<PiTelemetryService>.Instance, _root);
+        svc.Register(sid, @"C:\drop");
+        svc.GetSnapshot(sid).Should().NotBeNull();
+
+        svc.Unregister(sid);
+        svc.GetSnapshot(sid).Should().BeNull();
+    }
+}

--- a/tests/CodeScope.Core.Tests/PiTranscriptParserTests.cs
+++ b/tests/CodeScope.Core.Tests/PiTranscriptParserTests.cs
@@ -1,0 +1,143 @@
+using NoScope.CodeScope.Core.Services;
+
+namespace NoScope.CodeScope.Core.Tests;
+
+public sealed class PiTranscriptParserTests
+{
+    [Fact]
+    public void ParseLine_Session_Header_Extracts_Id_And_Cwd()
+    {
+        const string line = """
+        {"type":"session","version":3,"id":"f1e2d3c4-aaaa-bbbb-cccc-1234567890ab","timestamp":"2026-04-22T08:00:00.000Z","cwd":"/c/dev/codescope"}
+        """;
+
+        var entry = PiTranscriptParser.ParseLine(line);
+
+        entry.Should().NotBeNull();
+        entry!.Type.Should().Be("session");
+        entry.SessionId.Should().Be("f1e2d3c4-aaaa-bbbb-cccc-1234567890ab");
+        entry.Cwd.Should().Be("/c/dev/codescope");
+        entry.HasUsage.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseLine_Assistant_Message_With_Usage_Extracts_Tokens()
+    {
+        const string line = """
+        {"type":"message","id":"m1","parentId":"m0","timestamp":"2026-04-22T08:01:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Hi!"}],"provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":100,"output":50,"cacheRead":1000,"cacheWrite":200,"cost":{"total":0.001}},"stopReason":"stop"}}
+        """;
+
+        var entry = PiTranscriptParser.ParseLine(line);
+
+        entry.Should().NotBeNull();
+        entry!.Type.Should().Be("message");
+        entry.Role.Should().Be("assistant");
+        entry.InputTokens.Should().Be(100);
+        entry.OutputTokens.Should().Be(50);
+        entry.CacheReadTokens.Should().Be(1000);
+        entry.CacheCreationTokens.Should().Be(200);
+        entry.HasUsage.Should().BeTrue();
+        entry.StopReason.Should().Be("stop");
+        entry.Model.Should().Be("claude-sonnet-4-5");
+        entry.Provider.Should().Be("anthropic");
+        entry.Timestamp.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ParseLine_User_Message_Has_No_Usage()
+    {
+        const string line = """
+        {"type":"message","id":"m2","timestamp":"2026-04-22T08:00:00.000Z","message":{"role":"user","content":"hello"}}
+        """;
+
+        var entry = PiTranscriptParser.ParseLine(line);
+
+        entry.Should().NotBeNull();
+        entry!.Role.Should().Be("user");
+        entry.HasUsage.Should().BeFalse();
+        entry.InputTokens.Should().Be(0);
+    }
+
+    [Fact]
+    public void ParseLine_ToolResult_Message_Recognised()
+    {
+        const string line = """
+        {"type":"message","id":"m3","parentId":"m1","timestamp":"2026-04-22T08:02:00.000Z","message":{"role":"toolResult","toolCallId":"call_123","toolName":"bash","content":[{"type":"text","text":"ok"}],"isError":false}}
+        """;
+
+        var entry = PiTranscriptParser.ParseLine(line);
+
+        entry.Should().NotBeNull();
+        entry!.Type.Should().Be("message");
+        entry.Role.Should().Be("toolResult");
+        entry.HasUsage.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseLine_Tool_Use_StopReason_Surfaces()
+    {
+        const string line = """
+        {"type":"message","id":"m4","timestamp":"2026-04-22T08:03:00.000Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"c1","name":"bash"}],"provider":"anthropic","model":"x","usage":{"input":1,"output":2,"cacheRead":0,"cacheWrite":0},"stopReason":"tool_use"}}
+        """;
+
+        var entry = PiTranscriptParser.ParseLine(line);
+
+        entry.Should().NotBeNull();
+        entry!.StopReason.Should().Be("tool_use");
+        entry.HasUsage.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseLine_Compaction_Returns_NonNull_But_No_Usage()
+    {
+        const string line = """
+        {"type":"compaction","id":"c1","timestamp":"2026-04-22T09:00:00.000Z","tokensBefore":80000}
+        """;
+
+        var entry = PiTranscriptParser.ParseLine(line);
+
+        entry.Should().NotBeNull();
+        entry!.Type.Should().Be("compaction");
+        entry.HasUsage.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseLine_ModelChange_Surfaces_Model()
+    {
+        const string line = """
+        {"type":"model_change","id":"x1","timestamp":"2026-04-22T08:00:00.000Z","provider":"anthropic","modelId":"claude-opus-4-7"}
+        """;
+
+        var entry = PiTranscriptParser.ParseLine(line);
+
+        entry.Should().NotBeNull();
+        entry!.Type.Should().Be("model_change");
+        entry.Model.Should().Be("claude-opus-4-7");
+        entry.HasUsage.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseLine_Invalid_Json_Returns_Null()
+    {
+        PiTranscriptParser.ParseLine("{not json").Should().BeNull();
+        PiTranscriptParser.ParseLine("").Should().BeNull();
+        PiTranscriptParser.ParseLine("   ").Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractSessionIdFromFileName_Pulls_Trailing_Uuid()
+    {
+        // Pi files: "<timestamp>_<uuid>.jsonl" — e.g. "2026-04-22T08-00-00_<uuid>.jsonl".
+        var id = PiTranscriptParser.ExtractSessionIdFromFileName(
+            "2026-04-22T08-00-00-000Z_f1e2d3c4-aaaa-bbbb-cccc-1234567890ab.jsonl");
+        id.Should().Be("f1e2d3c4-aaaa-bbbb-cccc-1234567890ab");
+    }
+
+    [Fact]
+    public void ExtractSessionIdFromFileName_Returns_Null_For_Garbage()
+    {
+        PiTranscriptParser.ExtractSessionIdFromFileName("not-a-pi-file.jsonl").Should().BeNull();
+        PiTranscriptParser.ExtractSessionIdFromFileName("no-underscore.jsonl").Should().BeNull();
+        PiTranscriptParser.ExtractSessionIdFromFileName("trailing_not-a-uuid.jsonl").Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- Two new agents in the new-session menu: **π Pi** and **◈ OpenCode** (the latter was already shippable as a launcher; this commit gives it the same telemetry surface as Claude).
- Both surface the busy/idle dot, token-usage progress, and turn-duration via per-agent transcript watchers — same status-bar treatment Claude has had since v0.1.0.
- Resume-by-id wired through the existing `AgentProfile.ResumeByIdArgs` plumbing: `pi --session <uuid>` and `opencode-cli --session <uuid>`.
- 41 new tests; full suite 334/334 green.

## How it works

**Pi.dev** (`@mariozechner/pi-coding-agent`) writes a single-file JSONL transcript per session under `~/.pi/agent/sessions/--<encoded-cwd>--/<timestamp>_<uuid>.jsonl`. `usage.{input,output,cacheRead,cacheWrite}` + `stopReason ∈ {stop, tool_use}` map onto our existing telemetry shape. Discovery matches by the canonical `cwd` field in the session header so we don't have to predict Pi's directory-encoding scheme on Windows — content over filename.

**OpenCode** persists each message as its own JSON file under `%USERPROFILE%\.local\share\opencode\project\<slug>\storage\message\<sessionId>\msg_*.json`. Schema is upstream-defined in `packages/opencode/src/session/message.ts` (Effect Schema.Struct): `metadata.assistant.{tokens.{input,output,reasoning,cache.{read,write}}, modelID, providerID, path.{cwd,root}}` + `metadata.time.{created, completed?}`. Pending tool-use is flagged when a part has `type:"tool-invocation"` whose state is `call`/`partial-call`. On Windows the binary is `opencode-cli.exe` (npm `opencode-ai` package quirk).

`MainViewModel` routes telemetry register/unregister + adoption watch by agent id — Claude/Pi/OpenCode each go to their own backend, sharing `ApplyAdoption` and the same `ClaudeSessionTelemetry` event shape so `ApplyTelemetry` stays agent-agnostic.

## Test plan
- [ ] `dotnet test` — full suite green (334/334)
- [ ] Hand-test Pi tab: launch, prompt, watch dot go busy then idle; token readout updates
- [ ] Hand-test OpenCode tab: same
- [ ] Cross-group drag still works on a Pi/OpenCode tab (shared `SessionTabView` pool from #14)
- [ ] App restart hydrates a Pi/OpenCode session via `--session <id>` resume

## Notes
- Pi/OpenCode are model-agnostic CLIs, so `ContextWindowTokens` stays at 0 unless `ClaudeModelCatalog` recognises the underlying model id — status-bar percent indicator will be blank until then.
- Adoption for OpenCode requires at least one assistant message because that's where the cwd is recorded; sessions created but never run won't fire the callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)