### PR TITLE
perf: pause idle telemetry poll timers + OpenCode locate TTL (#36)

### DIFF
--- a/src/CodeScope.Core/Services/ClaudeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/ClaudeTelemetryService.cs
@@ -34,7 +34,8 @@ public sealed class ClaudeTelemetryService : IClaudeTelemetryService
         {
             // Start paused — RefreshTimerArmed() arms it on the first Register and disarms
             // it on the last Unregister, so an idle CodeScope (no agent sessions) doesn't
-            // burn 4×/sec across the four telemetry services for nothing. Issue #36.
+            // burn ~4 callbacks/sec per service (~15/sec across the four telemetry services
+            // combined: 3×250 ms + 1×350 ms) for nothing. Issue #36.
             _pollTimer = new Timer(_ => PollAll(), null, Timeout.Infinite, Timeout.Infinite);
         }
     }

--- a/src/CodeScope.Core/Services/ClaudeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/ClaudeTelemetryService.cs
@@ -15,6 +15,8 @@ public sealed class ClaudeTelemetryService : IClaudeTelemetryService
     private readonly string _projectsRoot;
     private readonly ConcurrentDictionary<string, Watch> _watches = new();
     private readonly Timer? _pollTimer;
+    private readonly object _timerLock = new();
+    private bool _timerArmed;
 
     public ClaudeTelemetryService(ILogger<ClaudeTelemetryService> logger)
         : this(logger, DefaultProjectsRoot(), enablePolling: true) { }
@@ -30,7 +32,10 @@ public sealed class ClaudeTelemetryService : IClaudeTelemetryService
         _projectsRoot = projectsRoot;
         if (enablePolling)
         {
-            _pollTimer = new Timer(_ => PollAll(), null, PollInterval, PollInterval);
+            // Start paused — RefreshTimerArmed() arms it on the first Register and disarms
+            // it on the last Unregister, so an idle CodeScope (no agent sessions) doesn't
+            // burn 4×/sec across the four telemetry services for nothing. Issue #36.
+            _pollTimer = new Timer(_ => PollAll(), null, Timeout.Infinite, Timeout.Infinite);
         }
     }
 
@@ -66,11 +71,37 @@ public sealed class ClaudeTelemetryService : IClaudeTelemetryService
 
         // Replay anything already on disk.
         TryRead(watch);
+
+        RefreshTimerArmed();
     }
 
     public void Unregister(string sessionId)
     {
         if (_watches.TryRemove(sessionId, out var watch)) { watch.Dispose(); }
+        RefreshTimerArmed();
+    }
+
+    /// <summary>
+    /// Arms the poll timer when at least one watch is registered, disarms it otherwise.
+    /// Prevents the 250 ms callback from firing continuously on an idle CodeScope.
+    /// </summary>
+    private void RefreshTimerArmed()
+    {
+        if (_pollTimer is null) { return; }
+        lock (_timerLock)
+        {
+            var shouldBeArmed = !_watches.IsEmpty;
+            if (shouldBeArmed == _timerArmed) { return; }
+            _pollTimer.Change(
+                shouldBeArmed ? PollInterval : Timeout.InfiniteTimeSpan,
+                shouldBeArmed ? PollInterval : Timeout.InfiniteTimeSpan);
+            _timerArmed = shouldBeArmed;
+        }
+    }
+
+    internal bool IsPollTimerArmedForTest
+    {
+        get { lock (_timerLock) { return _timerArmed; } }
     }
 
     public ClaudeSessionTelemetry? GetSnapshot(string sessionId) =>

--- a/src/CodeScope.Core/Services/CopilotTelemetryService.cs
+++ b/src/CodeScope.Core/Services/CopilotTelemetryService.cs
@@ -12,6 +12,8 @@ public sealed class CopilotTelemetryService : ICopilotTelemetryService
     private readonly string _sessionStateRoot;
     private readonly ConcurrentDictionary<string, Watch> _watches = new();
     private readonly Timer? _pollTimer;
+    private readonly object _timerLock = new();
+    private bool _timerArmed;
     private FileSystemWatcher? _rootWatcher;
 
     public CopilotTelemetryService(ILogger<CopilotTelemetryService> logger)
