### PR TITLE
feat: add project from a git URL (#20)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -5,13 +5,61 @@
 > **Intent:** cursor + last 1–2 sessions in depth, everything else a one-liner.
 > Old detail lives in `git log` — don't duplicate it here.
 
-**Last updated:** 2026-04-27 (session 23)
-**Branch:** `feature/pi-and-opencode-agents` (off `main`); pi.dev + opencode-cli telemetry committed as `26586d0`.
-**Head:** `26586d0` — see sessions 23 + 23b below.
+**Last updated:** 2026-04-29 (session 24)
+**Branch:** `feat/20-clone-from-url` (off `main`); add-project-from-git-url shipped as `f5b39de`.
+**Head:** `f5b39de` — see session 24 below.
 **Release:** `v0.1.0` shipped via GitHub Actions — https://github.com/maui1911/CodeScope/releases/tag/v0.1.0
-**Build status:** ✅ `dotnet build` clean. Full solution `dotnet test` 334/334 green (Core 202, Ui 115, App 17).
+**Build status:** ✅ `dotnet build` clean. Full solution `dotnet test` 379/379 (Core 233, Ui 129, App 17), modulo two known FSWatcher flakes (`ClaudeSessionDiscoveryTests.Callback_Fires_For_Each_New_Jsonl…` and `PiSessionDiscoveryTests.Discovers_New_Session_File_With_Matching_Cwd`).
 **Uncommitted work:** none beyond this HANDOFF update.
-**Unpushed commits:** entire `feature/pi-and-opencode-agents` branch (1 implementation commit + this HANDOFF commit) — no PR opened yet.
+**Unpushed commits:** entire `feat/20-clone-from-url` branch — spec + plan + 2 implementation commits + this HANDOFF — no PR opened yet.
+
+### Session 24 — Add project from a git URL (#20, shipped in `f5b39de`)
+
+User-visible: the "Add project" entry-point now opens a `NewProjectDialog`
+with two modes — *Existing folder* (today's behaviour) and *Clone from URL*.
+Clone mode shows an inline indeterminate spinner + "Cloning…" caption while
+`git clone` runs, and lets the user Cancel mid-flight (cancels the
+`CancellationToken`, kills git, cleans the partial target). On failure the
+dialog re-enables and renders git's stderr inline beneath the URL field — no
+toast, the user is still looking at the dialog.
+
+How:
+- `IGitService.CloneAsync(url, parentDir, folderName, ct)` shells out to
+  `git -C <parent> clone -- <url> <name>` via the existing `ProcessRunner`.
+  Pre-validates empty inputs, refuses non-existent parents, refuses non-empty
+  targets. `OperationCanceledException` propagates (consistent with every other
+  method on the service). 4 tests in `GitServiceCloneTests.cs`.
+- `NewProjectDialog` is a self-contained WPF Window mirroring `NewWorktreeDialog`'s
+  style. Owns its `CancellationTokenSource` for the duration of the clone;
+  Cancel during clone cancels without closing, Cancel when idle closes with
+  `DialogResult = false`. Failed/cancelled clones run a best-effort
+  `TryDeleteDir` so a retry isn't blocked by the destination-exists check.
+- `SidebarViewModel.AddProjectAsync` rewired through the dialog. New helper
+  `DefaultCloneParent()` walks recent-project parent → `%USERPROFILE%\source\repos`
+  → `%USERPROFILE%`. Drag-drop path (`AddProjectByPathAsync`) untouched.
+- `App.xaml.cs` registration of `SidebarViewModel` switched to named args
+  (positional was getting fragile with four picker/service params); the new
+  `pickNewProject` lambda captures `IGitService` once at registration.
+
+Spec: `docs/superpowers/specs/2026-04-29-add-project-from-git-url-design.md`.
+Plan: `docs/superpowers/plans/2026-04-29-add-project-from-git-url.md`.
+
+Files added/touched:
+- `src/CodeScope.Core/Services/IGitService.cs` (CloneAsync signature)
+- `src/CodeScope.Core/Services/GitService.cs` (CloneAsync implementation)
+- `tests/CodeScope.Core.Tests/GitServiceCloneTests.cs` (4 tests)
+- `src/CodeScope.Ui/Dialogs/NewProjectRequest.cs` (records)
+- `src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml` + `.xaml.cs` (dialog)
+- `src/CodeScope.Ui/ViewModels/SidebarViewModel.cs` + `.Commands.cs` (wiring)
+- `src/CodeScope.App/App.xaml.cs` (registration + named args)
+
+Open follow-ups:
+- Smoke-test the dev build manually before merging the PR — clone a real public
+  repo, a deliberately-bad URL (verify inline error), and a slow clone with
+  Cancel mid-flight (verify partial cleanup). The plan's Task 8 step 5 has the
+  exact recipe.
+- Out of scope (deliberate, can be follow-ups): submodule/shallow/branch options,
+  streaming clone progress (objects/deltas %), credential prompts.
 
 ### Session 23 — pi.dev agent support (committed in `26586d0`)
 

--- a/docs/superpowers/plans/2026-04-29-add-project-from-git-url.md
+++ b/docs/superpowers/plans/2026-04-29-add-project-from-git-url.md
@@ -1,0 +1,1015 @@
+# Add project from a git URL — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users add a CodeScope project either by picking an existing folder *or* by pasting a `.git` URL — with an inline cloning spinner so big repos show progress.
+
+**Architecture:** Add `IGitService.CloneAsync` (shell-out to `git clone`). Replace today's bare folder picker in `SidebarViewModel.AddProjectAsync` with a new `NewProjectDialog` that has a mode toggle and an inline busy state (it owns the `CloneAsync` call + cancellation). The dialog returns either an existing-folder path or the resolved path of a successful clone; the sidebar VM only ever calls `_store.AddProjectAsync` with that path.
+
+**Tech Stack:** .NET 10 / WPF / `CommunityToolkit.Mvvm` / `System.Diagnostics.Process` (via existing `ProcessRunner`). Tests run on xUnit with `Skippable` for git-on-PATH.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-add-project-from-git-url-design.md`.
+
+**File map (created or modified):**
+
+| File | What changes |
+|---|---|
+| `src/CodeScope.Core/Services/IGitService.cs` | Add `CloneAsync` signature |
+| `src/CodeScope.Core/Services/GitService.cs` | Implement `CloneAsync` |
+| `tests/CodeScope.Core.Tests/GitServiceCloneTests.cs` | New — 4 tests |
+| `src/CodeScope.Ui/Dialogs/NewProjectRequest.cs` | New — request + result records |
+| `src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml` | New — XAML UI |
+| `src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml.cs` | New — code-behind, owns clone + busy state |
+| `src/CodeScope.Ui/ViewModels/SidebarViewModel.cs` | New `_pickNewProject` field + ctor arg |
+| `src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs` | Rewire `AddProjectAsync` |
+| `src/CodeScope.App/App.xaml.cs` | Register `PickNewProject` delegate; pass to `SidebarViewModel` |
+
+---
+
+### Task 1: Add `CloneAsync` to `IGitService`
+
+**Files:**
+- Modify: `src/CodeScope.Core/Services/IGitService.cs`
+
+- [ ] **Step 1: Add the contract**
+
+Add the following method to the `IGitService` interface (place it next to `FetchAllAsync`/`PullAsync` for cohesion — line ~74):
+
+```csharp
+/// <summary>
+/// Runs <c>git -C &lt;parentDir&gt; clone -- &lt;url&gt; &lt;folderName&gt;</c>. Returns the
+/// absolute path of the resulting working tree on success. Fails verbatim with git's stderr
+/// on auth errors, network errors, "destination already exists", etc. Cancellation kills
+/// the git process; partially-cloned target directories are NOT auto-removed by this method
+/// (callers can clean up if they want — see <c>NewProjectDialog</c> for the pattern).
+/// </summary>
+Task<Result<string>> CloneAsync(string url, string parentDir, string folderName, CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Compile to confirm the interface change is well-formed**
+
+Run: `dotnet build src/CodeScope.Core/CodeScope.Core.csproj -c Debug`
+Expected: build succeeds (no implementation yet — `GitService` will fail-build in Task 2 if we ran the full solution build now, but `CodeScope.Core.csproj` alone has no implementer in the same project … actually `GitService` lives here too, so this WILL fail). Skip the build until Task 2 lands.
+
+(No commit yet — bundled with Task 2.)
+
+---
+
+### Task 2: Write the failing tests for `GitService.CloneAsync`
+
+**Files:**
+- Create: `tests/CodeScope.Core.Tests/GitServiceCloneTests.cs`
+
+- [ ] **Step 1: Write all four tests**
+
+```csharp
+using NoScope.CodeScope.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace NoScope.CodeScope.Core.Tests;
+
+public sealed class GitServiceCloneTests
+{
+    [SkippableFact]
+    public async Task Clone_From_Local_Bare_Repo_Succeeds()
+    {
+        Skip.If(!IsGitOnPath(), "git is not on PATH");
+
+        using var tmp = new TempDir();
+        var src = Path.Combine(tmp.Path, "src.git");
+        await RunGit(tmp.Path, $"init --bare \"{src}\"");
+        // Seed one commit so HEAD resolves after clone.
+        var seed = Path.Combine(tmp.Path, "seed");
+        Directory.CreateDirectory(seed);
+        await RunGit(seed, "init -b main");
+        await RunGit(seed, "config user.email test@test");
+        await RunGit(seed, "config user.name test");
+        await File.WriteAllTextAsync(Path.Combine(seed, "x.txt"), "hi");
+        await RunGit(seed, "add .");
+        await RunGit(seed, "commit -m seed");
+        await RunGit(seed, $"remote add origin \"{src}\"");
+        await RunGit(seed, "push -u origin main");
+
+        var svc = new GitService(NullLogger<GitService>.Instance);
+        var dest = Path.Combine(tmp.Path, "dest");
+        Directory.CreateDirectory(dest);
+
+        var result = await svc.CloneAsync(src, dest, "repo");
+
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : "");
+        result.Value.Should().Be(Path.Combine(dest, "repo"));
+        File.Exists(Path.Combine(result.Value, ".git", "HEAD")).Should().BeTrue();
+        File.Exists(Path.Combine(result.Value, "x.txt")).Should().BeTrue();
+    }
+
+    [SkippableFact]
+    public async Task Clone_Fails_When_Target_Already_Exists_NonEmpty()
+    {
+        Skip.If(!IsGitOnPath(), "git is not on PATH");
+
+        using var tmp = new TempDir();
+        var dest = Path.Combine(tmp.Path, "parent");
+        Directory.CreateDirectory(Path.Combine(dest, "repo"));
+        await File.WriteAllTextAsync(Path.Combine(dest, "repo", "block.txt"), "x");
+
+        var svc = new GitService(NullLogger<GitService>.Instance);
+
+        var result = await svc.CloneAsync("https://example.invalid/x.git", dest, "repo");
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [SkippableFact]
+    public async Task Clone_Fails_For_Garbage_Url()
+    {
+        Skip.If(!IsGitOnPath(), "git is not on PATH");
+
+        using var tmp = new TempDir();
+        var svc = new GitService(NullLogger<GitService>.Instance);
+
+        var result = await svc.CloneAsync("not a url at all", tmp.Path, "repo");
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [SkippableFact]
+    public async Task Clone_With_Cancelled_Token_Fails_Without_Leaving_Target()
+    {
+        Skip.If(!IsGitOnPath(), "git is not on PATH");
+
+        using var tmp = new TempDir();
+        var svc = new GitService(NullLogger<GitService>.Instance);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var result = await svc.CloneAsync("https://example.invalid/x.git", tmp.Path, "repo", cts.Token);
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    private static bool IsGitOnPath()
+    {
+        var paths = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+        var exeNames = OperatingSystem.IsWindows() ? new[] { "git.exe", "git.cmd" } : new[] { "git" };
+        return paths.Any(p => exeNames.Any(n => File.Exists(Path.Combine(p, n))));
+    }
+
+    private static async Task RunGit(string cwd, string args)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo("git", args)
+        {
+            WorkingDirectory = cwd,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        using var p = System.Diagnostics.Process.Start(psi)!;
+        await p.WaitForExitAsync();
+        if (p.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"git {args}: {await p.StandardError.ReadToEndAsync()}");
+        }
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"cs-clone-{Guid.NewGuid():N}");
+        public TempDir() => Directory.CreateDirectory(Path);
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests — they must fail because `CloneAsync` does not yet exist**
+
+Run: `dotnet test tests/CodeScope.Core.Tests/CodeScope.Core.Tests.csproj --filter "FullyQualifiedName~GitServiceCloneTests" -c Debug`
+Expected: build error — `IGitService` lacks `CloneAsync` (since Task 1's interface addition has nothing implementing it yet). That's the failing-test signal for this slice.
+
+(No commit yet — bundled with Task 3.)
+
+---
+
+### Task 3: Implement `GitService.CloneAsync`
+
+**Files:**
+- Modify: `src/CodeScope.Core/Services/GitService.cs`
+
+- [ ] **Step 1: Implement next to `FetchAllAsync` (after `PullAsync`, around line 206)**
+
+```csharp
+public async Task<Result<string>> CloneAsync(string url, string parentDir, string folderName, CancellationToken ct = default)
+{
+    if (string.IsNullOrWhiteSpace(url))
+    {
+        return Result<string>.Fail("URL is empty");
+    }
+    if (string.IsNullOrWhiteSpace(parentDir))
+    {
+        return Result<string>.Fail("Parent directory is empty");
+    }
+    if (string.IsNullOrWhiteSpace(folderName))
+    {
+        return Result<string>.Fail("Folder name is empty");
+    }
+
+    if (!Directory.Exists(parentDir))
+    {
+        return Result<string>.Fail($"Parent directory does not exist: {parentDir}");
+    }
+
+    var target = Path.Combine(parentDir, folderName);
+    if (Directory.Exists(target) && Directory.EnumerateFileSystemEntries(target).Any())
+    {
+        return Result<string>.Fail($"Destination already exists and is not empty: {target}");
+    }
+
+    // Quote both arguments and use `--` so URLs/folder names that start with a dash
+    // can't be parsed as flags.
+    var args = $"-C \"{parentDir}\" clone -- \"{url}\" \"{folderName}\"";
+    var result = await RunAsync(cwd: null, args, ct).ConfigureAwait(false);
+    return result.IsSuccess
+        ? Result<string>.Ok(target)
+        : Result<string>.Fail(result.Error);
+}
+```
+
+- [ ] **Step 2: Run the four tests — all four must now pass (or skip when git missing)**
+
+Run: `dotnet test tests/CodeScope.Core.Tests/CodeScope.Core.Tests.csproj --filter "FullyQualifiedName~GitServiceCloneTests" -c Debug`
+Expected: 4 passed (or skipped on a machine without git).
+
+- [ ] **Step 3: Run the full Core test suite to confirm nothing regressed**
+
+Run: `dotnet test tests/CodeScope.Core.Tests/CodeScope.Core.Tests.csproj -c Debug`
+Expected: all green (≥4 new passing on top of the existing baseline).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/CodeScope.Core/Services/IGitService.cs \
+        src/CodeScope.Core/Services/GitService.cs \
+        tests/CodeScope.Core.Tests/GitServiceCloneTests.cs
+git commit -m "feat(git): add CloneAsync (#20)"
+```
+
+---
+
+### Task 4: Add `NewProjectRequest` / `NewProjectResult` records
+
+**Files:**
+- Create: `src/CodeScope.Ui/Dialogs/NewProjectRequest.cs`
+
+- [ ] **Step 1: Create the file**
+
+```csharp
+namespace NoScope.CodeScope.Ui.Dialogs;
+
+/// <summary>
+/// Input envelope for <see cref="NewProjectDialog.PromptAsync(NewProjectRequest)"/>.
+/// </summary>
+/// <param name="DefaultCloneParent">Folder pre-filled in the "Parent folder" field of the
+/// Clone-from-URL mode. Caller picks: typically the parent of the most-recently-added
+/// project, falling back to <c>%USERPROFILE%\source\repos</c>.</param>
+public sealed record NewProjectRequest(string DefaultCloneParent);
+
+/// <summary>
+/// Result of <see cref="NewProjectDialog"/>. Exactly one of <see cref="ExistingFolder"/>
+/// or <see cref="ClonedPath"/> is non-null. <see cref="WasCloned"/> mirrors that for
+/// callers that want to vary the success-toast wording.
+/// </summary>
+/// <param name="ExistingFolder">Set when the user picked "Existing folder".</param>
+/// <param name="ClonedPath">Set when the dialog successfully cloned the URL.</param>
+/// <param name="WasCloned">True iff <see cref="ClonedPath"/> is set.</param>
+public sealed record NewProjectResult(string? ExistingFolder, string? ClonedPath, bool WasCloned);
+```
+
+- [ ] **Step 2: Build to confirm it compiles**
+
+Run: `dotnet build src/CodeScope.Ui/CodeScope.Ui.csproj -c Debug`
+Expected: build succeeds.
+
+(No commit — bundled with Tasks 5–6.)
+
+---
+
+### Task 5: Build the `NewProjectDialog` XAML
+
+**Files:**
+- Create: `src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml`
+
+- [ ] **Step 1: Write the XAML**
+
+The visual style mirrors `NewWorktreeDialog.xaml` (same `Window.Resources` block of token-based styles). Keep it simple — no popup, no toggle widget.
+
+```xml
+<Window
+    x:Class="NoScope.CodeScope.Ui.Dialogs.NewProjectDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Add project"
+    Width="540"
+    SizeToContent="Height"
+    ResizeMode="NoResize"
+    WindowStartupLocation="CenterOwner"
+    ShowInTaskbar="False"
+    WindowStyle="None"
+    AllowsTransparency="True"
+    Background="Transparent"
+    TextElement.Foreground="{DynamicResource Fig.Brush.Ink}"
+    TextElement.FontFamily="{DynamicResource Fig.Font.Sans}"
+    TextElement.FontSize="{DynamicResource Fig.Size.Body}">
+    <Window.Resources>
+        <Style x:Key="NP.FieldChrome" TargetType="Border">
+            <Setter Property="Height" Value="36" />
+            <Setter Property="Background" Value="{DynamicResource Fig.Brush.GlassDark}" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="6" />
+        </Style>
+        <Style x:Key="NP.InnerMonoBox" TargetType="TextBox">
+            <Setter Property="FontFamily" Value="{DynamicResource Fig.Font.Mono}" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.Ink}" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Padding" Value="12,0" />
+        </Style>
+        <Style x:Key="NP.FieldLabel" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.InkMuted}" />
+            <Setter Property="Margin" Value="0,0,0,6" />
+        </Style>
+        <Style x:Key="NP.PrimaryBtn" TargetType="Button">
+            <Setter Property="Height" Value="32" />
+            <Setter Property="Padding" Value="14,0" />
+            <Setter Property="Background" Value="{DynamicResource Accent.Primary}" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style x:Key="NP.GhostBtn" TargetType="Button" BasedOn="{StaticResource NP.PrimaryBtn}">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.InkMuted}" />
+        </Style>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource Fig.Brush.Panel}"
+            CornerRadius="10"
+            BorderBrush="{DynamicResource Fig.Brush.PanelBorder}"
+            BorderThickness="1"
+            Padding="0">
+        <Grid Margin="20,16,20,16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />  <!-- chrome bar (drag + close)   -->
+                <RowDefinition Height="Auto" />  <!-- mode toggle                 -->
+                <RowDefinition Height="Auto" />  <!-- existing-folder panel       -->
+                <RowDefinition Height="Auto" />  <!-- clone panel                 -->
+                <RowDefinition Height="Auto" />  <!-- error                       -->
+                <RowDefinition Height="Auto" />  <!-- buttons                     -->
+            </Grid.RowDefinitions>
+
+            <!-- Chrome bar: title left + close right; whole row is drag-handle. -->
+            <Grid Grid.Row="0" Margin="0,0,0,16" MouseLeftButtonDown="OnChromeDrag">
+                <TextBlock Text="ADD PROJECT"
+                           FontFamily="{DynamicResource Fig.Font.Mono}"
+                           FontSize="10"
+                           Foreground="{DynamicResource Accent.Primary}" />
+                <Button x:Name="CloseBtn"
+                        Content="×"
+                        Width="24" Height="24"
+                        HorizontalAlignment="Right"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Foreground="{DynamicResource Fig.Brush.InkMuted}"
+                        Cursor="Hand"
+                        Click="OnCancel" />
+            </Grid>
+
+            <!-- Mode toggle: two radio buttons. -->
+            <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,16">
+                <RadioButton x:Name="ModeExisting"
+                             Content="Existing folder"
+                             GroupName="NPMode"
+                             IsChecked="True"
+                             Margin="0,0,16,0"
+                             Checked="OnModeChanged" />
+                <RadioButton x:Name="ModeClone"
+                             Content="Clone from URL"
+                             GroupName="NPMode"
+                             Checked="OnModeChanged" />
+            </StackPanel>
+
+            <!-- Existing-folder panel. -->
+            <StackPanel x:Name="ExistingPanel" Grid.Row="2">
+                <TextBlock Text="FOLDER" Style="{StaticResource NP.FieldLabel}" />
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Border Grid.Column="0" Style="{StaticResource NP.FieldChrome}">
+                        <TextBox x:Name="ExistingPathBox"
+                                 Style="{StaticResource NP.InnerMonoBox}"
+                                 IsReadOnly="True" />
+                    </Border>
+                    <Button Grid.Column="1"
+                            Content="Browse…"
+                            Style="{StaticResource NP.GhostBtn}"
+                            Margin="8,0,0,0"
+                            Click="OnPickExisting" />
+                </Grid>
+            </StackPanel>
+
+            <!-- Clone panel. -->
+            <StackPanel x:Name="ClonePanel" Grid.Row="3" Visibility="Collapsed">
+                <TextBlock Text="GIT URL" Style="{StaticResource NP.FieldLabel}" />
+                <Border Style="{StaticResource NP.FieldChrome}" Margin="0,0,0,12">
+                    <TextBox x:Name="UrlBox" Style="{StaticResource NP.InnerMonoBox}" />
+                </Border>
+
+                <TextBlock Text="PARENT FOLDER" Style="{StaticResource NP.FieldLabel}" />
+                <Grid Margin="0,0,0,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Border Grid.Column="0" Style="{StaticResource NP.FieldChrome}">
+                        <TextBox x:Name="ParentBox" Style="{StaticResource NP.InnerMonoBox}" />
+                    </Border>
+                    <Button Grid.Column="1"
+                            Content="Browse…"
+                            Style="{StaticResource NP.GhostBtn}"
+                            Margin="8,0,0,0"
+                            Click="OnPickParent" />
+                </Grid>
+
+                <TextBlock Text="FOLDER NAME" Style="{StaticResource NP.FieldLabel}" />
+                <Border Style="{StaticResource NP.FieldChrome}">
+                    <TextBox x:Name="NameBox" Style="{StaticResource NP.InnerMonoBox}" />
+                </Border>
+            </StackPanel>
+
+            <!-- Inline error (used by clone failures). -->
+            <TextBlock x:Name="ErrorText"
+                       Grid.Row="4"
+                       Margin="0,12,0,0"
+                       TextWrapping="Wrap"
+                       FontFamily="{DynamicResource Fig.Font.Mono}"
+                       FontSize="11"
+                       Foreground="{DynamicResource Status.Brush.Err}"
+                       Visibility="Collapsed" />
+
+            <!-- Buttons row. -->
+            <Grid Grid.Row="5" Margin="0,20,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <!-- Busy indicator (visible only while cloning). -->
+                <StackPanel x:Name="BusyPanel"
+                            Grid.Column="0"
+                            Orientation="Horizontal"
+                            Visibility="Collapsed">
+                    <ProgressBar Width="120" Height="4" IsIndeterminate="True" Margin="0,0,10,0" />
+                    <TextBlock x:Name="BusyText"
+                               VerticalAlignment="Center"
+                               FontFamily="{DynamicResource Fig.Font.Mono}"
+                               FontSize="11"
+                               Foreground="{DynamicResource Fig.Brush.InkMuted}" />
+                </StackPanel>
+
+                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                    <Button x:Name="CancelBtn"
+                            Content="Cancel"
+                            Style="{StaticResource NP.GhostBtn}"
+                            Click="OnCancel" />
+                    <Button x:Name="AddBtn"
+                            Content="Add"
+                            Style="{StaticResource NP.PrimaryBtn}"
+                            Margin="8,0,0,0"
+                            IsDefault="True"
+                            Click="OnAdd" />
+                </StackPanel>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>
+```
+
+(No commit yet — bundled with Task 6.)
+
+---
+
+### Task 6: Implement `NewProjectDialog` code-behind
+
+**Files:**
+- Create: `src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml.cs`
+
+- [ ] **Step 1: Write the code-behind**
+
+```csharp
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using NoScope.CodeScope.Core.Services;
+
+namespace NoScope.CodeScope.Ui.Dialogs;
+
+public partial class NewProjectDialog : Window
+{
+    private readonly Func<string?> _pickFolder;
+    private readonly IGitService _git;
+    private CancellationTokenSource? _cloneCts;
+    private NewProjectResult? _result;
+
+    private NewProjectDialog(NewProjectRequest req, Func<string?> pickFolder, IGitService git)
+    {
+        _pickFolder = pickFolder;
+        _git = git;
+
+        InitializeComponent();
+
+        ParentBox.Text = req.DefaultCloneParent;
+        UrlBox.TextChanged += (_, _) => OnUrlChanged();
+        ParentBox.TextChanged += (_, _) => RefreshAddEnabled();
+        NameBox.TextChanged += (_, _) => RefreshAddEnabled();
+        ExistingPathBox.TextChanged += (_, _) => RefreshAddEnabled();
+
+        ApplyMode();
+        RefreshAddEnabled();
+    }
+
+    /// <summary>
+    /// Shows the dialog modally. When the user picks "Clone from URL" and clicks Add the
+    /// dialog awaits <c>git clone</c> with an inline spinner; on success the dialog closes
+    /// and the returned result carries the resolved local path.
+    /// </summary>
+    public static async Task<NewProjectResult?> PromptAsync(NewProjectRequest req, Func<string?> pickFolder, IGitService git)
+    {
+        var dlg = new NewProjectDialog(req, pickFolder, git) { Owner = Application.Current?.MainWindow };
+        var ok = dlg.ShowDialog();
+        // ShowDialog blocks until DialogResult is set. The clone path uses an async helper
+        // that closes the window when done — so by the time we get here, _result is final.
+        return ok == true ? dlg._result : null;
+    }
+
+    private bool IsCloneMode => ModeClone.IsChecked == true;
+
+    private void OnModeChanged(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded) { return; }
+        ApplyMode();
+        RefreshAddEnabled();
+    }
+
+    private void ApplyMode()
+    {
+        ExistingPanel.Visibility = IsCloneMode ? Visibility.Collapsed : Visibility.Visible;
+        ClonePanel.Visibility = IsCloneMode ? Visibility.Visible : Visibility.Collapsed;
+        ErrorText.Visibility = Visibility.Collapsed;
+        if (IsCloneMode) { UrlBox.Focus(); } else { /* leave focus alone */ }
+    }
+
+    private void OnUrlChanged()
+    {
+        // Auto-derive folder name from the URL's last segment, stripping ".git".
+        // Only overwrite when the user hasn't customised the field (i.e. it's empty
+        // or matches the previously-derived value).
+        var url = UrlBox.Text?.Trim() ?? string.Empty;
+        var derived = DeriveRepoName(url);
+        if (string.IsNullOrEmpty(NameBox.Text) || NameBox.Tag is string prev && prev == NameBox.Text)
+        {
+            NameBox.Text = derived;
+            NameBox.Tag = derived;
+        }
+        RefreshAddEnabled();
+    }
+
+    internal static string DeriveRepoName(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) { return string.Empty; }
+        var u = url.Trim().TrimEnd('/');
+        if (u.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+        {
+            u = u.Substring(0, u.Length - 4);
+        }
+        // Take the last segment after '/' or ':' (covers SCP-style 'git@host:owner/repo').
+        var slash = u.LastIndexOfAny(new[] { '/', ':' });
+        var leaf = slash >= 0 ? u.Substring(slash + 1) : u;
+        // Strip path-invalid chars defensively.
+        foreach (var bad in Path.GetInvalidFileNameChars()) { leaf = leaf.Replace(bad, '-'); }
+        return leaf;
+    }
+
+    internal static bool IsValidGitUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) { return false; }
+        var u = url.Trim();
+        if (u.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            || u.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            || u.StartsWith("ssh://", StringComparison.OrdinalIgnoreCase))
+        {
+            return u.Length > 8;
+        }
+        if (u.StartsWith("git@", StringComparison.OrdinalIgnoreCase))
+        {
+            // Require host + ':' + path.
+            var colon = u.IndexOf(':');
+            return colon > "git@".Length && colon < u.Length - 1;
+        }
+        return false;
+    }
+
+    private void RefreshAddEnabled()
+    {
+        if (IsCloneMode)
+        {
+            var urlOk = IsValidGitUrl(UrlBox.Text);
+            var parentOk = !string.IsNullOrWhiteSpace(ParentBox.Text) && Directory.Exists(ParentBox.Text);
+            var nameOk = !string.IsNullOrWhiteSpace(NameBox.Text)
+                && NameBox.Text.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+            AddBtn.IsEnabled = urlOk && parentOk && nameOk;
+        }
+        else
+        {
+            AddBtn.IsEnabled = !string.IsNullOrWhiteSpace(ExistingPathBox.Text) && Directory.Exists(ExistingPathBox.Text);
+        }
+    }
+
+    private void OnPickExisting(object sender, RoutedEventArgs e)
+    {
+        var picked = _pickFolder();
+        if (!string.IsNullOrWhiteSpace(picked))
+        {
+            ExistingPathBox.Text = picked;
+        }
+    }
+
+    private void OnPickParent(object sender, RoutedEventArgs e)
+    {
+        var picked = _pickFolder();
+        if (!string.IsNullOrWhiteSpace(picked))
+        {
+            ParentBox.Text = picked;
+        }
+    }
+
+    private async void OnAdd(object sender, RoutedEventArgs e)
+    {
+        if (!AddBtn.IsEnabled) { return; }
+
+        if (!IsCloneMode)
+        {
+            _result = new NewProjectResult(ExistingFolder: ExistingPathBox.Text.Trim(), ClonedPath: null, WasCloned: false);
+            DialogResult = true;
+            Close();
+            return;
+        }
+
+        var url = UrlBox.Text.Trim();
+        var parent = ParentBox.Text.Trim();
+        var name = NameBox.Text.Trim();
+
+        var target = Path.Combine(parent, name);
+        if (Directory.Exists(target) && Directory.EnumerateFileSystemEntries(target).Any())
+        {
+            ShowError($"Destination already exists: {target}");
+            return;
+        }
+
+        SetBusy(true, $"Cloning {name}…");
+        _cloneCts = new CancellationTokenSource();
+        Result<string> result;
+        try
+        {
+            result = await _git.CloneAsync(url, parent, name, _cloneCts.Token).ConfigureAwait(true);
+        }
+        catch (Exception ex)
+        {
+            result = Result<string>.Fail(ex.Message);
+        }
+        finally
+        {
+            _cloneCts.Dispose();
+            _cloneCts = null;
+        }
+
+        if (result.IsSuccess)
+        {
+            _result = new NewProjectResult(ExistingFolder: null, ClonedPath: result.Value, WasCloned: true);
+            DialogResult = true;
+            Close();
+            return;
+        }
+
+        // Failed or cancelled — clean up a partial target dir so a retry isn't blocked.
+        TryDeleteDir(target);
+        SetBusy(false, null);
+        ShowError(result.Error);
+    }
+
+    private void OnCancel(object sender, RoutedEventArgs e)
+    {
+        if (_cloneCts is { } cts)
+        {
+            // Cloning is in flight: cancel it, but do NOT close the window — the OnAdd
+            // continuation will return us to the editable state.
+            try { cts.Cancel(); } catch { /* already disposed */ }
+            return;
+        }
+        DialogResult = false;
+        Close();
+    }
+
+    private void OnChromeDrag(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton == MouseButton.Left) { DragMove(); }
+    }
+
+    private void SetBusy(bool busy, string? text)
+    {
+        BusyPanel.Visibility = busy ? Visibility.Visible : Visibility.Collapsed;
+        BusyText.Text = text ?? string.Empty;
+        AddBtn.IsEnabled = !busy && AddBtn.IsEnabled;
+        AddBtn.Visibility = busy ? Visibility.Collapsed : Visibility.Visible;
+        ModeExisting.IsEnabled = !busy;
+        ModeClone.IsEnabled = !busy;
+        UrlBox.IsEnabled = !busy;
+        ParentBox.IsEnabled = !busy;
+        NameBox.IsEnabled = !busy;
+        ExistingPathBox.IsEnabled = !busy;
+        if (busy) { ErrorText.Visibility = Visibility.Collapsed; }
+        else { RefreshAddEnabled(); }
+    }
+
+    private void ShowError(string text)
+    {
+        ErrorText.Text = text;
+        ErrorText.Visibility = Visibility.Visible;
+    }
+
+    private static void TryDeleteDir(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path)) { Directory.Delete(path, recursive: true); }
+        }
+        catch { /* best effort — partially-cloned trees can hold .pack files in use */ }
+    }
+}
+```
+
+- [ ] **Step 2: Build the Ui project to confirm**
+
+Run: `dotnet build src/CodeScope.Ui/CodeScope.Ui.csproj -c Debug`
+Expected: build succeeds.
+
+(No commit yet — bundled with Tasks 7–8.)
+
+---
+
+### Task 7: Wire the dialog into `SidebarViewModel`
+
+**Files:**
+- Modify: `src/CodeScope.Ui/ViewModels/SidebarViewModel.cs`
+- Modify: `src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs`
+
+- [ ] **Step 1: Add the `_pickNewProject` field + ctor argument**
+
+In `SidebarViewModel.cs`, alongside `_pickNewWorktree` (line 28):
+
+```csharp
+private readonly Func<NewProjectRequest, Task<NewProjectResult?>> _pickNewProject;
+```
+
+Add the ctor parameter (after `pickNewWorktree`):
+
+```csharp
+Func<NewProjectRequest, Task<NewProjectResult?>>? pickNewProject = null,
+```
+
+Initialize it (next to `_pickNewWorktree = ...`):
+
+```csharp
+_pickNewProject = pickNewProject ?? (_ => Task.FromResult<NewProjectResult?>(null));
+```
+
+- [ ] **Step 2: Replace `AddProjectAsync` body in `SidebarViewModel.Commands.cs`**
+
+Replace the existing `AddProjectAsync` (lines 14–21) with:
+
+```csharp
+[RelayCommand]
+private async Task AddProjectAsync()
+{
+    var request = new NewProjectRequest(DefaultCloneParent());
+    var picked = await _pickNewProject(request).ConfigureAwait(true);
+    if (picked is null) { return; }
+
+    var path = picked.ExistingFolder ?? picked.ClonedPath;
+    if (string.IsNullOrWhiteSpace(path)) { return; }
+
+    var r = await _store.AddProjectAsync(path, displayName: null).ConfigureAwait(true);
+    if (r.IsFailure)
+    {
+        _logger.LogWarning("AddProject failed: {Error}", r.Error);
+        ErrToast(picked.WasCloned ? "Cloned, but project add failed" : "Add project failed", r.Error);
+        return;
+    }
+
+    if (picked.WasCloned)
+    {
+        Toast("Project cloned", r.Value.Name, ToastSeverity.Ok);
+    }
+}
+
+private string DefaultCloneParent()
+{
+    // Most-recently-added project's parent → user's source-repos folder → home.
+    var recent = _store.Projects.LastOrDefault(p => !string.IsNullOrWhiteSpace(p.Path));
+    if (recent is not null)
+    {
+        var parent = System.IO.Path.GetDirectoryName(recent.Path.TrimEnd('\\', '/'));
+        if (!string.IsNullOrWhiteSpace(parent) && System.IO.Directory.Exists(parent))
+        {
+            return parent;
+        }
+    }
+    var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    var fallback = System.IO.Path.Combine(home, "source", "repos");
+    return System.IO.Directory.Exists(fallback) ? fallback : home;
+}
+```
+
+`AddProjectByPathAsync` (drag-drop) is left unchanged on purpose.
+
+- [ ] **Step 3: Build to confirm**
+
+Run: `dotnet build src/CodeScope.Ui/CodeScope.Ui.csproj -c Debug`
+Expected: build succeeds.
+
+(No commit yet — bundled with Task 8.)
+
+---
+
+### Task 8: Register `PickNewProject` in `App.xaml.cs`
+
+**Files:**
+- Modify: `src/CodeScope.App/App.xaml.cs`
+
+- [ ] **Step 1: Add the helper alongside `PickNewWorktree` (line 387)**
+
+```csharp
+private static Task<NoScope.CodeScope.Ui.Dialogs.NewProjectResult?> PickNewProject(NoScope.CodeScope.Ui.Dialogs.NewProjectRequest request)
+{
+    var git = _host?.Services.GetRequiredService<NoScope.CodeScope.Core.Services.IGitService>()
+        ?? throw new InvalidOperationException("Host not started");
+    return NoScope.CodeScope.Ui.Dialogs.NewProjectDialog.PromptAsync(request, PickFolder, git);
+}
+```
+
+(`_host` is already a private static field on `App` — check the top of the file; if it's not, add `private static IHost? _host;` at the field declarations.)
+
+- [ ] **Step 2: Wire it into the `SidebarViewModel` registration (line 135–143)**
+
+Update the registration to pass `PickNewProject` as the new optional ctor arg. Insert it in the position matching the ctor's parameter list:
+
+```csharp
+services.AddSingleton<SidebarViewModel>(sp => new SidebarViewModel(
+    sp.GetRequiredService<ISessionStore>(),
+    sp.GetRequiredService<ILogger<SidebarViewModel>>(),
+    PickFolder,
+    PickNewWorktree,
+    PickNewProject,
+    sp.GetRequiredService<IPullRequestService>(),
+    sp.GetRequiredService<NoScope.CodeScope.Ui.Services.IToastService>(),
+    sp.GetRequiredService<IAgentRegistry>(),
+    sp.GetRequiredService<IGitService>()));
+```
+
+(The `SidebarViewModel` ctor signature change in Task 7 placed `pickNewProject` immediately after `pickNewWorktree` — confirm parameter order matches before saving.)
+
+- [ ] **Step 3: Build the full solution**
+
+Run: `dotnet build CodeScope.sln -c Debug`
+Expected: clean build, no warnings introduced.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `dotnet test CodeScope.sln -c Debug`
+Expected: all green, with the 4 new `GitServiceCloneTests` running (or skipping when git is missing). Total count rises by 4 from the prior baseline.
+
+- [ ] **Step 5: Smoke-test the dev build manually**
+
+```pwsh
+$env:CODESCOPE_DEV = "1"
+dotnet run --project src/CodeScope.App
+```
+
+Verify in the running app:
+1. Click the "+" in the sidebar (or empty-state CTA) — the new dialog opens.
+2. *Existing folder* mode → Browse… → pick a folder → Add closes the dialog and the project appears in the sidebar.
+3. *Clone from URL* mode → paste any small public repo URL (e.g. `https://github.com/octocat/Hello-World.git`) → Add. Spinner + "Cloning…" appears, dialog stays open. On success: dialog closes, project appears, toast "Project cloned" fires.
+4. *Clone with bad URL* (e.g. `https://example.invalid/x.git`) → Add. Spinner runs, then the dialog re-enables fields and renders the git error inline beneath the URL field.
+5. *Clone + Cancel mid-flight* on a slow URL → Cancel button cancels the clone and re-enables the form. The target directory should not be left on disk.
+6. Drag-drop a folder onto the sidebar — still works, unchanged path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/CodeScope.Ui/Dialogs/NewProjectRequest.cs \
+        src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml \
+        src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml.cs \
+        src/CodeScope.Ui/ViewModels/SidebarViewModel.cs \
+        src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs \
+        src/CodeScope.App/App.xaml.cs
+git commit -m "feat: add-project from git URL with inline cloning state (#20)"
+```
+
+---
+
+### Task 9: Update `docs/HANDOFF.md`
+
+**Files:**
+- Modify: `docs/HANDOFF.md`
+
+- [ ] **Step 1: Add a session entry**
+
+At the top of the session-list area (right after the cursor / current-focus header), insert a new "Session 24 — Add project from a git URL (shipped)" block summarising:
+- Issue #20 closed.
+- New `IGitService.CloneAsync` + 4 tests.
+- New `NewProjectDialog` with mode toggle (Existing folder / Clone from URL) and inline busy state.
+- `SidebarViewModel.AddProjectAsync` rewired through the dialog; drag-drop path unchanged.
+- Files: list the same set as the commit.
+
+Keep it under 25 lines — this is the new top-of-handoff entry, not a deep dive.
+
+- [ ] **Step 2: Update the **Last updated** / **Branch** / **Head** lines at the top of HANDOFF.md to point at the new branch + commit SHA.**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/HANDOFF.md
+git commit -m "docs: handoff for #20 add-project from git URL"
+```
+
+---
+
+### Task 10: Push branch and open PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/20-clone-from-url
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "feat: add project from a git URL (#20)" --body "$(cat <<'EOF'
+## Summary
+- Adds an "Add project" dialog with two modes: pick an existing folder (today's behaviour) or clone from a git URL.
+- New `IGitService.CloneAsync` shells out to `git clone` and is owned by the dialog.
+- Cloning shows an inline spinner + "Cloning…" caption; Cancel kills the git process; failures render the stderr inline so the user can fix and retry without re-typing.
+
+Closes #20.
+
+## Test plan
+- [ ] `dotnet test CodeScope.sln -c Debug` — full suite green; 4 new `GitServiceCloneTests`.
+- [ ] Smoke: existing-folder mode adds a project as before.
+- [ ] Smoke: clone-from-URL with a real repo lands and adds.
+- [ ] Smoke: clone with bad URL surfaces error inline; dialog re-enables.
+- [ ] Smoke: cancel during clone returns cleanly; partial dir cleaned.
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- *NewProjectDialog with two modes* → Tasks 5–6.
+- *`IGitService.CloneAsync`* → Tasks 1–3.
+- *Inline busy state with spinner + cancel* → Task 6 (`SetBusy`, `_cloneCts`).
+- *Auto-derived folder name* → Task 6 (`OnUrlChanged` / `DeriveRepoName`).
+- *URL validation* → Task 6 (`IsValidGitUrl`).
+- *Default parent folder = most-recent project's parent → `%USERPROFILE%\source\repos`* → Task 7 (`DefaultCloneParent`).
+- *Pre-flight: target must not exist non-empty* → Task 3 (CloneAsync) + Task 6 (dialog pre-check before showing busy).
+- *Drag-drop unchanged* → Task 7 explicitly leaves `AddProjectByPathAsync` alone.
+- *4 Core tests (happy / target-exists / garbage URL / cancellation)* → Task 2.
+
+**Placeholder scan:** all code blocks present; no "TBD"/"TODO"/"add appropriate handling".
+
+**Type consistency:** `NewProjectResult(ExistingFolder, ClonedPath, WasCloned)` is consistent across Tasks 4, 6, 7. `Func<NewProjectRequest, Task<NewProjectResult?>>` is identical in `SidebarViewModel`, `App.xaml.cs`, and `NewProjectDialog.PromptAsync`. `IGitService.CloneAsync(url, parentDir, folderName, ct)` signature matches across interface, implementation, dialog call, and tests.

--- a/docs/superpowers/specs/2026-04-29-add-project-from-git-url-design.md
+++ b/docs/superpowers/specs/2026-04-29-add-project-from-git-url-design.md
@@ -13,11 +13,12 @@ Today the only way to add a project is to point CodeScope at an existing local f
 In:
 - A new `NewProjectDialog` with two modes: *Existing folder* (current behaviour) and *Clone from URL*.
 - A `git clone` shell-out on `IGitService`.
-- `SidebarViewModel.AddProjectAsync` rewired through the dialog; clone failures abort cleanly.
+- An inline busy state inside the dialog (spinner + "Cloning…") so the user sees progress on big repos.
+- `SidebarViewModel.AddProjectAsync` rewired through the dialog; clone failures surface inline.
 
 Out (YAGNI):
 - Auth prompts — rely on the OS git credential manager (same as every other git op in the app).
-- Streaming clone progress / cancellation — single shell-out + toast lifecycle, like `FetchAllAsync`.
+- Streaming clone progress (objects/deltas %) — an indeterminate spinner is enough for the "is it still working?" question. Real progress would need parsing `--progress` output on a separate stderr pump.
 - Submodule / shallow / branch / sparse options — can be added later if requested.
 
 ## UX
@@ -32,6 +33,15 @@ The "+" button (and the empty-state CTA) opens `NewProjectDialog`:
   - **Folder name** — text input. Auto-derived from the URL's repo segment on URL change (strip trailing `.git`); user-editable; must not already exist under the chosen parent.
 - "Add" is disabled until the active mode validates.
 
+When the user clicks **Add** in *Clone from URL* mode the dialog stays open and switches to a **busy state**:
+
+- Inputs and the mode toggle are disabled.
+- "Add" is replaced by an indeterminate spinner (`ProgressBar IsIndeterminate="True"`) plus the caption *"Cloning &lt;repo&gt;…"*.
+- "Cancel" stays enabled and aborts the clone via `CancellationToken` (kills the `git` process); the dialog returns to the editable state.
+- On success, the dialog closes with the result. On failure, the dialog returns to the editable state and renders the git error inline beneath the URL field — no toast, since the user is still looking at the dialog.
+
+*Existing folder* mode never shows the busy state; the dialog closes immediately and the store call is fast.
+
 Drag-drop of a folder onto the sidebar keeps using `AddProjectByPathAsync` — that path is unchanged.
 
 ## Components
@@ -42,18 +52,18 @@ Drag-drop of a folder onto the sidebar keeps using `AddProjectByPathAsync` — t
 public sealed record NewProjectRequest(string DefaultCloneParent);
 
 public sealed record NewProjectResult(
-    string? ExistingFolder,        // set when mode == Existing
-    string? CloneUrl,              // set when mode == Clone
-    string? CloneParent,
-    string? CloneFolderName);
+    string? ExistingFolder,   // set when user picked "Existing folder"
+    string? ClonedPath,       // set when the dialog successfully cloned
+    bool WasCloned);
 ```
 
-Exactly one of `ExistingFolder` or `CloneUrl` is non-null — the dialog's caller switches on which.
+Exactly one of `ExistingFolder` or `ClonedPath` is non-null. `WasCloned` is just for the caller's success-toast wording.
 
 ### `NewProjectDialog` (`Dialogs/NewProjectDialog.xaml[.cs]`)
 
-- Hosted in `App.xaml.cs` via a `Func<NewProjectRequest, NewProjectResult?> PickNewProject` delegate, registered alongside `PickFolder` and `PickNewWorktree`.
+- Hosted in `App.xaml.cs` via a `Func<NewProjectRequest, Task<NewProjectResult?>> PickNewProject` delegate, registered alongside `PickFolder` and `PickNewWorktree`. Async because the dialog awaits the clone before returning.
 - Reuses the existing folder-picker (the dialog accepts a `Func<string?> pickFolder` ctor argument so the WPF folder dialog stays in `App`).
+- Accepts an `IGitService gitService` ctor argument so the busy state can drive `CloneAsync` directly. The dialog owns the `CancellationTokenSource` for the clone — Cancel cancels it; closing the window cancels it.
 - Dialog styling follows `NewWorktreeDialog` (same shell, same buttons, same window-chrome treatment).
 
 ### `IGitService.CloneAsync`
@@ -71,20 +81,19 @@ Implementation: `git -C <parentDir> clone -- <url> <folderName>`, then return `P
 ### `SidebarViewModel.AddProjectAsync`
 
 ```
-result = _pickNewProject(new NewProjectRequest(DefaultCloneParent()))
-if result is null: return
+result = await _pickNewProject(new NewProjectRequest(DefaultCloneParent()))
+if result is null: return  // user cancelled
 
-if result.ExistingFolder is set:
-    _store.AddProjectAsync(result.ExistingFolder, displayName: null)
-else:
-    Toast("Cloning…", "<url>", ToastSeverity.Info)
-    cloned = await _git.CloneAsync(result.CloneUrl!, result.CloneParent!, result.CloneFolderName!)
-    if cloned.IsFailure:
-        ErrToast("Clone failed", cloned.Error, retry: () => AddProjectAsync())
-        return
-    _store.AddProjectAsync(cloned.Value, displayName: null)
-    Toast("Project cloned", folderName, ToastSeverity.Ok)
+// Clone (if any) already ran inside the dialog — result carries the resolved local path.
+var path = result.ExistingFolder ?? result.ClonedPath!
+var add = await _store.AddProjectAsync(path, displayName: null)
+if add.IsFailure:
+    ErrToast(result.WasCloned ? "Clone added but project add failed" : "Add project failed", add.Error)
+else if result.WasCloned:
+    Toast("Project cloned", add.Value.Name, ToastSeverity.Ok)
 ```
+
+`NewProjectResult` therefore carries the resolved local path (`ClonedPath` set after a successful clone) plus a `WasCloned` flag for the success-toast wording. The dialog is the only place that calls `IGitService.CloneAsync`.
 
 `DefaultCloneParent()` reads the most-recent project's parent off `_store.Projects`; falls back to `%USERPROFILE%\source\repos`.
 
@@ -104,8 +113,9 @@ Validation errors render inline under the offending field; "Add" stays disabled.
 
 ## Error handling
 
-- Clone failure → `ErrToast` with git's stderr text. The dialog has already closed; offering a retry that re-opens the dialog with the same inputs is overkill — the toast's "retry" simply re-runs `AddProjectAsync()` (re-opens an empty dialog), matching existing patterns.
-- If clone succeeds but `AddProjectAsync` fails (duplicate path, etc.) → log + toast; the clone is left on disk for the user to inspect.
+- Clone failure → dialog returns to editable state with git's stderr rendered inline beneath the URL field. User can edit and retry without re-typing anything. No toast.
+- Clone cancellation → dialog returns to editable state silently. The partially-cloned target directory is removed on a best-effort basis (`Directory.Delete(target, recursive: true)` swallowed) so a retry isn't blocked by the "target exists" check.
+- If clone succeeds but `_store.AddProjectAsync` fails (duplicate path, etc.) → toast + log; the clone is left on disk for the user to inspect.
 
 ## Tests (Core only, per project convention)
 
@@ -114,6 +124,7 @@ Validation errors render inline under the offending field; "Add" stays disabled.
 1. **Happy path** — `git init --bare` a local source, clone it via `CloneAsync`, assert `Result.IsSuccess` and that the returned path is a valid worktree (`HEAD` exists).
 2. **Target already exists** — pre-create the target directory, expect `Result.Failure`.
 3. **Invalid URL** — pass garbage, expect `Result.Failure` with non-empty error text.
+4. **Cancellation** — start a clone with an already-cancelled token, expect `Result.Failure` and no orphan target directory.
 
 No UI/dialog tests — same posture as `NewWorktreeDialog`.
 

--- a/docs/superpowers/specs/2026-04-29-add-project-from-git-url-design.md
+++ b/docs/superpowers/specs/2026-04-29-add-project-from-git-url-design.md
@@ -29,7 +29,7 @@ The "+" button (and the empty-state CTA) opens `NewProjectDialog`:
 - *Existing folder* mode: a single "Browse…" button → standard folder picker. Mirrors today's flow exactly.
 - *Clone from URL* mode shows three fields:
   - **Git URL** — text input. Validated against `https?://…`, `ssh://…`, or SCP-style `git@host:owner/repo.git`.
-  - **Parent folder** — read-only text + "Browse…" button. Defaults to the parent of the most recently added project (read off `IProjectStore`); falls back to `%USERPROFILE%\source\repos`.
+  - **Parent folder** — editable text input + "Browse…" button. Defaults to the parent of the most recently added project (read off `IProjectStore`); falls back to `%USERPROFILE%\source\repos`.
   - **Folder name** — text input. Auto-derived from the URL's repo segment on URL change (strip trailing `.git`); user-editable; must not already exist under the chosen parent.
 - "Add" is disabled until the active mode validates.
 
@@ -101,11 +101,7 @@ The drag-drop helper `AddProjectByPathAsync` and the palette command are not tou
 
 ## Validation rules
 
-- **URL:** non-empty, trimmed; matches one of:
-  - `^https?://\S+`
-  - `^ssh://\S+`
-  - `^git@\S+:\S+`
-  Anything else → "Enter a valid git URL".
+- **URL:** non-empty, trimmed; must match a supported scheme (http(s)://, ssh://, git@host:owner/repo). Invalid URLs disable the Add button; there is no dedicated inline error message — malformed or unreachable URLs that pass the basic scheme check are surfaced by the clone attempt itself.
 - **Parent folder:** must exist and be writable.
 - **Folder name:** non-empty, no `\\`/`/`, no path-invalid chars, and `Path.Combine(parent, name)` must not exist (or must be an empty directory — git refuses non-empty targets anyway, so we mirror that).
 
@@ -114,7 +110,7 @@ Validation errors render inline under the offending field; "Add" stays disabled.
 ## Error handling
 
 - Clone failure → dialog returns to editable state with git's stderr rendered inline beneath the URL field. User can edit and retry without re-typing anything. No toast.
-- Clone cancellation → dialog returns to editable state silently. The partially-cloned target directory is removed on a best-effort basis (`Directory.Delete(target, recursive: true)` swallowed) so a retry isn't blocked by the "target exists" check.
+- Clone cancellation → dialog returns to editable state silently. The partially-cloned target directory is removed on a best-effort basis.
 - If clone succeeds but `_store.AddProjectAsync` fails (duplicate path, etc.) → toast + log; the clone is left on disk for the user to inspect.
 
 ## Tests (Core only, per project convention)

--- a/docs/superpowers/specs/2026-04-29-add-project-from-git-url-design.md
+++ b/docs/superpowers/specs/2026-04-29-add-project-from-git-url-design.md
@@ -1,0 +1,126 @@
+# Add project from a git URL — design
+
+**Issue:** [#20](https://github.com/maui1911/CodeScope/issues/20) — *uitgebreider nieuw project window waar je evt ook een .git url kan toevoegen.*
+**Date:** 2026-04-29
+**Status:** approved
+
+## Problem
+
+Today the only way to add a project is to point CodeScope at an existing local folder. If the user wants to start work on a repo they don't have on disk yet, they have to clone it themselves in a separate shell, then come back and add it. The flow should let them paste a git URL and have CodeScope clone + register the project in one step.
+
+## Scope
+
+In:
+- A new `NewProjectDialog` with two modes: *Existing folder* (current behaviour) and *Clone from URL*.
+- A `git clone` shell-out on `IGitService`.
+- `SidebarViewModel.AddProjectAsync` rewired through the dialog; clone failures abort cleanly.
+
+Out (YAGNI):
+- Auth prompts — rely on the OS git credential manager (same as every other git op in the app).
+- Streaming clone progress / cancellation — single shell-out + toast lifecycle, like `FetchAllAsync`.
+- Submodule / shallow / branch / sparse options — can be added later if requested.
+
+## UX
+
+The "+" button (and the empty-state CTA) opens `NewProjectDialog`:
+
+- Two radio buttons: **Existing folder** (default) · **Clone from URL**.
+- *Existing folder* mode: a single "Browse…" button → standard folder picker. Mirrors today's flow exactly.
+- *Clone from URL* mode shows three fields:
+  - **Git URL** — text input. Validated against `https?://…`, `ssh://…`, or SCP-style `git@host:owner/repo.git`.
+  - **Parent folder** — read-only text + "Browse…" button. Defaults to the parent of the most recently added project (read off `IProjectStore`); falls back to `%USERPROFILE%\source\repos`.
+  - **Folder name** — text input. Auto-derived from the URL's repo segment on URL change (strip trailing `.git`); user-editable; must not already exist under the chosen parent.
+- "Add" is disabled until the active mode validates.
+
+Drag-drop of a folder onto the sidebar keeps using `AddProjectByPathAsync` — that path is unchanged.
+
+## Components
+
+### `NewProjectRequest` / `NewProjectResult` records (`CodeScope.Ui/Dialogs/`)
+
+```csharp
+public sealed record NewProjectRequest(string DefaultCloneParent);
+
+public sealed record NewProjectResult(
+    string? ExistingFolder,        // set when mode == Existing
+    string? CloneUrl,              // set when mode == Clone
+    string? CloneParent,
+    string? CloneFolderName);
+```
+
+Exactly one of `ExistingFolder` or `CloneUrl` is non-null — the dialog's caller switches on which.
+
+### `NewProjectDialog` (`Dialogs/NewProjectDialog.xaml[.cs]`)
+
+- Hosted in `App.xaml.cs` via a `Func<NewProjectRequest, NewProjectResult?> PickNewProject` delegate, registered alongside `PickFolder` and `PickNewWorktree`.
+- Reuses the existing folder-picker (the dialog accepts a `Func<string?> pickFolder` ctor argument so the WPF folder dialog stays in `App`).
+- Dialog styling follows `NewWorktreeDialog` (same shell, same buttons, same window-chrome treatment).
+
+### `IGitService.CloneAsync`
+
+```csharp
+Task<Result<string>> CloneAsync(
+    string url,
+    string parentDir,
+    string folderName,
+    CancellationToken ct = default);
+```
+
+Implementation: `git -C <parentDir> clone -- <url> <folderName>`, then return `Path.Combine(parentDir, folderName)`. Stderr from git is forwarded into `Result.Failure` verbatim (matches the rest of `GitService`'s contract). Pre-flight: refuse when the target directory already exists or is non-empty.
+
+### `SidebarViewModel.AddProjectAsync`
+
+```
+result = _pickNewProject(new NewProjectRequest(DefaultCloneParent()))
+if result is null: return
+
+if result.ExistingFolder is set:
+    _store.AddProjectAsync(result.ExistingFolder, displayName: null)
+else:
+    Toast("Cloning…", "<url>", ToastSeverity.Info)
+    cloned = await _git.CloneAsync(result.CloneUrl!, result.CloneParent!, result.CloneFolderName!)
+    if cloned.IsFailure:
+        ErrToast("Clone failed", cloned.Error, retry: () => AddProjectAsync())
+        return
+    _store.AddProjectAsync(cloned.Value, displayName: null)
+    Toast("Project cloned", folderName, ToastSeverity.Ok)
+```
+
+`DefaultCloneParent()` reads the most-recent project's parent off `_store.Projects`; falls back to `%USERPROFILE%\source\repos`.
+
+The drag-drop helper `AddProjectByPathAsync` and the palette command are not touched.
+
+## Validation rules
+
+- **URL:** non-empty, trimmed; matches one of:
+  - `^https?://\S+`
+  - `^ssh://\S+`
+  - `^git@\S+:\S+`
+  Anything else → "Enter a valid git URL".
+- **Parent folder:** must exist and be writable.
+- **Folder name:** non-empty, no `\\`/`/`, no path-invalid chars, and `Path.Combine(parent, name)` must not exist (or must be an empty directory — git refuses non-empty targets anyway, so we mirror that).
+
+Validation errors render inline under the offending field; "Add" stays disabled.
+
+## Error handling
+
+- Clone failure → `ErrToast` with git's stderr text. The dialog has already closed; offering a retry that re-opens the dialog with the same inputs is overkill — the toast's "retry" simply re-runs `AddProjectAsync()` (re-opens an empty dialog), matching existing patterns.
+- If clone succeeds but `AddProjectAsync` fails (duplicate path, etc.) → log + toast; the clone is left on disk for the user to inspect.
+
+## Tests (Core only, per project convention)
+
+`tests/CodeScope.Core.Tests/GitServiceCloneTests.cs`:
+
+1. **Happy path** — `git init --bare` a local source, clone it via `CloneAsync`, assert `Result.IsSuccess` and that the returned path is a valid worktree (`HEAD` exists).
+2. **Target already exists** — pre-create the target directory, expect `Result.Failure`.
+3. **Invalid URL** — pass garbage, expect `Result.Failure` with non-empty error text.
+
+No UI/dialog tests — same posture as `NewWorktreeDialog`.
+
+## Migration / rollout
+
+Pure addition. `projects.json` schema unchanged. Existing "Add project" entry-points (sidebar +, empty-state CTA, command palette) all funnel through `AddProjectAsync`; drag-drop stays on the unchanged path.
+
+## Open questions
+
+None.

--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -141,7 +141,6 @@ public partial class App : Application
                     return new SidebarViewModel(
                         store: sp.GetRequiredService<ISessionStore>(),
                         logger: sp.GetRequiredService<ILogger<SidebarViewModel>>(),
-                        pickFolder: PickFolder,
                         pickNewWorktree: PickNewWorktree,
                         pickNewProject: PickNewProject,
                         pullRequests: sp.GetRequiredService<IPullRequestService>(),

--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -132,15 +132,23 @@ public partial class App : Application
                 services.AddHostedService(sp => sp.GetRequiredService<WorktreeStatusPoller>());
                 services.AddSingleton<PullRequestStatusPoller>();
                 services.AddHostedService(sp => sp.GetRequiredService<PullRequestStatusPoller>());
-                services.AddSingleton<SidebarViewModel>(sp => new SidebarViewModel(
-                    sp.GetRequiredService<ISessionStore>(),
-                    sp.GetRequiredService<ILogger<SidebarViewModel>>(),
-                    PickFolder,
-                    PickNewWorktree,
-                    sp.GetRequiredService<IPullRequestService>(),
-                    sp.GetRequiredService<NoScope.CodeScope.Ui.Services.IToastService>(),
-                    sp.GetRequiredService<IAgentRegistry>(),
-                    sp.GetRequiredService<IGitService>()));
+                services.AddSingleton<SidebarViewModel>(sp =>
+                {
+                    var git = sp.GetRequiredService<IGitService>();
+                    Task<NoScope.CodeScope.Ui.Dialogs.NewProjectResult?> PickNewProject(NoScope.CodeScope.Ui.Dialogs.NewProjectRequest request)
+                        => NoScope.CodeScope.Ui.Dialogs.NewProjectDialog.PromptAsync(request, PickFolder, git);
+
+                    return new SidebarViewModel(
+                        store: sp.GetRequiredService<ISessionStore>(),
+                        logger: sp.GetRequiredService<ILogger<SidebarViewModel>>(),
+                        pickFolder: PickFolder,
+                        pickNewWorktree: PickNewWorktree,
+                        pickNewProject: PickNewProject,
+                        pullRequests: sp.GetRequiredService<IPullRequestService>(),
+                        toasts: sp.GetRequiredService<NoScope.CodeScope.Ui.Services.IToastService>(),
+                        agents: sp.GetRequiredService<IAgentRegistry>(),
+                        git: git);
+                });
                 services.AddSingleton<DiffPanelViewModel>();
                 services.AddSingleton<MainViewModel>(sp =>
                 {

--- a/src/CodeScope.Core/Services/GitService.cs
+++ b/src/CodeScope.Core/Services/GitService.cs
@@ -205,6 +205,41 @@ public sealed class GitService : IGitService
     public Task<Result<string>> FetchAllAsync(string workingDirectory, CancellationToken ct = default)
         => RunAsync(workingDirectory, "fetch --all --prune", ct);
 
+    public async Task<Result<string>> CloneAsync(string url, string parentDir, string folderName, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return Result<string>.Fail("URL is empty");
+        }
+        if (string.IsNullOrWhiteSpace(parentDir))
+        {
+            return Result<string>.Fail("Parent directory is empty");
+        }
+        if (string.IsNullOrWhiteSpace(folderName))
+        {
+            return Result<string>.Fail("Folder name is empty");
+        }
+
+        if (!Directory.Exists(parentDir))
+        {
+            return Result<string>.Fail($"Parent directory does not exist: {parentDir}");
+        }
+
+        var target = Path.Combine(parentDir, folderName);
+        if (Directory.Exists(target) && Directory.EnumerateFileSystemEntries(target).Any())
+        {
+            return Result<string>.Fail($"Destination already exists and is not empty: {target}");
+        }
+
+        // Quote both arguments and use `--` so URLs/folder names that start with a dash
+        // can't be parsed as flags.
+        var args = $"-C \"{parentDir}\" clone -- \"{url}\" \"{folderName}\"";
+        var result = await RunAsync(cwd: null, args, ct).ConfigureAwait(false);
+        return result.IsSuccess
+            ? Result<string>.Ok(target)
+            : Result<string>.Fail(result.Error);
+    }
+
     public async Task<Result<string>> DiscardChangesAsync(string workingDirectory, CancellationToken ct = default)
     {
         var reset = await RunAsync(workingDirectory, "reset --hard HEAD", ct).ConfigureAwait(false);

--- a/src/CodeScope.Core/Services/GitService.cs
+++ b/src/CodeScope.Core/Services/GitService.cs
@@ -220,12 +220,22 @@ public sealed class GitService : IGitService
             return Result<string>.Fail("Folder name is empty");
         }
 
+        if (folderName.Contains(Path.DirectorySeparatorChar) || folderName.Contains(Path.AltDirectorySeparatorChar) || folderName is ".." or ".")
+        {
+            return Result<string>.Fail($"Folder name must be a single directory name, not a path: {folderName}");
+        }
+
         if (!Directory.Exists(parentDir))
         {
             return Result<string>.Fail($"Parent directory does not exist: {parentDir}");
         }
 
-        var target = Path.Combine(parentDir, folderName);
+        var target = Path.GetFullPath(Path.Combine(parentDir, folderName));
+        if (!target.StartsWith(Path.GetFullPath(parentDir) + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+        {
+            return Result<string>.Fail($"Folder name resolves outside parent directory: {folderName}");
+        }
+
         if (Directory.Exists(target) && Directory.EnumerateFileSystemEntries(target).Any())
         {
             return Result<string>.Fail($"Destination already exists and is not empty: {target}");

--- a/src/CodeScope.Core/Services/GitService.cs
+++ b/src/CodeScope.Core/Services/GitService.cs
@@ -232,8 +232,9 @@ public sealed class GitService : IGitService
         }
 
         // Quote both arguments and use `--` so URLs/folder names that start with a dash
-        // can't be parsed as flags.
-        var args = $"-C \"{parentDir}\" clone -- \"{url}\" \"{folderName}\"";
+        // can't be parsed as flags. QuoteArg escapes inner double-quotes so we don't rely
+        // on UI-side input filtering at the service boundary.
+        var args = $"-C {ProcessRunner.QuoteArg(parentDir)} clone -- {ProcessRunner.QuoteArg(url)} {ProcessRunner.QuoteArg(folderName)}";
         var result = await RunAsync(cwd: null, args, ct).ConfigureAwait(false);
         return result.IsSuccess
             ? Result<string>.Ok(target)

--- a/src/CodeScope.Core/Services/IGitService.cs
+++ b/src/CodeScope.Core/Services/IGitService.cs
@@ -75,10 +75,12 @@ public interface IGitService
 
     /// <summary>
     /// Runs <c>git -C &lt;parentDir&gt; clone -- &lt;url&gt; &lt;folderName&gt;</c>. Returns the
-    /// absolute path of the resulting working tree on success. Fails verbatim with git's stderr
+    /// absolute path of the resulting working tree on success. Returns a failure message that
+    /// includes git's stderr (formatted by ProcessRunner, not raw stderr verbatim)
     /// on auth errors, network errors, "destination already exists", etc. Cancellation kills
-    /// the git process; partially-cloned target directories are NOT auto-removed by this method
-    /// (callers can clean up if they want — see <c>NewProjectDialog</c> for the pattern).
+    /// the git process tree via ProcessRunner; partially-cloned target directories are NOT
+    /// auto-removed by this method (callers can clean up if they want — see
+    /// <c>NewProjectDialog</c> for the pattern).
     /// </summary>
     Task<Result<string>> CloneAsync(string url, string parentDir, string folderName, CancellationToken ct = default);
 

--- a/src/CodeScope.Core/Services/IGitService.cs
+++ b/src/CodeScope.Core/Services/IGitService.cs
@@ -74,6 +74,15 @@ public interface IGitService
     Task<Result<string>> FetchAllAsync(string workingDirectory, CancellationToken ct = default);
 
     /// <summary>
+    /// Runs <c>git -C &lt;parentDir&gt; clone -- &lt;url&gt; &lt;folderName&gt;</c>. Returns the
+    /// absolute path of the resulting working tree on success. Fails verbatim with git's stderr
+    /// on auth errors, network errors, "destination already exists", etc. Cancellation kills
+    /// the git process; partially-cloned target directories are NOT auto-removed by this method
+    /// (callers can clean up if they want — see <c>NewProjectDialog</c> for the pattern).
+    /// </summary>
+    Task<Result<string>> CloneAsync(string url, string parentDir, string folderName, CancellationToken ct = default);
+
+    /// <summary>
     /// Destructively resets <paramref name="workingDirectory"/> to HEAD and removes untracked
     /// files/directories: <c>git reset --hard HEAD</c> followed by <c>git clean -fd</c>.
     /// The caller is responsible for confirming with the user first.

--- a/src/CodeScope.Core/Services/ProcessRunner.cs
+++ b/src/CodeScope.Core/Services/ProcessRunner.cs
@@ -50,6 +50,18 @@ public static class ProcessRunner
             using var process = Process.Start(psi)
                 ?? throw new InvalidOperationException($"Process.Start returned null for {toolLabel}");
 
+            // Cancellation contract: when the caller cancels, kill the child immediately so it
+            // can't keep running in the background after the awaits below throw OCE.
+            // `entireProcessTree: true` ensures git's underlying ssh/credential helpers also die.
+            // The static lambda + state arg avoids capturing `process` into a closure, which
+            // would otherwise hold a reference past the `using var process` disposal.
+            using var killOnCancel = ct.Register(static state =>
+            {
+                var p = (Process)state!;
+                try { if (!p.HasExited) { p.Kill(entireProcessTree: true); } }
+                catch { /* race: process exited between HasExited check and Kill, or already disposed */ }
+            }, process);
+
             var stdoutTask = process.StandardOutput.ReadToEndAsync(ct);
             var stderrTask = process.StandardError.ReadToEndAsync(ct);
 

--- a/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml
+++ b/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Add project"
-    Width="540"
+    Width="580"
     SizeToContent="Height"
     ResizeMode="NoResize"
     WindowStartupLocation="CenterOwner"
@@ -15,6 +15,24 @@
     TextElement.FontFamily="{DynamicResource Fig.Font.Sans}"
     TextElement.FontSize="{DynamicResource Fig.Size.Body}">
     <Window.Resources>
+        <!-- Dialog-local styles mirroring NewWorktreeDialog so the visual language matches. -->
+
+        <!-- Eyebrow: mono, small, accent, tracked caps. -->
+        <Style x:Key="NP.Eyebrow" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="{DynamicResource Fig.Font.Mono}" />
+            <Setter Property="FontSize" Value="10" />
+            <Setter Property="Foreground" Value="{DynamicResource Accent.Primary}" />
+            <Setter Property="TextOptions.TextFormattingMode" Value="Ideal" />
+        </Style>
+
+        <!-- Field label row. -->
+        <Style x:Key="NP.FieldLabel" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.InkMuted}" />
+        </Style>
+
+        <!-- 36px field chrome. -->
         <Style x:Key="NP.FieldChrome" TargetType="Border">
             <Setter Property="Height" Value="36" />
             <Setter Property="Background" Value="{DynamicResource Fig.Brush.GlassDark}" />
@@ -22,174 +40,519 @@
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="6" />
         </Style>
+
+        <!-- Borderless mono TextBox that sits inside a field chrome. -->
         <Style x:Key="NP.InnerMonoBox" TargetType="TextBox">
             <Setter Property="FontFamily" Value="{DynamicResource Fig.Font.Mono}" />
             <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="Medium" />
             <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.Ink}" />
+            <Setter Property="CaretBrush" Value="{DynamicResource Framer.Brush.Blue}" />
+            <Setter Property="SelectionBrush" Value="{DynamicResource Framer.Brush.Blue}" />
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0" />
             <Setter Property="VerticalContentAlignment" Value="Center" />
-            <Setter Property="Padding" Value="12,0" />
+            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="TextBox">
+                        <ScrollViewer x:Name="PART_ContentHost" VerticalAlignment="Center" />
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
-        <Style x:Key="NP.FieldLabel" TargetType="TextBlock">
-            <Setter Property="FontSize" Value="11" />
-            <Setter Property="FontWeight" Value="Medium" />
+
+        <!-- Close (×) button: 24px circle. -->
+        <Style x:Key="NP.CloseBtn" TargetType="Button">
+            <Setter Property="Width" Value="24" />
+            <Setter Property="Height" Value="24" />
+            <Setter Property="Background" Value="Transparent" />
             <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.InkMuted}" />
-            <Setter Property="Margin" Value="0,0,0,6" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="12">
+                            <Path x:Name="Glyph"
+                                  Data="M 0,0 L 8,8 M 8,0 L 0,8"
+                                  Stroke="{TemplateBinding Foreground}"
+                                  StrokeThickness="1.4"
+                                  StrokeStartLineCap="Round"
+                                  StrokeEndLineCap="Round"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="#1F1F1F" />
+                                <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.Ink}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
+
+        <!-- Ghost footer button. -->
+        <Style x:Key="NP.GhostBtn" TargetType="Button">
+            <Setter Property="Height" Value="32" />
+            <Setter Property="Padding" Value="14,0" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.InkMuted}" />
+            <Setter Property="FontFamily" Value="{DynamicResource Fig.Font.Sans}" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="6"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="#1F1F1F" />
+                                <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.Ink}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Primary footer button: Framer Blue, 32px, with kbd chip. -->
         <Style x:Key="NP.PrimaryBtn" TargetType="Button">
             <Setter Property="Height" Value="32" />
             <Setter Property="Padding" Value="14,0" />
             <Setter Property="Background" Value="{DynamicResource Accent.Primary}" />
-            <Setter Property="Foreground" Value="White" />
-            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.Canvas}" />
+            <Setter Property="FontFamily" Value="{DynamicResource Fig.Font.Sans}" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="6"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="#29A8FF" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Bg" Property="Background" Value="#1F1F1F" />
+                                <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.InkDim}" />
+                                <Setter Property="Cursor" Value="Arrow" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
-        <Style x:Key="NP.GhostBtn" TargetType="Button" BasedOn="{StaticResource NP.PrimaryBtn}">
+
+        <!-- Segmented mode-toggle button. Tag="active" flips to accent fill. -->
+        <Style x:Key="NP.SegBtn" TargetType="Button">
+            <Setter Property="Height" Value="28" />
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.InkMuted}" />
+            <Setter Property="FontFamily" Value="{DynamicResource Fig.Font.Sans}" />
+            <Setter Property="FontSize" Value="12.5" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="4">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="#1F1F1F" />
+                                <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.Ink}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="Tag" Value="active">
+                    <Setter Property="Background" Value="{DynamicResource Accent.Primary}" />
+                    <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.Canvas}" />
+                    <Setter Property="FontWeight" Value="SemiBold" />
+                </Trigger>
+            </Style.Triggers>
         </Style>
     </Window.Resources>
 
