### PR TITLE
Fix #21: tab title auto-follows worktree branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,5 +64,6 @@ dev-mode separation keeps working.
 - Read `docs/DECISIONS.md` before proposing architecture changes
 - Write the test first for `Core` services (TDD for logic, not UI)
 - Keep commits focused; one concern per commit
+- Never commit new work directly to `main` — always create a feature branch and open a PR (even for small changes). `main` is protected; pushing to it bypasses review
 - At the **end** of every working session, update `docs/HANDOFF.md` with the new cursor, commit SHAs, and anything a fresh session would need
 - Never leave `TODO` / `FIXME` without a linked issue number

--- a/src/CodeScope.App/MainWindow.xaml
+++ b/src/CodeScope.App/MainWindow.xaml
@@ -85,7 +85,6 @@
         <KeyBinding Key="W" Modifiers="Control" Command="{Binding CloseTabCommand}" />
         <KeyBinding Key="Tab" Modifiers="Control" Command="{Binding NextTabCommand}" />
         <KeyBinding Key="Tab" Modifiers="Control+Shift" Command="{Binding PrevTabCommand}" />
-        <KeyBinding Key="F2" Command="{Binding RenameSessionCommand}" />
         <KeyBinding Key="K" Modifiers="Control" Command="{Binding OpenCommandPaletteCommand}" />
         <KeyBinding Key="P" Modifiers="Control+Shift" Command="{Binding OpenCommandPaletteCommand}" />
         <KeyBinding Key="O" Modifiers="Control+Shift" Command="{Binding ToggleOverviewCommand}" />

--- a/src/CodeScope.Ui/Dialogs/RenameDialog.xaml
+++ b/src/CodeScope.Ui/Dialogs/RenameDialog.xaml
@@ -2,7 +2,7 @@
     x:Class="NoScope.CodeScope.Ui.Dialogs.RenameDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="Rename session"
+    Title="Rename"
     Width="440"
     SizeToContent="Height"
     ResizeMode="NoResize"
@@ -262,6 +262,7 @@
                             Text="RENAME"
                             Margin="0,0,0,4" />
                         <TextBlock
+                            x:Name="HeaderText"
                             FontFamily="Inter"
                             FontSize="16"
                             FontWeight="SemiBold"

--- a/src/CodeScope.Ui/Dialogs/RenameDialog.xaml
+++ b/src/CodeScope.Ui/Dialogs/RenameDialog.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Rename session"
-    Width="420"
+    Width="440"
     SizeToContent="Height"
     ResizeMode="NoResize"
     WindowStartupLocation="CenterOwner"
@@ -11,58 +11,310 @@
     WindowStyle="None"
     AllowsTransparency="True"
     Background="Transparent"