@@ -28,7 +30,8 @@ public sealed class CopilotTelemetryService : ICopilotTelemetryService
         _sessionStateRoot = sessionStateRoot;
         if (enablePolling)
         {
-            _pollTimer = new Timer(_ => PollAll(), null, PollInterval, PollInterval);
+            // Start paused — armed on first Register, disarmed on last Unregister. Issue #36.
+            _pollTimer = new Timer(_ => PollAll(), null, Timeout.Infinite, Timeout.Infinite);
         }
 
         // Single recursive watcher across the whole session-state root. Copilot creates
@@ -68,11 +71,33 @@ public sealed class CopilotTelemetryService : ICopilotTelemetryService
         {
             TryRead(watch);
         }
+
+        RefreshTimerArmed();
     }
 
     public void Unregister(string sessionId)
     {
         if (_watches.TryRemove(sessionId, out var watch)) { watch.Dispose(); }
+        RefreshTimerArmed();
+    }
+
+    private void RefreshTimerArmed()
+    {
+        if (_pollTimer is null) { return; }
+        lock (_timerLock)
+        {
+            var shouldBeArmed = !_watches.IsEmpty;
+            if (shouldBeArmed == _timerArmed) { return; }
+            _pollTimer.Change(
+                shouldBeArmed ? PollInterval : Timeout.InfiniteTimeSpan,
+                shouldBeArmed ? PollInterval : Timeout.InfiniteTimeSpan);
+            _timerArmed = shouldBeArmed;
+        }
+    }
+
+    internal bool IsPollTimerArmedForTest
+    {
+        get { lock (_timerLock) { return _timerArmed; } }
     }
 
     public ClaudeSessionTelemetry? GetSnapshot(string sessionId) =>

--- a/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
@@ -8,10 +8,20 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
 {
     private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(350);
 
+    /// <summary>
+    /// How long to skip the recursive <see cref="TryLocateMessageDir"/> scan after a
+    /// "not found" result. Without this, every poll (350 ms) re-runs a recursive
+    /// directory walk over the entire opencode data root for sessions whose message dir
+    /// hasn't materialised yet — visible CPU on warm sessions. Issue #36.
+    /// </summary>
+    private static readonly TimeSpan LocateNotFoundTtl = TimeSpan.FromSeconds(2);
+
     private readonly ILogger<OpenCodeTelemetryService> _logger;
     private readonly string _dataRoot;
     private readonly ConcurrentDictionary<string, Watch> _watches = new();
     private readonly Timer? _pollTimer;
+    private readonly object _timerLock = new();
+    private bool _timerArmed;
     private FileSystemWatcher? _rootWatcher;
 
     public OpenCodeTelemetryService(ILogger<OpenCodeTelemetryService> logger)
@@ -28,7 +38,8 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
         _dataRoot = dataRoot;
         if (enablePolling)
         {
-            _pollTimer = new Timer(_ => PollAll(), null, PollInterval, PollInterval);
+            // Start paused — armed on first Register, disarmed on last Unregister. Issue #36.
+            _pollTimer = new Timer(_ => PollAll(), null, Timeout.Infinite, Timeout.Infinite);
         }
 
         try
@@ -61,12 +72,35 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
         _watches[sessionId] = watch;
 
         watch.MessageDir = TryLocateMessageDir(sessionId);
+        if (watch.MessageDir is null) { watch.LastLocateMissAt = DateTimeOffset.UtcNow; }
         Recompute(watch);
+
+        RefreshTimerArmed();
     }
 
     public void Unregister(string sessionId)
     {
         if (_watches.TryRemove(sessionId, out var watch)) { watch.Dispose(); }
+        RefreshTimerArmed();
+    }
+
+    private void RefreshTimerArmed()
+    {
+        if (_pollTimer is null) { return; }
+        lock (_timerLock)
+        {
+            var shouldBeArmed = !_watches.IsEmpty;
+            if (shouldBeArmed == _timerArmed) { return; }
+            _pollTimer.Change(
+                shouldBeArmed ? PollInterval : Timeout.InfiniteTimeSpan,
+                shouldBeArmed ? PollInterval : Timeout.InfiniteTimeSpan);
+            _timerArmed = shouldBeArmed;
+        }
+    }
+
+    internal bool IsPollTimerArmedForTest
+    {
+        get { lock (_timerLock) { return _timerArmed; } }
     }
 
     public ClaudeSessionTelemetry? GetSnapshot(string sessionId) =>