-    <Border Background="{DynamicResource Surface.Panel}"
-            CornerRadius="10"
-            BorderBrush="{DynamicResource Surface.Border}"
+    <!-- Outer wrap keeps the drop-shadow margin; actual surface is the inner Border. -->
+    <Grid Margin="30">
+        <Border
+            x:Name="DialogSurface"
+            Background="#0A0A0A"
+            BorderBrush="#1F1F1F"
             BorderThickness="1"
-            Padding="0">
-        <Grid Margin="20,16,20,16">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+            CornerRadius="{DynamicResource Fig.Radius.Medium}"
+            Effect="{DynamicResource Shadow.Dialog}"
+            ClipToBounds="True"
+            MouseLeftButtonDown="OnChromeDrag">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <!-- head -->
+                    <RowDefinition Height="Auto" />
+                    <!-- body -->
+                    <RowDefinition Height="Auto" />
+                    <!-- foot -->
+                </Grid.RowDefinitions>
 
-            <!-- Chrome bar: title left + close right; whole row is drag-handle. -->
-            <Grid Grid.Row="0" Margin="0,0,0,16" MouseLeftButtonDown="OnChromeDrag">
-                <TextBlock Text="ADD PROJECT"
-                           FontFamily="{DynamicResource Fig.Font.Mono}"
-                           FontSize="10"
-                           Foreground="{DynamicResource Accent.Primary}" />
-                <Button x:Name="CloseBtn"
-                        Content="×"
-                        Width="24" Height="24"
-                        HorizontalAlignment="Right"
-                        Background="Transparent"
-                        BorderThickness="0"
-                        Foreground="{DynamicResource Fig.Brush.InkMuted}"
-                        Cursor="Hand"
+                <!-- ===== HEAD ===== -->
+                <Grid Grid.Row="0" Margin="24,20,24,16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" Orientation="Vertical">
+                        <TextBlock
+                            Style="{StaticResource NP.Eyebrow}"
+                            Text="ADD PROJECT"
+                            Margin="0,0,0,6" />
+                        <TextBlock
+                            FontSize="20"
+                            FontWeight="SemiBold"
+                            Foreground="{DynamicResource Fig.Brush.Ink}"
+                            Text="Add a project" />
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            FontSize="12"
+                            Foreground="{DynamicResource Fig.Brush.InkMuted}"
+                            Text="Bring a folder in, or clone a repo straight in." />
+                    </StackPanel>
+
+                    <Button
+                        Grid.Column="1"
+                        AutomationProperties.AutomationId="NewProjectCloseBtn"
+                        Style="{StaticResource NP.CloseBtn}"
+                        VerticalAlignment="Top"
+                        IsCancel="True"
                         Click="OnCancel" />
