### PR TITLE
Windows toast on agent turn-complete while minimized

### DIFF
--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -113,6 +113,12 @@ public partial class App : Application
                 services.AddSingleton<IOpenCodeTelemetryService, OpenCodeTelemetryService>();
                 services.AddSingleton<IOpenCodeSessionDiscovery, OpenCodeSessionDiscovery>();
                 services.AddSingleton<INotificationService, NotificationService>();
+                // Native Windows Action-Center toast on agent turn-complete. Fires only
+                // when the main window is minimized (gate lives in the implementation).
+                // The compat layer auto-registers an AUMID + COM activator on first use,
+                // so unpackaged WPF gets real Win10/11 toasts without a manual shortcut.
+                services.AddSingleton<NoScope.CodeScope.Ui.Services.IIdleToastNotifier,
+                    NoScope.CodeScope.App.Notifications.WindowsIdleToastNotifier>();
                 // Owns SessionTabView lifecycle so the inner HwndHost survives reparent on
                 // drag-between-groups. See spec
                 // docs/superpowers/specs/2026-04-26-cross-group-terminal-drag-design.md.
@@ -156,7 +162,8 @@ public partial class App : Application
                         sp.GetRequiredService<IPiTelemetryService>(),
                         sp.GetRequiredService<IPiSessionDiscovery>(),
                         sp.GetRequiredService<IOpenCodeTelemetryService>(),
-                        sp.GetRequiredService<IOpenCodeSessionDiscovery>());
+                        sp.GetRequiredService<IOpenCodeSessionDiscovery>(),
+                        sp.GetRequiredService<NoScope.CodeScope.Ui.Services.IIdleToastNotifier>());
                     var sidebar = sp.GetRequiredService<SidebarViewModel>();
                     vm.AttachSidebar(sidebar);
                     var diff = sp.GetRequiredService<DiffPanelViewModel>();

--- a/src/CodeScope.App/CodeScope.App.csproj
+++ b/src/CodeScope.App/CodeScope.App.csproj
@@ -2,7 +2,15 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net10.0-windows</TargetFramework>
+        <!--
+            10.0.19041.0 (Win10 2004) is the floor for the WinRT toast projection used by
+            Microsoft.Toolkit.Uwp.Notifications. Bumping only the App TFM keeps Core/Ui as
+            plain net10.0-windows (no WinRT surface), which preserves the "UI-free Core"
+            invariant and keeps the Ui project free of platform-version coupling.
+        -->
+        <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+        <!-- Match the TFM SDK so the WinRT analyzer doesn't flag 1903+ APIs (e.g. ToastNotification.ExpiresOnReboot). -->
+        <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
         <UseWPF>true</UseWPF>
         <RootNamespace>NoScope.CodeScope.App</RootNamespace>
         <AssemblyName>CodeScope</AssemblyName>
@@ -50,6 +58,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
         <PackageReference Include="Velopack" Version="0.0.1298" />
         <PackageReference Include="WPF-UI" Version="4.2.0" />
     </ItemGroup>

--- a/src/CodeScope.App/MainWindow.xaml.cs
+++ b/src/CodeScope.App/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using NoScope.CodeScope.App.Persistence;
 using NoScope.CodeScope.App.Toasts;
+using NoScope.CodeScope.Ui.Services;
 using NoScope.CodeScope.Ui.ViewModels;
 using NoScope.CodeScope.Ui.Views;
 using Wpf.Ui.Controls;
@@ -15,6 +16,7 @@ public partial class MainWindow : FluentWindow
 {
     private readonly MainViewModel _viewModel;
     private readonly ToastService _toasts;
+    private readonly IIdleToastNotifier _idleNotifier;
 
     // Cached per-VM view instances. Re-created EditorGroupViews would force the hosted
     // EasyTerminalControl HWND to tear down and respawn pwsh, so we hold on to them for
@@ -32,13 +34,20 @@ public partial class MainWindow : FluentWindow
     // CaptionButton style in MainWindow.xaml.
     private const double CaptionClusterWidth = 4 * 46.0;
 
-    public MainWindow(MainViewModel viewModel, ToastService toasts)
+    public MainWindow(MainViewModel viewModel, ToastService toasts, IIdleToastNotifier idleNotifier)
     {
         _viewModel = viewModel;
         _toasts = toasts;
+        _idleNotifier = idleNotifier;
         DataContext = viewModel;
 
         InitializeComponent();
+
+        // Click on a "turn complete" Action-Center toast → restore the window and select
+        // the session it pointed at. Activated is already dispatcher-marshalled by the
+        // notifier, so we can touch UI directly.
+        _idleNotifier.Activated += OnIdleToastActivated;
+        Closed += (_, _) => _idleNotifier.Activated -= OnIdleToastActivated;
 
         // The toast host binds Items off the service; the service is the single
         // dispatcher-marshalled owner of the visible-toast collection.
@@ -299,6 +308,15 @@ public partial class MainWindow : FluentWindow
             // Mouse released before DragMove latched — expected race, trace for diagnostics.
             System.Diagnostics.Debug.WriteLine($"[MainWindow] DragMove: {ex.Message}");
         }
+    }
+
+    private void OnIdleToastActivated(object? sender, string agentSessionId)
+    {
+        // Toast click grants the app foreground rights, so a plain Activate() reliably
+        // promotes us above other top-levels — no SetForegroundWindow / Topmost dance.
+        if (WindowState == WindowState.Minimized) { WindowState = WindowState.Normal; }
+        Activate();
+        _viewModel.ActivateSessionByAgentSessionId(agentSessionId);
     }
 
     private void OnCaptionMinimize(object sender, System.Windows.RoutedEventArgs e)

