### PR TITLE
perf: hard-cap visible error toasts + stable CI ids (#34)

### DIFF
--- a/src/CodeScope.App/CodeScope.App.csproj
+++ b/src/CodeScope.App/CodeScope.App.csproj
@@ -34,6 +34,10 @@
         <ProjectReference Include="..\CodeScope.Ui\CodeScope.Ui.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="CodeScope.App.Tests" />
+    </ItemGroup>
+
     <!--
         conpty.dll ships under runtimes/win10-x64/native in the Ci.Microsoft.Windows.Console.ConPTY
         package. The package only publishes win10-* RID assets and .NET 10 no longer falls back

--- a/src/CodeScope.App/Toasts/ToastService.cs
+++ b/src/CodeScope.App/Toasts/ToastService.cs
@@ -17,18 +17,49 @@ public sealed class ToastService : IToastService
     /// <summary>Bottom-up, newest-first stack. Cap matches spec §04 "max 3 visible".</summary>
     private const int MaxVisible = 3;
 
+    /// <summary>
+    /// Hard cap on visible error toasts. Errors are persistent (no auto-dismiss) so a
+    /// recurring poller-driven failure (e.g. <c>gh</c> not on PATH, FS-watcher race) can
+    /// stack VMs + their associated commands until the user dismisses each one manually.
+    /// Beyond this cap we drop the oldest visible error to keep the visible stack and
+    /// command-list bounded — the user still sees the latest <c>MaxVisibleErr</c> errors.
+    /// Issue #34. The first defence remains stable <c>Id</c>-dedupe at every poller call
+    /// site; this is the safety net for unstable-id stragglers.
+    /// </summary>
+    private const int MaxVisibleErr = 20;
+
     public ObservableCollection<ToastItemViewModel> Items { get; } = [];
 
     public void Show(ToastRequest request)
     {
         var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher is null) { return; }
-        if (!dispatcher.CheckAccess())
+        if (dispatcher is not null && !dispatcher.CheckAccess())
         {
             dispatcher.BeginInvoke(() => Show(request));
             return;
         }
 
+        ShowCore(request);
+    }
+
+    public void Dismiss(string id)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is not null && !dispatcher.CheckAccess())
+        {
+            dispatcher.BeginInvoke(() => Dismiss(id));
+            return;
+        }
+
+        DismissCore(id);
+    }
+
+    /// <summary>
+    /// Dispatcher-bound mutation of <see cref="Items"/>. Split out from <see cref="Show"/>
+    /// so tests can drive the cap/dedupe logic without spinning up a WPF dispatcher.
+    /// </summary>
+    internal void ShowCore(ToastRequest request)
+    {
         var duration = request.Duration ?? DefaultDuration(request.Severity);
 
         // De-dupe by id — same id within visible lifetime replaces in place. Kills the
@@ -48,9 +79,6 @@ public sealed class ToastService : IToastService
 
         // Cap at MaxVisible BUT errors never auto-fold (spec §04 "errors never fold")
         // — count only non-error toasts against the cap and only evict from that pool.
-        // If everything visible is an error and the user keeps stacking errors, we let
-        // the stack grow past MaxVisible so the user sees them all rather than silently
-        // dropping the oldest critical message on the floor.
         while (Items.Count(i => i.Severity != ToastSeverity.Err) > MaxVisible)
         {
             var victim = Items.FirstOrDefault(i => i.Severity != ToastSeverity.Err);
@@ -58,18 +86,19 @@ public sealed class ToastService : IToastService
             victim.StopTimer();
             Items.Remove(victim);
         }
+
+        // Hard cap on persistent error toasts (issue #34) — drop oldest beyond MaxVisibleErr.
+        while (Items.Count(i => i.Severity == ToastSeverity.Err) > MaxVisibleErr)
+        {
+            var victim = Items.FirstOrDefault(i => i.Severity == ToastSeverity.Err);
+            if (victim is null) { break; }
+            victim.StopTimer();
+            Items.Remove(victim);
+        }
     }
 
-    public void Dismiss(string id)
+    internal void DismissCore(string id)
     {
-        var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher is null) { return; }
-        if (!dispatcher.CheckAccess())
-        {
-            dispatcher.BeginInvoke(() => Dismiss(id));
-            return;
-        }
-
         var match = Items.FirstOrDefault(i => i.Id == id);
         if (match is null) { return; }
         match.StopTimer();

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.StoreSync.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.StoreSync.cs
@@ -187,9 +187,11 @@ public sealed partial class SidebarViewModel
         if (previous is null || pr is null || previous.CiStatus == pr.CiStatus) { return; }
 
         var label = pvm is not null ? $"{pvm.Name} · {wvm.DisplayBranch}" : wvm.DisplayBranch;