-            </Grid>
-
-            <!-- Mode toggle: two radio buttons. -->
-            <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,16">
-                <RadioButton x:Name="ModeExisting"
-                             Content="Existing folder"
-                             GroupName="NPMode"
-                             IsChecked="True"
-                             Margin="0,0,16,0"
-                             Checked="OnModeChanged" />
-                <RadioButton x:Name="ModeClone"
-                             Content="Clone from URL"
-                             GroupName="NPMode"
-                             Checked="OnModeChanged" />
-            </StackPanel>
-
-            <!-- Existing-folder panel. -->
-            <StackPanel x:Name="ExistingPanel" Grid.Row="2">
-                <TextBlock Text="FOLDER" Style="{StaticResource NP.FieldLabel}" />
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <Border Grid.Column="0" Style="{StaticResource NP.FieldChrome}">
-                        <TextBox x:Name="ExistingPathBox"
-                                 Style="{StaticResource NP.InnerMonoBox}"
-                                 IsReadOnly="True" />
-                    </Border>
-                    <Button Grid.Column="1"
-                            Content="Browse…"
-                            Style="{StaticResource NP.GhostBtn}"
-                            Margin="8,0,0,0"
-                            Click="OnPickExisting" />
-                </Grid>
-            </StackPanel>
-
-            <!-- Clone panel. -->
-            <StackPanel x:Name="ClonePanel" Grid.Row="3" Visibility="Collapsed">
-                <TextBlock Text="GIT URL" Style="{StaticResource NP.FieldLabel}" />
-                <Border Style="{StaticResource NP.FieldChrome}" Margin="0,0,0,12">
-                    <TextBox x:Name="UrlBox" Style="{StaticResource NP.InnerMonoBox}" />
-                </Border>
-
-                <TextBlock Text="PARENT FOLDER" Style="{StaticResource NP.FieldLabel}" />
-                <Grid Margin="0,0,0,12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <Border Grid.Column="0" Style="{StaticResource NP.FieldChrome}">
-                        <TextBox x:Name="ParentBox" Style="{StaticResource NP.InnerMonoBox}" />
-                    </Border>
-                    <Button Grid.Column="1"
-                            Content="Browse…"
-                            Style="{StaticResource NP.GhostBtn}"
-                            Margin="8,0,0,0"
-                            Click="OnPickParent" />
                 </Grid>
 