@@ -102,14 +136,27 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
 
     private void PollAll()
     {
+        var now = DateTimeOffset.UtcNow;
         foreach (var watch in _watches.Values)
         {
             try
             {
                 if (watch.MessageDir is null)
                 {
+                    // Throttle the recursive scan — the directory only appears once opencode
+                    // writes its first message file, and a 350 ms recursive walk over the
+                    // entire data root every tick is wasteful. Issue #36.
+                    if (watch.LastLocateMissAt is { } missedAt && now - missedAt < LocateNotFoundTtl)
+                    {
+                        continue;
+                    }
                     watch.MessageDir = TryLocateMessageDir(watch.SessionId);
-                    if (watch.MessageDir is null) { continue; }
+                    if (watch.MessageDir is null)
+                    {
+                        watch.LastLocateMissAt = now;
+                        continue;
+                    }
+                    watch.LastLocateMissAt = null;
                 }
                 Recompute(watch);
             }
@@ -232,6 +279,7 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
     {
         public string SessionId { get; } = sessionId;
         public string? MessageDir { get; set; }
+        public DateTimeOffset? LastLocateMissAt { get; set; }
         public readonly HashSet<string> SeenFiles = new(StringComparer.OrdinalIgnoreCase);
         public readonly List<OpenCodeMessageEntry> Entries = [];
         public ClaudeSessionTelemetry? Snapshot;

--- a/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
@@ -72,7 +72,12 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
         _watches[sessionId] = watch;
 
         watch.MessageDir = TryLocateMessageDir(sessionId);
-        if (watch.MessageDir is null) { watch.LastLocateMissAt = DateTimeOffset.UtcNow; }
+        if (watch.MessageDir is null)
+        {
+            // Atomic 8-byte write — Register and PollAll both touch this field, so a plain
+            // DateTimeOffset? assignment would race (the struct is >8 bytes, not atomic).
+            Interlocked.Exchange(ref watch.LastLocateMissAtTicks, DateTimeOffset.UtcNow.UtcTicks);
+        }
         Recompute(watch);
 
         RefreshTimerArmed();
@@ -146,17 +151,18 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
                     // Throttle the recursive scan — the directory only appears once opencode
                     // writes its first message file, and a 350 ms recursive walk over the
                     // entire data root every tick is wasteful. Issue #36.
-                    if (watch.LastLocateMissAt is { } missedAt && now - missedAt < LocateNotFoundTtl)
+                    var missTicks = Interlocked.Read(ref watch.LastLocateMissAtTicks);
+                    if (missTicks != 0 && now.UtcTicks - missTicks < LocateNotFoundTtl.Ticks)
                     {
                         continue;
                     }
                     watch.MessageDir = TryLocateMessageDir(watch.SessionId);
                     if (watch.MessageDir is null)
                     {
-                        watch.LastLocateMissAt = now;
+                        Interlocked.Exchange(ref watch.LastLocateMissAtTicks, now.UtcTicks);
                         continue;
                     }
-                    watch.LastLocateMissAt = null;
+                    Interlocked.Exchange(ref watch.LastLocateMissAtTicks, 0);
                 }
                 Recompute(watch);
             }
@@ -279,7 +285,10 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
     {
         public string SessionId { get; } = sessionId;
         public string? MessageDir { get; set; }
-        public DateTimeOffset? LastLocateMissAt { get; set; }
+        // UTC ticks of the last failed TryLocateMessageDir attempt; 0 = never missed.
+        // Stored as a long so Register and PollAll can write/read atomically via
+        // Interlocked operations (DateTimeOffset? is >8 bytes and not torn-read safe).
+        public long LastLocateMissAtTicks;
         public readonly HashSet<string> SeenFiles = new(StringComparer.OrdinalIgnoreCase);
         public readonly List<OpenCodeMessageEntry> Entries = [];
         public ClaudeSessionTelemetry? Snapshot;

--- a/src/CodeScope.Core/Services/PiTelemetryService.cs
+++ b/src/CodeScope.Core/Services/PiTelemetryService.cs
@@ -12,6 +12,8 @@ public sealed class PiTelemetryService : IPiTelemetryService
     private readonly string _sessionsRoot;
     private readonly ConcurrentDictionary<string, Watch> _watches = new();
     private readonly Timer? _pollTimer;
+    private readonly object _timerLock = new();
+    private bool _timerArmed;
     private FileSystemWatcher? _rootWatcher;
 
     public PiTelemetryService(ILogger<PiTelemetryService> logger)
@@ -28,7 +30,8 @@ public sealed class PiTelemetryService : IPiTelemetryService
         _sessionsRoot = sessionsRoot;
         if (enablePolling)
         {
-            _pollTimer = new Timer(_ => PollAll(), null, PollInterval, PollInterval);
+            // Start paused — armed on first Register, disarmed on last Unregister. Issue #36.
+            _pollTimer = new Timer(_ => PollAll(), null, Timeout.Infinite, Timeout.Infinite);
         }
 
         // Single recursive watcher across the whole sessions root: cheaper than one per
@@ -73,11 +76,33 @@ public sealed class PiTelemetryService : IPiTelemetryService
             watch.FilePath = existing;
             TryRead(watch);
         }
+
+        RefreshTimerArmed();
     }
 
     public void Unregister(string sessionId)
     {
         if (_watches.TryRemove(sessionId, out var watch)) { watch.Dispose(); }
+        RefreshTimerArmed();
+    }
+
+    private void RefreshTimerArmed()
+    {
+        if (_pollTimer is null) { return; }
+        lock (_timerLock)
+        {
+            var shouldBeArmed = !_watches.IsEmpty;
+            if (shouldBeArmed == _timerArmed) { return; }
+            _pollTimer.Change(
+                shouldBeArmed ? PollInterval : Timeout.InfiniteTimeSpan,
+                shouldBeArmed ? PollInterval : Timeout.InfiniteTimeSpan);
+            _timerArmed = shouldBeArmed;
+        }
+    }
+
+    internal bool IsPollTimerArmedForTest
+    {
+        get { lock (_timerLock) { return _timerArmed; } }
     }
 
     public ClaudeSessionTelemetry? GetSnapshot(string sessionId) =>