-    TextElement.Foreground="{DynamicResource Fig.Brush.Ink}"
-    TextElement.FontFamily="{DynamicResource Fig.Font.Sans}"
-    TextElement.FontSize="{DynamicResource Fig.Size.Body}">
-    <Border
-        Background="{DynamicResource Fig.Brush.SurfaceDialog}"
-        CornerRadius="{DynamicResource Fig.Radius.Medium}"
-        BorderBrush="{DynamicResource Accent.Ring}"
-        BorderThickness="1"
-        Effect="{DynamicResource Shadow.Dialog}"
-        Margin="30"
-        Padding="24"
-        MouseLeftButtonDown="OnChromeDrag">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <TextBlock
-                Grid.Row="0"
-                Text="RENAME SESSION"
-                Style="{DynamicResource Fig.Style.MonoLabel}"
-                Margin="0,0,0,14" />
-            <TextBlock
-                Grid.Row="1"
-                Text="New name:"
-                Margin="0,0,0,6"
-                Foreground="{DynamicResource Fig.Brush.InkMuted}" />
-            <TextBox
-                Grid.Row="2"
-                x:Name="NameBox"
-                AutomationProperties.AutomationId="RenameNameBox"
-                Style="{DynamicResource Fig.Style.TextBox}"
-                Margin="0,0,0,18" />
-            <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button
-                    AutomationProperties.AutomationId="RenameCancelBtn"
-                    Style="{DynamicResource Fig.Style.Button.Glass}"
-                    Content="Cancel"
-                    Margin="0,0,8,0"
-                    Padding="18,7"
-                    IsCancel="True"
-                    Click="OnCancel" />
-                <Button
-                    AutomationProperties.AutomationId="RenameOkBtn"
-                    Style="{DynamicResource Fig.Style.Button.Pill}"
-                    Content="Rename"
-                    Padding="18,7"
-                    IsDefault="True"
-                    Click="OnOk" />
-            </StackPanel>
-        </Grid>
-    </Border>
+    TextElement.FontFamily="Inter"
+    TextElement.FontSize="13"
+    TextElement.Foreground="#FFFFFF"
+    SnapsToDevicePixels="True"
+    UseLayoutRounding="True">
+
+    <!-- Tokens lifted 1:1 from the dialog system spec (see ConfirmDialog.xaml §03).
+         Hard-coded so the dialog primitive doesn't drift when app brushes evolve. -->
+    <Window.Resources>
+        <SolidColorBrush x:Key="Dlg.Surface"   Color="#0A0A0A" />
+        <SolidColorBrush x:Key="Dlg.FooterBg"  Color="#070707" />
+        <SolidColorBrush x:Key="Dlg.Border"    Color="#2A2A2A" />
+        <SolidColorBrush x:Key="Dlg.BorderDim" Color="#1F1F1F" />
+        <SolidColorBrush x:Key="Dlg.Elev"      Color="#141414" />
+        <SolidColorBrush x:Key="Dlg.Elev2"     Color="#1A1A1A" />
+        <SolidColorBrush x:Key="Dlg.Text"      Color="#FFFFFF" />
+        <SolidColorBrush x:Key="Dlg.Text2"     Color="#A0A0A0" />
+        <SolidColorBrush x:Key="Dlg.Text3"     Color="#606060" />
+        <SolidColorBrush x:Key="Dlg.Accent"    Color="#0099FF" />
+        <SolidColorBrush x:Key="Dlg.AccentHov" Color="#1AA8FF" />
+        <SolidColorBrush x:Key="Dlg.IconBg"    Color="#1A0099FF" />
+        <SolidColorBrush x:Key="Dlg.IconBrd"   Color="#400099FF" />
+
+        <!-- Ghost button (Cancel). Transparent → elev on hover. -->
+        <Style x:Key="Dlg.Btn.Ghost" TargetType="Button">
+            <Setter Property="Height" Value="32" />
+            <Setter Property="Padding" Value="14,0" />
+            <Setter Property="MinWidth" Value="72" />
+            <Setter Property="FontFamily" Value="Inter" />
+            <Setter Property="FontSize" Value="12.5" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Foreground" Value="{StaticResource Dlg.Text2}" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="6"
+                                Padding="{TemplateBinding Padding}"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                TextBlock.Foreground="{TemplateBinding Foreground}"
+                                TextBlock.FontFamily="{TemplateBinding FontFamily}"
+                                TextBlock.FontSize="{TemplateBinding FontSize}"
+                                TextBlock.FontWeight="{TemplateBinding FontWeight}" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="{StaticResource Dlg.Elev}" />
+                                <Setter Property="Foreground" Value="{StaticResource Dlg.Text}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Primary button (accent fill, black text). -->
+        <Style x:Key="Dlg.Btn.Primary" TargetType="Button">
+            <Setter Property="Height" Value="32" />
+            <Setter Property="Padding" Value="14,0" />
+            <Setter Property="MinWidth" Value="80" />
+            <Setter Property="FontFamily" Value="Inter" />
+            <Setter Property="FontSize" Value="12.5" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="#000000" />
+            <Setter Property="Background" Value="{StaticResource Dlg.Accent}" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="6"
+                                Padding="{TemplateBinding Padding}"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                TextBlock.Foreground="{TemplateBinding Foreground}"
+                                TextBlock.FontFamily="{TemplateBinding FontFamily}"
+                                TextBlock.FontSize="{TemplateBinding FontSize}"
+                                TextBlock.FontWeight="{TemplateBinding FontWeight}" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="{StaticResource Dlg.AccentHov}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Close glyph (X). -->
+        <Style x:Key="Dlg.Btn.Close" TargetType="Button">
+            <Setter Property="Width" Value="24" />
+            <Setter Property="Height" Value="24" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Foreground" Value="{StaticResource Dlg.Text3}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="4"
+                                SnapsToDevicePixels="True">
+                            <Path Width="12" Height="12"
+                                  Stretch="None"
+                                  Stroke="{TemplateBinding Foreground}"
+                                  StrokeThickness="1.4"
+                                  StrokeStartLineCap="Round"
+                                  StrokeEndLineCap="Round"
+                                  Data="M 2,2 L 10,10 M 10,2 L 2,10"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="{StaticResource Dlg.Elev}" />
+                                <Setter Property="Foreground" Value="{StaticResource Dlg.Text}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- TextBox: dark elev surface, accent ring on focus. -->
+        <Style x:Key="Dlg.TextBox" TargetType="TextBox">
+            <Setter Property="Height" Value="34" />
+            <Setter Property="Padding" Value="10,0" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="FontFamily" Value="Inter" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="{StaticResource Dlg.Text}" />
+            <Setter Property="CaretBrush" Value="{StaticResource Dlg.Text}" />
+            <Setter Property="SelectionBrush" Value="{StaticResource Dlg.Accent}" />
+            <Setter Property="Background" Value="{StaticResource Dlg.Elev}" />
+            <Setter Property="BorderBrush" Value="{StaticResource Dlg.Border}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="TextBox">
+                        <Border x:Name="Br"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="6">
+                            <ScrollViewer x:Name="PART_ContentHost"
+                                          Margin="{TemplateBinding Padding}"
+                                          VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsFocused" Value="True">
+                                <Setter TargetName="Br" Property="BorderBrush" Value="{StaticResource Dlg.Accent}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <DropShadowEffect x:Key="Dlg.Shadow"
+                          BlurRadius="80"
+                          Direction="270"
+                          ShadowDepth="30"
+                          Opacity="0.55"
+                          Color="Black" />
+    </Window.Resources>
+
+    <Grid>
+        <Border
+            x:Name="ScrimBorder"
+            Background="#8C000000"
+            MouseLeftButtonDown="OnCancel">
+            <Border.Effect>
+                <BlurEffect Radius="2" />
+            </Border.Effect>
+        </Border>
+
+        <Border
+            Background="{StaticResource Dlg.Surface}"
+            BorderBrush="{StaticResource Dlg.Border}"
+            BorderThickness="1"
+            CornerRadius="12"
+            Margin="30"
+            Effect="{StaticResource Dlg.Shadow}"
+            MouseLeftButtonDown="OnChromeDrag"
+            SnapsToDevicePixels="True"
+            UseLayoutRounding="True">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <!-- HEAD -->
+                <Grid Grid.Row="0" Margin="24,20,24,4">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border
+                        Grid.Column="0"
+                        Width="32" Height="32"
+                        Margin="0,0,14,0"
+                        VerticalAlignment="Top"
+                        CornerRadius="8"
+                        BorderThickness="1"
+                        Background="{StaticResource Dlg.IconBg}"
+                        BorderBrush="{StaticResource Dlg.IconBrd}">
+                        <Viewbox Width="16" Height="16">
+                            <!-- pencil glyph -->
+                            <Path Width="16" Height="16"
+                                  Stretch="None"
+                                  StrokeThickness="1.5"
+                                  StrokeStartLineCap="Round"
+                                  StrokeEndLineCap="Round"
+                                  StrokeLineJoin="Round"
+                                  Stroke="{StaticResource Dlg.Accent}"
+                                  Fill="Transparent"
+                                  Data="M 2,12 L 2,14 L 4,14 L 12,6 L 10,4 Z M 10,4 L 12,2 L 14,4 L 12,6" />
+                        </Viewbox>
+                    </Border>
+
+                    <StackPanel Grid.Column="1" VerticalAlignment="Top" Margin="0,4,0,0">
+                        <TextBlock
+                            FontFamily="Consolas, 'JetBrains Mono'"
+                            FontSize="10.5"
+                            FontWeight="Medium"
+                            Foreground="{StaticResource Dlg.Text3}"
+                            Typography.Capitals="AllSmallCaps"
+                            Text="RENAME"
+                            Margin="0,0,0,4" />
+                        <TextBlock
+                            FontFamily="Inter"
+                            FontSize="16"
+                            FontWeight="SemiBold"
+                            LineHeight="21"
+                            TextWrapping="Wrap"
+                            Foreground="{StaticResource Dlg.Text}"
+                            Text="Rename session" />
+                    </StackPanel>
+
+                    <Button
+                        Grid.Column="2"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource Dlg.Btn.Close}"
+                        Click="OnCancel" />
+                </Grid>
+
+                <!-- BODY -->
+                <StackPanel Grid.Row="1" Margin="24,10,24,20">
+                    <TextBlock
+                        Margin="0,0,0,8"
+                        Foreground="{StaticResource Dlg.Text2}"
+                        Text="New name" />
+                    <TextBox
+                        x:Name="NameBox"
+                        AutomationProperties.AutomationId="RenameNameBox"
+                        Style="{StaticResource Dlg.TextBox}" />
+                </StackPanel>
+
+                <!-- FOOT -->
+                <Border
+                    Grid.Row="2"
+                    Background="{StaticResource Dlg.FooterBg}"
+                    BorderBrush="{StaticResource Dlg.BorderDim}"
+                    BorderThickness="0,1,0,0"
+                    CornerRadius="0,0,12,12"
+                    Padding="20,14">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button
+                            AutomationProperties.AutomationId="RenameCancelBtn"
+                            Style="{StaticResource Dlg.Btn.Ghost}"
+                            Content="Cancel"
+                            IsCancel="True"
+                            Click="OnCancel" />
+                        <Button
+                            AutomationProperties.AutomationId="RenameOkBtn"
+                            Style="{StaticResource Dlg.Btn.Primary}"
+                            Content="Rename"
+                            Margin="8,0,0,0"
+                            IsDefault="True"
+                            Click="OnOk" />
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+    </Grid>
 </Window>