-        // Stable id keyed on worktree+PR so a flapping CI replaces the existing toast in
-        // place rather than stacking — see #34.
-        var ciId = $"ci-{worktreeId}-{pr.Number}";
+        // Stable id keyed on project+worktree+PR so a flapping CI replaces the existing
+        // toast in place rather than stacking. projectId is required because Worktree.Id
+        // ("primary" for every project's primary) is not globally unique — without it,
+        // CI toasts from different projects sharing a PR number would clobber each other.
+        var ciId = $"ci-{projectId}-{worktreeId}-{pr.Number}";
         switch (pr.CiStatus)
         {
             case CiStatus.Success:

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.StoreSync.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.StoreSync.cs
@@ -187,13 +187,16 @@ public sealed partial class SidebarViewModel
         if (previous is null || pr is null || previous.CiStatus == pr.CiStatus) { return; }
 
         var label = pvm is not null ? $"{pvm.Name} · {wvm.DisplayBranch}" : wvm.DisplayBranch;
+        // Stable id keyed on worktree+PR so a flapping CI replaces the existing toast in
+        // place rather than stacking — see #34.
+        var ciId = $"ci-{worktreeId}-{pr.Number}";
         switch (pr.CiStatus)
         {
             case CiStatus.Success:
-                Toast($"CI passed on #{pr.Number}", label, ToastSeverity.Ok);
+                Toast($"CI passed on #{pr.Number}", label, ToastSeverity.Ok, id: ciId);
                 break;
             case CiStatus.Failure:
-                Toast($"CI failed on #{pr.Number}", label, ToastSeverity.Err);
+                Toast($"CI failed on #{pr.Number}", label, ToastSeverity.Err, id: ciId);
                 break;
         }
     }

--- a/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/SidebarViewModel.cs
@@ -108,10 +108,10 @@ public sealed partial class SidebarViewModel : ObservableObject
     /// </summary>
     public Func<string, string, Task<Func<Task>>>? CloseWorktreeSessionsAsync { get; set; }
 
-    private void Toast(string title, string message, ToastSeverity severity)
+    private void Toast(string title, string message, ToastSeverity severity, string? id = null)
     {
         if (_toasts is null) { return; }
-        _toasts.Show(new ToastRequest(severity, title, message));
+        _toasts.Show(new ToastRequest(severity, title, message, Id: id));
     }
 
     /// <summary>

--- a/tests/CodeScope.App.Tests/ToastServiceTests.cs
+++ b/tests/CodeScope.App.Tests/ToastServiceTests.cs
@@ -22,8 +22,8 @@ public sealed class ToastServiceTests
         }
 
         svc.Items.Count(i => i.Severity == ToastSeverity.Info).Should().Be(3);
-        // Oldest dropped, newest retained — last three indices survive.
-        svc.Items.Select(i => i.Title).Should().BeEquivalentTo(["Info 2", "Info 3", "Info 4"]);
+        // Oldest dropped, newest retained — last three indices survive, in insertion order.
+        svc.Items.Select(i => i.Title).Should().Equal("Info 2", "Info 3", "Info 4");
     }
 
     [Fact]
@@ -37,8 +37,8 @@ public sealed class ToastServiceTests
         }
 
         svc.Items.Count.Should().Be(20);
-        // Oldest 5 dropped; 5..24 retained.
-        svc.Items.Select(i => i.Title).Should().BeEquivalentTo(
+        // Oldest 5 dropped; 5..24 retained, in insertion order.
+        svc.Items.Select(i => i.Title).Should().Equal(
             Enumerable.Range(5, 20).Select(i => $"Err {i}"));
     }
 