-                <TextBlock Text="FOLDER NAME" Style="{StaticResource NP.FieldLabel}" />
-                <Border Style="{StaticResource NP.FieldChrome}">
-                    <TextBox x:Name="NameBox" Style="{StaticResource NP.InnerMonoBox}" />
-                </Border>
-            </StackPanel>
+                <!-- ===== BODY ===== -->
+                <StackPanel Grid.Row="1" Margin="24,0,24,16">
 
-            <!-- Inline error (used by clone failures). -->
-            <TextBlock x:Name="ErrorText"
-                       Grid.Row="4"
-                       Margin="0,12,0,0"
-                       TextWrapping="Wrap"
-                       FontFamily="{DynamicResource Fig.Font.Mono}"
-                       FontSize="11"
-                       Foreground="{DynamicResource Severity.Err}"
-                       Visibility="Collapsed" />
+                    <!-- Segmented mode toggle. -->
+                    <Border Background="{DynamicResource Fig.Brush.GlassDark}"
+                            CornerRadius="6"
+                            Padding="2"
+                            Margin="0,0,0,16">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Button x:Name="ModeExistingBtn"
+                                    Grid.Column="0"
+                                    AutomationProperties.AutomationId="NewProjectModeExistingBtn"
+                                    Style="{StaticResource NP.SegBtn}"
+                                    Content="Existing folder"
+                                    Click="OnModeExistingClick" />
+                            <Button x:Name="ModeCloneBtn"
+                                    Grid.Column="1"
+                                    AutomationProperties.AutomationId="NewProjectModeCloneBtn"
+                                    Style="{StaticResource NP.SegBtn}"
+                                    Content="Clone from URL"
+                                    Click="OnModeCloneClick" />
+                        </Grid>
+                    </Border>
 
