### PR TITLE
perf: gate OverviewViewModel rebuilds on visibility (#30)

### DIFF
--- a/src/CodeScope.Ui/ViewModels/MainViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/MainViewModel.cs
@@ -193,6 +193,15 @@ public sealed partial class MainViewModel : ObservableObject
     [ObservableProperty]
     private bool _isOverviewVisible;
 
+    /// <summary>
+    /// Mirror visibility into <see cref="OverviewViewModel.IsActive"/> so the Overview VM
+    /// suppresses the per-tick rebuild while it isn't on stage. Issue #30.
+    /// </summary>
+    partial void OnIsOverviewVisibleChanged(bool value)
+    {
+        if (Overview is { } o) { o.IsActive = value; }
+    }
+
     [RelayCommand]
     private void ToggleOverview() => IsOverviewVisible = !IsOverviewVisible;
 

--- a/src/CodeScope.Ui/ViewModels/OverviewViewModel.cs
+++ b/src/CodeScope.Ui/ViewModels/OverviewViewModel.cs
@@ -19,6 +19,21 @@ public sealed partial class OverviewViewModel : ObservableObject
     private readonly ObservableCollection<EditorGroupViewModel> _groups;
     private readonly IAgentRegistry? _agents;
 
+    /// <summary>
+    /// Tracks whether the Overview screen is currently visible. While hidden every status
+    /// tick (worktree poller every 3s, PR poller every 30s) and every Tabs/Projects mutation
+    /// would otherwise rebuild <see cref="Cards"/> + <see cref="FilteredCards"/> from
+    /// scratch — meaningful continuous GC churn behind a screen the user isn't even looking
+    /// at. We instead set <see cref="_dirty"/> when an event fires while hidden, and flush
+    /// a single rebuild on the hidden→visible transition. Subscriptions stay armed so the
+    /// dirty flag remains honest across the gap. Issue #30.
+    /// </summary>
+    // Default: hidden. Most sessions start with the workspace on stage; MainViewModel flips
+    // IsActive on when the user toggles IsOverviewVisible. The constructor's unconditional
+    // initial Rebuild() seeds Cards once; gated rebuilds take over from there.
+    private bool _isActive;
+    private bool _dirty;
+
     public OverviewViewModel(
         SidebarViewModel sidebar,
         ObservableCollection<EditorGroupViewModel> groups,
@@ -38,6 +53,26 @@ public sealed partial class OverviewViewModel : ObservableObject
         foreach (var p in _sidebar.Projects) { HookProject(p); }
 
         Rebuild();
+    }
+
+    /// <summary>
+    /// Set to <c>true</c> when the Overview is visible, <c>false</c> when hidden. Drives
+    /// the gate that suppresses rebuilds while the screen isn't on stage. The host
+    /// (<see cref="MainViewModel"/>) flips this in lockstep with <c>IsOverviewVisible</c>.
+    /// </summary>
+    public bool IsActive
+    {
+        get => _isActive;
+        set
+        {
+            if (_isActive == value) { return; }
+            _isActive = value;
+            if (value && _dirty)
+            {
+                _dirty = false;
+                RebuildOnUi();
+            }
+        }
     }
 
     private IEnumerable<SessionTabViewModel> AllTabs => _groups.SelectMany(g => g.Tabs);
@@ -121,10 +156,16 @@ public sealed partial class OverviewViewModel : ObservableObject
 
     /// <summary>
     /// Marshal the rebuild to the UI thread — store events fire from background pollers and we
-    /// touch ObservableCollections here.
+    /// touch ObservableCollections here. Gated on <see cref="IsActive"/> so hidden Overview
+    /// only sets the dirty flag and defers the rebuild to the next show.
     /// </summary>
     private void RebuildOnUi()
     {
+        if (!_isActive)
+        {
+            _dirty = true;
+            return;
+        }
         if (Application.Current?.Dispatcher is { } d && !d.CheckAccess())
         {
             d.BeginInvoke(Rebuild);

--- a/tests/CodeScope.Ui.Tests/OverviewViewModelGatingTests.cs
+++ b/tests/CodeScope.Ui.Tests/OverviewViewModelGatingTests.cs
@@ -1,0 +1,120 @@
+using System.Collections.ObjectModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using NoScope.CodeScope.Core.Models;
+using NoScope.CodeScope.Core.Services;
+using NoScope.CodeScope.Ui.ViewModels;
+
+namespace NoScope.CodeScope.Ui.Tests;
+
+/// <summary>
+/// Verifies the rebuild gate added in #30 — while <c>IsActive</c> is false, store / tab /
+/// worktree-property events flip a dirty flag instead of rebuilding the cards. The first
+/// IsActive=true after a dirty interval triggers a single rebuild.
+/// </summary>
+public sealed class OverviewViewModelGatingTests
+{
+    private static OverviewViewModel BuildVM(
+        out SidebarViewModel sidebar,
+        out ObservableCollection<EditorGroupViewModel> groups)
+    {
+        var store = Substitute.For<ISessionStore>();
+        store.Projects.Returns([]);
+        sidebar = new SidebarViewModel(store, NullLogger<SidebarViewModel>.Instance);
+        groups = [];
+        return new OverviewViewModel(sidebar, groups);
+    }
+
+    private static EditorGroupViewModel MakeGroup() =>
+        new();
+
+    private static (string projectId, WorktreeViewModel wt, SessionTabViewModel tab) MakeTab(
+        SidebarViewModel sidebar, string projectId = "p1", string wtId = "w1")
+    {
+        var pvm = new ProjectViewModel(new Project { Id = projectId, Name = projectId, Path = $@"C:\repo\{projectId}" });
+        var wvm = new WorktreeViewModel(projectId, new Worktree { Id = wtId, Path = $@"C:\repo\{projectId}\{wtId}", Branch = wtId });
+        pvm.Worktrees.Add(wvm);
+        sidebar.Projects.Add(pvm);
+        var tab = new SessionTabViewModel(
+            new SessionDescriptor { Id = "s1", WorkingDirectory = wvm.Path, Shell = "pwsh.exe", Title = "s1" },
+            projectId,
+            agentId: null,
+            displayNameOverride: "s1");
+        return (projectId, wvm, tab);
+    }
+
+    [Fact]
+    public void Hidden_DefersRebuilds_UntilIsActive_FlipsTrue()
+    {
+        var vm = BuildVM(out var sidebar, out var groups);
+
+        // Default: IsActive=false. Constructor's initial Rebuild has run once, Cards is empty.
+        vm.IsActive.Should().BeFalse();
+        vm.Cards.Should().BeEmpty();
+
+        // Stage a tab in a group while hidden — should NOT rebuild Cards.
+        var group = MakeGroup();
+        groups.Add(group);
+        var made = MakeTab(sidebar);
+        group.Tabs.Add(made.tab);
+
+        vm.Cards.Should().BeEmpty("rebuild was deferred while IsActive=false");
+
+        // Become active → single rebuild flushes the dirty interval.
+        vm.IsActive = true;
+        vm.Cards.Should().HaveCount(1);
+        vm.Cards[0].Session.Should().BeSameAs(made.tab);
+    }
+
+    [Fact]
+    public void Active_RebuildsImmediately_OnEvent()
+    {
+        var vm = BuildVM(out var sidebar, out var groups);
+
+        vm.IsActive = true; // simulate user has opened the Overview
+
+        var group = MakeGroup();
+        groups.Add(group);
+        var made = MakeTab(sidebar);
+        group.Tabs.Add(made.tab);
+
+        vm.Cards.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void HiddenAgain_StopsRebuilds_AndResumesOnNextActivation()
+    {
+        var vm = BuildVM(out var sidebar, out var groups);
+
+        // First activation rebuild + add tab.
+        vm.IsActive = true;
+        var group = MakeGroup();
+        groups.Add(group);
+        var made1 = MakeTab(sidebar, projectId: "p1", wtId: "w1");
+        group.Tabs.Add(made1.tab);
+        vm.Cards.Should().HaveCount(1);
+
+        // Hide → subsequent additions stay deferred.
+        vm.IsActive = false;
+        var made2 = MakeTab(sidebar, projectId: "p2", wtId: "w2");
+        group.Tabs.Add(made2.tab);
+        vm.Cards.Should().HaveCount(1, "Cards still reflects the pre-hide rebuild");
+
+        // Re-activate → single rebuild reflects the new tab too.
+        vm.IsActive = true;
+        vm.Cards.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void IsActive_NoOp_WhenAssignedSameValue()
+    {
+        var vm = BuildVM(out var sidebar, out var groups);
+
+        var rebuildCount = 0;
+        vm.Cards.CollectionChanged += (_, _) => rebuildCount++;
+
+        // No-op assignments don't rebuild.
+        vm.IsActive = false;
+        vm.IsActive = false;
+        rebuildCount.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

\`OverviewViewModel\` subscribes to \`IsDirty\` / \`Ahead\` / \`Behind\` / \`PullRequest\` / \`DisplayBranch\` on every \`WorktreeViewModel\` plus Tabs/Projects/Worktrees collection mutations. Those events fire from the 3 s \`WorktreeStatusPoller\` and 30 s \`PullRequestStatusPoller\` — so the Overview was rebuilding its \`Cards\` + \`FilteredCards\` collections on every tick even while the screen wasn't visible. Meaningful continuous GC / CPU pressure. 🔴 high.

\`OverviewViewModel.IsActive\` (default false) now gates \`RebuildOnUi\`: while inactive the rebuild flips a \`_dirty\` flag and returns. The first \`IsActive=true\` after a dirty interval triggers a single rebuild. Subscriptions stay armed so the dirty flag remains honest across the gap.

\`MainViewModel\` mirrors \`IsOverviewVisible\` into \`Overview.IsActive\` via a generated \`OnIsOverviewVisibleChanged\` partial method, so the gate stays in lockstep with the existing toggle/show/hide commands.

Fixes #30.

## Test plan

- [x] \`OverviewViewModelGatingTests.Hidden_DefersRebuilds_UntilIsActive_FlipsTrue\` — adds a tab while hidden, asserts Cards stays empty; flips IsActive=true, asserts Cards has 1.
- [x] \`OverviewViewModelGatingTests.Active_RebuildsImmediately_OnEvent\` — flips active first, asserts Cards updates on the same tick.
- [x] \`OverviewViewModelGatingTests.HiddenAgain_StopsRebuilds_AndResumesOnNextActivation\` — covers active → hidden → active across multiple events.
- [x] \`OverviewViewModelGatingTests.IsActive_NoOp_WhenAssignedSameValue\` — guards against spurious rebuilds on identity assignments.
- [x] All existing tests still green (modulo the documented FSWatcher discovery flake noted in HANDOFF.md, which passes in isolation).