--- a/src/CodeScope.Ui/Dialogs/RenameDialog.xaml.cs
+++ b/src/CodeScope.Ui/Dialogs/RenameDialog.xaml.cs
@@ -12,17 +12,19 @@ public partial class RenameDialog : Window
 
     public string? ResultName { get; private set; }
 
-    private RenameDialog(string current)
+    private RenameDialog(string current, string title)
     {
         InitializeComponent();
+        Title = title;
+        HeaderText.Text = title;
         NameBox.Text = current;
         NameBox.Focus();
         NameBox.SelectAll();
     }
 
-    public static string? Prompt(string current)
+    public static string? Prompt(string current, string title = "Rename session")
     {
-        var dlg = new RenameDialog(current) { Owner = Application.Current?.MainWindow };
+        var dlg = new RenameDialog(current, title) { Owner = Application.Current?.MainWindow };
         return dlg.ShowDialog() == true ? dlg.ResultName : null;
     }
 

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.Palette.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.Palette.cs
@@ -25,7 +25,6 @@ public sealed partial class MainViewModel
             new("Close current tab", "Ctrl+W",         () => { CloseTabCommand.Execute(null); return Task.CompletedTask; }, Icon: "×"),
             new("Next tab",          "Ctrl+Tab",       () => { NextTabCommand.Execute(null); return Task.CompletedTask; }, Icon: "→"),
             new("Previous tab",      "Ctrl+Shift+Tab", () => { PrevTabCommand.Execute(null); return Task.CompletedTask; }, Icon: "←"),
