### PR TITLE
fix: kill entire process tree on tab close + fix conpty.dll glob (#26)

### DIFF
--- a/src/CodeScope.App/CodeScope.App.csproj
+++ b/src/CodeScope.App/CodeScope.App.csproj
@@ -43,7 +43,7 @@
         both `dotnet build` and `dotnet publish` drop it beside CodeScope.exe.
     -->
     <ItemGroup>
-        <Content Include="$(NuGetPackageRoot)ci.microsoft.windows.console.conpty\*\runtimes\win10-x64\native\conpty.dll">
+        <Content Include="$(NuGetPackageRoot)\ci.microsoft.windows.console.conpty\*\runtimes\win10-x64\native\conpty.dll">
             <Link>conpty.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
@@ -235,6 +235,18 @@ public partial class SessionTabView : UserControl
         var term = Terminal.DisconnectConPTYTerm();
         try { term?.CloseStdinToApp(); }
         catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[SessionTabView] Teardown CloseStdin: {ex.Message}"); }
+        // Kill the entire process tree (pwsh + agent child) instead of just the direct child.
+        // StopExternalTermOnly() calls Process.Kill() without EntireProcessTree, which leaves
+        // the agent (claude, copilot, etc.) alive as an orphan. We use the Process property
+        // directly to kill the tree, then fall through to StopExternalTermOnly for cleanup.
+        try
+        {
+            if (term?.Process is { HasExited: false } proc)
+            {
+                proc.Kill(EntireProcessTree: true);
+            }
+        }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[SessionTabView] Teardown KillTree: {ex.Message}"); }
         try { term?.StopExternalTermOnly(); }
         catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[SessionTabView] Teardown StopExternal: {ex.Message}"); }
         _started = false;


### PR DESCRIPTION
Fixes #26

**Two fixes:**

1. **Process tree kill on tab close** — `SessionTabView.Teardown()` now calls `Process.Kill(EntireProcessTree: true)` before `StopExternalTermOnly()`. Previously only `StopExternalTermOnly()` was called, which uses `Kill()` without `EntireProcessTree` — this killed pwsh but could leave the agent child process alive as an orphan.

2. **conpty.dll glob path** — added backslash separator between `$(NuGetPackageRoot)` and the package name in `CodeScope.App.csproj`. Without it, a custom NuGet root without trailing slash (e.g. `D:\packages\nuget`) produced an invalid path and conpty.dll was never copied to the output dir — every terminal tab died instantly with `DllNotFoundException`.

**Tests:** 385/385 green (no test changes needed — teardown is UI-layer, validated by manual smoke test with dev build).