-            <!-- Buttons row. -->
-            <Grid Grid.Row="5" Margin="0,20,0,0">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
+                    <!-- Existing-folder panel. -->
+                    <Grid x:Name="ExistingPanel">
+                        <StackPanel>
+                            <TextBlock Style="{StaticResource NP.FieldLabel}"
+                                       Text="FOLDER"
+                                       Margin="0,0,0,6" />
+                            <Border Style="{StaticResource NP.FieldChrome}">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock
+                                        Grid.Column="0"
+                                        Margin="12,0,10,0"
+                                        VerticalAlignment="Center"
+                                        FontFamily="{DynamicResource Fig.Font.Mono}"
+                                        FontSize="12"
+                                        Foreground="{DynamicResource Accent.Primary}"
+                                        Text="$" />
+                                    <TextBox
+                                        Grid.Column="1"
+                                        x:Name="ExistingPathBox"
+                                        AutomationProperties.AutomationId="NewProjectExistingPathBox"
+                                        Style="{StaticResource NP.InnerMonoBox}"
+                                        Margin="0,0,10,0"
+                                        IsReadOnly="True" />
+                                    <Button
+                                        Grid.Column="2"
+                                        AutomationProperties.AutomationId="NewProjectPickExistingBtn"
+                                        Click="OnPickExisting"
+                                        Cursor="Hand"
+                                        FocusVisualStyle="{x:Null}"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        Padding="0">
+                                        <Button.Template>
+                                            <ControlTemplate TargetType="Button">
+                                                <Border x:Name="Seg"
+                                                        Background="{TemplateBinding Background}"
+                                                        BorderBrush="#1F1F1F"
+                                                        BorderThickness="1,0,0,0"
+                                                        Padding="10,0,12,0">
+                                                    <ContentPresenter VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                                </Border>
+                                                <ControlTemplate.Triggers>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter TargetName="Seg" Property="Background" Value="#1F1F1F" />
+                                                    </Trigger>
+                                                </ControlTemplate.Triggers>
+                                            </ControlTemplate>
+                                        </Button.Template>
+                                        <TextBlock
+                                            VerticalAlignment="Center"
+                                            FontFamily="{DynamicResource Fig.Font.Mono}"
+                                            FontSize="10"
+                                            Foreground="{DynamicResource Fig.Brush.InkDim}"
+                                            Text="Browse" />
+                                    </Button>
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+                    </Grid>
 
