### PR TITLE
Taskbar overlay badge: green idle / red busy-count (#18)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -7,11 +7,11 @@
 
 **Last updated:** 2026-04-30 (session 25)
 **Branch:** `iconbubbely` (off `main`); taskbar overlay badge feature, rebased onto `main` after #22 + #23 merged. PR #25 open.
-**Head:** see session 25 — head SHA bumps after the rebase + remaining review-fix commits replay.
+**Head:** `51229ee` (will bump after this HANDOFF update commits) — see session 25 below.
 **Release:** `v0.1.0` shipped via GitHub Actions — https://github.com/maui1911/CodeScope/releases/tag/v0.1.0
-**Build status:** ✅ `dotnet build CodeScope.sln` clean. Full solution `dotnet test` ~385 green (Core 233 inc. clone tests; Ui 135 — 129 pre-rebase + 6 new in `MainViewModelTaskbarBadgeTests`; App 17), modulo two known FSWatcher flakes (`ClaudeSessionDiscoveryTests.Callback_Fires_For_Each_New_Jsonl…` and `PiSessionDiscoveryTests.Discovers_New_Session_File_With_Matching_Cwd` — pass in isolation).
-**Uncommitted work:** this HANDOFF entry.
-**Unpushed commits:** `iconbubbely` rebased onto `origin/main`; needs `git push --force-with-lease` after the rebase finishes and tests confirm green. PR #25 will pick up the new tip.
+**Build status:** ✅ `dotnet build CodeScope.sln` clean. Full solution `dotnet test` 385/385 green (Core 233, Ui 135, App 17), modulo two known FSWatcher flakes (`ClaudeSessionDiscoveryTests.Callback_Fires_For_Each_New_Jsonl…` and `PiSessionDiscoveryTests.Discovers_New_Session_File_With_Matching_Cwd` — pass in isolation).
+**Uncommitted work:** this HANDOFF cursor tweak.
+**Unpushed commits:** `iconbubbely` rebased onto `origin/main` (10 commits, all post-`e1ee4ea`); needs `git push --force-with-lease` because the rebase rewrote SHAs. PR #25 will pick up the new tip automatically.
 
 ### Session 25 — taskbar overlay badge (#18, PR #25)
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -5,15 +5,105 @@
 > **Intent:** cursor + last 1–2 sessions in depth, everything else a one-liner.
 > Old detail lives in `git log` — don't duplicate it here.
 
-**Last updated:** 2026-04-29 (session 24)
-**Branch:** `feat/20-clone-from-url` (off `main`); add-project-from-git-url shipped as `f5b39de`.
-**Head:** `f5b39de` — see session 24 below.
+**Last updated:** 2026-04-30 (session 25)
+**Branch:** `iconbubbely` (off `main`); taskbar overlay badge feature, rebased onto `main` after #22 + #23 merged. PR #25 open.
+**Head:** see session 25 — head SHA bumps after the rebase + remaining review-fix commits replay.
 **Release:** `v0.1.0` shipped via GitHub Actions — https://github.com/maui1911/CodeScope/releases/tag/v0.1.0
-**Build status:** ✅ `dotnet build` clean. Full solution `dotnet test` 379/379 (Core 233, Ui 129, App 17), modulo two known FSWatcher flakes (`ClaudeSessionDiscoveryTests.Callback_Fires_For_Each_New_Jsonl…` and `PiSessionDiscoveryTests.Discovers_New_Session_File_With_Matching_Cwd`).
-**Uncommitted work:** none beyond this HANDOFF update.
-**Unpushed commits:** entire `feat/20-clone-from-url` branch — spec + plan + 2 implementation commits + this HANDOFF — no PR opened yet.
+**Build status:** ✅ `dotnet build CodeScope.sln` clean. Full solution `dotnet test` ~385 green (Core 233 inc. clone tests; Ui 135 — 129 pre-rebase + 6 new in `MainViewModelTaskbarBadgeTests`; App 17), modulo two known FSWatcher flakes (`ClaudeSessionDiscoveryTests.Callback_Fires_For_Each_New_Jsonl…` and `PiSessionDiscoveryTests.Discovers_New_Session_File_With_Matching_Cwd` — pass in isolation).
+**Uncommitted work:** this HANDOFF entry.
+**Unpushed commits:** `iconbubbely` rebased onto `origin/main`; needs `git push --force-with-lease` after the rebase finishes and tests confirm green. PR #25 will pick up the new tip.
 
-### Session 24 — Add project from a git URL (#20, shipped in `f5b39de`)
+### Session 25 — taskbar overlay badge (#18, PR #25)
+
+User-visible: the Windows taskbar icon now carries a small overlay that
+reflects aggregate agent activity across the whole app — green dot when ≥1
+agent tab is registered and all idle, red disc with the busy count digit
+otherwise. 10+ busy renders `9` with a small superscript `+` so the badge
+stays one digit wide. No overlay when the workspace has zero agent tabs (or
+only shell tabs). `Description` text is set in parallel for screen readers
+(`"All agents idle"` / `"3 agents working"` / empty). Hand-verified against
+the dev build; user-confirmed the green-idle state and the
+top-right-of-icon position (Windows positions the overlay closest to screen
+content, so a top-of-screen taskbar gets the badge anchored top-right of
+the icon — that placement is Windows-controlled, not configurable).
+
+How:
+
+- New `ITaskbarBadgeService` (UI singleton) owns
+  `Window.TaskbarItemInfo.Overlay` + `.Description` on the active main
+  window. Default impl `TaskbarBadgeService` rasterises a 16×16
+  `BitmapSource` via `DrawingVisual` + `RenderTargetBitmap`: filled disc
+  (radius 7), 1 px contrast ring (radius 7.5, 40 % black) for legibility on
+  light AND dark taskbars, optional centred white digit (Segoe UI Variable,
+  weight 700, em 10) and optional super-scripted "+" (em 6) at top-right.
+  Brushes resolve from theme (`Signal.Ok` / `Signal.Warn`) — same tokens
+  the in-app status dots use; `Brushes.Red` defensive fallback.
+- New `MainViewModel.TaskbarBadge.cs` partial: `BusyAgentCount`,
+  `AgentTabCount` derived properties + private `RecomputeTaskbarBadge`.
+  `IsAgentTab` excludes shell sentinel (case-insensitive); shell-only tabs
+  and soft-closed history rows don't move the badge. The recompute fires
+  from `RaiseStatusBarChanged()` — every per-tab `Status` change and every
+  `Tabs.CollectionChanged` already hits that path, so no new subscriptions.
+  Backing fields initialise to `-1` so the first recompute always fires;
+  subsequent calls early-out via a change flag, so the rasteriser is **not**
+  invoked on token/turn telemetry ticks (fixed in review).
+- DI + XAML wiring in `App.xaml.cs` (singleton registration + ctor arg
+  passthrough to `MainViewModel`) and `MainWindow.xaml` (declares
+  `<TaskbarItemInfo />` once so the property is non-null on first paint).
+
+Files added:
+- `src/CodeScope.Ui/Services/ITaskbarBadgeService.cs`
+- `src/CodeScope.Ui/Services/TaskbarBadgeService.cs`
+- `src/CodeScope.Ui/ViewModels/MainViewModel.TaskbarBadge.cs`
+- `tests/CodeScope.Ui.Tests/MainViewModelTaskbarBadgeTests.cs` — 6 tests:
+  empty workspace, idle agent, 2-busy-of-3, 12-busy raw count, shell
+  exclusion, and a status-flip case that drives the real
+  `HookStatusBarSources → RaiseStatusBarChanged → RecomputeTaskbarBadge`
+  pipeline (not the test bypass). `Apply` rasteriser is hand-verified
+  per project convention (no UI tests).
+
+Files touched:
+- `src/CodeScope.Ui/ViewModels/MainViewModel.cs` — new field + optional
+  `ITaskbarBadgeService? taskbarBadge` ctor param.
+- `src/CodeScope.Ui/ViewModels/MainViewModel.StatusBar.cs` — single
+  `RecomputeTaskbarBadge();` call appended to `RaiseStatusBarChanged()`.
+- `src/CodeScope.App/MainWindow.xaml` — `<ui:FluentWindow.TaskbarItemInfo>`
+  block.
+- `src/CodeScope.App/App.xaml.cs` — singleton registration; new ctor arg
+  on the `MainViewModel` factory.
+
+Spec / plan: `docs/superpowers/specs/2026-04-29-taskbar-overlay-badge-design.md`,
+`docs/superpowers/plans/2026-04-29-taskbar-overlay-badge.md`. Visual mockup
+locked at `scratch/badge-mockup.html` (gitignored — re-render with the
+HTTP-server route in the spec if tweaking the design).
+
+Three review passes (in order), all fed back into the same branch:
+1. Internal review found a perf nit — counts walked `AllTabs` twice per tick
+   and fired `PropertyChanged` on every recompute. Fixed with a single
+   `foreach` and change-only notifications.
+2. `/codex:review` flagged the `StatusFlip_TriggersRecompute` test as
+   verifying the test bypass instead of the production wiring it claimed.
+   Replaced with a version that calls `HookStatusBarSources()` and asserts
+   on the real `PropertyChanged → RaiseStatusBarChanged` pipeline.
+3. GitHub `copilot-pull-request-reviewer` flagged that `Apply()` was firing
+   on every `RaiseStatusBarChanged` tick (incl. token/turn telemetry) even
+   when counts hadn't moved → redundant rasterisation. Fixed by gating
+   `Apply()` behind a change flag inside `RecomputeTaskbarBadge`.
+
+Open follow-ups:
+- **Concern flagged but accepted as design**: `TaskbarBadgeService` resolves
+  `Application.Current.MainWindow` on every call; if the app ever spawns a
+  modal/splash that becomes the foreground window, the badge could be
+  applied to the wrong window. Single-window app today; revisit when adding
+  a real splash screen.
+- **High-DPI `9⁺` legibility** unverified — only exercised at 100 % scaling.
+  If blurry on a 200 %+ taskbar, follow-up is a 32×32 super-sample render
+  (the bitmap stays 16×16 logical; we just render at twice the resolution
+  and let Windows downscale).
+- **Bonus matrix item** (10+ concurrently busy → `9⁺`) not yet hand-tested
+  in production; covered by unit tests but visual-only.
+
+### Session 24 — Add project from a git URL (#20, shipped in `e1ee4ea`)
 
 User-visible: the "Add project" entry-point now opens a `NewProjectDialog`
 with two modes — *Existing folder* (today's behaviour) and *Clone from URL*.
@@ -52,14 +142,6 @@ Files added/touched:
 - `src/CodeScope.Ui/Dialogs/NewProjectDialog.xaml` + `.xaml.cs` (dialog)
 - `src/CodeScope.Ui/ViewModels/SidebarViewModel.cs` + `.Commands.cs` (wiring)
 - `src/CodeScope.App/App.xaml.cs` (registration + named args)
-
-Open follow-ups:
-- Smoke-test the dev build manually before merging the PR — clone a real public
-  repo, a deliberately-bad URL (verify inline error), and a slow clone with
-  Cancel mid-flight (verify partial cleanup). The plan's Task 8 step 5 has the
-  exact recipe.
-- Out of scope (deliberate, can be follow-ups): submodule/shallow/branch options,
-  streaming clone progress (objects/deltas %), credential prompts.
 
 ### Session 23 — pi.dev agent support (committed in `26586d0`)
 

--- a/docs/superpowers/plans/2026-04-29-taskbar-overlay-badge.md
+++ b/docs/superpowers/plans/2026-04-29-taskbar-overlay-badge.md
@@ -1,0 +1,568 @@
+# Taskbar overlay badge — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #18 — show a green dot on the Windows taskbar icon when ≥1 agent tab is registered and all idle, a red badge with the busy-count digit when ≥1 busy, "9⁺" above 9, no overlay when there are no agent tabs.
+
+**Architecture:** Aggregate `TabStatus` across `MainViewModel.AllTabs`, exclude `shell` profile, push the count into a new `ITaskbarBadgeService` which rasterises a 16×16 `BitmapSource` via `DrawingVisual` + `RenderTargetBitmap` and assigns it to `MainWindow.TaskbarItemInfo.Overlay`. Reuses the existing per-tab `Status` `PropertyChanged` plumbing in `MainViewModel.StatusBar.cs` — no new event subscriptions needed.
+
+**Tech Stack:** .NET 10, C# 14, WPF (`System.Windows.Shell.TaskbarItemInfo`, `RenderTargetBitmap`, `DrawingVisual`, `FormattedText`), CommunityToolkit.Mvvm, NSubstitute / xUnit / FluentAssertions for tests.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-taskbar-overlay-badge-design.md`
+
+**File structure**
+
+| Path                                                                      | Action  | Responsibility                                                                                            |
+| ------------------------------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `src/CodeScope.Ui/Services/ITaskbarBadgeService.cs`                       | create  | One-method contract: `void Apply(int busyCount, int agentTabCount);`                                      |
+| `src/CodeScope.Ui/Services/TaskbarBadgeService.cs`                        | create  | WPF rasteriser; sets `MainWindow.TaskbarItemInfo.Overlay` + `Description`                                 |
+| `src/CodeScope.App/MainWindow.xaml`                                       | modify  | Add `<Window.TaskbarItemInfo><TaskbarItemInfo/></Window.TaskbarItemInfo>` once                            |
+| `src/CodeScope.App/App.xaml.cs`                                           | modify  | Register `ITaskbarBadgeService` singleton; pass to `MainViewModel`                                        |
+| `src/CodeScope.Ui/ViewModels/MainViewModel.cs`                            | modify  | Optional ctor param `ITaskbarBadgeService? taskbarBadge`; field `_taskbarBadge`                           |
+| `src/CodeScope.Ui/ViewModels/MainViewModel.TaskbarBadge.cs`               | create  | Partial: `BusyAgentCount`, `AgentTabCount` derived props + `RecomputeTaskbarBadge()`                       |
+| `src/CodeScope.Ui/ViewModels/MainViewModel.StatusBar.cs`                  | modify  | One-line addition inside `RaiseStatusBarChanged` to also call `RecomputeTaskbarBadge()`                    |
+| `tests/CodeScope.Ui.Tests/MainViewModelTaskbarBadgeTests.cs`              | create  | Aggregator unit tests — count logic, shell exclusion, recompute on Status change                          |
+
+---
+
+### Task 1: Service contract and skeleton
+
+**Files:**
+- Create: `src/CodeScope.Ui/Services/ITaskbarBadgeService.cs`
+- Create: `src/CodeScope.Ui/Services/TaskbarBadgeService.cs`
+
+- [ ] **Step 1: Create the interface**
+
+`src/CodeScope.Ui/Services/ITaskbarBadgeService.cs`:
+
+```csharp
+namespace NoScope.CodeScope.Ui.Services;
+
+/// <summary>
+/// Updates the application's taskbar overlay icon to reflect aggregate agent activity.
+/// </summary>
+public interface ITaskbarBadgeService
+{
+    /// <summary>
+    /// Apply a new badge state. The service decides the visual:
+    /// <list type="bullet">
+    ///   <item><c>agentTabCount == 0</c> → no overlay (cleared).</item>
+    ///   <item><c>busyCount == 0 &amp;&amp; agentTabCount &gt; 0</c> → green dot.</item>
+    ///   <item><c>busyCount &gt;= 1</c> → red disc with the busy digit; <c>busyCount &gt; 9</c> renders <c>9⁺</c>.</item>
+    /// </list>
+    /// </summary>
+    void Apply(int busyCount, int agentTabCount);
+}
+```
+
+- [ ] **Step 2: Create the implementation skeleton (no rendering yet)**
+
+`src/CodeScope.Ui/Services/TaskbarBadgeService.cs`:
+
+```csharp
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace NoScope.CodeScope.Ui.Services;
+
+/// <summary>
+/// Default <see cref="ITaskbarBadgeService"/> implementation. Looks up the active
+/// <see cref="Application.MainWindow"/> on each call and assigns
+/// <c>TaskbarItemInfo.Overlay</c> / <c>Description</c>. Rendering is pure WPF —
+/// <see cref="DrawingVisual"/> rasterised via <see cref="RenderTargetBitmap"/>.
+/// </summary>
+public sealed class TaskbarBadgeService : ITaskbarBadgeService
+{
+    public void Apply(int busyCount, int agentTabCount)
+    {
+        var win = Application.Current?.MainWindow;
+        if (win is null) { return; }
+        if (win.TaskbarItemInfo is null) { win.TaskbarItemInfo = new System.Windows.Shell.TaskbarItemInfo(); }
+
+        if (agentTabCount == 0)
+        {
+            win.TaskbarItemInfo.Overlay = null;
+            win.TaskbarItemInfo.Description = string.Empty;
+            return;
+        }
+
+        if (busyCount == 0)
+        {
+            win.TaskbarItemInfo.Overlay = BuildOverlay(digit: null, plus: false, fillKey: "Signal.Ok");
+            win.TaskbarItemInfo.Description = "All agents idle";
+            return;
+        }
+
+        var capped = busyCount > 9 ? "9" : busyCount.ToString();
+        win.TaskbarItemInfo.Overlay = BuildOverlay(digit: capped, plus: busyCount > 9, fillKey: "Signal.Warn");
+        win.TaskbarItemInfo.Description = $"{busyCount} agents working";
+    }
+
+    private static BitmapSource BuildOverlay(string? digit, bool plus, string fillKey)
+    {
+        // Filled in Task 3.
+        var rt = new RenderTargetBitmap(16, 16, 96, 96, PixelFormats.Pbgra32);
+        rt.Freeze();
+        return rt;
+    }
+}
+```
+
+- [ ] **Step 3: Build to verify both files compile**
+
+Run: `dotnet build src/CodeScope.Ui/CodeScope.Ui.csproj -c Debug`
+Expected: PASS, no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/CodeScope.Ui/Services/ITaskbarBadgeService.cs src/CodeScope.Ui/Services/TaskbarBadgeService.cs
+git commit -m "feat(ui): scaffold ITaskbarBadgeService"
+```
+
+---
+
+### Task 2: Aggregator partial on `MainViewModel`
+
+**Files:**
+- Create: `src/CodeScope.Ui/ViewModels/MainViewModel.TaskbarBadge.cs`
+- Modify: `src/CodeScope.Ui/ViewModels/MainViewModel.cs` (ctor + field only)
+- Modify: `src/CodeScope.Ui/ViewModels/MainViewModel.StatusBar.cs` (one extra call)
+
+- [ ] **Step 1: Add the failing test file**
+
+Create `tests/CodeScope.Ui.Tests/MainViewModelTaskbarBadgeTests.cs`:
+
+```csharp
+using FluentAssertions;
+using NoScope.CodeScope.Core.Models;
+using NoScope.CodeScope.Core.Services;
+using NoScope.CodeScope.Ui.Services;
+using NoScope.CodeScope.Ui.ViewModels;
+using NSubstitute;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace NoScope.CodeScope.Ui.Tests;
+
+public sealed class MainViewModelTaskbarBadgeTests
+{
+    [Fact]
+    public void EmptyWorkspace_TriggersClear()
+    {
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        var vm = NewMainViewModel(badge);
+
+        // No tabs added — first refresh fires from ctor / hook setup.
+        vm.RecomputeTaskbarBadgeForTests();
+
+        badge.Received().Apply(0, 0);
+    }
+
+    [Fact]
+    public void IdleAgentTab_GreenSignal()
+    {
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        var vm = NewMainViewModel(badge);
+        vm.Tabs.Add(NewAgentTab("claude", TabStatus.Idle));
+
+        vm.RecomputeTaskbarBadgeForTests();
+
+        badge.Received().Apply(0, 1);
+    }
+
+    [Fact]
+    public void TwoBusyOfThree_RedTwo()
+    {
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        var vm = NewMainViewModel(badge);
+        vm.Tabs.Add(NewAgentTab("claude", TabStatus.Busy));
+        vm.Tabs.Add(NewAgentTab("codex", TabStatus.Busy));
+        vm.Tabs.Add(NewAgentTab("pi", TabStatus.Idle));
+
+        vm.RecomputeTaskbarBadgeForTests();
+
+        badge.Received().Apply(2, 3);
+    }
+
+    [Fact]
+    public void TwelveBusy_RawCountPassedThrough()
+    {
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        var vm = NewMainViewModel(badge);
+        for (var i = 0; i < 12; i++) { vm.Tabs.Add(NewAgentTab("claude", TabStatus.Busy)); }
+
+        vm.RecomputeTaskbarBadgeForTests();
+
+        badge.Received().Apply(12, 12);
+    }
+
+    [Fact]
+    public void ShellTab_NotCounted()
+    {
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        var vm = NewMainViewModel(badge);
+        vm.Tabs.Add(NewAgentTab(MainViewModel.ShellSentinel, TabStatus.Busy));
+        vm.Tabs.Add(NewAgentTab("claude", TabStatus.Idle));
+
+        vm.RecomputeTaskbarBadgeForTests();
+
+        badge.Received().Apply(0, 1);
+    }
+
+    [Fact]
+    public void StatusFlip_TriggersRecompute()
+    {
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        var vm = NewMainViewModel(badge);
+        var tab = NewAgentTab("claude", TabStatus.Idle);
+        vm.Tabs.Add(tab);
+        badge.ClearReceivedCalls();
+
+        tab.Status = TabStatus.Busy;
+
+        badge.Received().Apply(1, 1);
+    }
+
+    private static MainViewModel NewMainViewModel(ITaskbarBadgeService badge)
+    {
+        var sm = Substitute.For<ISessionManager>();
+        var store = Substitute.For<ISessionStore>();
+        var agents = Substitute.For<IAgentRegistry>();
+        agents.GetAll().Returns(Array.Empty<AgentProfile>());
+        var vm = new MainViewModel(
+            sm, store, agents, NullLogger<MainViewModel>.Instance,
+            pickFolder: () => null,
+            taskbarBadge: badge);
+        return vm;
+    }
+
+    private static SessionTabViewModel NewAgentTab(string agentId, TabStatus status)
+    {
+        var desc = new SessionDescriptor(
+            Id: Guid.NewGuid().ToString(),
+            DisplayName: "tab",
+            WorkingDirectory: "C:/work",
+            AgentProfile: agentId == MainViewModel.ShellSentinel
+                ? null
+                : new AgentProfile(Id: agentId, DisplayName: agentId, Command: agentId,
+                    Args: Array.Empty<string>(), ResumeArgs: Array.Empty<string>(),
+                    ResumeByIdArgs: Array.Empty<string>(), SessionIdFlag: null, Icon: null,
+                    ContextWindowTokens: 0));
+        var tab = new SessionTabViewModel(desc) { AgentId = agentId };
+        tab.Status = status;
+        return tab;
+    }
+}
+```
+
+> **Note:** the exact `SessionDescriptor` / `AgentProfile` ctor shapes vary by codebase generation — match the records' current signatures if compiler complains. The test depends only on `agentId` (or null) being attached to the tab so the aggregator can filter.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/CodeScope.Ui.Tests/CodeScope.Ui.Tests.csproj --filter "FullyQualifiedName~MainViewModelTaskbarBadgeTests" -c Debug`
+Expected: FAIL — compile errors (`taskbarBadge` ctor param, `RecomputeTaskbarBadgeForTests` method don't exist yet).
+
+- [ ] **Step 3: Add the partial file with derived properties**
+
+Create `src/CodeScope.Ui/ViewModels/MainViewModel.TaskbarBadge.cs`:
+
+```csharp
+using System.Linq;
+using NoScope.CodeScope.Ui.Services;
+
+namespace NoScope.CodeScope.Ui.ViewModels;
+
+/// <summary>
+/// Window-level aggregation that drives <see cref="ITaskbarBadgeService"/>. Reuses the
+/// existing tab-status hooks in <see cref="MainViewModel"/>.<see cref="HookStatusBarSources"/>;
+/// the call site lives inside <see cref="RaiseStatusBarChanged"/> so we don't subscribe twice
+/// to the same <see cref="SessionTabViewModel.Status"/> events.
+/// </summary>
+public sealed partial class MainViewModel
+{
+    /// <summary>Number of <see cref="AllTabs"/> whose <see cref="SessionTabViewModel.Status"/> is <see cref="TabStatus.Busy"/>, excluding shell tabs.</summary>
+    public int BusyAgentCount => AllTabs.Count(IsAgentBusy);
+
+    /// <summary>Number of <see cref="AllTabs"/> bound to a real agent profile (not shell).</summary>
+    public int AgentTabCount => AllTabs.Count(IsAgentTab);
+
+    private static bool IsAgentTab(SessionTabViewModel t)
+        => !string.IsNullOrEmpty(t.AgentId)
+           && !string.Equals(t.AgentId, ShellSentinel, System.StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAgentBusy(SessionTabViewModel t)
+        => IsAgentTab(t) && t.Status == TabStatus.Busy;
+
+    private void RecomputeTaskbarBadge()
+    {
+        _taskbarBadge?.Apply(BusyAgentCount, AgentTabCount);
+        OnPropertyChanged(nameof(BusyAgentCount));
+        OnPropertyChanged(nameof(AgentTabCount));
+    }
+
+    /// <summary>Test-only entry point — production code reaches the same path through <c>RaiseStatusBarChanged</c>.</summary>
+    internal void RecomputeTaskbarBadgeForTests() => RecomputeTaskbarBadge();
+}
+```
+
+- [ ] **Step 4: Add the field + ctor param to `MainViewModel.cs`**
+
+In `src/CodeScope.Ui/ViewModels/MainViewModel.cs`, add a field below the existing private fields (around line 40):
+
+```csharp
+private readonly ITaskbarBadgeService? _taskbarBadge;
+```
+
+Add a new optional ctor parameter to the existing constructor signature. The current ctor (around line 42) ends with `IIdleToastNotifier? idleNotifier = null)` — append a new optional param after it:
+
+```csharp
+        IIdleToastNotifier? idleNotifier = null,
+        ITaskbarBadgeService? taskbarBadge = null)
+```
+
+Inside the ctor body (after the existing `_idleNotifier = idleNotifier;` line), add:
+
+```csharp
+        _taskbarBadge = taskbarBadge;
+```
+
+- [ ] **Step 5: Wire the recompute call in `MainViewModel.StatusBar.cs`**
+
+Inside `RaiseStatusBarChanged()` (in `src/CodeScope.Ui/ViewModels/MainViewModel.StatusBar.cs`), add a single call at the end (after the last `OnPropertyChanged(...)`):
+
+```csharp
+    private void RaiseStatusBarChanged()
+    {
+        // ... existing OnPropertyChanged calls unchanged ...
+        OnPropertyChanged(nameof(StatusTurnDurationVisible));
+        RecomputeTaskbarBadge();
+    }
+```
+
+> Why here: `HookStatusBarSources` already subscribes to per-tab `Status` `PropertyChanged`, group `Tabs.CollectionChanged`, and `Groups.CollectionChanged`. Every transition that should refresh the badge already fires `RaiseStatusBarChanged`. No new hooks needed.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `dotnet test tests/CodeScope.Ui.Tests/CodeScope.Ui.Tests.csproj --filter "FullyQualifiedName~MainViewModelTaskbarBadgeTests" -c Debug`
+Expected: PASS — six tests green.
+
+> If the `StatusFlip_TriggersRecompute` test fails because `RaiseStatusBarChanged` isn't reachable in unit tests (no Sidebar attached), call `HookStatusBarSources()` once at the top of the test helper after `vm.AttachSidebar(...)`. If `MainViewModel` doesn't expose a public `Sidebar` factory, leave that single test relying on the `RecomputeTaskbarBadgeForTests()` direct call and remove the auto-fire assertion — flag it in the commit message.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/CodeScope.Ui/ViewModels/MainViewModel.TaskbarBadge.cs src/CodeScope.Ui/ViewModels/MainViewModel.cs src/CodeScope.Ui/ViewModels/MainViewModel.StatusBar.cs tests/CodeScope.Ui.Tests/MainViewModelTaskbarBadgeTests.cs
+git commit -m "feat(ui): MainViewModel aggregates BusyAgentCount → ITaskbarBadgeService"
+```
+
+---
+
+### Task 3: Implement the WPF rasteriser
+
+**Files:**
+- Modify: `src/CodeScope.Ui/Services/TaskbarBadgeService.cs`
+
+- [ ] **Step 1: Replace the placeholder `BuildOverlay`**
+
+Replace the body of `TaskbarBadgeService` with the full rendering implementation:
+
+```csharp
+using System.Globalization;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace NoScope.CodeScope.Ui.Services;
+
+public sealed class TaskbarBadgeService : ITaskbarBadgeService
+{
+    public void Apply(int busyCount, int agentTabCount)
+    {
+        var win = Application.Current?.MainWindow;
+        if (win is null) { return; }
+        if (win.TaskbarItemInfo is null) { win.TaskbarItemInfo = new System.Windows.Shell.TaskbarItemInfo(); }
+
+        if (agentTabCount == 0)
+        {
+            win.TaskbarItemInfo.Overlay = null;
+            win.TaskbarItemInfo.Description = string.Empty;
+            return;
+        }
+
+        if (busyCount == 0)
+        {
+            win.TaskbarItemInfo.Overlay = BuildOverlay(digit: null, plus: false, fillKey: "Signal.Ok");
+            win.TaskbarItemInfo.Description = "All agents idle";
+            return;
+        }
+
+        var capped = busyCount > 9 ? "9" : busyCount.ToString(CultureInfo.InvariantCulture);
+        win.TaskbarItemInfo.Overlay = BuildOverlay(digit: capped, plus: busyCount > 9, fillKey: "Signal.Warn");
+        win.TaskbarItemInfo.Description = busyCount == 1 ? "1 agent working" : $"{busyCount} agents working";
+    }
+
+    private static BitmapSource BuildOverlay(string? digit, bool plus, string fillKey)
+    {
+        var fill = (Application.Current?.TryFindResource(fillKey) as Brush) ?? Brushes.Red;
+        var ring = new SolidColorBrush(Color.FromArgb(102, 0, 0, 0)); // ~40% black
+        ring.Freeze();
+
+        var visual = new DrawingVisual();
+        using (var dc = visual.RenderOpen())
+        {
+            // Disc + ring centred at (8,8). Inner radius 7 for the fill, outer 7.5 for a 1 px contrast ring.
+            dc.DrawEllipse(fill, null, new Point(8, 8), 7, 7);
+            dc.DrawEllipse(null, new Pen(ring, 1), new Point(8, 8), 7.5, 7.5);
+
+            if (digit is not null)
+            {
+                var typeface = new Typeface(
+                    new FontFamily("Segoe UI Variable, Segoe UI"),
+                    FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
+
+                var digitText = new FormattedText(
+                    digit,
+                    CultureInfo.InvariantCulture, FlowDirection.LeftToRight,
+                    typeface, emSize: 10, Brushes.White, pixelsPerDip: 1.0)
+                { TextAlignment = TextAlignment.Center };
+
+                // Centre the digit slightly left of (8,8) when "+" is also drawn so the pair reads centred.
+                var dx = plus ? 7.0 : 8.0;
+                var dy = 8.0 - (digitText.Height / 2);
+                dc.DrawText(digitText, new Point(dx, dy));
+
+                if (plus)
+                {
+                    var plusText = new FormattedText(
+                        "+",
+                        CultureInfo.InvariantCulture, FlowDirection.LeftToRight,
+                        typeface, emSize: 6, Brushes.White, pixelsPerDip: 1.0)
+                    { TextAlignment = TextAlignment.Center };
+                    var px = 12.5;
+                    var py = 4.5 - (plusText.Height / 2);
+                    dc.DrawText(plusText, new Point(px, py));
+                }
+            }
+        }
+
+        var rt = new RenderTargetBitmap(16, 16, 96, 96, PixelFormats.Pbgra32);
+        rt.Render(visual);
+        rt.Freeze();
+        return rt;
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `dotnet build src/CodeScope.Ui/CodeScope.Ui.csproj -c Debug`
+Expected: PASS, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/CodeScope.Ui/Services/TaskbarBadgeService.cs
+git commit -m "feat(ui): TaskbarBadgeService renders 16x16 overlay via DrawingVisual"
+```
+
+---
+
+### Task 4: Wire DI + XAML
+
+**Files:**
+- Modify: `src/CodeScope.App/MainWindow.xaml`
+- Modify: `src/CodeScope.App/App.xaml.cs`
+
+- [ ] **Step 1: Declare `TaskbarItemInfo` in MainWindow**
+
+In `src/CodeScope.App/MainWindow.xaml`, immediately after the closing `</ui:FluentWindow.Resources>` tag (or anywhere inside `<ui:FluentWindow>` outside `Resources`), add:
+
+```xml
+    <ui:FluentWindow.TaskbarItemInfo>
+        <TaskbarItemInfo />
+    </ui:FluentWindow.TaskbarItemInfo>
+```
+
+> The element is empty by design — the service mutates `Overlay` / `Description` at runtime. Declaring it once in XAML guarantees `Window.TaskbarItemInfo` is non-null on first paint, so the service's `if (win.TaskbarItemInfo is null) ...` branch only fires for design-time / test scenarios.
+
+- [ ] **Step 2: Register the service in DI**
+
+In `src/CodeScope.App/App.xaml.cs`, add a registration alongside the existing UI singletons (around line 127, near `ISessionViewHostPool`):
+
+```csharp
+                services.AddSingleton<NoScope.CodeScope.Ui.Services.ITaskbarBadgeService,
+                    NoScope.CodeScope.Ui.Services.TaskbarBadgeService>();
+```
+
+In the `MainViewModel` factory just below (around line 152), append the new service to the constructor argument list — the call ends with `sp.GetRequiredService<NoScope.CodeScope.Ui.Services.IIdleToastNotifier>())`. Add a comma after that argument and add:
+
+```csharp
+                        sp.GetRequiredService<NoScope.CodeScope.Ui.Services.ITaskbarBadgeService>());
+```
+
+- [ ] **Step 3: Build the full solution**
+
+Run: `dotnet build CodeScope.sln -c Debug`
+Expected: PASS — solution compiles cleanly.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `dotnet test CodeScope.sln -c Debug`
+Expected: PASS — every existing test plus the six new ones in `MainViewModelTaskbarBadgeTests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/CodeScope.App/MainWindow.xaml src/CodeScope.App/App.xaml.cs
+git commit -m "feat(app): wire TaskbarBadgeService into MainWindow + DI"
+```
+
+---
+
+### Task 5: Hand-verification (no auto-test)
+
+**Files:** none
+
+- [ ] **Step 1: Run the dev build side-by-side**
+
+```pwsh
+$env:CODESCOPE_DEV = "1"
+dotnet run --project src/CodeScope.App
+```
+
+- [ ] **Step 2: Verify the matrix**
+
+Tick each visually against the dev build's taskbar icon:
+
+- Dev build launched with no projects → no overlay.
+- Add a project, start a Claude session → green dot within ~500 ms of first telemetry.
+- Type a prompt that triggers a long response → dot turns red with `1`.
+- Open a second tab in another worktree, start it → red `2`.
+- Let one finish → red `1`.
+- Let both finish → green dot.
+- Close both tabs → no overlay.
+- (Optional) Open ten busy sessions to confirm `9⁺` rendering — readable at 100 % DPI.
+
+If anything misrenders, the most likely culprit is `BuildOverlay` font sizing on a high-DPI display; flag it in HANDOFF as a follow-up rather than blocking ship.
+
+- [ ] **Step 3: Update HANDOFF**
+
+Append a session entry to `docs/HANDOFF.md` describing the new feature, the touched files, the commit SHAs (from Tasks 1–4), and any rough edges discovered during hand-verification.
+
+- [ ] **Step 4: Commit HANDOFF**
+
+```bash
+git add docs/HANDOFF.md
+git commit -m "docs(handoff): taskbar overlay badge shipped"
+```
+
+---
+
+## Open follow-ups (out of scope)
+
+- Per-agent colour coding on the badge (e.g. claude-blue, codex-green) — workspace-wide aggregate is the established direction.
+- Click handler on the overlay — `TaskbarItemInfo.Overlay` does not expose a click event upstream.
+- 32×32 super-sampled render path for 200 %+ taskbars — only if hand-verification flags aliasing.
+- Plural-grammar polish on `Description` for screen readers (`"1 agent working"` vs `"2 agents working"` is already handled, but tests don't cover it).
+

--- a/docs/superpowers/specs/2026-04-29-taskbar-overlay-badge-design.md
+++ b/docs/superpowers/specs/2026-04-29-taskbar-overlay-badge-design.md
@@ -1,0 +1,171 @@
+# Taskbar overlay badge — design
+
+> Issue: [#18](https://github.com/maui1911/CodeScope/issues/18) — "bolletje groen / rood bij taskbar icon"
+> Date: 2026-04-29
+> Status: Draft → ready for plan
+
+## Problem
+
+The CodeScope window can host many parallel agent sessions. When the user
+alt-tabs away or minimises the window, the only signals that an agent is busy
+or has just gone idle are (a) the toast on turn-complete (#16) and (b) the
+in-app status dots — neither visible while the app is buried under other
+windows. The user wants a Teams-style taskbar overlay: red badge with a
+single-digit count of busy agents, green dot when ≥1 agent is registered and
+all are idle, no overlay when there are no agent sessions.
+
+## Behaviour
+
+| Aggregate state                                  | Overlay shown                                  |
+| ------------------------------------------------ | ---------------------------------------------- |
+| 0 agent tabs (only shell tabs, or no tabs)       | none — `TaskbarItemInfo.Overlay = null`        |
+| ≥1 agent tab, all `TabStatus.Idle`               | green dot, no number                           |
+| 1–9 agent tabs `TabStatus.Busy`                  | red dot with the count digit                   |
+| 10+ agent tabs `TabStatus.Busy`                  | red dot with `9` plus a small superscript `+`  |
+
+"Busy" reuses the existing `TabStatus.Busy` rollup — i.e.
+`ClaudeActivityState ∈ { Composing, PendingToolUse }`. Shell sessions and
+soft-closed history rows are not counted; only live tabs whose
+`Descriptor.AgentProfile.Id != "shell"`.
+
+`TaskbarItemInfo.Description` is set in parallel to the overlay and used by
+screen readers / hover tooltips: `"3 agents working"` / `"All agents idle"`
+/ empty.
+
+Updates fire live (no debounce) — the existing in-app dot rollup is already
+push-driven from the same `Status` change events, and the taskbar should
+match that cadence.
+
+## Architecture
+
+### `MainViewModel` aggregator (existing class, three new members)
+
+```csharp
+[ObservableProperty] private int _busyAgentCount;
+[ObservableProperty] private int _agentTabCount;
+
+private void RecomputeTaskbarBadge()
+{
+    var agents = 0;
+    var busy = 0;
+    foreach (var tab in Tabs)
+    {
+        if (tab.Descriptor?.AgentProfile?.Id is null or "shell") continue;
+        agents++;
+        if (tab.Status == TabStatus.Busy) busy++;
+    }
+    AgentTabCount = agents;
+    BusyAgentCount = busy;
+    _taskbarBadge?.Apply(busy, agents);
+}
+```
+
+Triggers (existing wires already exist for the in-app dot rollup):
+- `Tabs.CollectionChanged` (covers add/remove across all editor groups)
+- per-tab `Status` `PropertyChanged`
+- per-tab `Descriptor` change (rare — agent adoption / restore)
+
+No recompute on drag-between-groups: `Tabs` membership is unchanged when
+`MoveTabToGroup` reparents a tab.
+
+### `TaskbarBadgeService` (new, in `CodeScope.Ui.Services`)
+
+```csharp
+public interface ITaskbarBadgeService
+{
+    void Apply(int busyCount, int agentTabCount);
+}
+```
+
+Singleton; resolves the active `MainWindow` lazily via
+`Application.Current.MainWindow`. Sets `MainWindow.TaskbarItemInfo.Overlay`
+and `.Description`.
+
+Three branches:
+
+1. `agentTabCount == 0` → `Overlay = null; Description = ""`.
+2. `agentTabCount > 0 && busyCount == 0` → green dot via
+   `BuildOverlay(digit: null, plus: false, fill: Signal.Ok)`;
+   description `"All agents idle"`.
+3. `busyCount >= 1` → red dot via
+   `BuildOverlay(digit: Math.Min(busyCount, 9).ToString(), plus: busyCount > 9, fill: Signal.Warn)`;
+   description `"{busyCount} agents working"` (plural always — single-agent
+   `"1 agent working"` polish acceptable but not blocking).
+
+`BuildOverlay` is a `DrawingVisual` → `RenderTargetBitmap` rasteriser, 16×16
+at 96 DPI:
+
+- Filled `EllipseGeometry`, centre (8,8), radius 7, brush from theme
+  resource (`Signal.Ok` / `Signal.Warn` — same brushes the in-app dots use).
+- 1 px outer ring at 40 % black for taskbar contrast (centre 8,8, radius 7.5).
+- Digit (when present): `FormattedText`, Segoe UI Variable / Inter, weight
+  700, font size ~10 px, white, centred on (7,8) when `plus`, (8,8) otherwise.
+- Plus (when `plus`): `FormattedText("+")`, weight 700, font size ~6 px,
+  white, anchored at (12.5, 4.5) — top-right superscript inside the disc.
+- `Freeze()` the resulting `BitmapSource` before assignment.
+
+Mockup locked in `scratch/badge-mockup.html` (visual companion screenshot).
+
+If 200 % DPI shows visible aliasing, the follow-up is to render at 32×32 and
+let Windows downscale. Flagged but not blocking — Windows accepts any
+`ImageSource` and 16×16 is the historical contract.
+
+### Wiring
+
+- `App.xaml.cs` — register `ITaskbarBadgeService → TaskbarBadgeService` as
+  a singleton; pass to `MainViewModel` ctor (optional param, like
+  `ISessionViewHostPool`).
+- `MainWindow.xaml` — `<Window.TaskbarItemInfo><TaskbarItemInfo/></Window.TaskbarItemInfo>`.
+- `MainViewModel` — call `RecomputeTaskbarBadge()` from the same handlers
+  that already fire for the in-app dot rollup; no new event subscriptions.
+
+## Tests
+
+`tests/CodeScope.Ui.Tests/MainViewModelTaskbarBadgeTests.cs` — count logic
+only (the rasteriser is hand-verified WPF rendering, consistent with the
+project's "no UI tests" convention):
+
+- 0 agent tabs → `Apply(0, 0)`.
+- 1 agent tab, idle → `Apply(0, 1)`.
+- 3 agent tabs, 2 busy → `Apply(2, 3)`.
+- 12 agent tabs, 12 busy → `Apply(12, 12)` (service decides "9+" — VM passes
+  raw count).
+- Shell-only tab is excluded from `AgentTabCount` and `BusyAgentCount`.
+- Soft-closed history rows are excluded (they are not in `Tabs`).
+- Recompute fires when a tab's `Status` flips from Idle → Busy and back.
+
+`ITaskbarBadgeService` is mocked with NSubstitute; tests assert the
+arguments to `Apply`, not the rendered bitmap.
+
+## Out of scope
+
+- Per-agent colour coding (e.g. claude-blue, codex-green). The badge is a
+  workspace-wide aggregate; per-agent signal is the in-app dots' job.
+- Click handlers on the overlay (e.g. "click red badge → focus first busy
+  tab"). Windows' `TaskbarItemInfo.Overlay` doesn't expose a click event;
+  the user already has the toast (#16) for jump-to-session.
+- Jump-list integration. Separate feature.
+- Sound or tray-icon flash on transitions. Toasts cover this.
+
+## Risks / open items
+
+- **High DPI rendering** — 16×16 source might alias on 200 %+ taskbars.
+  Acceptance criterion: legible on the user's 100 % display; revisit only
+  if hand-test shows blurriness.
+- **Many `Status` change events during a token stream.** The in-app dots
+  already absorb this with no perf issue — same path, same load.
+- **Agent profile id `"shell"` as the exclusion key.** If a future agent
+  profile uses a different "no-agent" sentinel, the rule needs updating.
+  Single source of truth lives in `AgentRegistry.BuildDefaults`.
+
+## Acceptance
+
+- Open CodeScope with no projects → no overlay.
+- Open a project, start a Claude session → green dot appears within ~500 ms
+  of the first telemetry sample.
+- Type a prompt → dot turns red with `1`.
+- Open a second tab, both busy → `2`.
+- One tab finishes → `1`.
+- Both finish → green.
+- Close every tab → no overlay.
+- 10+ busy → `9⁺` (single-digit width, super-script "+").

--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -126,6 +126,8 @@ public partial class App : Application
                 // docs/superpowers/specs/2026-04-26-cross-group-terminal-drag-design.md.
                 services.AddSingleton<NoScope.CodeScope.Ui.Services.ISessionViewHostPool,
                     NoScope.CodeScope.Ui.Services.SessionViewHostPool>();
+                services.AddSingleton<NoScope.CodeScope.Ui.Services.ITaskbarBadgeService,
+                    NoScope.CodeScope.Ui.Services.TaskbarBadgeService>();
                 // Pollers are registered as singletons so the Refresh command can resolve them
                 // from DI; the hosted-service indirection re-uses the same instance.
                 services.AddSingleton<WorktreeStatusPoller>();
@@ -174,7 +176,8 @@ public partial class App : Application
                         sp.GetRequiredService<IOpenCodeSessionDiscovery>(),
                         sp.GetRequiredService<ICopilotTelemetryService>(),
                         sp.GetRequiredService<ICopilotSessionDiscovery>(),
-                        sp.GetRequiredService<NoScope.CodeScope.Ui.Services.IIdleToastNotifier>());
+                        sp.GetRequiredService<NoScope.CodeScope.Ui.Services.IIdleToastNotifier>(),
+                        sp.GetRequiredService<NoScope.CodeScope.Ui.Services.ITaskbarBadgeService>());
                     var sidebar = sp.GetRequiredService<SidebarViewModel>();
                     vm.AttachSidebar(sidebar);
                     var diff = sp.GetRequiredService<DiffPanelViewModel>();

--- a/src/CodeScope.App/MainWindow.xaml
+++ b/src/CodeScope.App/MainWindow.xaml
@@ -79,6 +79,9 @@
         </Style>
     </ui:FluentWindow.Resources>
 
+    <ui:FluentWindow.TaskbarItemInfo>
+        <TaskbarItemInfo />
+    </ui:FluentWindow.TaskbarItemInfo>
 
     <ui:FluentWindow.InputBindings>
         <KeyBinding Key="T" Modifiers="Control" Command="{Binding NewSessionCommand}" />

--- a/src/CodeScope.Ui/Services/ITaskbarBadgeService.cs
+++ b/src/CodeScope.Ui/Services/ITaskbarBadgeService.cs
@@ -10,7 +10,10 @@ public interface ITaskbarBadgeService
     /// <list type="bullet">
     ///   <item><c>agentTabCount == 0</c> → no overlay (cleared).</item>
     ///   <item><c>busyCount == 0 &amp;&amp; agentTabCount &gt; 0</c> → green dot.</item>
-    ///   <item><c>busyCount &gt;= 1</c> → red disc with the busy digit; <c>busyCount &gt; 9</c> renders <c>9⁺</c>.</item>
+    ///   <item>
+    ///     <c>busyCount &gt;= 1</c> → red disc with the busy digit;
+    ///     <c>busyCount &gt; 9</c> renders <c>9⁺</c>.
+    ///   </item>
     /// </list>
     /// </summary>
     void Apply(int busyCount, int agentTabCount);

--- a/src/CodeScope.Ui/Services/ITaskbarBadgeService.cs
+++ b/src/CodeScope.Ui/Services/ITaskbarBadgeService.cs
@@ -1,0 +1,17 @@
+namespace NoScope.CodeScope.Ui.Services;
+
+/// <summary>
+/// Updates the application's taskbar overlay icon to reflect aggregate agent activity.
+/// </summary>
+public interface ITaskbarBadgeService
+{
+    /// <summary>
+    /// Apply a new badge state. The service decides the visual:
+    /// <list type="bullet">
+    ///   <item><c>agentTabCount == 0</c> → no overlay (cleared).</item>
+    ///   <item><c>busyCount == 0 &amp;&amp; agentTabCount &gt; 0</c> → green dot.</item>
+    ///   <item><c>busyCount &gt;= 1</c> → red disc with the busy digit; <c>busyCount &gt; 9</c> renders <c>9⁺</c>.</item>
+    /// </list>
+    /// </summary>
+    void Apply(int busyCount, int agentTabCount);
+}

--- a/src/CodeScope.Ui/Services/TaskbarBadgeService.cs
+++ b/src/CodeScope.Ui/Services/TaskbarBadgeService.cs
@@ -1,0 +1,47 @@
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace NoScope.CodeScope.Ui.Services;
+
+/// <summary>
+/// Default <see cref="ITaskbarBadgeService"/> implementation. Looks up the active
+/// <see cref="Application.MainWindow"/> on each call and assigns
+/// <c>TaskbarItemInfo.Overlay</c> / <c>Description</c>. Rendering is pure WPF —
+/// <see cref="DrawingVisual"/> rasterised via <see cref="RenderTargetBitmap"/>.
+/// </summary>
+public sealed class TaskbarBadgeService : ITaskbarBadgeService
+{
+    public void Apply(int busyCount, int agentTabCount)
+    {
+        var win = Application.Current?.MainWindow;
+        if (win is null) { return; }
+        if (win.TaskbarItemInfo is null) { win.TaskbarItemInfo = new System.Windows.Shell.TaskbarItemInfo(); }
+
+        if (agentTabCount == 0)
+        {
+            win.TaskbarItemInfo.Overlay = null;
+            win.TaskbarItemInfo.Description = string.Empty;
+            return;
+        }
+
+        if (busyCount == 0)
+        {
+            win.TaskbarItemInfo.Overlay = BuildOverlay(digit: null, plus: false, fillKey: "Signal.Ok");
+            win.TaskbarItemInfo.Description = "All agents idle";
+            return;
+        }
+
+        var capped = busyCount > 9 ? "9" : busyCount.ToString();
+        win.TaskbarItemInfo.Overlay = BuildOverlay(digit: capped, plus: busyCount > 9, fillKey: "Signal.Warn");
+        win.TaskbarItemInfo.Description = $"{busyCount} agents working";
+    }
+
+    private static BitmapSource BuildOverlay(string? digit, bool plus, string fillKey)
+    {
+        // Filled in Task 3.
+        var rt = new RenderTargetBitmap(16, 16, 96, 96, PixelFormats.Pbgra32);
+        rt.Freeze();
+        return rt;
+    }
+}

--- a/src/CodeScope.Ui/Services/TaskbarBadgeService.cs
+++ b/src/CodeScope.Ui/Services/TaskbarBadgeService.cs
@@ -1,15 +1,10 @@
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
 namespace NoScope.CodeScope.Ui.Services;
 
-/// <summary>
-/// Default <see cref="ITaskbarBadgeService"/> implementation. Looks up the active
-/// <see cref="Application.MainWindow"/> on each call and assigns
-/// <c>TaskbarItemInfo.Overlay</c> / <c>Description</c>. Rendering is pure WPF —
-/// <see cref="DrawingVisual"/> rasterised via <see cref="RenderTargetBitmap"/>.
-/// </summary>
 public sealed class TaskbarBadgeService : ITaskbarBadgeService
 {
     public void Apply(int busyCount, int agentTabCount)
@@ -32,15 +27,58 @@ public sealed class TaskbarBadgeService : ITaskbarBadgeService
             return;
         }
 
-        var capped = busyCount > 9 ? "9" : busyCount.ToString();
+        var capped = busyCount > 9 ? "9" : busyCount.ToString(CultureInfo.InvariantCulture);
         win.TaskbarItemInfo.Overlay = BuildOverlay(digit: capped, plus: busyCount > 9, fillKey: "Signal.Warn");
-        win.TaskbarItemInfo.Description = $"{busyCount} agents working";
+        win.TaskbarItemInfo.Description = busyCount == 1 ? "1 agent working" : $"{busyCount} agents working";
     }
 
     private static BitmapSource BuildOverlay(string? digit, bool plus, string fillKey)
     {
-        // Filled in Task 3.
+        var fill = (Application.Current?.TryFindResource(fillKey) as Brush) ?? Brushes.Red;
+        var ring = new SolidColorBrush(Color.FromArgb(102, 0, 0, 0)); // ~40% black for taskbar contrast
+        ring.Freeze();
+
+        var visual = new DrawingVisual();
+        using (var dc = visual.RenderOpen())
+        {
+            // Filled disc + 1 px contrast ring centred at (8,8). Inner radius 7 leaves 1 px margin
+            // for the ring (outer radius 7.5) so it sits cleanly inside the 16×16 frame.
+            dc.DrawEllipse(fill, null, new Point(8, 8), 7, 7);
+            dc.DrawEllipse(null, new Pen(ring, 1), new Point(8, 8), 7.5, 7.5);
+
+            if (digit is not null)
+            {
+                var typeface = new Typeface(
+                    new FontFamily("Segoe UI Variable, Segoe UI"),
+                    FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
+
+                var digitText = new FormattedText(
+                    digit,
+                    CultureInfo.InvariantCulture, FlowDirection.LeftToRight,
+                    typeface, emSize: 10, Brushes.White, pixelsPerDip: 1.0)
+                { TextAlignment = TextAlignment.Center };
+
+                // Shift the digit slightly left when "+" is also drawn so the pair reads centred.
+                var dx = plus ? 7.0 : 8.0;
+                var dy = 8.0 - (digitText.Height / 2);
+                dc.DrawText(digitText, new Point(dx, dy));
+
+                if (plus)
+                {
+                    var plusText = new FormattedText(
+                        "+",
+                        CultureInfo.InvariantCulture, FlowDirection.LeftToRight,
+                        typeface, emSize: 6, Brushes.White, pixelsPerDip: 1.0)
+                    { TextAlignment = TextAlignment.Center };
+                    var px = 12.5;
+                    var py = 4.5 - (plusText.Height / 2);
+                    dc.DrawText(plusText, new Point(px, py));
+                }
+            }
+        }
+
         var rt = new RenderTargetBitmap(16, 16, 96, 96, PixelFormats.Pbgra32);
+        rt.Render(visual);
         rt.Freeze();
         return rt;
     }

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.StatusBar.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.StatusBar.cs
@@ -149,6 +149,7 @@ public sealed partial class MainViewModel
         OnPropertyChanged(nameof(StatusTurnsVisible));
         OnPropertyChanged(nameof(StatusTurnDurationText));
         OnPropertyChanged(nameof(StatusTurnDurationVisible));
+        RecomputeTaskbarBadge();
     }
 
     private WorktreeViewModel? ResolveFocusedWorktree()

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.TaskbarBadge.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.TaskbarBadge.cs
@@ -10,8 +10,8 @@ namespace NoScope.CodeScope.Ui.ViewModels;
 /// </summary>
 public sealed partial class MainViewModel
 {
-    private int _busyAgentCount;
-    private int _agentTabCount;
+    private int _busyAgentCount = -1;
+    private int _agentTabCount = -1;
 
     public int BusyAgentCount => _busyAgentCount;
     public int AgentTabCount => _agentTabCount;
@@ -31,18 +31,21 @@ public sealed partial class MainViewModel
             if (tab.Status == TabStatus.Busy) { busy++; }
         }
 
+        var changed = false;
         if (agents != _agentTabCount)
         {
             _agentTabCount = agents;
             OnPropertyChanged(nameof(AgentTabCount));
+            changed = true;
         }
         if (busy != _busyAgentCount)
         {
             _busyAgentCount = busy;
             OnPropertyChanged(nameof(BusyAgentCount));
+            changed = true;
         }
 
-        _taskbarBadge?.Apply(busy, agents);
+        if (changed) { _taskbarBadge?.Apply(busy, agents); }
     }
 
     /// <summary>Test-only entry point — production path runs through <c>RaiseStatusBarChanged</c>.</summary>

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.TaskbarBadge.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.TaskbarBadge.cs
@@ -1,31 +1,48 @@
-using System.Linq;
 using NoScope.CodeScope.Ui.Services;
 
 namespace NoScope.CodeScope.Ui.ViewModels;
 
 /// <summary>
-/// Window-level aggregation that drives <see cref="ITaskbarBadgeService"/>. Reuses the
-/// existing tab-status hooks in <see cref="MainViewModel"/>.<see cref="HookStatusBarSources"/>;
-/// the call site lives inside <see cref="RaiseStatusBarChanged"/> so we don't subscribe twice
-/// to the same <see cref="SessionTabViewModel.Status"/> events.
+/// Window-level aggregation that drives <see cref="ITaskbarBadgeService"/>. The recompute
+/// fires from <see cref="RaiseStatusBarChanged"/>, which already runs on every per-tab
+/// <see cref="SessionTabViewModel.Status"/> change and every <see cref="EditorGroupViewModel.Tabs"/>
+/// mutation — no separate subscription needed.
 /// </summary>
 public sealed partial class MainViewModel
 {
-    public int BusyAgentCount => AllTabs.Count(IsAgentBusy);
-    public int AgentTabCount => AllTabs.Count(IsAgentTab);
+    private int _busyAgentCount;
+    private int _agentTabCount;
+
+    public int BusyAgentCount => _busyAgentCount;
+    public int AgentTabCount => _agentTabCount;
 
     private static bool IsAgentTab(SessionTabViewModel t)
         => !string.IsNullOrEmpty(t.AgentId)
            && !string.Equals(t.AgentId, ShellSentinel, System.StringComparison.OrdinalIgnoreCase);
 
-    private static bool IsAgentBusy(SessionTabViewModel t)
-        => IsAgentTab(t) && t.Status == TabStatus.Busy;
-
     private void RecomputeTaskbarBadge()
     {
-        _taskbarBadge?.Apply(BusyAgentCount, AgentTabCount);
-        OnPropertyChanged(nameof(BusyAgentCount));
-        OnPropertyChanged(nameof(AgentTabCount));
+        var busy = 0;
+        var agents = 0;
+        foreach (var tab in AllTabs)
+        {
+            if (!IsAgentTab(tab)) { continue; }
+            agents++;
+            if (tab.Status == TabStatus.Busy) { busy++; }
+        }
+
+        if (agents != _agentTabCount)
+        {
+            _agentTabCount = agents;
+            OnPropertyChanged(nameof(AgentTabCount));
+        }
+        if (busy != _busyAgentCount)
+        {
+            _busyAgentCount = busy;
+            OnPropertyChanged(nameof(BusyAgentCount));
+        }
+
+        _taskbarBadge?.Apply(busy, agents);
     }
 
     /// <summary>Test-only entry point — production path runs through <c>RaiseStatusBarChanged</c>.</summary>

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.TaskbarBadge.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.TaskbarBadge.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using NoScope.CodeScope.Ui.Services;
+
+namespace NoScope.CodeScope.Ui.ViewModels;
+
+/// <summary>
+/// Window-level aggregation that drives <see cref="ITaskbarBadgeService"/>. Reuses the
+/// existing tab-status hooks in <see cref="MainViewModel"/>.<see cref="HookStatusBarSources"/>;
+/// the call site lives inside <see cref="RaiseStatusBarChanged"/> so we don't subscribe twice
+/// to the same <see cref="SessionTabViewModel.Status"/> events.
+/// </summary>
+public sealed partial class MainViewModel
+{
+    public int BusyAgentCount => AllTabs.Count(IsAgentBusy);
+    public int AgentTabCount => AllTabs.Count(IsAgentTab);
+
+    private static bool IsAgentTab(SessionTabViewModel t)
+        => !string.IsNullOrEmpty(t.AgentId)
+           && !string.Equals(t.AgentId, ShellSentinel, System.StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAgentBusy(SessionTabViewModel t)
+        => IsAgentTab(t) && t.Status == TabStatus.Busy;
+
+    private void RecomputeTaskbarBadge()
+    {
+        _taskbarBadge?.Apply(BusyAgentCount, AgentTabCount);
+        OnPropertyChanged(nameof(BusyAgentCount));
+        OnPropertyChanged(nameof(AgentTabCount));
+    }
+
+    /// <summary>Test-only entry point — production path runs through <c>RaiseStatusBarChanged</c>.</summary>
+    internal void RecomputeTaskbarBadgeForTests() => RecomputeTaskbarBadge();
+}

--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -35,6 +35,7 @@ public sealed partial class MainViewModel : ObservableObject
     private readonly ICopilotTelemetryService? _copilotTelemetry;
     private readonly ICopilotSessionDiscovery? _copilotDiscovery;
     private readonly IIdleToastNotifier? _idleNotifier;
+    private readonly ITaskbarBadgeService? _taskbarBadge;
     private readonly Dictionary<string, ClaudeActivityState> _lastActivity = [];
     // Per-tab discovery watcher — disposed on adoption or tab close.
     private readonly Dictionary<string, IDisposable> _discoveryWatches = [];
@@ -57,7 +58,8 @@ public sealed partial class MainViewModel : ObservableObject
         IOpenCodeSessionDiscovery? opencodeDiscovery = null,
         ICopilotTelemetryService? copilotTelemetry = null,
         ICopilotSessionDiscovery? copilotDiscovery = null,
-        IIdleToastNotifier? idleNotifier = null)
+        IIdleToastNotifier? idleNotifier = null,
+        ITaskbarBadgeService? taskbarBadge = null)
     {
         _sessionManager = sessionManager;
         _store = store;
@@ -76,6 +78,7 @@ public sealed partial class MainViewModel : ObservableObject
         _copilotTelemetry = copilotTelemetry;
         _copilotDiscovery = copilotDiscovery;
         _idleNotifier = idleNotifier;
+        _taskbarBadge = taskbarBadge;
         SessionViewPool = sessionViewPool;
         if (_telemetry is not null) { _telemetry.Updated += OnTelemetryUpdated; }
         // All telemetry backends emit ClaudeSessionTelemetry — same handler routes any source

--- a/tests/CodeScope.Ui.Tests/MainViewModelTaskbarBadgeTests.cs
+++ b/tests/CodeScope.Ui.Tests/MainViewModelTaskbarBadgeTests.cs
@@ -1,0 +1,159 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NoScope.CodeScope.Core.Services;
+using NoScope.CodeScope.Ui.Services;
+using NoScope.CodeScope.Ui.ViewModels;
+
+namespace NoScope.CodeScope.Ui.Tests;
+
+/// <summary>
+/// Unit tests for the <see cref="MainViewModel"/> taskbar-badge aggregation logic.
+/// The production path fires via <see cref="MainViewModel.RaiseStatusBarChanged"/> →
+/// <c>RecomputeTaskbarBadge</c>; tests use the internal
+/// <see cref="MainViewModel.RecomputeTaskbarBadgeForTests"/> bypass so we don't need a
+/// full sidebar/HookStatusBarSources wiring.
+/// </summary>
+public sealed class MainViewModelTaskbarBadgeTests
+{
+    // ──── Helpers ────────────────────────────────────────────────────────────
+
+    private static SessionDescriptor MakeDescriptor(string id = "s1") =>
+        new()
+        {
+            Id = id,
+            WorkingDirectory = @"C:\repo",
+            Shell = "pwsh.exe",
+            ShellArgs = [],
+            Title = id,
+        };
+
+    /// <summary>
+    /// Creates an agent tab (non-empty, non-"shell" AgentId).
+    /// </summary>
+    private static SessionTabViewModel AgentTab(string agentId = "claude", string id = "s1", TabStatus status = TabStatus.Idle) =>
+        new(MakeDescriptor(id), projectId: null, agentId: agentId, displayNameOverride: agentId)
+        {
+            Status = status,
+        };
+
+    /// <summary>
+    /// Creates a shell tab (null AgentId — same as a plain shell session).
+    /// </summary>
+    private static SessionTabViewModel ShellTab(string id = "shell1", TabStatus status = TabStatus.Idle) =>
+        new(MakeDescriptor(id), projectId: null, agentId: null, displayNameOverride: "shell")
+        {
+            Status = status,
+        };
+
+    private static MainViewModel MakeVm(ITaskbarBadgeService badge, params SessionTabViewModel[] tabs)
+    {
+        var store = Substitute.For<ISessionStore>();
+        store.Projects.Returns([]);
+
+        var manager = Substitute.For<ISessionManager>();
+        var agents = Substitute.For<IAgentRegistry>();
+        agents.GetAll().Returns([]);
+
+        var vm = new MainViewModel(
+            manager,
+            store,
+            agents,
+            NullLogger<MainViewModel>.Instance,
+            pickFolder: () => null,
+            taskbarBadge: badge);
+
+        foreach (var t in tabs)
+        {
+            vm.Tabs.Add(t);
+        }
+
+        return vm;
+    }
+
+    // ──── Tests ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EmptyWorkspace_TriggersClear()
+    {
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        var vm = MakeVm(badge);
+
+        vm.RecomputeTaskbarBadgeForTests();
+
+        badge.Received(1).Apply(0, 0);
+    }
+
+    [Fact]
+    public void IdleAgentTab_GreenSignal()
+    {
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        var vm = MakeVm(badge, AgentTab(status: TabStatus.Idle));
+
+        vm.RecomputeTaskbarBadgeForTests();
+
+        badge.Received(1).Apply(0, 1);
+    }
+
+    [Fact]
+    public void TwoBusyOfThree_RedTwo()
+    {
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        var vm = MakeVm(badge,
+            AgentTab("claude", "s1", TabStatus.Busy),
+            AgentTab("codex",  "s2", TabStatus.Busy),
+            AgentTab("pi",     "s3", TabStatus.Idle));
+
+        vm.RecomputeTaskbarBadgeForTests();
+
+        badge.Received(1).Apply(2, 3);
+    }
+
+    [Fact]
+    public void TwelveBusy_RawCountPassedThrough()
+    {
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        var tabs = Enumerable.Range(1, 12)
+                             .Select(i => AgentTab("claude", $"s{i}", TabStatus.Busy))
+                             .ToArray();
+        var vm = MakeVm(badge, tabs);
+
+        vm.RecomputeTaskbarBadgeForTests();
+
+        // Cap is the service's responsibility, not the VM's — raw counts are forwarded.
+        badge.Received(1).Apply(12, 12);
+    }
+
+    [Fact]
+    public void ShellTab_NotCounted()
+    {
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        // A shell tab that is Busy must not increment either count.
+        var vm = MakeVm(badge,
+            ShellTab("shell1", TabStatus.Busy),
+            AgentTab("claude", "s1", TabStatus.Idle));
+
+        vm.RecomputeTaskbarBadgeForTests();
+
+        badge.Received(1).Apply(0, 1);
+    }
+
+    [Fact]
+    public void StatusFlip_TriggersRecompute()
+    {
+        // NOTE: This test manually calls RecomputeTaskbarBadgeForTests() instead of relying on
+        // the HookStatusBarSources/PropertyChanged pipeline. The production wiring fires via
+        // RaiseStatusBarChanged (which is only hooked after HookStatusBarSources is called from
+        // MainWindow.Loaded), so in a unit test without a real sidebar we drive recompute directly.
+        // The production wiring is covered by the existing StatusBar integration hooks.
+        var badge = Substitute.For<ITaskbarBadgeService>();
+        var tab = AgentTab("claude", "s1", TabStatus.Idle);
+        var vm = MakeVm(badge, tab);
+
+        vm.RecomputeTaskbarBadgeForTests();
+        badge.Received(1).Apply(0, 1);
+
+        tab.Status = TabStatus.Busy;
+        vm.RecomputeTaskbarBadgeForTests();
+
+        badge.Received(1).Apply(1, 1);
+    }
+}

--- a/tests/CodeScope.Ui.Tests/MainViewModelTaskbarBadgeTests.cs
+++ b/tests/CodeScope.Ui.Tests/MainViewModelTaskbarBadgeTests.cs
@@ -7,10 +7,10 @@ namespace NoScope.CodeScope.Ui.Tests;
 
 /// <summary>
 /// Unit tests for the <see cref="MainViewModel"/> taskbar-badge aggregation logic.
-/// The production path fires via <see cref="MainViewModel.RaiseStatusBarChanged"/> →
-/// <c>RecomputeTaskbarBadge</c>; tests use the internal
-/// <see cref="MainViewModel.RecomputeTaskbarBadgeForTests"/> bypass so we don't need a
-/// full sidebar/HookStatusBarSources wiring.
+/// Most cases drive recompute directly via <c>RecomputeTaskbarBadgeForTests</c> to keep
+/// the count assertions tight; <see cref="StatusFlip_TriggersRecompute_ViaProductionHook"/>
+/// exercises the real <see cref="MainViewModel.HookStatusBarSources"/> →
+/// <c>RaiseStatusBarChanged</c> → <c>RecomputeTaskbarBadge</c> wiring end-to-end.
 /// </summary>
 public sealed class MainViewModelTaskbarBadgeTests
 {
@@ -29,7 +29,10 @@ public sealed class MainViewModelTaskbarBadgeTests
     /// <summary>
     /// Creates an agent tab (non-empty, non-"shell" AgentId).
     /// </summary>
-    private static SessionTabViewModel AgentTab(string agentId = "claude", string id = "s1", TabStatus status = TabStatus.Idle) =>
+    private static SessionTabViewModel AgentTab(
+        string agentId = "claude",
+        string id = "s1",
+        TabStatus status = TabStatus.Idle) =>
         new(MakeDescriptor(id), projectId: null, agentId: agentId, displayNameOverride: agentId)
         {
             Status = status,
@@ -137,23 +140,20 @@ public sealed class MainViewModelTaskbarBadgeTests
     }
 
     [Fact]
-    public void StatusFlip_TriggersRecompute()
+    public void StatusFlip_TriggersRecompute_ViaProductionHook()
     {
-        // NOTE: This test manually calls RecomputeTaskbarBadgeForTests() instead of relying on
-        // the HookStatusBarSources/PropertyChanged pipeline. The production wiring fires via
-        // RaiseStatusBarChanged (which is only hooked after HookStatusBarSources is called from
-        // MainWindow.Loaded), so in a unit test without a real sidebar we drive recompute directly.
-        // The production wiring is covered by the existing StatusBar integration hooks.
+        // Drives the same path as production: HookStatusBarSources subscribes to per-tab
+        // Status PropertyChanged; flipping Status fires RaiseStatusBarChanged which calls
+        // RecomputeTaskbarBadge. Sidebar isn't needed — that branch in HookStatusBarSources
+        // is gated by `Sidebar is not null`.
         var badge = Substitute.For<ITaskbarBadgeService>();
         var tab = AgentTab("claude", "s1", TabStatus.Idle);
         var vm = MakeVm(badge, tab);
-
-        vm.RecomputeTaskbarBadgeForTests();
-        badge.Received(1).Apply(0, 1);
+        vm.HookStatusBarSources();
+        badge.ClearReceivedCalls();
 
         tab.Status = TabStatus.Busy;
-        vm.RecomputeTaskbarBadgeForTests();
 
-        badge.Received(1).Apply(1, 1);
+        badge.Received().Apply(1, 1);
     }
 }


### PR DESCRIPTION
## Summary

- Adds a Windows taskbar overlay icon that aggregates per-tab `TabStatus` across the whole app: green dot when ≥1 agent tab is registered and all idle, red disc with the busy-count digit otherwise. 10+ busy renders `9` plus a small superscript `+` so the badge stays one digit wide. No overlay when there are zero agent tabs (or only shell tabs). `TaskbarItemInfo.Description` is set in parallel for screen readers / hover tooltips (`"All agents idle"` / `"3 agents working"` / empty).
- Reuses the existing `Signal.Ok` / `Signal.Warn` brushes the in-app status dots already use, no new design tokens.
- Pushes the count from `MainViewModel` (new `BusyAgentCount` / `AgentTabCount` derived properties, single-pass tab walk that only fires `PropertyChanged` on actual change) into a new `ITaskbarBadgeService` UI singleton; the rasteriser is a `DrawingVisual` → `RenderTargetBitmap` 16×16 bitmap with a filled disc, 1 px contrast ring, and Segoe UI Variable Bold digit/super-script.
- Recompute is wired into the existing `RaiseStatusBarChanged()` path — every per-tab `Status` change and every `Tabs.CollectionChanged` already hits it, so no new event subscriptions.

Spec: `docs/superpowers/specs/2026-04-29-taskbar-overlay-badge-design.md`
Plan: `docs/superpowers/plans/2026-04-29-taskbar-overlay-badge.md`

Closes #18.

## Test plan

- [x] `dotnet build CodeScope.sln -c Debug` — clean
- [x] `dotnet test CodeScope.sln -c Debug` — 381/381 green (Core 229, Ui 135 incl. 6 new in `MainViewModelTaskbarBadgeTests`, App 17)
- [x] Hand-verified against the dev build (`CODESCOPE_DEV=1`): no overlay with no projects, green dot when one Claude tab is idle.
- [ ] (Acceptance bonus) 10+ concurrently-busy sessions to confirm `9⁺` rendering at 100 % DPI — not exercised yet, low risk; flagged in HANDOFF as a follow-up if blurry on a high-DPI taskbar.

## Notes

- Windows controls overlay placement (always on the corner of the taskbar tile that points to screen content). User-confirmed: with the taskbar pinned at the top of the screen, the badge correctly anchors top-right of the tile. Customising the corner would require replacing `MainWindow.Icon` dynamically — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)