--- a/src/CodeScope.App/Notifications/WindowsIdleToastNotifier.cs
+++ b/src/CodeScope.App/Notifications/WindowsIdleToastNotifier.cs
@@ -1,0 +1,140 @@
+using System.Windows;
+using Microsoft.Extensions.Logging;
+using Microsoft.Toolkit.Uwp.Notifications;
+using NoScope.CodeScope.Ui.Services;
+
+namespace NoScope.CodeScope.App.Notifications;
+
+/// <summary>
+/// Windows Action-Center toast implementation of <see cref="IIdleToastNotifier"/>. Uses
+/// the <c>Microsoft.Toolkit.Uwp.Notifications</c> compat layer so the unpackaged WPF host
+/// gets a real WinRT toast (visible while the window is minimized) without us hand-rolling
+/// AUMID + COM-activator registration.
+///
+/// <para>The minimize gate lives here, not at the call site, so the activity-FSM hook in
+/// <c>MainViewModel</c> stays a one-liner. We also de-dupe per session id within a short
+/// window to absorb the FSWatcher-then-poll re-fires that the telemetry layer is known
+/// to emit (~100–500 ms apart).</para>
+/// </summary>
+public sealed class WindowsIdleToastNotifier : IIdleToastNotifier, IDisposable
+{
+    private const string ArgKey = "agentSessionId";
+    private const string ActionKey = "action";
+    private const string ActionFocus = "focus";
+    private static readonly TimeSpan DedupeWindow = TimeSpan.FromSeconds(2);
+
+    private readonly ILogger<WindowsIdleToastNotifier> _logger;
+    private readonly Dictionary<string, DateTimeOffset> _lastFiredBySession = [];
+    private readonly Lock _gate = new();
+    private bool _activatedHookInstalled;
+    private bool _disposed;
+
+    public WindowsIdleToastNotifier(ILogger<WindowsIdleToastNotifier> logger)
+    {
+        _logger = logger;
+        // The compat layer's OnActivated subscription is what triggers AUMID + COM activator
+        // registration on first use. Subscribing eagerly so a click that arrives before the
+        // first NotifyTurnComplete (unlikely, but possible after a future API addition)
+        // still routes correctly.
+        TryInstallActivatedHook();
+    }
+
+    public event EventHandler<string>? Activated;
+
+    public void NotifyTurnComplete(string agentSessionId, string sessionTitle, string detail)
+    {
+        if (string.IsNullOrWhiteSpace(agentSessionId)) { return; }
+        if (!IsMainWindowMinimized()) { return; }
+
+        // De-dupe: telemetry transitions fire from FSWatcher *and* the poll fallback
+        // (~100–500 ms apart) and would otherwise stack two identical toasts.
+        lock (_gate)
+        {
+            if (_lastFiredBySession.TryGetValue(agentSessionId, out var last)
+                && DateTimeOffset.UtcNow - last < DedupeWindow)
+            {
+                return;
+            }
+            _lastFiredBySession[agentSessionId] = DateTimeOffset.UtcNow;
+        }
+
+        try
+        {
+            new ToastContentBuilder()
+                .AddArgument(ActionKey, ActionFocus)
+                .AddArgument(ArgKey, agentSessionId)
+                .AddText(sessionTitle)
+                .AddText(detail)
+                .Show(toast =>
+                {
+                    // ExpiresOnReboot keeps Action Center clean: a click after a reboot wouldn't
+                    // reach our (now-dead) COM activator anyway, so the entry would be a dead end.
+                    toast.ExpiresOnReboot = true;
+                });
+        }
+        catch (Exception ex)
+        {
+            // Toast surface is non-essential; never let it bring the app down. Common failures
+            // are sandbox / missing Start-menu shortcut on first run before Velopack registered.
+            _logger.LogDebug(ex, "Toast Show failed for session {SessionId}", agentSessionId);
+        }
+    }
+
+    private void TryInstallActivatedHook()
+    {
+        if (_activatedHookInstalled) { return; }
+        try
+        {
+            ToastNotificationManagerCompat.OnActivated += OnToastActivated;
+            _activatedHookInstalled = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to install toast Activated hook");
+        }
+    }
+
+    private void OnToastActivated(ToastNotificationActivatedEventArgsCompat e)
+    {
+        try
+        {
+            var args = ToastArguments.Parse(e.Argument);
+            if (!args.Contains(ArgKey)) { return; }
+            var sid = args[ArgKey];
+            if (string.IsNullOrEmpty(sid)) { return; }
+
+            // The compat layer fires this on a background thread; marshal back to the WPF
+            // dispatcher before raising so subscribers (MainWindow) can touch UI freely.
+            var app = Application.Current;
+            if (app?.Dispatcher is { } d)
+            {
+                d.BeginInvoke(() => Activated?.Invoke(this, sid));
+            }
+            else
+            {
+                Activated?.Invoke(this, sid);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Toast activation parse failed: {Argument}", e.Argument);
+        }
+    }
+
+    private static bool IsMainWindowMinimized()
+    {
+        var win = Application.Current?.MainWindow;
+        return win is not null && win.WindowState == WindowState.Minimized;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) { return; }
+        _disposed = true;
+        if (_activatedHookInstalled)
+        {
+            try { ToastNotificationManagerCompat.OnActivated -= OnToastActivated; }
+            catch (Exception ex) { _logger.LogTrace(ex, "Detach toast hook"); }
+        }
+    }
+}

