### PR TITLE
perf: OpenCode telemetry running aggregates (#31)

### DIFF
--- a/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
@@ -193,11 +193,32 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
 
     private void Recompute(Watch watch)
     {
-        if (watch.MessageDir is null || !Directory.Exists(watch.MessageDir)) { return; }
+        if (watch.MessageDir is null) { return; }
+        DirectoryInfo dirInfo;
+        try { dirInfo = new DirectoryInfo(watch.MessageDir); }
+        catch (Exception ex)
+        {
+            _logger.LogTrace(ex, "OpenCode telemetry: dir stat failed for {Path}", watch.MessageDir);
+            return;
+        }
+        if (!dirInfo.Exists) { return; }
+        var dirMtime = dirInfo.LastWriteTimeUtc;
+
         lock (watch.ReadLock)
         {
             try
             {
+                // Quiet-tick short-circuit: OpenCode bumps the directory's mtime whenever a new
+                // message file is created. If the directory's mtime hasn't moved since our last
+                // walk AND we already produced a snapshot, there can't be anything new to parse.
+                // Skips the per-tick `EnumerateFiles` + per-file `FileInfo` syscalls on idle
+                // sessions (the dominant case). Capture the mtime BEFORE the walk so a file
+                // that lands between this check and our enumerate is still picked up next tick.
+                if (dirMtime <= watch.LastWalkedDirMtime && watch.Snapshot is not null)
+                {
+                    return;
+                }
+
                 // OpenCode never modifies a message file once written, so each file is parsed at
                 // most once. Files are filtered by mtime against a watermark; same-tick siblings
                 // are disambiguated by a tiny set holding only files at the watermark instant.
@@ -258,6 +279,11 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
                     }
                     anyNewParsed = true;
                 }
+
+                // Record the dir mtime captured before the walk — next tick can short-circuit
+                // unless the dir has changed again. Done unconditionally (even when the walk
+                // produced nothing new) so a "no-change" tick still updates the bar.
+                watch.LastWalkedDirMtime = dirMtime;
 
                 if (watch.LastEntry is null) { return; }
                 if (!anyNewParsed && watch.Snapshot is not null) { return; }
@@ -341,6 +367,10 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
         // tick — vanishingly small in practice.
         public DateTime MtimeWatermark = DateTime.MinValue;
         public readonly HashSet<string> SeenAtWatermark = new(StringComparer.OrdinalIgnoreCase);
+
+        // Directory mtime captured at the start of the most recent successful Recompute walk.
+        // Used to short-circuit subsequent quiet-tick walks when no new file has appeared.
+        public DateTime LastWalkedDirMtime = DateTime.MinValue;
 
         // Running aggregates — replaces the per-file Entries list. Each candidate is the entry
         // with the largest metadata.time.created within its slice (overall / role=user /

--- a/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
@@ -198,34 +198,76 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
         {
             try
             {
-                // OpenCode never modifies a message file once written — files are appended to the
-                // directory only. So we only parse files we haven't seen yet, then re-aggregate
-                // the in-memory entry list to derive the snapshot.
+                // OpenCode never modifies a message file once written, so each file is parsed at
+                // most once. Files are filtered by mtime against a watermark; same-tick siblings
+                // are disambiguated by a tiny set holding only files at the watermark instant.
+                // No per-message retention — three running aggregates cover the whole snapshot:
+                // last-by-CreatedAt overall (activity FSM), last user (turn duration), last
+                // assistant-with-usage (tokens + model + lastTurnAt). Issue #31.
+                var anyNewParsed = false;
                 foreach (var file in Directory.EnumerateFiles(watch.MessageDir, "msg_*.json"))
                 {
-                    if (watch.SeenFiles.Contains(file)) { continue; }
+                    FileInfo info;
+                    try { info = new FileInfo(file); }
+                    catch (Exception ex)
+                    {
+                        _logger.LogTrace(ex, "OpenCode telemetry: stat failed for {Path}", file);
+                        continue;
+                    }
+                    if (!info.Exists) { continue; }
+
+                    var lwt = info.LastWriteTimeUtc;
+                    if (lwt < watch.MtimeWatermark) { continue; }
+                    if (lwt == watch.MtimeWatermark && watch.SeenAtWatermark.Contains(file)) { continue; }
+
                     string content;
                     try { content = File.ReadAllText(file); }
                     catch (IOException) { continue; } // mid-write race — pick it up next poll
+
                     var entry = OpenCodeMessageParser.ParseContent(content);
                     if (entry is null) { continue; }
-                    watch.SeenFiles.Add(file);
-                    watch.Entries.Add(entry);
+
+                    if (lwt > watch.MtimeWatermark)
+                    {
+                        watch.MtimeWatermark = lwt;
+                        watch.SeenAtWatermark.Clear();
+                    }
+                    watch.SeenAtWatermark.Add(file);
+
+                    // Update the three CreatedAt-keyed aggregates. Files can land out of disk-order
+                    // (filesystem semantics, not OpenCode's fault), so each candidate is the entry
+                    // with the largest CreatedAt for its slice — not just "the last one we saw."
+                    var ec = entry.CreatedAt ?? DateTimeOffset.MinValue;
+                    if (watch.LastEntry is null || ec > (watch.LastEntry.CreatedAt ?? DateTimeOffset.MinValue))
+                    {
+                        watch.LastEntry = entry;
+                    }
+                    if (entry.Role == "user" &&
+                        (watch.LastUser is null || ec > (watch.LastUser.CreatedAt ?? DateTimeOffset.MinValue)))
+                    {
+                        watch.LastUser = entry;
+                    }
+                    if (entry.HasUsage)
+                    {
+                        if (watch.LastAssistantWithUsage is null ||
+                            ec > (watch.LastAssistantWithUsage.CreatedAt ?? DateTimeOffset.MinValue))
+                        {
+                            watch.LastAssistantWithUsage = entry;
+                        }
+                        watch.TurnCount += 1;
+                    }
+                    anyNewParsed = true;
                 }
 
-                if (watch.Entries.Count == 0) { return; }
+                if (watch.LastEntry is null) { return; }
+                if (!anyNewParsed && watch.Snapshot is not null) { return; }
 
-                // Order canonically by metadata.time.created so file-system enumeration order
-                // doesn't skew the activity FSM.
-                watch.Entries.Sort((a, b) =>
-                    Nullable.Compare(a.CreatedAt, b.CreatedAt));
-
-                var lastAssistantWithUsage = watch.Entries.LastOrDefault(e => e.HasUsage);
-                var lastEntry = watch.Entries[^1];
-                var lastUser = watch.Entries.LastOrDefault(e => e.Role == "user");
+                var lastAssistantWithUsage = watch.LastAssistantWithUsage;
+                var lastEntry = watch.LastEntry;
+                var lastUser = watch.LastUser;
 
                 var contextTokens = lastAssistantWithUsage?.ContextTokens ?? 0;
-                var turns = watch.Entries.Count(e => e.HasUsage);
+                var turns = watch.TurnCount;
                 var lastTurnAt = lastAssistantWithUsage?.CompletedAt ?? lastAssistantWithUsage?.CreatedAt;
                 TimeSpan? lastDuration = null;
                 if (lastAssistantWithUsage is not null && lastUser?.CreatedAt is { } userCreated
@@ -285,12 +327,29 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
     {
         public string SessionId { get; } = sessionId;
         public string? MessageDir { get; set; }
+
         // UTC ticks of the last failed TryLocateMessageDir attempt; 0 = never missed.
         // Stored as a long so Register and PollAll can write/read atomically via
         // Interlocked operations (DateTimeOffset? is >8 bytes and not torn-read safe).
         public long LastLocateMissAtTicks;
-        public readonly HashSet<string> SeenFiles = new(StringComparer.OrdinalIgnoreCase);
-        public readonly List<OpenCodeMessageEntry> Entries = [];
+
+        // mtime-based "have we seen this file" gate — replaces the unbounded SeenFiles HashSet.
+        // OpenCode never modifies a written file, so file mtime is stable and a watermark is
+        // sufficient. SeenAtWatermark holds only files at exactly the watermark instant
+        // (same-tick siblings on coarse-resolution clocks); it resets whenever the watermark
+        // advances, so its size is bounded by the number of messages written within one mtime
+        // tick — vanishingly small in practice.
+        public DateTime MtimeWatermark = DateTime.MinValue;
+        public readonly HashSet<string> SeenAtWatermark = new(StringComparer.OrdinalIgnoreCase);
+
+        // Running aggregates — replaces the per-file Entries list. Each candidate is the entry
+        // with the largest metadata.time.created within its slice (overall / role=user /
+        // assistant-with-usage). TurnCount is incremented on every newly-parsed HasUsage entry.
+        public OpenCodeMessageEntry? LastEntry;
+        public OpenCodeMessageEntry? LastUser;
+        public OpenCodeMessageEntry? LastAssistantWithUsage;
+        public int TurnCount;
+
         public ClaudeSessionTelemetry? Snapshot;
         public readonly object ReadLock = new();
 

--- a/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
+++ b/src/CodeScope.Core/Services/OpenCodeTelemetryService.cs
@@ -220,12 +220,20 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
                 }
 
                 // OpenCode never modifies a message file once written, so each file is parsed at
-                // most once. Files are filtered by mtime against a watermark; same-tick siblings
-                // are disambiguated by a tiny set holding only files at the watermark instant.
-                // No per-message retention — three running aggregates cover the whole snapshot:
-                // last-by-CreatedAt overall (activity FSM), last user (turn duration), last
-                // assistant-with-usage (tokens + model + lastTurnAt). Issue #31.
+                // most once. Files are filtered by mtime against a watermark snapshotted at loop
+                // entry; same-tick siblings are disambiguated by a tiny set holding only files
+                // at the watermark instant. The watermark is advanced AFTER the walk because
+                // EnumerateFiles is not mtime-ordered: if we advanced mid-loop, an older sibling
+                // returned later in the iteration would be filtered against the freshly-bumped
+                // watermark and skipped permanently (its CreatedAt entry never reaching
+                // LastUser/LastEntry/TurnCount). No per-message retention — three running
+                // aggregates cover the whole snapshot: last-by-CreatedAt overall (activity FSM),
+                // last user (turn duration), last assistant-with-usage (tokens + model +
+                // lastTurnAt). Issue #31.
                 var anyNewParsed = false;
+                var entryWatermark = watch.MtimeWatermark;
+                var maxMtimeSeen = entryWatermark;
+                HashSet<string>? newSeenAtMax = null;
                 foreach (var file in Directory.EnumerateFiles(watch.MessageDir, "msg_*.json"))
                 {
                     FileInfo info;
@@ -238,8 +246,8 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
                     if (!info.Exists) { continue; }
 
                     var lwt = info.LastWriteTimeUtc;
-                    if (lwt < watch.MtimeWatermark) { continue; }
-                    if (lwt == watch.MtimeWatermark && watch.SeenAtWatermark.Contains(file)) { continue; }
+                    if (lwt < entryWatermark) { continue; }
+                    if (lwt == entryWatermark && watch.SeenAtWatermark.Contains(file)) { continue; }
 
                     string content;
                     try { content = File.ReadAllText(file); }
@@ -248,12 +256,18 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
                     var entry = OpenCodeMessageParser.ParseContent(content);
                     if (entry is null) { continue; }
 
-                    if (lwt > watch.MtimeWatermark)
+                    // Track the post-loop watermark + the set of files exactly at it. Files
+                    // strictly between entryWatermark and maxMtimeSeen don't need to be tracked
+                    // — next tick will filter them out by the new watermark anyway.
+                    if (lwt > maxMtimeSeen)
                     {
-                        watch.MtimeWatermark = lwt;
-                        watch.SeenAtWatermark.Clear();
+                        maxMtimeSeen = lwt;
+                        newSeenAtMax = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { file };
                     }
-                    watch.SeenAtWatermark.Add(file);
+                    else if (lwt == maxMtimeSeen)
+                    {
+                        (newSeenAtMax ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase)).Add(file);
+                    }
 
                     // Update the three CreatedAt-keyed aggregates. Files can land out of disk-order
                     // (filesystem semantics, not OpenCode's fault), so each candidate is the entry
@@ -278,6 +292,18 @@ public sealed class OpenCodeTelemetryService : IOpenCodeTelemetryService
                         watch.TurnCount += 1;
                     }
                     anyNewParsed = true;
+                }
+
+                // Commit the watermark only after the walk so mid-loop advances can't filter
+                // out older siblings returned later by EnumerateFiles.
+                if (newSeenAtMax is not null)
+                {
+                    if (maxMtimeSeen > entryWatermark)
+                    {
+                        watch.MtimeWatermark = maxMtimeSeen;
+                        watch.SeenAtWatermark.Clear();
+                    }
+                    foreach (var f in newSeenAtMax) { watch.SeenAtWatermark.Add(f); }
                 }
 
                 // Record the dir mtime captured before the walk — next tick can short-circuit

--- a/tests/CodeScope.Core.Tests/OpenCodeTelemetryServiceTests.cs
+++ b/tests/CodeScope.Core.Tests/OpenCodeTelemetryServiceTests.cs
@@ -126,6 +126,45 @@ public sealed class OpenCodeTelemetryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Recompute_Aggregates_Are_Incremental_Across_Many_Messages()
+    {
+        // Issue #31: retention is bounded by three CreatedAt-keyed candidates + a turn count,
+        // not the previous unbounded Entries list. Writing 100 messages and then one more must
+        // produce TurnCount == 51 — if the watermark/SeenAtWatermark gating is wrong, the new
+        // file would re-trigger a parse of every prior file (turn count would balloon).
+        var sid = "ses-many";
+        var dir = MessageDirFor("repo", sid);
+
+        for (var i = 0; i < 50; i++)
+        {
+            File.WriteAllText(Path.Combine(dir, $"msg_u_{i:D3}.json"), UserJson($"u_{i}", sid, 1000 + i * 2));
+            File.WriteAllText(Path.Combine(dir, $"msg_a_{i:D3}.json"),
+                AssistantJson($"a_{i}", sid, 1000 + i * 2 + 1, completed: 1000 + i * 2 + 1,
+                    input: 1, output: 1, cacheRead: 0, cacheWrite: 0, model: "x"));
+        }
+
+        using var svc = new OpenCodeTelemetryService(
+            NullLogger<OpenCodeTelemetryService>.Instance, _root, enablePolling: true);
+        svc.Register(sid, @"C:\repo");
+
+        svc.GetSnapshot(sid)!.TurnCount.Should().Be(50);
+
+        // Add one more turn — count must increment to 51, never re-counting prior files.
+        var newCreated = 1000 + 50 * 2 + 100;
+        await File.WriteAllTextAsync(Path.Combine(dir, "msg_a_extra.json"),
+            AssistantJson("a_extra", sid, newCreated, completed: newCreated + 1,
+                input: 1, output: 1, cacheRead: 0, cacheWrite: 0, model: "x"));
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline && (svc.GetSnapshot(sid)?.TurnCount ?? 0) < 51)
+        {
+            await Task.Delay(100);
+        }
+
+        svc.GetSnapshot(sid)!.TurnCount.Should().Be(51);
+    }
+
+    [Fact]
     public void Unregister_Drops_Snapshot()
     {
         var sid = "ses-drop";

--- a/tests/CodeScope.Core.Tests/OpenCodeTelemetryServiceTests.cs
+++ b/tests/CodeScope.Core.Tests/OpenCodeTelemetryServiceTests.cs
@@ -165,6 +165,44 @@ public sealed class OpenCodeTelemetryServiceTests : IDisposable
     }
 
     [Fact]
+    public void OutOfOrder_Mtimes_Are_All_Parsed_In_Single_Walk()
+    {
+        // Issue #31 follow-up: Directory.EnumerateFiles is not mtime-ordered. If the watermark
+        // were advanced mid-loop, an older sibling returned later in the iteration would be
+        // filtered against the freshly-bumped watermark and skipped permanently — its
+        // CreatedAt entry never reaching LastUser/LastEntry/TurnCount. This test forces that
+        // exact ordering by writing the assistant file FIRST (so it sorts first by name) and
+        // then back-dating the user file's LastWriteTimeUtc to a strictly earlier instant.
+        var sid = "ses-ooo";
+        var dir = MessageDirFor("repo", sid);
+
+        // Assistant file enumerated first (alphabetical: msg_a < msg_u). Newest mtime wins.
+        var assistantPath = Path.Combine(dir, "msg_a.json");
+        File.WriteAllText(assistantPath,
+            AssistantJson("msg_a", sid, 200, completed: 300, input: 7, output: 9, cacheRead: 0, cacheWrite: 0, model: "x"));
+        var userPath = Path.Combine(dir, "msg_u.json");
+        File.WriteAllText(userPath, UserJson("msg_u", sid, 100));
+
+        // Force out-of-order mtimes: assistant strictly NEWER than user, but enumerated first.
+        var now = DateTime.UtcNow;
+        File.SetLastWriteTimeUtc(userPath, now - TimeSpan.FromSeconds(10));
+        File.SetLastWriteTimeUtc(assistantPath, now);
+
+        using var svc = new OpenCodeTelemetryService(NullLogger<OpenCodeTelemetryService>.Instance, _root);
+        svc.Register(sid, @"C:\repo");
+
+        var snap = svc.GetSnapshot(sid);
+        snap.Should().NotBeNull();
+        // Both files must contribute: TurnCount=1 (assistant has usage), and the user→assistant
+        // pair must produce a non-null LastTurnDuration. If the user file is skipped, LastUser
+        // stays null and LastTurnDuration stays null even though the assistant was parsed.
+        snap!.TurnCount.Should().Be(1);
+        snap.LastTurnDuration.Should().NotBeNull(
+            "the user file (older mtime, enumerated second) must still be parsed so the user→assistant pair yields a duration");
+        snap.Activity.Should().Be(ClaudeActivityState.Idle);
+    }
+
+    [Fact]
     public void Unregister_Drops_Snapshot()
     {
         var sid = "ses-drop";


### PR DESCRIPTION
## Summary

\`OpenCodeTelemetryService.Watch\` retained every parsed \`OpenCodeMessageEntry\` in an unbounded list + every filename in a \`HashSet\`, then re-sorted the entire list every \`Recompute\` (350 ms timer or FS event). For long OpenCode sessions this grew linearly in memory and CPU. 🔴 high.

Replaced with three CreatedAt-keyed running candidates + a turn counter:

- \`LastEntry\` — newest by \`metadata.time.created\`, drives the activity FSM
- \`LastUser\` — drives turn duration
- \`LastAssistantWithUsage\` — drives \`ContextTokens\`, \`ModelId\`, \`lastTurnAt\`, \`lastDuration\`
- \`TurnCount\` — incremented per HasUsage entry on first parse

Each candidate is updated only when an incoming entry's \`CreatedAt\` strictly exceeds the existing candidate's, so out-of-disk-order arrivals still converge on the right snapshot.

\`SeenFiles\` HashSet replaced with an mtime watermark + a tiny \`SeenAtWatermark\` disambiguator set holding only files whose mtime equals the watermark instant. OpenCode never modifies a written file, so mtime is stable. Set size is bounded by the number of messages written within one filesystem tick — vanishingly small.

Fixes #31.

## Test plan

- [x] \`OpenCodeTelemetryServiceTests.Recompute_Aggregates_Are_Incremental_Across_Many_Messages\` — seeds 100 files (50 user + 50 assistant), Registers, asserts TurnCount==50; writes one more, asserts TurnCount==51. The old code re-counted on every Recompute; the new code increments on first parse only, so a regression in the watermark/SeenAtWatermark gating would surface as TurnCount > 51.
- [x] All existing OpenCode tests still green (snapshot/activity/file-discovery semantics preserved).
- [x] Full suite: 396/396 (Core 234, Ui 141, App 21).