### PR TITLE
perf: dev-mode memory watchdog + document scrollback-cap blocker (#35)

### DIFF
--- a/src/CodeScope.App/App.xaml.cs
+++ b/src/CodeScope.App/App.xaml.cs
@@ -134,6 +134,14 @@ public partial class App : Application
                 services.AddHostedService(sp => sp.GetRequiredService<WorktreeStatusPoller>());
                 services.AddSingleton<PullRequestStatusPoller>();
                 services.AddHostedService(sp => sp.GetRequiredService<PullRequestStatusPoller>());
+
+                // Dev-only memory watchdog — surfaces working-set creep + live-session count
+                // every 5 min so per-session scrollback retention regressions (issue #35)
+                // don't go unnoticed during long dev runs. Never registered in production.
+                if (NoScope.CodeScope.Core.AppPaths.IsDevMode)
+                {
+                    services.AddHostedService<NoScope.CodeScope.App.Diagnostics.MemoryWatchdog>();
+                }
                 services.AddSingleton<SidebarViewModel>(sp =>
                 {
                     var git = sp.GetRequiredService<IGitService>();

--- a/src/CodeScope.App/Diagnostics/MemoryWatchdog.cs
+++ b/src/CodeScope.App/Diagnostics/MemoryWatchdog.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NoScope.CodeScope.Core.Services;
@@ -60,8 +59,10 @@ public sealed class MemoryWatchdog(ILogger<MemoryWatchdog> logger, ISessionStore
     {
         try
         {
-            var proc = Process.GetCurrentProcess();
-            var ws = proc.WorkingSet64;
+            // Environment.WorkingSet returns the same value as Process.WorkingSet64 without
+            // allocating a Process instance (which holds an unmanaged handle that would leak
+            // every tick if not disposed).
+            var ws = Environment.WorkingSet;
             var sessionCount = store.Projects.Sum(p => p.Sessions.Count(s => s.ClosedAt is null));
             var deltaBytes = lastWorkingSet == 0 ? 0 : ws - lastWorkingSet;
             var wsMb = ws / (1024.0 * 1024.0);

--- a/src/CodeScope.App/Diagnostics/MemoryWatchdog.cs
+++ b/src/CodeScope.App/Diagnostics/MemoryWatchdog.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NoScope.CodeScope.Core.Services;
+
+namespace NoScope.CodeScope.App.Diagnostics;
+
+/// <summary>
+/// Dev-mode-only memory watchdog. Logs <see cref="Process.WorkingSet64"/> every cadence
+/// and surfaces a warning when the working set has grown by a non-trivial amount since
+/// the last log. Helps catch retention regressions during long dev sessions where
+/// per-session terminal scrollback (the dominant working-set contributor at scale, see
+/// issue #35) could otherwise creep up unnoticed.
+/// <para>
+/// Only registered when <c>CODESCOPE_DEV=1</c> at process start — the cadence is loose
+/// enough that it'd be harmless in production, but there's no value in surfacing internal
+/// memory chatter to end users.
+/// </para>
+/// <para>
+/// Why not also cap scrollback per session: <c>Microsoft.Terminal.Wpf</c> 1.22 doesn't
+/// expose the underlying renderer's history-line cap on its public API
+/// (<c>ITerminalConnection</c> / <c>TerminalContainer</c>). Capping would require either
+/// a fork that surfaces the upstream <c>HwndTerminal</c> setting or a periodic synthetic
+/// "clear scrollback" sequence written into the pty — both are out of scope for a
+/// telemetry tweak. This watchdog is the observability half; the cap is parked until
+/// upstream surfaces an API.
+/// </para>
+/// </summary>
+public sealed class MemoryWatchdog(ILogger<MemoryWatchdog> logger, ISessionStore store) : BackgroundService
+{
+    /// <summary>
+    /// Working-set growth threshold beyond which the periodic log line gets bumped from
+    /// Trace to Warning. 50 MB chosen as roughly the cost of one fat ConPTY scrollback
+    /// at maximum default size — anything larger per cadence is worth surfacing.
+    /// </summary>
+    private const long GrowthThresholdBytes = 50L * 1024 * 1024;
+
+    private static readonly TimeSpan Cadence = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan InitialDelay = TimeSpan.FromMinutes(1);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try { await Task.Delay(InitialDelay, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { return; }
+
+        var lastWorkingSet = 0L;
+        using var timer = new PeriodicTimer(Cadence);
+        try
+        {
+            do
+            {
+                Snapshot(ref lastWorkingSet);
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false));
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+    }
+
+    private void Snapshot(ref long lastWorkingSet)
+    {
+        try
+        {
+            var proc = Process.GetCurrentProcess();
+            var ws = proc.WorkingSet64;
+            var sessionCount = store.Projects.Sum(p => p.Sessions.Count(s => s.ClosedAt is null));
+            var deltaBytes = lastWorkingSet == 0 ? 0 : ws - lastWorkingSet;
+            var wsMb = ws / (1024.0 * 1024.0);
+            var deltaMb = deltaBytes / (1024.0 * 1024.0);
+
+            if (lastWorkingSet > 0 && deltaBytes >= GrowthThresholdBytes)
+            {
+                logger.LogWarning(
+                    "MemoryWatchdog: working set grew {DeltaMb:F0} MB since last tick (now {WsMb:F0} MB across {Sessions} live session(s))",
+                    deltaMb, wsMb, sessionCount);
+            }
+            else
+            {
+                logger.LogTrace(
+                    "MemoryWatchdog: working set {WsMb:F0} MB, delta {DeltaMb:+0;-0;0} MB, {Sessions} live session(s)",
+                    wsMb, deltaMb, sessionCount);
+            }
+
+            lastWorkingSet = ws;
+        }
+        catch (Exception ex)
+        {
+            logger.LogTrace(ex, "MemoryWatchdog: snapshot failed");
+        }
+    }
+}

--- a/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SessionTabView.xaml.cs
@@ -303,6 +303,12 @@ public partial class SessionTabView : UserControl
         });
 
         var cmd = vm.CommandLine;
+        // No scrollback cap parameter is available — Microsoft.Terminal.Wpf 1.22 doesn't
+        // expose the underlying renderer's history-line setting on its public API, and
+        // EasyWindowsTerminalControl's `term.Start` only takes width/height/logOutput.
+        // Per-session scrollback dominates working set at scale (issue #35); we surface
+        // creep via MemoryWatchdog in dev mode rather than try to cap it here. Revisit if
+        // upstream surfaces an API.
         _ = Task.Run(() =>
         {
             try { term.Start(cmd, consoleWidth: 120, consoleHeight: 32, logOutput: false); }


### PR DESCRIPTION
## Summary

Investigated whether \`EasyWindowsTerminalControl\` (1.0.36) or \`Microsoft.Terminal.Wpf\` (1.22) exposes a scrollback-line cap on its public API. They don't:

- \`ITerminalConnection\`: \`Start\` / \`WriteInput\` / \`Resize\` / \`Close\` only.
- \`TerminalContainer\`: \`Resize\`, \`AutoResize\`, \`Connection\`, \`UserScroll\`, \`TerminalScrolled\` event — no history-line setting.
- \`EasyWindowsTerminalControl.TermPTY.Start\` takes only \`consoleWidth\`, \`consoleHeight\`, \`logOutput\`.

So per-session scrollback is set by the renderer's hard-coded default. Capping it would require a fork of \`Microsoft.Terminal.Wpf\` (or a synthetic clear-scrollback escape sequence written into the pty, which is invasive). Out of scope for a perf tweak.

Shipping the **observability half** instead — option 2 from the issue:

- New \`MemoryWatchdog\` \`BackgroundService\`. Polls \`Process.WorkingSet64\` every 5 min, logs live-session count alongside.
- Logs at Trace on quiet ticks, **Warning** when growth ≥ 50 MB since last tick (≈ one fat ConPTY scrollback budget — anything larger per cadence is worth surfacing).
- Registered **only when \`CODESCOPE_DEV=1\`** at process start, via the existing \`AppPaths.IsDevMode\` gate. Never active in production builds.

Inline comment near \`SessionTabView.term.Start\` documents the upstream-API blocker so future passes don't re-derive it.

Fixes #35.

## Test plan

- [x] \`dotnet build CodeScope.sln\` clean.
- [x] Full suite green modulo the documented FSWatcher discovery flake (passes in isolation; HANDOFF.md tracks it).
- [x] Watchdog itself is observability-only — no behaviour to test, just \`Process.WorkingSet64\` + \`ILogger\`. Threshold/cadence are static.

## Why not a unit test for the watchdog

The class is a thin shim around \`Process.WorkingSet64\` + \`ILogger\` + \`PeriodicTimer\`. Mocking either the process working set or wall-clock time to assert "warning fires after 50 MB growth" would be ceremonial — the test would just rephrase the implementation. The value is operational, not behavioural; verifying it fires correctly is what running it in dev does.