--- a/src/CodeScope.App/Notifications/WindowsIdleToastNotifier.cs
+++ b/src/CodeScope.App/Notifications/WindowsIdleToastNotifier.cs
@@ -19,8 +19,6 @@ namespace NoScope.CodeScope.App.Notifications;
 public sealed class WindowsIdleToastNotifier : IIdleToastNotifier, IDisposable
 {
     private const string ArgKey = "agentSessionId";
-    private const string ActionKey = "action";
-    private const string ActionFocus = "focus";
     private static readonly TimeSpan DedupeWindow = TimeSpan.FromSeconds(2);
 
     private readonly ILogger<WindowsIdleToastNotifier> _logger;
@@ -47,21 +45,28 @@ public sealed class WindowsIdleToastNotifier : IIdleToastNotifier, IDisposable
         if (!IsMainWindowMinimized()) { return; }
 
         // De-dupe: telemetry transitions fire from FSWatcher *and* the poll fallback
-        // (~100–500 ms apart) and would otherwise stack two identical toasts.
+        // (~100–500 ms apart) and would otherwise stack two identical toasts. Anything
+        // older than the de-dupe window can no longer suppress a future toast, so we
+        // prune in-place — the dict stays bounded to "sessions seen in the last 2 s",
+        // a handful of entries at most.
         lock (_gate)
         {
-            if (_lastFiredBySession.TryGetValue(agentSessionId, out var last)
-                && DateTimeOffset.UtcNow - last < DedupeWindow)
+            var now = DateTimeOffset.UtcNow;
+            var cutoff = now - DedupeWindow;
+            foreach (var staleKey in _lastFiredBySession
+                         .Where(kv => kv.Value < cutoff)
+                         .Select(kv => kv.Key)
+                         .ToList())
             {
-                return;
+                _lastFiredBySession.Remove(staleKey);
             }
-            _lastFiredBySession[agentSessionId] = DateTimeOffset.UtcNow;
+            if (_lastFiredBySession.ContainsKey(agentSessionId)) { return; }
+            _lastFiredBySession[agentSessionId] = now;
         }
 
         try
         {
             new ToastContentBuilder()
-                .AddArgument(ActionKey, ActionFocus)
                 .AddArgument(ArgKey, agentSessionId)
                 .AddText(sessionTitle)
                 .AddText(detail)

--- a/src/CodeScope.Ui/Services/IIdleToastNotifier.cs
+++ b/src/CodeScope.Ui/Services/IIdleToastNotifier.cs
@@ -16,7 +16,10 @@ public interface IIdleToastNotifier
 {
     /// <summary>
     /// Shows a "turn complete" toast for the given session if the host window is
-    /// minimized; otherwise no-op. Safe to call from any thread.
+    /// minimized; otherwise no-op. Must be called on the WPF dispatcher — the
+    /// implementation reads <c>Application.Current.MainWindow.WindowState</c>, which
+    /// is dispatcher-affined. Existing call sites (<c>MainViewModel.PushActivityNotification</c>
+    /// → <c>ApplyTelemetry</c>) already marshal onto the dispatcher before invoking.
     /// </summary>
     /// <param name="agentSessionId">
     /// The agent-side session id (Claude UUID etc.) — embedded in the toast as the

--- a/src/CodeScope.Ui/Services/IIdleToastNotifier.cs
+++ b/src/CodeScope.Ui/Services/IIdleToastNotifier.cs
@@ -1,0 +1,35 @@
+namespace NoScope.CodeScope.Ui.Services;
+
+/// <summary>
+/// Surfaces a native Windows toast (Action Center) when an agent's turn completes —
+/// but only when the main app window is minimized. Click activation routes back via
+/// <see cref="Activated"/> with the agent session id so the host can restore the
+/// window and focus the matching tab.
+/// </summary>
+/// <remarks>
+/// The implementation owns the gate: callers fire-and-forget on every transition to
+/// Idle and the notifier itself decides whether the user actually sees a toast. That
+/// keeps the activity-FSM call site (<c>MainViewModel.PushActivityNotification</c>)
+/// free of window-state plumbing.
+/// </remarks>
+public interface IIdleToastNotifier
+{
+    /// <summary>
+    /// Shows a "turn complete" toast for the given session if the host window is
+    /// minimized; otherwise no-op. Safe to call from any thread.
+    /// </summary>
+    /// <param name="agentSessionId">
+    /// The agent-side session id (Claude UUID etc.) — embedded in the toast as the
+    /// activation argument so click-routing can match the right tab.
+    /// </param>
+    /// <param name="sessionTitle">Display name shown on the toast.</param>
+    /// <param name="detail">Body line, e.g. "Turn complete · 14s".</param>
+    void NotifyTurnComplete(string agentSessionId, string sessionTitle, string detail);
+
+    /// <summary>
+    /// Raised when the user clicks a toast emitted by this notifier. Argument is the
+    /// agent session id originally passed to <see cref="NotifyTurnComplete"/>. Marshalled
+    /// onto the WPF dispatcher by the implementation.
+    /// </summary>
+    event EventHandler<string>? Activated;
+}

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -32,6 +32,7 @@ public sealed partial class MainViewModel : ObservableObject
     private readonly IPiSessionDiscovery? _piDiscovery;
     private readonly IOpenCodeTelemetryService? _opencodeTelemetry;
     private readonly IOpenCodeSessionDiscovery? _opencodeDiscovery;
+    private readonly IIdleToastNotifier? _idleNotifier;
     private readonly Dictionary<string, ClaudeActivityState> _lastActivity = [];
     // Per-tab discovery watcher — disposed on adoption or tab close.
     private readonly Dictionary<string, IDisposable> _discoveryWatches = [];
@@ -51,7 +52,8 @@ public sealed partial class MainViewModel : ObservableObject
         IPiTelemetryService? piTelemetry = null,
         IPiSessionDiscovery? piDiscovery = null,
         IOpenCodeTelemetryService? opencodeTelemetry = null,
-        IOpenCodeSessionDiscovery? opencodeDiscovery = null)
+        IOpenCodeSessionDiscovery? opencodeDiscovery = null,
+        IIdleToastNotifier? idleNotifier = null)
     {
         _sessionManager = sessionManager;
         _store = store;
@@ -67,6 +69,7 @@ public sealed partial class MainViewModel : ObservableObject
         _piDiscovery = piDiscovery;
         _opencodeTelemetry = opencodeTelemetry;
         _opencodeDiscovery = opencodeDiscovery;
+        _idleNotifier = idleNotifier;
         SessionViewPool = sessionViewPool;
         if (_telemetry is not null) { _telemetry.Updated += OnTelemetryUpdated; }
         // All telemetry backends emit ClaudeSessionTelemetry — same handler routes any source
@@ -843,6 +846,18 @@ public sealed partial class MainViewModel : ObservableObject
         => Groups.FirstOrDefault(g => g.Tabs.Contains(tab));
 
     /// <summary>
+    /// Selects the tab whose persisted session has the given agent-side session id (Claude
+    /// UUID etc.). Called by the host after a Windows toast click so the right tab is in
+    /// front when the window restores. No-op if no live tab matches.
+    /// </summary>
+    public void ActivateSessionByAgentSessionId(string agentSessionId)
+    {
+        if (string.IsNullOrEmpty(agentSessionId)) { return; }
+        var target = AllTabs.FirstOrDefault(t => FindStoredSession(t)?.AgentSessionId == agentSessionId);
+        if (target is not null) { SelectedTab = target; }
+    }
+
+    /// <summary>
     /// True when <paramref name="agent"/> accepts a caller-supplied session id on launch
     /// — i.e. has a <see cref="AgentProfile.SessionIdFlag"/>. Drives whether
     /// <c>NewSessionAsync</c> / <c>DuplicateTabAsync</c> mint a UUID to persist.
@@ -1329,10 +1344,27 @@ public sealed partial class MainViewModel : ObservableObject
     /// </summary>
     private void PushActivityNotification(SessionTabViewModel tab, ClaudeSessionTelemetry snap)
     {
-        if (_notifications is null) { return; }
         var prev = _lastActivity.TryGetValue(snap.SessionId, out var p) ? p : ClaudeActivityState.Unknown;
         _lastActivity[snap.SessionId] = snap.Activity;
         if (prev == snap.Activity) { return; }
+
+        // Windows Action-Center toast on turn-complete — visible while the whole app is
+        // minimized (which is the only time it actually fires; the notifier owns the
+        // WindowState.Minimized gate). Independent of the in-app bell's SelectedTab
+        // suppression: a minimized window means the user can't see the tab no matter which
+        // one it is. AgentSessionId is the click-routing key.
+        if (snap.Activity == ClaudeActivityState.Idle
+            && prev is ClaudeActivityState.PendingToolUse or ClaudeActivityState.Composing
+            && _idleNotifier is not null
+            && !string.IsNullOrEmpty(snap.SessionId))
+        {
+            var detailLine = snap.LastTurnDuration is { } dur
+                ? $"Turn complete · {FormatDuration(dur.TotalSeconds)}"
+                : "Turn complete.";
+            _idleNotifier.NotifyTurnComplete(snap.SessionId, tab.DisplayName, detailLine);
+        }
+
+        if (_notifications is null) { return; }
         // Don't pester the user about the tab they're actively staring at.
         if (ReferenceEquals(tab, SelectedTab)) { return; }
 

--- a/tests/CodeScope.App.Tests/CodeScope.App.Tests.csproj
+++ b/tests/CodeScope.App.Tests/CodeScope.App.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0-windows</TargetFramework>
+        <!-- Matches CodeScope.App's TFM (bumped for the WinRT toast projection). -->
+        <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
         <UseWPF>true</UseWPF>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
## Summary

- Surface a native Windows Action-Center toast when an agent's turn completes (`Composing`/`PendingToolUse` → `Idle`), but only while the main window is minimized.
- Click on the toast restores the window and selects the tab whose agent session id matches — no more digging through tabs after coming back from another app.
- Keeps existing in-app bell + status dots untouched; this is purely additive surface for the case the user can't see the window.

## Implementation notes

- New `IIdleToastNotifier` (in `CodeScope.Ui/Services`) keeps `MainViewModel.PushActivityNotification` platform-free. The minimize gate, per-session de-dupe (2s window, absorbs FSWatcher-then-poll re-fires), and toast Activated routing all live inside the implementation.
- `WindowsIdleToastNotifier` (in `CodeScope.App/Notifications`) uses `Microsoft.Toolkit.Uwp.Notifications` 7.1.3, which auto-handles AUMID + COM-activator registration for unpackaged WPF. No manual shortcut wiring needed; Velopack's existing Start-menu entry coexists.
- TFM bumped: `CodeScope.App` and `CodeScope.App.Tests` go from `net10.0-windows` to `net10.0-windows10.0.19041.0` to pick up the WinRT projection. `Core` and `Ui` stay platform-version-free (Core's "UI-free" invariant is preserved).
- Click flow: `WindowsIdleToastNotifier.Activated` (dispatcher-marshalled) → `MainWindow.OnIdleToastActivated` → `WindowState = Normal` + `Activate()` + `MainViewModel.ActivateSessionByAgentSessionId(sid)`.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 287/288 green; the 1 failure is the pre-existing `ClaudeSessionDiscovery` FSWatcher timing flake documented in HANDOFF (passes on isolated re-run, not a regression)
- [x] Hand-tested in dev build (`CODESCOPE_DEV=1`): minimize → agent finishes turn → toast appears → click → window restores with right tab selected
- [ ] Side-by-side dev + installed v0.1.0 sanity: separate AUMID/CLSIDs derived from each build's path, so they should coexist without hijacking each other's toasts