--- a/tests/CodeScope.Core.Tests/TelemetryTimerArmingTests.cs
+++ b/tests/CodeScope.Core.Tests/TelemetryTimerArmingTests.cs
@@ -1,0 +1,89 @@
+using NoScope.CodeScope.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace NoScope.CodeScope.Core.Tests;
+
+/// <summary>
+/// Verifies the four telemetry services pause their poll timer when no watches are
+/// registered and re-arm it on the first <c>Register</c>. Without this, an idle
+/// CodeScope (no agent sessions) burns ~8 timer callbacks/sec across the four
+/// services for nothing. Issue #36.
+/// </summary>
+public sealed class TelemetryTimerArmingTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "cs-tel-arm-" + Guid.NewGuid().ToString("n"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void Claude_Timer_Disarmed_Until_First_Register()
+    {
+        using var svc = new ClaudeTelemetryService(NullLogger<ClaudeTelemetryService>.Instance, _root, enablePolling: true);
+        svc.IsPollTimerArmedForTest.Should().BeFalse();
+
+        svc.Register("a", @"C:\dev\a");
+        svc.IsPollTimerArmedForTest.Should().BeTrue();
+
+        svc.Register("b", @"C:\dev\b");
+        svc.IsPollTimerArmedForTest.Should().BeTrue();
+
+        svc.Unregister("a");
+        svc.IsPollTimerArmedForTest.Should().BeTrue();
+
+        svc.Unregister("b");
+        svc.IsPollTimerArmedForTest.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Pi_Timer_Disarmed_Until_First_Register()
+    {
+        using var svc = new PiTelemetryService(NullLogger<PiTelemetryService>.Instance, _root, enablePolling: true);
+        svc.IsPollTimerArmedForTest.Should().BeFalse();
+
+        svc.Register("a", @"C:\dev\a");
+        svc.IsPollTimerArmedForTest.Should().BeTrue();
+
+        svc.Unregister("a");
+        svc.IsPollTimerArmedForTest.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Copilot_Timer_Disarmed_Until_First_Register()
+    {
+        using var svc = new CopilotTelemetryService(NullLogger<CopilotTelemetryService>.Instance, _root, enablePolling: true);
+        svc.IsPollTimerArmedForTest.Should().BeFalse();
+
+        svc.Register("a", @"C:\dev\a");
+        svc.IsPollTimerArmedForTest.Should().BeTrue();
+
+        svc.Unregister("a");
+        svc.IsPollTimerArmedForTest.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OpenCode_Timer_Disarmed_Until_First_Register()
+    {
+        using var svc = new OpenCodeTelemetryService(NullLogger<OpenCodeTelemetryService>.Instance, _root, enablePolling: true);
+        svc.IsPollTimerArmedForTest.Should().BeFalse();
+
+        svc.Register("a", @"C:\dev\a");
+        svc.IsPollTimerArmedForTest.Should().BeTrue();
+
+        svc.Unregister("a");
+        svc.IsPollTimerArmedForTest.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Disabled_Polling_Stays_Disarmed_Forever()
+    {
+        // Test-seam constructor (enablePolling=false) — no timer at all, so the arming
+        // flag stays false through Register/Unregister. Existing telemetry tests rely on this.
+        using var svc = new ClaudeTelemetryService(NullLogger<ClaudeTelemetryService>.Instance, _root);
+        svc.IsPollTimerArmedForTest.Should().BeFalse();
+        svc.Register("a", @"C:\dev\a");
+        svc.IsPollTimerArmedForTest.Should().BeFalse();
+    }
+}

--- a/tests/CodeScope.Core.Tests/TelemetryTimerArmingTests.cs
+++ b/tests/CodeScope.Core.Tests/TelemetryTimerArmingTests.cs
@@ -6,8 +6,8 @@ namespace NoScope.CodeScope.Core.Tests;
 /// <summary>
 /// Verifies the four telemetry services pause their poll timer when no watches are
 /// registered and re-arm it on the first <c>Register</c>. Without this, an idle
-/// CodeScope (no agent sessions) burns ~8 timer callbacks/sec across the four
-/// services for nothing. Issue #36.
+/// CodeScope (no agent sessions) burns ~4 callbacks/sec per service — ~15/sec across
+/// the four (3×250 ms + 1×350 ms) — for nothing. Issue #36.
 /// </summary>
 public sealed class TelemetryTimerArmingTests : IDisposable
 {


### PR DESCRIPTION
## Summary

Four telemetry services (Claude / Pi / OpenCode / Copilot) each fired a 250–350 ms \`System.Threading.Timer\` for process lifetime — ~8 idle callbacks/sec across the suite with zero agent sessions registered. Now:

- Each timer starts paused (\`Timeout.Infinite\`) at construction.
- A new private \`RefreshTimerArmed()\` arms it on the first \`Register\` and disarms it when the last \`Unregister\` empties \`_watches\`. Lock + change-only flag avoid redundant \`Timer.Change\` calls under concurrent register/unregister.
- **OpenCode bonus**: \`TryLocateMessageDir\` does a recursive \`Directory.EnumerateDirectories\` over the entire data root every poll for unsettled sessions. Added a 2 s "not found" TTL so the recursive scan only re-runs every 2 s instead of every 350 ms while the message directory is materialising.

## Discovery services — checked, no change needed

#36 mentions discovery services as having the same pattern. They don't: each \`Watch(...)\` call creates its own \`Timer\` inside the returned \`WatchHandle\` and disposes it with the handle. With zero active watches there are zero timers. Only the four telemetry services had the always-on root timer.

Fixes #36.

## Test plan

- [x] \`TelemetryTimerArmingTests.Claude_Timer_Disarmed_Until_First_Register\` (and matching tests for Pi / Copilot / OpenCode) — covers the disarmed→armed→still-armed→disarmed transitions through Register/Unregister.
- [x] \`TelemetryTimerArmingTests.Disabled_Polling_Stays_Disarmed_Forever\` — guards the \`enablePolling: false\` test-seam constructor used by the existing tests.
- [x] All existing telemetry tests still green (they use \`enablePolling: false\` so they never depended on the timer).
- [x] Full suite: 400/400 with the documented FSWatcher flakes noted in \`HANDOFF.md\`.