-                <!-- Busy indicator (visible only while cloning). -->
-                <StackPanel x:Name="BusyPanel"
-                            Grid.Column="0"
-                            Orientation="Horizontal"
-                            Visibility="Collapsed">
-                    <ProgressBar Width="120" Height="4" IsIndeterminate="True" Margin="0,0,10,0" />
-                    <TextBlock x:Name="BusyText"
-                               VerticalAlignment="Center"
+                    <!-- Clone-from-URL panel. -->
+                    <Grid x:Name="ClonePanel" Visibility="Collapsed">
+                        <StackPanel>
+                            <!-- GIT URL -->
+                            <TextBlock Style="{StaticResource NP.FieldLabel}"
+                                       Text="GIT URL"
+                                       Margin="0,0,0,6" />
+                            <Border Style="{StaticResource NP.FieldChrome}" Margin="0,0,0,12">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock
+                                        Grid.Column="0"
+                                        Margin="12,0,8,0"
+                                        VerticalAlignment="Center"
+                                        FontFamily="{DynamicResource Fig.Font.Mono}"
+                                        FontSize="12"
+                                        Foreground="{DynamicResource Accent.Primary}"
+                                        Text="&#x29C9;" />
+                                    <TextBox
+                                        Grid.Column="1"
+                                        x:Name="UrlBox"
+                                        AutomationProperties.AutomationId="NewProjectUrlBox"
+                                        Style="{StaticResource NP.InnerMonoBox}"
+                                        Margin="0,0,12,0" />
+                                </Grid>
+                            </Border>
+
+                            <!-- PARENT FOLDER -->
+                            <TextBlock Style="{StaticResource NP.FieldLabel}"
+                                       Text="PARENT FOLDER"
+                                       Margin="0,0,0,6" />
+                            <Border Style="{StaticResource NP.FieldChrome}" Margin="0,0,0,12">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock
+                                        Grid.Column="0"
+                                        Margin="12,0,10,0"
+                                        VerticalAlignment="Center"
+                                        FontFamily="{DynamicResource Fig.Font.Mono}"
+                                        FontSize="12"
+                                        Foreground="{DynamicResource Accent.Primary}"
+                                        Text="$" />
+                                    <TextBox
+                                        Grid.Column="1"
+                                        x:Name="ParentBox"
+                                        AutomationProperties.AutomationId="NewProjectParentBox"
+                                        Style="{StaticResource NP.InnerMonoBox}"
+                                        Margin="0,0,10,0" />
+                                    <Button
+                                        Grid.Column="2"
+                                        AutomationProperties.AutomationId="NewProjectPickParentBtn"
+                                        Click="OnPickParent"
+                                        Cursor="Hand"
+                                        FocusVisualStyle="{x:Null}"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        Padding="0">
+                                        <Button.Template>
+                                            <ControlTemplate TargetType="Button">
+                                                <Border x:Name="Seg"
+                                                        Background="{TemplateBinding Background}"
+                                                        BorderBrush="#1F1F1F"
+                                                        BorderThickness="1,0,0,0"
+                                                        Padding="10,0,12,0">
+                                                    <ContentPresenter VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                                </Border>
+                                                <ControlTemplate.Triggers>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter TargetName="Seg" Property="Background" Value="#1F1F1F" />
+                                                    </Trigger>
+                                                </ControlTemplate.Triggers>
+                                            </ControlTemplate>
+                                        </Button.Template>
+                                        <TextBlock
+                                            VerticalAlignment="Center"
+                                            FontFamily="{DynamicResource Fig.Font.Mono}"
+                                            FontSize="10"
+                                            Foreground="{DynamicResource Fig.Brush.InkDim}"
+                                            Text="Browse" />
+                                    </Button>
+                                </Grid>
+                            </Border>
+
+                            <!-- FOLDER NAME -->
+                            <TextBlock Style="{StaticResource NP.FieldLabel}"
+                                       Text="FOLDER NAME"
+                                       Margin="0,0,0,6" />
+                            <Border Style="{StaticResource NP.FieldChrome}">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock
+                                        Grid.Column="0"
+                                        Margin="12,0,8,0"
+                                        VerticalAlignment="Center"
+                                        FontFamily="{DynamicResource Fig.Font.Mono}"
+                                        FontSize="12"
+                                        Foreground="{DynamicResource Fig.Brush.InkDim}"
+                                        Text="/" />
+                                    <TextBox
+                                        Grid.Column="1"
+                                        x:Name="NameBox"
+                                        AutomationProperties.AutomationId="NewProjectNameBox"
+                                        Style="{StaticResource NP.InnerMonoBox}"
+                                        Margin="0,0,12,0" />
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- Inline error (used by clone failures). -->
+                    <TextBlock x:Name="ErrorText"
+                               Margin="0,12,0,0"
+                               TextWrapping="Wrap"
                                FontFamily="{DynamicResource Fig.Font.Mono}"
                                FontSize="11"
-                               Foreground="{DynamicResource Fig.Brush.InkMuted}" />
+                               Foreground="{DynamicResource Severity.Err}"
+                               Visibility="Collapsed" />
                 </StackPanel>
 
-                <StackPanel Grid.Column="1" Orientation="Horizontal">
-                    <Button x:Name="CancelBtn"
-                            Content="Cancel"
+                <!-- ===== FOOT ===== -->
+                <Border
+                    Grid.Row="2"
+                    Background="#080808"
+                    BorderBrush="#1F1F1F"
+                    BorderThickness="0,1,0,0">
+                    <Grid Margin="24,14,24,18">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <!-- Meta caption (left). Replaced by BusyPanel during clone. -->
+                        <TextBlock
+                            Grid.Column="0"
+                            x:Name="FootMeta"
+                            VerticalAlignment="Center"
+                            FontFamily="{DynamicResource Fig.Font.Mono}"
+                            FontSize="10.5"
+                            Foreground="{DynamicResource Fig.Brush.InkDim}"
+                            TextTrimming="CharacterEllipsis"
+                            Text="add project · …" />
+
+                        <StackPanel
+                            Grid.Column="0"
+                            x:Name="BusyPanel"
+                            Orientation="Horizontal"
+                            VerticalAlignment="Center"
+                            Visibility="Collapsed">
+                            <ProgressBar Width="80" Height="3" IsIndeterminate="True" Margin="0,0,10,0" />
+                            <TextBlock x:Name="BusyText"
+                                       VerticalAlignment="Center"
+                                       FontFamily="{DynamicResource Fig.Font.Mono}"
+                                       FontSize="10.5"
+                                       Foreground="{DynamicResource Fig.Brush.InkMuted}" />
+                        </StackPanel>
+
+                        <Button
+                            Grid.Column="1"
+                            x:Name="CancelBtn"
+                            AutomationProperties.AutomationId="NewProjectCancelBtn"
                             Style="{StaticResource NP.GhostBtn}"
+                            Content="Cancel"
+                            Margin="0,0,8,0"
+                            IsCancel="True"
                             Click="OnCancel" />
-                    <Button x:Name="AddBtn"
-                            Content="Add"
+
+                        <Button
+                            Grid.Column="2"
+                            x:Name="AddBtn"
+                            AutomationProperties.AutomationId="NewProjectAddBtn"
                             Style="{StaticResource NP.PrimaryBtn}"
-                            Margin="8,0,0,0"
                             IsDefault="True"
-                            Click="OnAdd" />
-                </StackPanel>
+                            IsEnabled="False"
+                            Click="OnAdd">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <TextBlock Text="Add" VerticalAlignment="Center" />
+                                <Border
+                                    Margin="8,0,0,0"
+                                    Background="#26000000"
+                                    CornerRadius="3"
+                                    Padding="5,2,5,2">
+                                    <TextBlock
+                                        FontFamily="{DynamicResource Fig.Font.Mono}"
+                                        FontSize="10"
+                                        Foreground="#B3000000"
+                                        Text="&#x21B5;" />
+                                </Border>
+                            </StackPanel>
+                        </Button>
+                    </Grid>
+                </Border>
             </Grid>
-        </Grid>
-    </Border>
+        </Border>
+    </Grid>
 </Window>

--- a/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml
+++ b/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml
@@ -185,10 +185,21 @@
                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
                         </Border>
                         <ControlTemplate.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsMouseOver" Value="True" />
+                                    <Condition Property="Tag" Value="{x:Null}" />
+                                </MultiTrigger.Conditions>
                                 <Setter TargetName="Bg" Property="Background" Value="#1F1F1F" />
                                 <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.Ink}" />
-                            </Trigger>
+                            </MultiTrigger>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsMouseOver" Value="True" />
+                                    <Condition Property="Tag" Value="active" />
+                                </MultiTrigger.Conditions>
+                                <Setter TargetName="Bg" Property="Background" Value="#29A8FF" />
+                            </MultiTrigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
                 </Setter.Value>