-            new("Rename session",    "F2",             () => { RenameSessionCommand.Execute(null); return Task.CompletedTask; }, Icon: "✎"),
             new("Toggle diff panel", "Ctrl+D",         () => { ToggleDiffPanelCommand.Execute(null); return Task.CompletedTask; }, Icon: "≡"),
             new("Focus sidebar filter", "Ctrl+F",      () => { FocusSidebarFilterCommand.Execute(null); return Task.CompletedTask; }, Icon: "⌕"),
             new("Refresh all",          "F5",          () => { RefreshAllCommand.Execute(null); return Task.CompletedTask; }, Icon: "↻"),

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -443,7 +443,9 @@ public sealed partial class MainViewModel : ObservableObject
             return;
         }
 
-        var vm = new SessionTabViewModel(descriptor, project.Id, session.AgentId, session.DisplayName, agent?.Icon);
+        // Tab labels always follow the worktree's current branch (§4); we do not pass
+        // session.DisplayName as an override. Sidebar history rows still honor it.
+        var vm = new SessionTabViewModel(descriptor, project.Id, session.AgentId, displayNameOverride: null, agent?.Icon);
         FocusedGroup.Tabs.Add(vm);
         SelectedTab = vm;
         BeginAgentAdoption(descriptor.Id, agent?.Id, targetFolder, DateTimeOffset.UtcNow);
@@ -769,7 +771,9 @@ public sealed partial class MainViewModel : ObservableObject
         var added = await _store.AddSessionAsync(project.Id, session).ConfigureAwait(true);
         if (added.IsFailure) { _logger.LogWarning("DuplicateTab AddSession: {Error}", added.Error); return; }
 