--- a/tests/CodeScope.App.Tests/ToastServiceTests.cs
+++ b/tests/CodeScope.App.Tests/ToastServiceTests.cs
@@ -1,0 +1,82 @@
+using NoScope.CodeScope.App.Toasts;
+using NoScope.CodeScope.Ui.Services;
+
+namespace NoScope.CodeScope.App.Tests;
+
+/// <summary>
+/// Drives <see cref="ToastService.ShowCore"/> directly so tests don't need a WPF
+/// dispatcher. Covers the two caps (non-error visible cap + persistent-error hard cap)
+/// and the id-dedupe contract that prevents poller-driven retries from stacking.
+/// Issue #34.
+/// </summary>
+public sealed class ToastServiceTests
+{
+    [Fact]
+    public void NonErrorToasts_AreCappedAtThree()
+    {
+        var svc = new ToastService();
+
+        for (var i = 0; i < 5; i++)
+        {
+            svc.ShowCore(new ToastRequest(ToastSeverity.Info, $"Info {i}", null));
+        }
+
+        svc.Items.Count(i => i.Severity == ToastSeverity.Info).Should().Be(3);
+        // Oldest dropped, newest retained — last three indices survive.
+        svc.Items.Select(i => i.Title).Should().BeEquivalentTo(["Info 2", "Info 3", "Info 4"]);
+    }
+
+    [Fact]
+    public void ErrorToasts_AreCappedHardAtTwenty()
+    {
+        var svc = new ToastService();
+
+        for (var i = 0; i < 25; i++)
+        {
+            svc.ShowCore(new ToastRequest(ToastSeverity.Err, $"Err {i}", null));
+        }
+
+        svc.Items.Count.Should().Be(20);
+        // Oldest 5 dropped; 5..24 retained.
+        svc.Items.Select(i => i.Title).Should().BeEquivalentTo(
+            Enumerable.Range(5, 20).Select(i => $"Err {i}"));
+    }
+
+    [Fact]
+    public void StableIdReplacesExistingErrorInPlace_SoCapNeverHits()
+    {
+        var svc = new ToastService();
+
+        for (var i = 0; i < 100; i++)
+        {
+            svc.ShowCore(new ToastRequest(
+                ToastSeverity.Err,
+                $"Poll #{i}",
+                "gh not found",
+                Id: "gh-missing"));
+        }
+
+        svc.Items.Should().HaveCount(1);
+        svc.Items[0].Title.Should().Be("Poll #99");
+    }
+
+    [Fact]
+    public void NonErrorAndErrorCaps_AreIndependent()
+    {
+        var svc = new ToastService();
+
+        // 30 errors → trimmed to 20.
+        for (var i = 0; i < 30; i++)
+        {
+            svc.ShowCore(new ToastRequest(ToastSeverity.Err, $"Err {i}", null));
+        }
+        // Then 5 infos → trimmed to 3.
+        for (var i = 0; i < 5; i++)
+        {
+            svc.ShowCore(new ToastRequest(ToastSeverity.Info, $"Info {i}", null));
+        }
+
+        svc.Items.Count(i => i.Severity == ToastSeverity.Err).Should().Be(20);
+        svc.Items.Count(i => i.Severity == ToastSeverity.Info).Should().Be(3);
+    }
+}


### PR DESCRIPTION
## Summary

Error toasts use `Timeout.InfiniteTimeSpan`, so a recurring poller-driven failure (e.g. \`gh\` not on PATH) could stack persistent toast VMs + their commands until each was manually dismissed.

Two complementary changes:

1. **Hard cap on visible errors (20)** in \`ToastService\` — beyond that the oldest visible error is dropped so the visible stack and command list stay bounded. Non-error cap (3, spec §04) is unchanged.
2. **Stable CI toast id** \`ci-<worktree>-<pr#>\` in \`SidebarViewModel.ApplyPullRequest\` — a flapping CI now replaces the existing toast in place rather than stacking on every state transition.

\`Show\`/\`Dismiss\` are split into thin dispatcher-marshalling shells over \`ShowCore\`/\`DismissCore\` so the cap/dedupe logic is unit-testable without a WPF dispatcher; \`InternalsVisibleTo\` wired for \`CodeScope.App.Tests\`.

Fixes #34.

## Audit notes

Other Err call sites are user-action driven (Pull, Rebase, Discard, Rename, etc.) — they fire once per click and the existing id-replace path already handles spammed clicks. \`WorktreeStatusPoller\` already uses \`Id: \"prune-{worktreeId}\"\` (#34's example). The CI-toast call site was the remaining poller-driven Err with no Id; now fixed.

## Test plan

- [x] \`ToastServiceTests.NonErrorToasts_AreCappedAtThree\`
- [x] \`ToastServiceTests.ErrorToasts_AreCappedHardAtTwenty\`
- [x] \`ToastServiceTests.StableIdReplacesExistingErrorInPlace_SoCapNeverHits\` — drives 100 same-id errors, only one survives
- [x] \`ToastServiceTests.NonErrorAndErrorCaps_AreIndependent\`
- [x] Full suite: 401/401 with the documented FSWatcher flake noted in \`HANDOFF.md\` (passes in isolation, unrelated)