### PR TITLE
Sidebar: "Open remote in browser" on project/worktree menus

### DIFF
--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
@@ -226,6 +226,82 @@ public sealed partial class SidebarViewModel
     }
 
     [RelayCommand]
+    private async Task OpenRemoteRepositoryAsync(object? target)
+    {
+        var path = ResolvePath(target);
+        if (string.IsNullOrWhiteSpace(path) || _git is null) { return; }
+
+        var r = await _git.GetRemoteUrlAsync(path).ConfigureAwait(true);
+        if (r.IsFailure || string.IsNullOrWhiteSpace(r.Value))
+        {
+            ErrToast("No remote", r.IsFailure ? r.Error : "No 'origin' remote configured");
+            return;
+        }
+
+        var webUrl = ToRemoteWebUrl(r.Value!);
+        if (string.IsNullOrWhiteSpace(webUrl))
+        {
+            ErrToast("Open repository failed", $"Could not derive web URL from '{r.Value}'");
+            return;
+        }
+
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(webUrl)
+            {
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "OpenRemoteRepository failed for {Url}", webUrl);
+            ErrToast("Open repository failed", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Convert a git remote (SCP-style <c>git@host:owner/repo.git</c>, <c>ssh://git@host/owner/repo.git</c>,
+    /// or <c>https://host/owner/repo.git</c>) into a browser URL by stripping the trailing
+    /// <c>.git</c> and rewriting SSH forms to HTTPS. Returns <c>null</c> when the remote does
+    /// not look like an HTTP-reachable repository.
+    /// </summary>
+    internal static string? ToRemoteWebUrl(string remoteUrl)
+    {
+        var url = remoteUrl.Trim();
+        if (url.Length == 0) { return null; }
+
+        if (url.StartsWith("git@", StringComparison.OrdinalIgnoreCase))
+        {
+            var at = url.IndexOf('@');
+            var colon = url.IndexOf(':', at);
+            if (colon < 0) { return null; }
+            var host = url.Substring(at + 1, colon - at - 1);
+            var rest = url.Substring(colon + 1);
+            url = $"https://{host}/{rest}";
+        }
+        else if (url.StartsWith("ssh://", StringComparison.OrdinalIgnoreCase))
+        {
+            var rest = url.Substring("ssh://".Length);
+            var slash = rest.IndexOf('/');
+            if (slash < 0) { return null; }
+            var hostPart = rest.Substring(0, slash);
+            var at = hostPart.IndexOf('@');
+            var host = at >= 0 ? hostPart.Substring(at + 1) : hostPart;
+            url = $"https://{host}{rest.Substring(slash)}";
+        }
+
+        if (url.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+        {
+            url = url.Substring(0, url.Length - 4);
+        }
+
+        return url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            || url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            ? url
+            : null;
+    }
+
+    [RelayCommand]
     private void OpenInWindowsTerminal(object? target)
     {
         var path = ResolvePath(target);

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
@@ -234,7 +234,7 @@ public sealed partial class SidebarViewModel
         var r = await _git.GetRemoteUrlAsync(path).ConfigureAwait(true);
         if (r.IsFailure || string.IsNullOrWhiteSpace(r.Value))
         {
-            ErrToast("No remote", r.IsFailure ? r.Error : "No 'origin' remote configured");
+            ErrToast("No remote", r.IsFailure ? r.Error : "Could not obtain 'origin' remote URL");
             return;
         }
 

--- a/src/CodeScope.Ui/Views/SidebarView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SidebarView.xaml.cs
@@ -625,20 +625,49 @@ public partial class SidebarView : UserControl
 
     private static Separator BuildSeparator() => new();
 
-    /// <summary>
-    /// Cheap, synchronous probe for an <c>origin</c> remote on a project. Reads <c>.git/config</c>
-    /// directly so the menu builder doesn't have to spawn <c>git remote get-url</c> on every right
-    /// click. Returns false when the path is missing, the config can't be read, or the file
-    /// contains no <c>[remote "origin"]</c> section. Worktrees share the project's config so the
-    /// caller passes the project path, not the worktree path.
-    /// </summary>
+    private static bool TryGetGitConfigPath(string? projectPath, out string? configPath)
+    {
+        configPath = null;
+        if (string.IsNullOrWhiteSpace(projectPath)) { return false; }
+
+        var gitPath = System.IO.Path.Combine(projectPath, ".git");
+
+        if (System.IO.Directory.Exists(gitPath))
+        {
+            var directConfigPath = System.IO.Path.Combine(gitPath, "config");
+            if (System.IO.File.Exists(directConfigPath))
+            {
+                configPath = directConfigPath;
+                return true;
+            }
+            return false;
+        }
+
+        if (!System.IO.File.Exists(gitPath)) { return false; }
+
+        var gitPointer = System.IO.File.ReadAllText(gitPath).Trim();
+        const string gitDirPrefix = "gitdir:";
+        if (!gitPointer.StartsWith(gitDirPrefix, StringComparison.OrdinalIgnoreCase)) { return false; }
+
+        var gitDir = gitPointer[gitDirPrefix.Length..].Trim();
+        if (string.IsNullOrWhiteSpace(gitDir)) { return false; }
+
+        var resolvedGitDir = System.IO.Path.IsPathRooted(gitDir)
+            ? gitDir
+            : System.IO.Path.GetFullPath(System.IO.Path.Combine(projectPath, gitDir));
+
+        var resolvedConfigPath = System.IO.Path.Combine(resolvedGitDir, "config");
+        if (!System.IO.File.Exists(resolvedConfigPath)) { return false; }
+
+        configPath = resolvedConfigPath;
+        return true;
+    }
+
     private static bool HasOriginRemote(string? projectPath)
     {
-        if (string.IsNullOrWhiteSpace(projectPath)) { return false; }
         try
         {
-            var configPath = System.IO.Path.Combine(projectPath, ".git", "config");
-            if (!System.IO.File.Exists(configPath)) { return false; }
+            if (!TryGetGitConfigPath(projectPath, out var configPath) || configPath is null) { return false; }
             var text = System.IO.File.ReadAllText(configPath);
             return text.Contains("[remote \"origin\"]", StringComparison.Ordinal);
         }

--- a/src/CodeScope.Ui/Views/SidebarView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SidebarView.xaml.cs
@@ -350,6 +350,12 @@ public partial class SidebarView : UserControl
         TreeContextMenu.Items.Add(BuildItem(
             "Open in Windows Terminal", "Ctx.Icon.WinTerminal", null,
             () => vm.OpenInWindowsTerminalCommand.Execute(wt)));
+        if (HasOriginRemote(owner?.Path))
+        {
+            TreeContextMenu.Items.Add(BuildItem(
+                "Open remote in browser", "Ctx.Icon.Link", null,
+                () => vm.OpenRemoteRepositoryCommand.Execute(wt)));
+        }
 
         // Copy → submenu
         var copyRoot = new MenuItem { Header = "Copy", Icon = IconFor("Ctx.Icon.Clipboard") };
@@ -438,6 +444,12 @@ public partial class SidebarView : UserControl
         TreeContextMenu.Items.Add(BuildItem(
             "Open in Windows Terminal", "Ctx.Icon.WinTerminal", null,
             () => vm.OpenInWindowsTerminalCommand.Execute(proj)));
+        if (HasOriginRemote(proj.Path))
+        {
+            TreeContextMenu.Items.Add(BuildItem(
+                "Open remote in browser", "Ctx.Icon.Link", null,
+                () => vm.OpenRemoteRepositoryCommand.Execute(proj)));
+        }
         TreeContextMenu.Items.Add(BuildItem(
             "Copy path", "Ctx.Icon.Clipboard", "Ctrl+Alt+C",
             () => vm.CopyPathCommand.Execute(proj)));
@@ -612,6 +624,29 @@ public partial class SidebarView : UserControl
     }
 
     private static Separator BuildSeparator() => new();
+
+    /// <summary>
+    /// Cheap, synchronous probe for an <c>origin</c> remote on a project. Reads <c>.git/config</c>
+    /// directly so the menu builder doesn't have to spawn <c>git remote get-url</c> on every right
+    /// click. Returns false when the path is missing, the config can't be read, or the file
+    /// contains no <c>[remote "origin"]</c> section. Worktrees share the project's config so the
+    /// caller passes the project path, not the worktree path.
+    /// </summary>
+    private static bool HasOriginRemote(string? projectPath)
+    {
+        if (string.IsNullOrWhiteSpace(projectPath)) { return false; }
+        try
+        {
+            var configPath = System.IO.Path.Combine(projectPath, ".git", "config");
+            if (!System.IO.File.Exists(configPath)) { return false; }
+            var text = System.IO.File.ReadAllText(configPath);
+            return text.Contains("[remote \"origin\"]", StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     /// <summary>Runs <paramref name="action"/> with the main-window view-model if present.
     /// Replaces the `Application.Current?.MainWindow?.DataContext is MainViewModel main` guard

--- a/tests/CodeScope.Ui.Tests/ToRemoteWebUrlTests.cs
+++ b/tests/CodeScope.Ui.Tests/ToRemoteWebUrlTests.cs
@@ -1,0 +1,45 @@
+using NoScope.CodeScope.Ui.ViewModels;
+
+namespace NoScope.CodeScope.Ui.Tests;
+
+public sealed class ToRemoteWebUrlTests
+{
+    [Theory]
+    [InlineData("https://github.com/owner/repo.git", "https://github.com/owner/repo")]
+    [InlineData("https://github.com/owner/repo", "https://github.com/owner/repo")]
+    [InlineData("http://gitea.local/owner/repo.git", "http://gitea.local/owner/repo")]
+    [InlineData("https://github.com/owner/repo.git  ", "https://github.com/owner/repo")]
+    public void Https_RemovesTrailingDotGit(string remote, string expected)
+    {
+        SidebarViewModel.ToRemoteWebUrl(remote).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("git@github.com:owner/repo.git", "https://github.com/owner/repo")]
+    [InlineData("git@github.com:owner/repo", "https://github.com/owner/repo")]
+    [InlineData("git@gitea.internal:org/project.git", "https://gitea.internal/org/project")]
+    public void ScpStyle_ConvertedToHttps(string remote, string expected)
+    {
+        SidebarViewModel.ToRemoteWebUrl(remote).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("ssh://git@github.com/owner/repo.git", "https://github.com/owner/repo")]
+    [InlineData("ssh://git@github.com/owner/repo", "https://github.com/owner/repo")]
+    [InlineData("ssh://github.com/owner/repo.git", "https://github.com/owner/repo")]
+    public void SshScheme_ConvertedToHttps(string remote, string expected)
+    {
+        SidebarViewModel.ToRemoteWebUrl(remote).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("ftp://example.com/repo")]
+    [InlineData("not-a-url")]
+    public void InvalidOrUnsupported_ReturnsNull(string remote)
+    {
+        SidebarViewModel.ToRemoteWebUrl(remote).Should().BeNull();
+    }
+
+}


### PR DESCRIPTION
## Summary
- New context-menu entry under **Reveal** on both project and worktree rows that opens the repo's `origin` remote in the default browser.
- Host-agnostic URL normalization: `git@host:owner/repo.git`, `ssh://git@host/...`, and `https://` forms all map to a clean web URL with the trailing `.git` stripped — works for GitHub, Gitea, GHES, self-hosted.
- Entry is omitted entirely when `.git/config` has no `[remote "origin"]`, so unconfigured projects don't see a dead command. Probe reads the config file synchronously (small, OS-cached) instead of spawning `git remote get-url` per right click.

## Test plan
- [ ] Right-click a project with a GitHub origin → "Open remote in browser" launches the repo page.
- [ ] Right-click a worktree under that project → same entry opens the same URL (worktrees share the project's `.git/config`).
- [ ] Right-click a project with no `origin` remote → entry is hidden.
- [ ] SSH-form remote (`git@github.com:owner/repo.git`) still resolves to `https://github.com/owner/repo`.
- [ ] Non-GitHub remote (Gitea/GHES) opens the corresponding host.