--- a/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml
+++ b/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml
@@ -1,0 +1,195 @@
+<Window
+    x:Class="NoScope.CodeScope.Ui.Dialogs.NewProjectDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Add project"
+    Width="540"
+    SizeToContent="Height"
+    ResizeMode="NoResize"
+    WindowStartupLocation="CenterOwner"
+    ShowInTaskbar="False"
+    WindowStyle="None"
+    AllowsTransparency="True"
+    Background="Transparent"
+    TextElement.Foreground="{DynamicResource Fig.Brush.Ink}"
+    TextElement.FontFamily="{DynamicResource Fig.Font.Sans}"
+    TextElement.FontSize="{DynamicResource Fig.Size.Body}">
+    <Window.Resources>
+        <Style x:Key="NP.FieldChrome" TargetType="Border">
+            <Setter Property="Height" Value="36" />
+            <Setter Property="Background" Value="{DynamicResource Fig.Brush.GlassDark}" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="6" />
+        </Style>
+        <Style x:Key="NP.InnerMonoBox" TargetType="TextBox">
+            <Setter Property="FontFamily" Value="{DynamicResource Fig.Font.Mono}" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.Ink}" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Padding" Value="12,0" />
+        </Style>
+        <Style x:Key="NP.FieldLabel" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.InkMuted}" />
+            <Setter Property="Margin" Value="0,0,0,6" />
+        </Style>
+        <Style x:Key="NP.PrimaryBtn" TargetType="Button">
+            <Setter Property="Height" Value="32" />
+            <Setter Property="Padding" Value="14,0" />
+            <Setter Property="Background" Value="{DynamicResource Accent.Primary}" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style x:Key="NP.GhostBtn" TargetType="Button" BasedOn="{StaticResource NP.PrimaryBtn}">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="{DynamicResource Fig.Brush.InkMuted}" />
+        </Style>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource Surface.Panel}"
+            CornerRadius="10"
+            BorderBrush="{DynamicResource Surface.Border}"
+            BorderThickness="1"
+            Padding="0">
+        <Grid Margin="20,16,20,16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <!-- Chrome bar: title left + close right; whole row is drag-handle. -->
+            <Grid Grid.Row="0" Margin="0,0,0,16" MouseLeftButtonDown="OnChromeDrag">
+                <TextBlock Text="ADD PROJECT"
+                           FontFamily="{DynamicResource Fig.Font.Mono}"
+                           FontSize="10"
+                           Foreground="{DynamicResource Accent.Primary}" />
+                <Button x:Name="CloseBtn"
+                        Content="×"
+                        Width="24" Height="24"
+                        HorizontalAlignment="Right"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Foreground="{DynamicResource Fig.Brush.InkMuted}"
+                        Cursor="Hand"
+                        Click="OnCancel" />
+            </Grid>
+
+            <!-- Mode toggle: two radio buttons. -->
+            <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,16">
+                <RadioButton x:Name="ModeExisting"
+                             Content="Existing folder"
+                             GroupName="NPMode"
+                             IsChecked="True"
+                             Margin="0,0,16,0"
+                             Checked="OnModeChanged" />
+                <RadioButton x:Name="ModeClone"
+                             Content="Clone from URL"
+                             GroupName="NPMode"
+                             Checked="OnModeChanged" />
+            </StackPanel>
+
+            <!-- Existing-folder panel. -->
+            <StackPanel x:Name="ExistingPanel" Grid.Row="2">
+                <TextBlock Text="FOLDER" Style="{StaticResource NP.FieldLabel}" />
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Border Grid.Column="0" Style="{StaticResource NP.FieldChrome}">
+                        <TextBox x:Name="ExistingPathBox"
+                                 Style="{StaticResource NP.InnerMonoBox}"
+                                 IsReadOnly="True" />
+                    </Border>
+                    <Button Grid.Column="1"
+                            Content="Browse…"
+                            Style="{StaticResource NP.GhostBtn}"
+                            Margin="8,0,0,0"
+                            Click="OnPickExisting" />
+                </Grid>
+            </StackPanel>
+
+            <!-- Clone panel. -->
+            <StackPanel x:Name="ClonePanel" Grid.Row="3" Visibility="Collapsed">
+                <TextBlock Text="GIT URL" Style="{StaticResource NP.FieldLabel}" />
+                <Border Style="{StaticResource NP.FieldChrome}" Margin="0,0,0,12">
+                    <TextBox x:Name="UrlBox" Style="{StaticResource NP.InnerMonoBox}" />
+                </Border>
+
+                <TextBlock Text="PARENT FOLDER" Style="{StaticResource NP.FieldLabel}" />
+                <Grid Margin="0,0,0,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Border Grid.Column="0" Style="{StaticResource NP.FieldChrome}">
+                        <TextBox x:Name="ParentBox" Style="{StaticResource NP.InnerMonoBox}" />
+                    </Border>
+                    <Button Grid.Column="1"
+                            Content="Browse…"
+                            Style="{StaticResource NP.GhostBtn}"
+                            Margin="8,0,0,0"
+                            Click="OnPickParent" />
+                </Grid>
+
+                <TextBlock Text="FOLDER NAME" Style="{StaticResource NP.FieldLabel}" />
+                <Border Style="{StaticResource NP.FieldChrome}">
+                    <TextBox x:Name="NameBox" Style="{StaticResource NP.InnerMonoBox}" />
+                </Border>
+            </StackPanel>
+
+            <!-- Inline error (used by clone failures). -->
+            <TextBlock x:Name="ErrorText"
+                       Grid.Row="4"
+                       Margin="0,12,0,0"
+                       TextWrapping="Wrap"
+                       FontFamily="{DynamicResource Fig.Font.Mono}"
+                       FontSize="11"
+                       Foreground="{DynamicResource Severity.Err}"
+                       Visibility="Collapsed" />
+
+            <!-- Buttons row. -->
+            <Grid Grid.Row="5" Margin="0,20,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <!-- Busy indicator (visible only while cloning). -->
+                <StackPanel x:Name="BusyPanel"
+                            Grid.Column="0"
+                            Orientation="Horizontal"
+                            Visibility="Collapsed">
+                    <ProgressBar Width="120" Height="4" IsIndeterminate="True" Margin="0,0,10,0" />
+                    <TextBlock x:Name="BusyText"
+                               VerticalAlignment="Center"
+                               FontFamily="{DynamicResource Fig.Font.Mono}"
+                               FontSize="11"
+                               Foreground="{DynamicResource Fig.Brush.InkMuted}" />
+                </StackPanel>
+
+                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                    <Button x:Name="CancelBtn"
+                            Content="Cancel"
+                            Style="{StaticResource NP.GhostBtn}"
+                            Click="OnCancel" />
+                    <Button x:Name="AddBtn"
+                            Content="Add"
+                            Style="{StaticResource NP.PrimaryBtn}"
+                            Margin="8,0,0,0"
+                            IsDefault="True"
+                            Click="OnAdd" />
+                </StackPanel>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml.cs
+++ b/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml.cs
@@ -1,0 +1,255 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using NoScope.CodeScope.Core;
+using NoScope.CodeScope.Core.Services;
+
+namespace NoScope.CodeScope.Ui.Dialogs;
+
+public partial class NewProjectDialog : Window
+{
+    private readonly Func<string?> _pickFolder;
+    private readonly IGitService _git;
+    private CancellationTokenSource? _cloneCts;
+    private NewProjectResult? _result;
+
+    private NewProjectDialog(NewProjectRequest req, Func<string?> pickFolder, IGitService git)
+    {
+        _pickFolder = pickFolder;
+        _git = git;
+
+        InitializeComponent();
+
+        ParentBox.Text = req.DefaultCloneParent;
+        UrlBox.TextChanged += (_, _) => OnUrlChanged();
+        ParentBox.TextChanged += (_, _) => RefreshAddEnabled();
+        NameBox.TextChanged += (_, _) => RefreshAddEnabled();
+        ExistingPathBox.TextChanged += (_, _) => RefreshAddEnabled();
+
+        ApplyMode();
+        RefreshAddEnabled();
+    }
+
+    /// <summary>
+    /// Shows the dialog modally. When the user picks "Clone from URL" and clicks Add the
+    /// dialog awaits <c>git clone</c> with an inline spinner; on success the dialog closes
+    /// and the returned result carries the resolved local path.
+    /// </summary>
+    public static Task<NewProjectResult?> PromptAsync(NewProjectRequest req, Func<string?> pickFolder, IGitService git)
+    {
+        var dlg = new NewProjectDialog(req, pickFolder, git) { Owner = Application.Current?.MainWindow };
+        // ShowDialog blocks until DialogResult is set. The clone path uses an async helper
+        // (OnAdd) that closes the window when done — by the time ShowDialog returns, _result is final.
+        var ok = dlg.ShowDialog();
+        return Task.FromResult(ok == true ? dlg._result : null);
+    }
+
+    private bool IsCloneMode => ModeClone.IsChecked == true;
+
+    private void OnModeChanged(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded) { return; }
+        ApplyMode();
+        RefreshAddEnabled();
+    }
+
+    private void ApplyMode()
+    {
+        ExistingPanel.Visibility = IsCloneMode ? Visibility.Collapsed : Visibility.Visible;
+        ClonePanel.Visibility = IsCloneMode ? Visibility.Visible : Visibility.Collapsed;
+        ErrorText.Visibility = Visibility.Collapsed;
+        if (IsCloneMode) { UrlBox.Focus(); } else { /* leave focus alone */ }
+    }
+
+    private void OnUrlChanged()
+    {
+        // Auto-derive folder name from the URL's last segment, stripping ".git".
+        // Only overwrite when the user hasn't customised the field (i.e. it's empty
+        // or matches the previously-derived value).
+        var url = UrlBox.Text?.Trim() ?? string.Empty;
+        var derived = DeriveRepoName(url);
+        if (string.IsNullOrEmpty(NameBox.Text) || (NameBox.Tag is string prev && prev == NameBox.Text))
+        {
+            NameBox.Text = derived;
+            NameBox.Tag = derived;
+        }
+        RefreshAddEnabled();
+    }
+
+    internal static string DeriveRepoName(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) { return string.Empty; }
+        var u = url.Trim().TrimEnd('/');
+        if (u.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+        {
+            u = u.Substring(0, u.Length - 4);
+        }
+        // Take the last segment after '/' or ':' (covers SCP-style 'git@host:owner/repo').
+        var slash = u.LastIndexOfAny(['/', ':']);
+        var leaf = slash >= 0 ? u.Substring(slash + 1) : u;
+        // Strip path-invalid chars defensively.
+        foreach (var bad in Path.GetInvalidFileNameChars()) { leaf = leaf.Replace(bad, '-'); }
+        return leaf;
+    }
+
+    internal static bool IsValidGitUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) { return false; }
+        var u = url.Trim();
+        if (u.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            || u.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            || u.StartsWith("ssh://", StringComparison.OrdinalIgnoreCase))
+        {
+            return u.Length > 8;
+        }
+        if (u.StartsWith("git@", StringComparison.OrdinalIgnoreCase))
+        {
+            // Require host + ':' + path.
+            var colon = u.IndexOf(':');
+            return colon > "git@".Length && colon < u.Length - 1;
+        }
+        return false;
+    }
+
+    private void RefreshAddEnabled()
+    {
+        if (IsCloneMode)
+        {
+            var urlOk = IsValidGitUrl(UrlBox.Text);
+            var parentOk = !string.IsNullOrWhiteSpace(ParentBox.Text) && Directory.Exists(ParentBox.Text);
+            var nameOk = !string.IsNullOrWhiteSpace(NameBox.Text)
+                && NameBox.Text.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+            AddBtn.IsEnabled = urlOk && parentOk && nameOk;
+        }
+        else
+        {
+            AddBtn.IsEnabled = !string.IsNullOrWhiteSpace(ExistingPathBox.Text) && Directory.Exists(ExistingPathBox.Text);
+        }
+    }
+
+    private void OnPickExisting(object sender, RoutedEventArgs e)
+    {
+        var picked = _pickFolder();
+        if (!string.IsNullOrWhiteSpace(picked))
+        {
+            ExistingPathBox.Text = picked;
+        }
+    }
+
+    private void OnPickParent(object sender, RoutedEventArgs e)
+    {
+        var picked = _pickFolder();
+        if (!string.IsNullOrWhiteSpace(picked))
+        {
+            ParentBox.Text = picked;
+        }
+    }
+
+    private async void OnAdd(object sender, RoutedEventArgs e)
+    {
+        if (!AddBtn.IsEnabled) { return; }
+
+        ErrorText.Visibility = Visibility.Collapsed;
+
+        if (!IsCloneMode)
+        {
+            _result = new NewProjectResult(ExistingFolder: ExistingPathBox.Text.Trim(), ClonedPath: null, WasCloned: false);
+            DialogResult = true;
+            Close();
+            return;
+        }
+
+        var url = UrlBox.Text.Trim();
+        var parent = ParentBox.Text.Trim();
+        var name = NameBox.Text.Trim();
+
+        var target = Path.Combine(parent, name);
+        if (Directory.Exists(target) && Directory.EnumerateFileSystemEntries(target).Any())
+        {
+            ShowError($"Destination already exists: {target}");
+            return;
+        }
+
+        SetBusy(true, $"Cloning {name}…");
+        _cloneCts = new CancellationTokenSource();
+        Result<string> result;
+        try
+        {
+            result = await _git.CloneAsync(url, parent, name, _cloneCts.Token).ConfigureAwait(true);
+        }
+        // Broad catch is intentional: OnAdd is async void (WPF event handler),
+        // so an uncaught exception here would crash the AppDomain.
+        catch (Exception ex)
+        {
+            result = Result<string>.Fail(ex.Message);
+        }
+        finally
+        {
+            _cloneCts.Dispose();
+            _cloneCts = null;
+        }
+
+        if (result.IsSuccess)
+        {
+            _result = new NewProjectResult(ExistingFolder: null, ClonedPath: result.Value, WasCloned: true);
+            DialogResult = true;
+            Close();
+            return;
+        }
+
+        // Failed or cancelled — clean up a partial target dir so a retry isn't blocked.
+        TryDeleteDir(target);
+        SetBusy(false, null);
+        ShowError(result.Error);
+    }
+
+    private void OnCancel(object sender, RoutedEventArgs e)
+    {
+        if (_cloneCts is { } cts)
+        {
+            // Cloning is in flight: cancel it, but do NOT close the window — the OnAdd
+            // continuation will return us to the editable state.
+            try { cts.Cancel(); } catch { /* already disposed */ }
+            return;
+        }
+        DialogResult = false;
+        Close();
+    }
+
+    private void OnChromeDrag(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton == MouseButton.Left) { DragMove(); }
+    }
+
+    private void SetBusy(bool busy, string? text)
+    {
+        BusyPanel.Visibility = busy ? Visibility.Visible : Visibility.Collapsed;
+        BusyText.Text = text ?? string.Empty;
+        AddBtn.IsEnabled = !busy && AddBtn.IsEnabled;
+        AddBtn.Visibility = busy ? Visibility.Collapsed : Visibility.Visible;
+        ModeExisting.IsEnabled = !busy;
+        ModeClone.IsEnabled = !busy;
+        UrlBox.IsEnabled = !busy;
+        ParentBox.IsEnabled = !busy;
+        NameBox.IsEnabled = !busy;
+        ExistingPathBox.IsEnabled = !busy;
+        if (busy) { ErrorText.Visibility = Visibility.Collapsed; }
+        else { RefreshAddEnabled(); }
+    }
+
+    private void ShowError(string text)
+    {
+        ErrorText.Text = text;
+        ErrorText.Visibility = Visibility.Visible;
+    }
+
+    private static void TryDeleteDir(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path)) { Directory.Delete(path, recursive: true); }
+        }
+        catch { /* best effort — partially-cloned trees can hold .pack files in use */ }
+    }
+}

--- a/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml.cs
+++ b/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml.cs
@@ -13,6 +13,7 @@ public partial class NewProjectDialog : Window
     private readonly IGitService _git;
     private CancellationTokenSource? _cloneCts;
     private NewProjectResult? _result;
+    private bool _isCloneMode;
 
     private NewProjectDialog(NewProjectRequest req, Func<string?> pickFolder, IGitService git)
     {
@@ -45,11 +46,20 @@ public partial class NewProjectDialog : Window
         return Task.FromResult(ok == true ? dlg._result : null);
     }
 
-    private bool IsCloneMode => ModeClone.IsChecked == true;
+    private bool IsCloneMode => _isCloneMode;
 
-    private void OnModeChanged(object sender, RoutedEventArgs e)
+    private void OnModeExistingClick(object sender, RoutedEventArgs e)
     {
-        if (!IsLoaded) { return; }
+        if (_isCloneMode == false) { return; }
+        _isCloneMode = false;
+        ApplyMode();
+        RefreshAddEnabled();
+    }
+
+    private void OnModeCloneClick(object sender, RoutedEventArgs e)
+    {
+        if (_isCloneMode) { return; }
+        _isCloneMode = true;
         ApplyMode();
         RefreshAddEnabled();
     }
@@ -59,6 +69,11 @@ public partial class NewProjectDialog : Window
         ExistingPanel.Visibility = IsCloneMode ? Visibility.Collapsed : Visibility.Visible;
         ClonePanel.Visibility = IsCloneMode ? Visibility.Visible : Visibility.Collapsed;
         ErrorText.Visibility = Visibility.Collapsed;
+
+        // Drive the segmented-toggle visual via Tag (consumed by NP.SegBtn style triggers).
+        ModeExistingBtn.Tag = IsCloneMode ? null : "active";
+        ModeCloneBtn.Tag = IsCloneMode ? "active" : null;
+
         if (IsCloneMode) { UrlBox.Focus(); } else { /* leave focus alone */ }
     }
 
@@ -121,10 +136,18 @@ public partial class NewProjectDialog : Window
             var nameOk = !string.IsNullOrWhiteSpace(NameBox.Text)
                 && NameBox.Text.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
             AddBtn.IsEnabled = urlOk && parentOk && nameOk;
+
+            // Footer summary — empty values render as "…" placeholders.
+            var url = string.IsNullOrWhiteSpace(UrlBox.Text) ? "…" : UrlBox.Text.Trim();
+            var name = string.IsNullOrWhiteSpace(NameBox.Text) ? "…" : NameBox.Text.Trim();
+            FootMeta.Text = $"git clone · {url} → {name}";
         }
         else
         {
             AddBtn.IsEnabled = !string.IsNullOrWhiteSpace(ExistingPathBox.Text) && Directory.Exists(ExistingPathBox.Text);
+
+            var path = string.IsNullOrWhiteSpace(ExistingPathBox.Text) ? "…" : ExistingPathBox.Text.Trim();
+            FootMeta.Text = $"add project · {path}";
         }
     }
 