-        var vm = new SessionTabViewModel(descriptor, project.Id, session.AgentId, session.DisplayName, agent?.Icon);
+        // Tab labels always follow the worktree's current branch (§4); we do not pass
+        // session.DisplayName as an override. Sidebar history rows still honor it.
+        var vm = new SessionTabViewModel(descriptor, project.Id, session.AgentId, displayNameOverride: null, agent?.Icon);
         FocusedGroup.Tabs.Add(vm);
         SelectedTab = vm;
         BeginAgentAdoption(descriptor.Id, agent?.Id, folder, DateTimeOffset.UtcNow);
@@ -997,50 +1001,61 @@ public sealed partial class MainViewModel : ObservableObject
         SelectedTab = tabs[(idx - 1 + tabs.Count) % tabs.Count];
     }
 
-    [RelayCommand]
-    private async Task RenameSessionAsync(SessionTabViewModel? tab)
+    /// <summary>
+    /// Recompute the "Project · branch" label for every tab whose session lives in the given
+    /// worktree. Source of truth is the freshly-mutated <see cref="Worktree.Branch"/> on the
+    /// store — the same value the sidebar reads, which is why the sidebar already kept up while
+    /// the tabs went stale (issue #21).
+    /// </summary>
+    private void RefreshTabTitlesForWorktree(string projectId, string worktreeId)
     {
-        tab ??= SelectedTab;
-        if (tab is null) { return; }
-        var newName = Dialogs.RenameDialog.Prompt(tab.DisplayName);
-        if (newName is null) { return; }
-        await _store.RenameSessionAsync(tab.Descriptor.Id, newName).ConfigureAwait(true);
+        var project = _store.Projects.FirstOrDefault(p => p.Id == projectId);
+        if (project is null) { return; }
+        var worktree = project.Worktrees.FirstOrDefault(w => w.Id == worktreeId);
+        if (worktree is null) { return; }
+
+        var branch = string.IsNullOrWhiteSpace(worktree.Branch)
+            ? (worktree.IsPrimary ? "main" : "(no branch)")
+            : worktree.Branch;
+        var title = $"{project.Name} · {branch}";
+
+        foreach (var tab in AllTabs)
+        {
+            if (tab.ProjectId != projectId) { continue; }
+            var session = project.Sessions.FirstOrDefault(s => s.Id == tab.Descriptor.Id);
+            if (session?.WorktreeId != worktreeId) { continue; }
+            tab.DisplayName = title;
+        }
     }
 
     private void OnStoreChanged(object? sender, SessionStoreChange change)
     {
         void Apply()
         {
-            // SessionAdded/SessionRenamed are intentionally not handled here. Tab membership is owned by
-            // MainViewModel — NewSessionAsync, DuplicateTabAsync, TryRestoreSessionAsync, and
+            // SessionAdded/SessionRenamed/Soft-close are intentionally not handled here. Tab membership is
+            // owned by MainViewModel — NewSessionAsync, DuplicateTabAsync, TryRestoreSessionAsync, and
             // RestoreClosedWorktreeSessionsAsync each add their VM directly to FocusedGroup.Tabs and the
-            // store mutation is the side-effect, not the source of truth. The sidebar projection
-            // (SidebarViewModel.StoreSync) consumes those events for its own tree.
+            // store mutation is the side-effect, not the source of truth. SessionRenamed is also ignored:
+            // tab titles always follow the worktree's current branch (§4), so any manual rename done
+            // through the sidebar (closed-session history) only affects the sidebar label. The sidebar
+            // projection (SidebarViewModel.StoreSync) consumes the rename event for its own tree.
             switch (change)
             {
                 case SessionStoreChange.Loaded loaded:
                     HydrateFromLoaded(loaded);
                     break;
-                case SessionStoreChange.SessionRenamed renamed:
-                    var t = AllTabs.FirstOrDefault(x => x.Descriptor.Id == renamed.SessionId);
-                    if (t is not null)
-                    {
-                        t.DisplayName = renamed.NewName ?? t.Descriptor.Title;
-                    }
-                    break;
                 case SessionStoreChange.WorktreeStatusUpdated wtStatus:
-                    // Reflect dirty state on tab titles bound to this worktree.
-                    foreach (var tab in AllTabs)
-                    {
-                        var p = _store.Projects.FirstOrDefault(x => x.Id == tab.ProjectId);
-                        var session = p?.Sessions.FirstOrDefault(s => s.Id == tab.Descriptor.Id);
-                        if (session?.WorktreeId != wtStatus.WorktreeId) { continue; }
-
-                        // Top-bar spec §4: tab label is just "Project · branch". Dirty state
-                        // is carried by the sidebar ("chg" slug) and the status dot — no glyph
-                        // suffixing the title.
-                        tab.DisplayName = tab.Descriptor.Title;
-                    }
+                    // Branch can change underneath us — `git checkout other`, `git branch -m`, or the
+                    // status poll picking up an externally-renamed branch — so we recompute the
+                    // "Project · branch" label every time. Top-bar spec §4: dirty state is carried by
+                    // the sidebar dot, not by the tab label.
+                    RefreshTabTitlesForWorktree(wtStatus.ProjectId, wtStatus.WorktreeId);
+                    break;
+                case SessionStoreChange.WorktreeRenamed wtRenamed:
+                    // Worktree path rename doesn't usually shift the branch, but the project name we
+                    // splice into the title might be derived from the worktree, and a fresh recompute
+                    // is cheap.
+                    RefreshTabTitlesForWorktree(wtRenamed.ProjectId, wtRenamed.WorktreeId);
                     break;
                 case SessionStoreChange.SessionRemoved removed:
                     foreach (var g in Groups)
@@ -1113,7 +1128,7 @@ public sealed partial class MainViewModel : ObservableObject
                     descriptor = descriptor with { Title = $"{p.Name} · {branch}" };
                 }
 
-                var vm = new SessionTabViewModel(descriptor, p.Id, s.AgentId, s.DisplayName);
+                var vm = new SessionTabViewModel(descriptor, p.Id, s.AgentId, displayNameOverride: null);
                 var targetIdx = 0;
                 if (_pendingSessionToGroup is not null
                     && _pendingSessionToGroup.TryGetValue(s.Id, out var saved)

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -445,7 +445,7 @@ public sealed partial class MainViewModel : ObservableObject
 
         // Tab labels always follow the worktree's current branch (§4); we do not pass
         // session.DisplayName as an override. Sidebar history rows still honor it.
-        var vm = new SessionTabViewModel(descriptor, project.Id, session.AgentId, displayNameOverride: null, agent?.Icon);
+        var vm = new SessionTabViewModel(descriptor, project.Id, session.AgentId, displayNameOverride: null, icon: agent?.Icon);
         FocusedGroup.Tabs.Add(vm);
         SelectedTab = vm;
         BeginAgentAdoption(descriptor.Id, agent?.Id, targetFolder, DateTimeOffset.UtcNow);
@@ -773,7 +773,7 @@ public sealed partial class MainViewModel : ObservableObject
 
         // Tab labels always follow the worktree's current branch (§4); we do not pass
         // session.DisplayName as an override. Sidebar history rows still honor it.
-        var vm = new SessionTabViewModel(descriptor, project.Id, session.AgentId, displayNameOverride: null, agent?.Icon);
+        var vm = new SessionTabViewModel(descriptor, project.Id, session.AgentId, displayNameOverride: null, icon: agent?.Icon);
         FocusedGroup.Tabs.Add(vm);
         SelectedTab = vm;
         BeginAgentAdoption(descriptor.Id, agent?.Id, folder, DateTimeOffset.UtcNow);
@@ -1015,7 +1015,9 @@ public sealed partial class MainViewModel : ObservableObject
         if (worktree is null) { return; }
 
         var branch = string.IsNullOrWhiteSpace(worktree.Branch)
-            ? (worktree.IsPrimary ? "main" : "(no branch)")
+            ? (worktree.IsPrimary
+                ? (string.IsNullOrWhiteSpace(project.DefaultBranch) ? "main" : project.DefaultBranch)
+                : "(no branch)")
             : worktree.Branch;
         var title = $"{project.Name} · {branch}";
 
@@ -1052,9 +1054,9 @@ public sealed partial class MainViewModel : ObservableObject
                     RefreshTabTitlesForWorktree(wtStatus.ProjectId, wtStatus.WorktreeId);
                     break;
                 case SessionStoreChange.WorktreeRenamed wtRenamed:
-                    // Worktree path rename doesn't usually shift the branch, but the project name we
-                    // splice into the title might be derived from the worktree, and a fresh recompute
-                    // is cheap.
+                    // A worktree rename is a cheap trigger to recompute titles so the tab strip stays
+                    // consistent with the latest worktree state, even when the effective title is
+                    // unchanged.
                     RefreshTabTitlesForWorktree(wtRenamed.ProjectId, wtRenamed.WorktreeId);
                     break;
                 case SessionStoreChange.SessionRemoved removed:

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
@@ -409,7 +409,7 @@ public sealed partial class SidebarViewModel
         if (worktree is null || worktree.IsPrimary) { return; }
 
         var currentLeaf = System.IO.Path.GetFileName(worktree.Path.TrimEnd('\\', '/'));
-        var newLeaf = Dialogs.RenameDialog.Prompt(currentLeaf);
+        var newLeaf = Dialogs.RenameDialog.Prompt(currentLeaf, "Rename worktree");
         if (string.IsNullOrWhiteSpace(newLeaf) || string.Equals(newLeaf, currentLeaf, StringComparison.Ordinal))
         {
             return;

--- a/src/CodeScope.Ui/Views/GroupStripView.xaml
+++ b/src/CodeScope.Ui/Views/GroupStripView.xaml
@@ -69,25 +69,10 @@
                                     <Setter.Value>
                                         <ControlTemplate TargetType="ListBoxItem">
                                             <Grid MouseDown="OnTabMouseDown">
-                                                <Grid.ContextMenu>
-                                                    <ContextMenu>
-                                                        <MenuItem
-                                                            AutomationProperties.AutomationId="TabCtx_Rename"
-                                                            Header="Rename…"
-                                                            Command="{Binding DataContext.RenameSessionCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                            CommandParameter="{Binding}" />
-                                                        <MenuItem
-                                                            AutomationProperties.AutomationId="TabCtx_Duplicate"
-                                                            Header="Duplicate"
-                                                            Command="{Binding DataContext.DuplicateTabCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                            CommandParameter="{Binding}" />
-                                                        <MenuItem
-                                                            AutomationProperties.AutomationId="TabCtx_Close"
-                                                            Header="Close"
-                                                            Command="{Binding DataContext.CloseTabCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                            CommandParameter="{Binding}" />
-                                                    </ContextMenu>
-                                                </Grid.ContextMenu>
+                                                <!-- Right-click context menu (Rename / Duplicate / Close) was removed
+                                                     with issue #21: tab labels auto-follow the worktree's branch, so
+                                                     manual rename is gone, and Duplicate/Close are reachable from the
+                                                     sidebar tree menu (and Close from the tab's middle-click + ✕). -->
                                                 <Border
                                                     x:Name="TabPill"
                                                     Background="Transparent"


### PR DESCRIPTION
## Summary

- Tab label in the top bar now recomputes `"{Project} · {branch}"` from the live `Worktree.Branch` whenever `WorktreeStatusUpdated` or `WorktreeRenamed` fires, instead of using the value baked in at session creation. The sidebar already worked because it reads `Worktree.Branch` directly — same source of truth now.
- Removed manual tab rename: the right-click ContextMenu on the tab strip is gone (Rename / Duplicate / Close), along with `MainViewModel.RenameSessionAsync` + `RenameSessionCommand`, the `F2` keybinding, and the "Rename session" palette entry. Closing a tab still works via the ✕ glyph and middle-click.
- Sidebar rename for closed-session history rows is untouched — still useful to label work whose branch is gone. `SessionStore.RenameSessionAsync`, `Session.DisplayName`, and the `SessionRenamed` event remain.
- Modernised `RenameDialog.xaml`: swapped the old `Fig.Style.Button.Pill` look for the dialog system's `Dlg.Btn.Ghost` / `Dlg.Btn.Primary` primitives (matches `ConfirmDialog`).
- CLAUDE.md: added "never commit directly to `main`; always feature branch + PR" under Workflow.

Closes #21.

## Test plan

- [x] `dotnet test` — 375 / 375 green
- [ ] Manual: rename a branch via terminal `git branch -m foo bar` inside an open session → tab title updates on next status poll
- [ ] Manual: `git checkout otherbranch` inside a session → tab title flips
- [ ] Manual: right-click on a tab → no context menu appears
- [ ] Manual: F2 no longer opens rename dialog
- [ ] Manual: sidebar right-click "Rename…" on a closed session in history still works, and the new dialog buttons look modern

🤖 Generated with [Claude Code](https://claude.com/claude-code)