@@ -225,11 +248,11 @@ public partial class NewProjectDialog : Window
     private void SetBusy(bool busy, string? text)
     {
         BusyPanel.Visibility = busy ? Visibility.Visible : Visibility.Collapsed;
+        FootMeta.Visibility = busy ? Visibility.Collapsed : Visibility.Visible;
         BusyText.Text = text ?? string.Empty;
-        AddBtn.IsEnabled = !busy && AddBtn.IsEnabled;
         AddBtn.Visibility = busy ? Visibility.Collapsed : Visibility.Visible;
-        ModeExisting.IsEnabled = !busy;
-        ModeClone.IsEnabled = !busy;
+        ModeExistingBtn.IsEnabled = !busy;
+        ModeCloneBtn.IsEnabled = !busy;
         UrlBox.IsEnabled = !busy;
         ParentBox.IsEnabled = !busy;
         NameBox.IsEnabled = !busy;

--- a/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml.cs
+++ b/src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml.cs
@@ -1,7 +1,9 @@
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
 using NoScope.CodeScope.Core;
 using NoScope.CodeScope.Core.Services;
 
@@ -116,7 +118,8 @@ public partial class NewProjectDialog : Window
             || u.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
             || u.StartsWith("ssh://", StringComparison.OrdinalIgnoreCase))
         {
-            return u.Length > 8;
+            var afterScheme = u.IndexOf("://", StringComparison.Ordinal) + 3;
+            return afterScheme < u.Length;
         }
         if (u.StartsWith("git@", StringComparison.OrdinalIgnoreCase))
         {
@@ -132,15 +135,17 @@ public partial class NewProjectDialog : Window
         if (IsCloneMode)
         {
             var urlOk = IsValidGitUrl(UrlBox.Text);
-            var parentOk = !string.IsNullOrWhiteSpace(ParentBox.Text) && Directory.Exists(ParentBox.Text);
-            var nameOk = !string.IsNullOrWhiteSpace(NameBox.Text)
-                && NameBox.Text.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+            var parent = ParentBox.Text?.Trim() ?? string.Empty;
+            var name = NameBox.Text?.Trim() ?? string.Empty;
+            var parentOk = !string.IsNullOrWhiteSpace(parent) && Directory.Exists(parent);
+            var nameOk = !string.IsNullOrWhiteSpace(name)
+                && name.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
             AddBtn.IsEnabled = urlOk && parentOk && nameOk;
 
             // Footer summary — empty values render as "…" placeholders.
-            var url = string.IsNullOrWhiteSpace(UrlBox.Text) ? "…" : UrlBox.Text.Trim();
-            var name = string.IsNullOrWhiteSpace(NameBox.Text) ? "…" : NameBox.Text.Trim();
-            FootMeta.Text = $"git clone · {url} → {name}";
+            var urlDisplay = string.IsNullOrWhiteSpace(UrlBox.Text) ? "…" : UrlBox.Text.Trim();
+            var nameDisplay = string.IsNullOrEmpty(name) ? "…" : name;
+            FootMeta.Text = $"git clone · {urlDisplay} → {nameDisplay}";
         }
         else
         {
@@ -177,7 +182,7 @@ public partial class NewProjectDialog : Window
 
         if (!IsCloneMode)
         {
-            _result = new NewProjectResult(ExistingFolder: ExistingPathBox.Text.Trim(), ClonedPath: null, WasCloned: false);
+            _result = new NewProjectResult(ExistingFolder: ExistingPathBox.Text.Trim(), ClonedPath: null);
             DialogResult = true;
             Close();
             return;
@@ -201,6 +206,14 @@ public partial class NewProjectDialog : Window
         {
             result = await _git.CloneAsync(url, parent, name, _cloneCts.Token).ConfigureAwait(true);
         }
+        catch (OperationCanceledException)
+        {
+            _cloneCts.Dispose();
+            _cloneCts = null;
+            TryDeleteDir(target);
+            SetBusy(false, null);
+            return; // silent return to editable state
+        }
         // Broad catch is intentional: OnAdd is async void (WPF event handler),
         // so an uncaught exception here would crash the AppDomain.
         catch (Exception ex)
@@ -209,13 +222,13 @@ public partial class NewProjectDialog : Window
         }
         finally
         {
-            _cloneCts.Dispose();
+            _cloneCts?.Dispose();
             _cloneCts = null;
         }
 
         if (result.IsSuccess)
         {
-            _result = new NewProjectResult(ExistingFolder: null, ClonedPath: result.Value, WasCloned: true);
+            _result = new NewProjectResult(ExistingFolder: null, ClonedPath: result.Value);
             DialogResult = true;
             Close();
             return;
@@ -242,7 +255,27 @@ public partial class NewProjectDialog : Window
 
     private void OnChromeDrag(object sender, MouseButtonEventArgs e)
     {
-        if (e.ChangedButton == MouseButton.Left) { DragMove(); }
+        if (e.ChangedButton != MouseButton.Left) { return; }
+        if (e.OriginalSource is DependencyObject d && IsInInteractive(d)) { return; }
+        DragMove();
+    }
+
+    private static bool IsInInteractive(DependencyObject node)
+    {
+        for (var cur = node; cur is not null; cur = VisualTreeHelper.GetParent(cur))
+        {
+            if (cur is TextBox or Button or Popup or ListBox or ListBoxItem) { return true; }
+        }
+        return false;
+    }
+
+    protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
+    {
+        if (_cloneCts is { } cts)
+        {
+            try { cts.Cancel(); } catch { }
+        }
+        base.OnClosing(e);
     }
 
     private void SetBusy(bool busy, string? text)

--- a/src/CodeScope.Ui/Dialogs/NewProjectRequest.cs
+++ b/src/CodeScope.Ui/Dialogs/NewProjectRequest.cs
@@ -10,10 +10,12 @@ public sealed record NewProjectRequest(string DefaultCloneParent);
 
 /// <summary>
 /// Result of <see cref="NewProjectDialog"/>. Exactly one of <see cref="ExistingFolder"/>
-/// or <see cref="ClonedPath"/> is non-null. <see cref="WasCloned"/> mirrors that for
-/// callers that want to vary the success-toast wording.
+/// or <see cref="ClonedPath"/> is non-null. <see cref="WasCloned"/> is derived from
+/// <see cref="ClonedPath"/> so callers can vary the success-toast wording.
 /// </summary>
 /// <param name="ExistingFolder">Set when the user picked "Existing folder".</param>
 /// <param name="ClonedPath">Set when the dialog successfully cloned the URL.</param>
-/// <param name="WasCloned">True iff <see cref="ClonedPath"/> is set.</param>
-public sealed record NewProjectResult(string? ExistingFolder, string? ClonedPath, bool WasCloned);
+public sealed record NewProjectResult(string? ExistingFolder, string? ClonedPath)
+{
+    public bool WasCloned => ClonedPath is not null;
+}

--- a/src/CodeScope.Ui/Dialogs/NewProjectRequest.cs
+++ b/src/CodeScope.Ui/Dialogs/NewProjectRequest.cs
@@ -1,0 +1,19 @@
+namespace NoScope.CodeScope.Ui.Dialogs;
+
+/// <summary>
+/// Input envelope for <see cref="NewProjectDialog.PromptAsync(NewProjectRequest, System.Func{string?}, NoScope.CodeScope.Core.Services.IGitService)"/>.
+/// </summary>
+/// <param name="DefaultCloneParent">Folder pre-filled in the "Parent folder" field of the
+/// Clone-from-URL mode. Caller picks: typically the parent of the most-recently-added
+/// project, falling back to <c>%USERPROFILE%\source\repos</c>.</param>
+public sealed record NewProjectRequest(string DefaultCloneParent);
+
+/// <summary>
+/// Result of <see cref="NewProjectDialog"/>. Exactly one of <see cref="ExistingFolder"/>
+/// or <see cref="ClonedPath"/> is non-null. <see cref="WasCloned"/> mirrors that for
+/// callers that want to vary the success-toast wording.
+/// </summary>
+/// <param name="ExistingFolder">Set when the user picked "Existing folder".</param>
+/// <param name="ClonedPath">Set when the dialog successfully cloned the URL.</param>
+/// <param name="WasCloned">True iff <see cref="ClonedPath"/> is set.</param>
+public sealed record NewProjectResult(string? ExistingFolder, string? ClonedPath, bool WasCloned);

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
@@ -49,6 +49,12 @@ public sealed partial class SidebarViewModel
             }
         }
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home) || !System.IO.Directory.Exists(home))
+        {
+            // Locked-down sandboxes / malformed profile env: GetTempPath() always returns
+            // an existing directory, so the dialog never has to deal with a bogus default.
+            return System.IO.Path.GetTempPath();
+        }
         var fallback = System.IO.Path.Combine(home, "source", "repos");
         return System.IO.Directory.Exists(fallback) ? fallback : home;
     }

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.Commands.cs
@@ -1,4 +1,5 @@
 using NoScope.CodeScope.Core.Models;
+using NoScope.CodeScope.Ui.Dialogs;
 using NoScope.CodeScope.Ui.Services;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
@@ -14,10 +15,42 @@ public sealed partial class SidebarViewModel
     [RelayCommand]
     private async Task AddProjectAsync()
     {
-        var folder = _pickFolder();
-        if (string.IsNullOrWhiteSpace(folder)) { return; }
-        var r = await _store.AddProjectAsync(folder, displayName: null).ConfigureAwait(true);
-        if (r.IsFailure) { _logger.LogWarning("AddProject failed: {Error}", r.Error); }
+        var request = new NewProjectRequest(DefaultCloneParent());
+        var picked = await _pickNewProject(request).ConfigureAwait(true);
+        if (picked is null) { return; }
+
+        var path = picked.ExistingFolder ?? picked.ClonedPath;
+        if (string.IsNullOrWhiteSpace(path)) { return; }
+
+        var r = await _store.AddProjectAsync(path, displayName: null).ConfigureAwait(true);
+        if (r.IsFailure)
+        {
+            _logger.LogWarning("AddProject failed: {Error}", r.Error);
+            ErrToast(picked.WasCloned ? "Cloned, but project add failed" : "Add project failed", r.Error);
+            return;
+        }
+
+        if (picked.WasCloned)
+        {
+            Toast("Project cloned", r.Value.Name, ToastSeverity.Ok);
+        }
+    }
+
+    private string DefaultCloneParent()
+    {
+        // Most-recently-added project's parent → user's source-repos folder → home.
+        var recent = _store.Projects.LastOrDefault(p => !string.IsNullOrWhiteSpace(p.Path));
+        if (recent is not null)
+        {
+            var parent = System.IO.Path.GetDirectoryName(recent.Path.TrimEnd('\\', '/'));
+            if (!string.IsNullOrWhiteSpace(parent) && System.IO.Directory.Exists(parent))
+            {
+                return parent;
+            }
+        }
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var fallback = System.IO.Path.Combine(home, "source", "repos");
+        return System.IO.Directory.Exists(fallback) ? fallback : home;
     }
 
     /// <summary>

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
@@ -26,12 +26,14 @@ public sealed partial class SidebarViewModel : ObservableObject
     private readonly ILogger<SidebarViewModel> _logger;
     private readonly Func<string?> _pickFolder;
     private readonly Func<NewWorktreeRequest, NewWorktreeResult?> _pickNewWorktree;
+    private readonly Func<NewProjectRequest, Task<NewProjectResult?>> _pickNewProject;
 
     public SidebarViewModel(
         ISessionStore store,
         ILogger<SidebarViewModel> logger,
         Func<string?>? pickFolder = null,
         Func<NewWorktreeRequest, NewWorktreeResult?>? pickNewWorktree = null,
+        Func<NewProjectRequest, Task<NewProjectResult?>>? pickNewProject = null,
         IPullRequestService? pullRequests = null,
         IToastService? toasts = null,
         IAgentRegistry? agents = null,
@@ -45,6 +47,7 @@ public sealed partial class SidebarViewModel : ObservableObject
         _logger = logger;
         _pickFolder = pickFolder ?? (() => null);
         _pickNewWorktree = pickNewWorktree ?? (_ => null);
+        _pickNewProject = pickNewProject ?? (_ => Task.FromResult<NewProjectResult?>(null));
         Projects = [];
         Projects.CollectionChanged += (_, _) =>
         {

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
@@ -24,14 +24,12 @@ public sealed partial class SidebarViewModel : ObservableObject
     private readonly IAgentRegistry? _agents;
     private readonly IGitService? _git;
     private readonly ILogger<SidebarViewModel> _logger;
-    private readonly Func<string?> _pickFolder;
     private readonly Func<NewWorktreeRequest, NewWorktreeResult?> _pickNewWorktree;
     private readonly Func<NewProjectRequest, Task<NewProjectResult?>> _pickNewProject;
 
     public SidebarViewModel(
         ISessionStore store,
         ILogger<SidebarViewModel> logger,
-        Func<string?>? pickFolder = null,
         Func<NewWorktreeRequest, NewWorktreeResult?>? pickNewWorktree = null,
         Func<NewProjectRequest, Task<NewProjectResult?>>? pickNewProject = null,
         IPullRequestService? pullRequests = null,
@@ -45,7 +43,6 @@ public sealed partial class SidebarViewModel : ObservableObject
         _agents = agents;
         _git = git;
         _logger = logger;
-        _pickFolder = pickFolder ?? (() => null);
         _pickNewWorktree = pickNewWorktree ?? (_ => null);
         _pickNewProject = pickNewProject ?? (_ => Task.FromResult<NewProjectResult?>(null));
         Projects = [];

--- a/tests/CodeScope.Core.Tests/GitServiceCloneTests.cs
+++ b/tests/CodeScope.Core.Tests/GitServiceCloneTests.cs
@@ -1,0 +1,122 @@
+using NoScope.CodeScope.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace NoScope.CodeScope.Core.Tests;
+
+public sealed class GitServiceCloneTests
+{
+    [SkippableFact]
+    public async Task Clone_From_Local_Bare_Repo_Succeeds()
+    {
+        Skip.If(!IsGitOnPath(), "git is not on PATH");
+
+        using var tmp = new TempDir();
+        var src = Path.Combine(tmp.Path, "src.git");
+        await RunGit(tmp.Path, $"init --bare -b main \"{src}\"");
+        // Seed one commit so HEAD resolves after clone.
+        var seed = Path.Combine(tmp.Path, "seed");
+        Directory.CreateDirectory(seed);
+        await RunGit(seed, "init -b main");
+        await RunGit(seed, "config user.email test@test");
+        await RunGit(seed, "config user.name test");
+        await File.WriteAllTextAsync(Path.Combine(seed, "x.txt"), "hi");
+        await RunGit(seed, "add .");
+        await RunGit(seed, "commit -m seed");
+        await RunGit(seed, $"remote add origin \"{src}\"");
+        await RunGit(seed, "push -u origin main");
+
+        var svc = new GitService(NullLogger<GitService>.Instance);
+        var dest = Path.Combine(tmp.Path, "dest");
+        Directory.CreateDirectory(dest);
+
+        var result = await svc.CloneAsync(src, dest, "repo");
+
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : "");
+        result.Value.Should().Be(Path.Combine(dest, "repo"));
+        File.Exists(Path.Combine(result.Value, ".git", "HEAD")).Should().BeTrue();
+        File.Exists(Path.Combine(result.Value, "x.txt")).Should().BeTrue();
+    }
+
+    [SkippableFact]
+    public async Task Clone_Fails_When_Target_Already_Exists_NonEmpty()
+    {
+        Skip.If(!IsGitOnPath(), "git is not on PATH");
+
+        using var tmp = new TempDir();
+        var dest = Path.Combine(tmp.Path, "parent");
+        Directory.CreateDirectory(Path.Combine(dest, "repo"));
+        await File.WriteAllTextAsync(Path.Combine(dest, "repo", "block.txt"), "x");
+
+        var svc = new GitService(NullLogger<GitService>.Instance);
+
+        var result = await svc.CloneAsync("https://example.invalid/x.git", dest, "repo");
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [SkippableFact]
+    public async Task Clone_Fails_For_Garbage_Url()
+    {
+        Skip.If(!IsGitOnPath(), "git is not on PATH");
+
+        using var tmp = new TempDir();
+        var svc = new GitService(NullLogger<GitService>.Instance);
+
+        var result = await svc.CloneAsync("not a url at all", tmp.Path, "repo");
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [SkippableFact]
+    public async Task Clone_With_PreCancelled_Token_Throws_OperationCanceled()
+    {
+        Skip.If(!IsGitOnPath(), "git is not on PATH");
+
+        using var tmp = new TempDir();
+        var svc = new GitService(NullLogger<GitService>.Instance);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Func<Task> act = () => svc.CloneAsync("https://example.invalid/x.git", tmp.Path, "repo", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private static bool IsGitOnPath()
+    {
+        var paths = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+        var exeNames = OperatingSystem.IsWindows() ? new[] { "git.exe", "git.cmd" } : new[] { "git" };
+        return paths.Any(p => exeNames.Any(n => File.Exists(Path.Combine(p, n))));
+    }
+
+    private static async Task RunGit(string cwd, string args)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo("git", args)
+        {
+            WorkingDirectory = cwd,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        using var p = System.Diagnostics.Process.Start(psi)!;
+        await p.WaitForExitAsync();
+        if (p.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"git {args}: {await p.StandardError.ReadToEndAsync()}");
+        }
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"cs-clone-{Guid.NewGuid():N}");
+        public TempDir() => Directory.CreateDirectory(Path);
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an "Add project" dialog with two modes: pick an existing folder (today's behaviour) or clone from a git URL.
- New `IGitService.CloneAsync` shells out to `git clone` and is owned by the dialog.
- Cloning shows an inline indeterminate spinner + "Cloning…" caption; Cancel kills the git process; failures render git's stderr inline so the user can fix and retry without re-typing.

Closes #20.

## Test plan
- [x] `dotnet test CodeScope.sln -c Debug` — full suite green; 4 new `GitServiceCloneTests`.
- [ ] Smoke: existing-folder mode adds a project as before.
- [ ] Smoke: clone-from-URL with a real repo lands and the project appears in the sidebar.
- [ ] Smoke: clone with bad URL surfaces error inline; dialog re-enables and the user can fix and retry.
- [ ] Smoke: cancel during a slow clone returns cleanly; partial target dir cleaned.
- [ ] Smoke: drag-drop folder onto sidebar still works (unchanged path).

Spec: `docs/superpowers/specs/2026-04-29-add-project-from-git-url-design.md`
Plan: `docs/superpowers/plans/2026-04-29-add-project-from-git-url.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)