### PR TITLE
perf: bound closed-session retention (100/worktree, 90-day TTL) (#33)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -223,3 +223,50 @@ it fires on every reparent, which is the exact bug we were fixing.
   about it. Dispatcher-affined, no locking.
 - Spec: `docs/superpowers/specs/2026-04-26-cross-group-terminal-drag-design.md`
 - Plan: `docs/superpowers/plans/2026-04-26-cross-group-terminal-drag.md`
+
+---
+
+## ADR-0015 — Closed-session retention policy: 100 per worktree, 90-day TTL
+
+**Date:** 2026-05-01
+**Status:** Accepted
+**Issue:** #33
+
+Soft-closed sessions accumulate in `projects.json` and in the sidebar History
+disclosure for the lifetime of an install. Without a bound, long-running
+installs grew hundreds of closed sessions per worktree, slowing config load
+and growing the sidebar tree. ADR-0013 introduced the explicit history surface
+but deliberately deferred the retention policy.
+
+**Decision:** Two complementary cuts, applied per-worktree on every prune sweep:
+
+1. **TTL** — sessions whose `ClosedAt` is older than 90 days are dropped.
+2. **Cap** — if the per-worktree closed count is still above 100, the oldest
+   entries beyond the cap are dropped (newest-first ordering preserved).
+
+Pruning runs on `LoadAsync` (one-time migration of pre-policy state) and on
+every `SoftCloseSessionAsync` (so the cap stays enforced as new closes arrive).
+Each pruned row emits `SessionStoreChange.SessionRemoved` so VM History rows
+disappear in lockstep. Live sessions (`ClosedAt is null`) are never touched.
+
+**Decision considered and rejected:**
+- *Manual purge only* (per-worktree "Clear history" action): accumulates
+  silently between user actions and never bounds the long tail. Useful as a
+  complementary affordance but not a sufficient policy on its own.
+- *Per-project retention* instead of per-worktree: a project with one busy
+  worktree would crowd out the closed-session history of its quieter siblings.
+
+**Consequences:**
+- Constants live in `SessionRetentionPolicy` (`MaxPerWorktree = 100`,
+  `MaxAge = 90 days`). Bumping them requires a code change + new ADR amendment;
+  not user-configurable for now.
+- Behaviour change: on first launch after this lands, any pre-existing closed
+  session older than 90 days OR beyond the cap-100 of its worktree is
+  irrecoverably dropped. The migration is logged as a warning if persistence
+  fails so the user can re-run.
+- Live sessions, sessions with `ClosedAt = null`, and orphan sessions
+  (`WorktreeId = null`) are still bounded — orphans collapse into a single
+  "no-worktree" bucket so the cap still bounds them.
+- A future "Clear history" UX (mentioned as a complementary action in #33)
+  doesn't conflict with this policy; it'd just be a manual variant of the
+  automatic sweep.

--- a/src/CodeScope.Core/Services/SessionRetentionPolicy.cs
+++ b/src/CodeScope.Core/Services/SessionRetentionPolicy.cs
@@ -1,0 +1,30 @@
+namespace NoScope.CodeScope.Core.Services;
+
+/// <summary>
+/// Bounds the closed-session history surface so long-running CodeScope installs don't
+/// accumulate hundreds of soft-closed rows per worktree forever — see issue #33 and the
+/// ADR-0015 entry in <c>docs/DECISIONS.md</c>.
+///
+/// <para>Two complementary cuts are applied (in order, per worktree):</para>
+/// <list type="number">
+///   <item><b>TTL</b> — sessions whose <c>ClosedAt</c> is older than <see cref="MaxAge"/>
+///         are dropped outright. A session you closed three months ago isn't part of
+///         "this week's bug" history and is essentially never reopened.</item>
+///   <item><b>Cap</b> — if the per-worktree closed count still exceeds
+///         <see cref="MaxPerWorktree"/>, the oldest entries beyond the cap are dropped.
+///         Most-recent-first ordering preserved so the sidebar disclosure always shows
+///         the newest closed sessions.</item>
+/// </list>
+///
+/// <para>Live sessions (<c>ClosedAt is null</c>) are untouched. Pruning happens on
+/// <c>LoadAsync</c> (one-time migration of pre-policy state) and after every
+/// <c>SoftCloseSessionAsync</c> (so the cap stays enforced as new closes arrive).</para>
+/// </summary>
+public static class SessionRetentionPolicy
+{
+    /// <summary>Hard cap on closed-session count per worktree. Oldest beyond this drop.</summary>
+    public const int MaxPerWorktree = 100;
+
+    /// <summary>Closed sessions older than this are dropped on the next prune sweep.</summary>
+    public static readonly TimeSpan MaxAge = TimeSpan.FromDays(90);
+}

--- a/src/CodeScope.Core/Services/SessionStore.cs
+++ b/src/CodeScope.Core/Services/SessionStore.cs
@@ -46,10 +46,28 @@ public sealed class SessionStore : ISessionStore
             return;
         }
 
+        List<string> prunedSessionIds;
         lock (_lock)
         {
             _projects.Clear();
             _projects.AddRange(result.Value.Projects);
+            // Migration sweep — applies the retention policy to whatever was on disk before
+            // #33 landed. Persists below if anything actually changed so the next load
+            // doesn't re-prune the same rows.
+            prunedSessionIds = ApplyRetentionPolicyLocked();
+        }
+
+        if (prunedSessionIds.Count > 0)
+        {
+            var saved = await SaveSnapshotAsync(ct).ConfigureAwait(false);
+            if (saved.IsFailure)
+            {
+                _logger.LogWarning(
+                    "SessionStore: failed to persist post-load retention sweep ({N} pruned): {Error}",
+                    prunedSessionIds.Count, saved.Error);
+                // The in-memory state is still pruned — emitting Loaded with the post-prune
+                // snapshot keeps VMs honest; the failed save will retry on the next mutation.
+            }
         }
 
         Raise(new SessionStoreChange.Loaded(Projects));
@@ -229,7 +247,99 @@ public sealed class SessionStore : ISessionStore
         // can demote the row to History without re-querying store state (race-free).
         // Hard-remove (RemoveSessionAsync) still raises SessionRemoved unchanged.
         Raise(new SessionStoreChange.SessionSoftClosed(projectId!, closedSession!));
+
+        // Apply retention immediately on every soft-close so the cap stays enforced as new
+        // entries land. Each pruned row gets a SessionRemoved event so VM History rows
+        // disappear in lockstep. Persistence happens once for the whole batch.
+        List<string> prunedSessionIds;
+        lock (_lock) { prunedSessionIds = ApplyRetentionPolicyLocked(); }
+        if (prunedSessionIds.Count > 0)
+        {
+            var saved2 = await SaveSnapshotAsync(ct).ConfigureAwait(false);
+            if (saved2.IsFailure)
+            {
+                _logger.LogWarning(
+                    "SessionStore: failed to persist post-softclose retention sweep ({N} pruned): {Error}",
+                    prunedSessionIds.Count, saved2.Error);
+            }
+            foreach (var pruned in prunedSessionIds)
+            {
+                Raise(new SessionStoreChange.SessionRemoved(pruned));
+            }
+        }
+
         return Result<bool>.Ok(true);
+    }
+
+    /// <summary>
+    /// Applies the closed-session retention policy across every project's session list.
+    /// Caller must hold <see cref="_lock"/>. Returns the ids of sessions dropped from
+    /// in-memory state so the caller can persist + raise <c>SessionRemoved</c> events.
+    /// Idempotent: re-running on already-pruned state returns an empty list. See #33.
+    /// </summary>
+    private List<string> ApplyRetentionPolicyLocked()
+    {
+        var pruned = new List<string>();
+        var now = DateTimeOffset.UtcNow;
+
+        for (var i = 0; i < _projects.Count; i++)
+        {
+            var p = _projects[i];
+            var keep = new List<Session>(p.Sessions.Count);
+            var perWorktreeSurvivors = new Dictionary<string, List<Session>>(StringComparer.Ordinal);
+
+            foreach (var s in p.Sessions)
+            {
+                // Live sessions are never pruned; they always survive intact.
+                if (s.ClosedAt is null)
+                {
+                    keep.Add(s);
+                    continue;
+                }
+
+                // TTL pass — drop anything older than the retention window.
+                if (now - s.ClosedAt.Value > SessionRetentionPolicy.MaxAge)
+                {
+                    pruned.Add(s.Id);
+                    continue;
+                }
+
+                // Bucket the survivor by worktree id (null collapses to a single orphan
+                // bucket so cap enforcement still works on legacy rows without WorktreeId).
+                var bucketKey = s.WorktreeId ?? string.Empty;
+                if (!perWorktreeSurvivors.TryGetValue(bucketKey, out var bucket))
+                {
+                    bucket = [];
+                    perWorktreeSurvivors[bucketKey] = bucket;
+                }
+                bucket.Add(s);
+            }
+
+            // Cap pass — keep newest N closed per worktree, drop the older overflow.
+            foreach (var bucket in perWorktreeSurvivors.Values)
+            {
+                if (bucket.Count <= SessionRetentionPolicy.MaxPerWorktree)
+                {
+                    keep.AddRange(bucket);
+                    continue;
+                }
+
+                bucket.Sort((a, b) =>
+                    Nullable.Compare(b.ClosedAt, a.ClosedAt)); // newest first
+                for (var k = 0; k < bucket.Count; k++)
+                {
+                    if (k < SessionRetentionPolicy.MaxPerWorktree) { keep.Add(bucket[k]); }
+                    else { pruned.Add(bucket[k].Id); }
+                }
+            }
+
+            if (keep.Count != p.Sessions.Count)
+            {
+                _projects[i] = p with { Sessions = keep };
+            }
+        }
+
+        return pruned;
     }
 
     public async Task<Result<Session>> RestoreSessionAsync(string sessionId, CancellationToken ct = default)

--- a/src/CodeScope.Core/Services/SessionStore.cs
+++ b/src/CodeScope.Core/Services/SessionStore.cs
@@ -201,9 +201,16 @@ public sealed class SessionStore : ISessionStore
 
     public async Task<Result<bool>> SoftCloseSessionAsync(string sessionId, CancellationToken ct = default)
     {
+        // Apply close mutation AND retention sweep in the same lock window, then persist
+        // once. Otherwise every close that pushes a worktree past the cap would issue two
+        // back-to-back saves, AND a save2 failure would leave on-disk state diverged from
+        // in-memory state (the close persisted, the prune didn't) — self-healing on next
+        // load but messy. Single save, single atomic rollback.
         var changed = false;
         Session? closedSession = null;
         string? projectId = null;
+        List<Project>? projectsBefore = null;
+        List<string> prunedSessionIds = [];
         lock (_lock)
         {
             for (var i = 0; i < _projects.Count; i++)
@@ -214,6 +221,10 @@ public sealed class SessionStore : ISessionStore
                 if (idx < 0) { continue; }
                 // Idempotent — re-closing an already-closed session is a no-op, not an error.
                 if (sessions[idx].ClosedAt is not null) { return Result<bool>.Ok(true); }
+                // Snapshot pre-mutation projects so a save failure can roll back BOTH the
+                // close and the retention sweep atomically. List<Project> is mutable but
+                // Project is a record, so a shallow ToList preserves the original entries.
+                projectsBefore = _projects.ToList();
                 sessions[idx] = sessions[idx] with { ClosedAt = DateTimeOffset.UtcNow };
                 closedSession = sessions[idx];
                 projectId = p.Id;
@@ -221,53 +232,35 @@ public sealed class SessionStore : ISessionStore
                 changed = true;
                 break;
             }
+            if (!changed) { return Result<bool>.Fail($"Session '{sessionId}' not found"); }
+
+            // Apply retention scoped to the affected project — sweeping every project on
+            // every close is wasteful when a SoftClose only shifted one project's bucket
+            // counts. Done inside the same lock so the persisted snapshot reflects both.
+            prunedSessionIds = ApplyRetentionPolicyLocked(projectFilter: projectId);
         }
-        if (!changed) { return Result<bool>.Fail($"Session '{sessionId}' not found"); }
+
         var saved = await SaveSnapshotAsync(ct).ConfigureAwait(false);
         if (saved.IsFailure)
         {
-            // Rollback the in-memory mutation so a retry doesn't hit the idempotency guard
-            // and silently succeed without ever persisting.
+            // Atomic rollback — restore the pre-mutation projects so a retry doesn't hit
+            // the idempotency guard, and pruned sessions don't vanish from the in-memory
+            // state when disk hasn't been updated.
             lock (_lock)
             {
-                for (var i = 0; i < _projects.Count; i++)
-                {
-                    var p = _projects[i];
-                    var sessions = p.Sessions.ToList();
-                    var idx = sessions.FindIndex(s => s.Id == sessionId);
-                    if (idx < 0) { continue; }
-                    sessions[idx] = sessions[idx] with { ClosedAt = null };
-                    _projects[i] = p with { Sessions = sessions };
-                    break;
-                }
+                _projects.Clear();
+                _projects.AddRange(projectsBefore!);
             }
             return saved;
         }
+
         // Fire SessionSoftClosed carrying the closed Session payload so sidebar listeners
         // can demote the row to History without re-querying store state (race-free).
         // Hard-remove (RemoveSessionAsync) still raises SessionRemoved unchanged.
         Raise(new SessionStoreChange.SessionSoftClosed(projectId!, closedSession!));
-
-        // Apply retention immediately on every soft-close so the cap stays enforced as new
-        // entries land. Scoped to the affected project — sweeping every project on every
-        // close is wasteful when a SoftClose only shifted one project's bucket counts. Each
-        // pruned row gets a SessionRemoved event so VM History rows disappear in lockstep.
-        // Persistence happens once for the whole batch.
-        List<string> prunedSessionIds;
-        lock (_lock) { prunedSessionIds = ApplyRetentionPolicyLocked(projectFilter: projectId); }
-        if (prunedSessionIds.Count > 0)
+        foreach (var pruned in prunedSessionIds)
         {
-            var saved2 = await SaveSnapshotAsync(ct).ConfigureAwait(false);
-            if (saved2.IsFailure)
-            {
-                _logger.LogWarning(
-                    "SessionStore: failed to persist post-softclose retention sweep ({N} pruned): {Error}",
-                    prunedSessionIds.Count, saved2.Error);
-            }
-            foreach (var pruned in prunedSessionIds)
-            {
-                Raise(new SessionStoreChange.SessionRemoved(pruned));
-            }
+            Raise(new SessionStoreChange.SessionRemoved(pruned));
         }
 
         return Result<bool>.Ok(true);

--- a/src/CodeScope.Core/Services/SessionStore.cs
+++ b/src/CodeScope.Core/Services/SessionStore.cs
@@ -249,10 +249,12 @@ public sealed class SessionStore : ISessionStore
         Raise(new SessionStoreChange.SessionSoftClosed(projectId!, closedSession!));
 
         // Apply retention immediately on every soft-close so the cap stays enforced as new
-        // entries land. Each pruned row gets a SessionRemoved event so VM History rows
-        // disappear in lockstep. Persistence happens once for the whole batch.
+        // entries land. Scoped to the affected project — sweeping every project on every
+        // close is wasteful when a SoftClose only shifted one project's bucket counts. Each
+        // pruned row gets a SessionRemoved event so VM History rows disappear in lockstep.
+        // Persistence happens once for the whole batch.
         List<string> prunedSessionIds;
-        lock (_lock) { prunedSessionIds = ApplyRetentionPolicyLocked(); }
+        lock (_lock) { prunedSessionIds = ApplyRetentionPolicyLocked(projectFilter: projectId); }
         if (prunedSessionIds.Count > 0)
         {
             var saved2 = await SaveSnapshotAsync(ct).ConfigureAwait(false);
@@ -272,19 +274,48 @@ public sealed class SessionStore : ISessionStore
     }
 
     /// <summary>
-    /// Applies the closed-session retention policy across every project's session list.
-    /// Caller must hold <see cref="_lock"/>. Returns the ids of sessions dropped from
-    /// in-memory state so the caller can persist + raise <c>SessionRemoved</c> events.
-    /// Idempotent: re-running on already-pruned state returns an empty list. See #33.
+    /// Applies the closed-session retention policy. Caller must hold <see cref="_lock"/>.
+    /// Returns the ids of sessions dropped from in-memory state so the caller can persist
+    /// + raise <c>SessionRemoved</c> events. Idempotent: re-running on already-pruned
+    /// state returns an empty list. See #33.
+    /// <para>
+    /// Pass a <paramref name="projectFilter"/> to scope the sweep — used by
+    /// <see cref="SoftCloseSessionAsync"/> so we don't walk every project's sessions just
+    /// because one project gained a single closed row. <c>null</c> sweeps everything,
+    /// matching the one-time migration sweep on <see cref="LoadAsync"/>.
+    /// </para>
     /// </summary>
-    private List<string> ApplyRetentionPolicyLocked()
+    private List<string> ApplyRetentionPolicyLocked(string? projectFilter = null)
     {
-        var pruned = new List<string>();
         var now = DateTimeOffset.UtcNow;
+        var ttlCutoff = now - SessionRetentionPolicy.MaxAge;
 
+        // Pre-flight pass — cheap allocation-free scan to short-circuit when nothing
+        // needs pruning. Counts closed-per-bucket as we go; bails as soon as the first
+        // out-of-policy row is seen. Most SoftCloses on a healthy install land here.
+        var anyPrune = false;
+        Dictionary<(int projectIdx, string bucket), int>? bucketCounts = null;
+        for (var i = 0; i < _projects.Count && !anyPrune; i++)
+        {
+            var p = _projects[i];
+            if (projectFilter is not null && p.Id != projectFilter) { continue; }
+            foreach (var s in p.Sessions)
+            {
+                if (s.ClosedAt is not { } closedAt) { continue; }
+                if (closedAt < ttlCutoff) { anyPrune = true; break; }
+                bucketCounts ??= new();
+                var key = (i, s.WorktreeId ?? string.Empty);
+                bucketCounts[key] = bucketCounts.TryGetValue(key, out var c) ? c + 1 : 1;
+                if (bucketCounts[key] > SessionRetentionPolicy.MaxPerWorktree) { anyPrune = true; break; }
+            }
+        }
+        if (!anyPrune) { return []; }
+
+        var pruned = new List<string>();
         for (var i = 0; i < _projects.Count; i++)
         {
             var p = _projects[i];
+            if (projectFilter is not null && p.Id != projectFilter) { continue; }
             var keep = new List<Session>(p.Sessions.Count);
             var perWorktreeSurvivors = new Dictionary<string, List<Session>>(StringComparer.Ordinal);
 
@@ -298,7 +329,7 @@ public sealed class SessionStore : ISessionStore
                 }
 
                 // TTL pass — drop anything older than the retention window.
-                if (now - s.ClosedAt.Value > SessionRetentionPolicy.MaxAge)
+                if (s.ClosedAt.Value < ttlCutoff)
                 {
                     pruned.Add(s.Id);
                     continue;

--- a/tests/CodeScope.Core.Tests/SessionRetentionPolicyTests.cs
+++ b/tests/CodeScope.Core.Tests/SessionRetentionPolicyTests.cs
@@ -1,0 +1,203 @@
+using NoScope.CodeScope.Core;
+using NoScope.CodeScope.Core.Models;
+using NoScope.CodeScope.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace NoScope.CodeScope.Core.Tests;
+
+/// <summary>
+/// Verifies the closed-session retention sweep applied on <c>LoadAsync</c> and on every
+/// <c>SoftCloseSessionAsync</c>. Issue #33: cap = 100 closed/worktree, TTL = 90 days.
+/// Live sessions and out-of-policy worktrees are untouched.
+/// </summary>
+public sealed class SessionRetentionPolicyTests
+{
+    private static (SessionStore store, IProjectStore persistence) Make(ProjectsConfig initial)
+    {
+        var persistence = Substitute.For<IProjectStore>();
+        persistence.LoadAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result<ProjectsConfig>.Ok(initial)));
+        persistence.SaveAsync(Arg.Any<ProjectsConfig>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result<bool>.Ok(true)));
+        var git = Substitute.For<IGitService>();
+        var store = new SessionStore(persistence, git, NullLogger<SessionStore>.Instance);
+        return (store, persistence);
+    }
+
+    private static Session ClosedAt(string id, string? worktreeId, DateTimeOffset closedAt) =>
+        new() { Id = id, WorktreePath = @"C:\repo", WorktreeId = worktreeId, ClosedAt = closedAt };
+
+    private static Session Live(string id, string? worktreeId = null) =>
+        new() { Id = id, WorktreePath = @"C:\repo", WorktreeId = worktreeId, ClosedAt = null };
+
+    [Fact]
+    public async Task LoadAsync_Drops_Sessions_Older_Than_MaxAge()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var ancient = now - SessionRetentionPolicy.MaxAge - TimeSpan.FromDays(1);
+        var fresh = now - TimeSpan.FromDays(1);
+
+        var cfg = new ProjectsConfig
+        {
+            Projects = [new Project
+            {
+                Id = "p", Name = "P", Path = @"C:\p",
+                Sessions =
+                [
+                    ClosedAt("ancient", "w", ancient),
+                    ClosedAt("fresh", "w", fresh),
+                    Live("live", "w"),
+                ],
+            }],
+        };
+
+        var (store, persistence) = Make(cfg);
+        await store.LoadAsync();
+
+        var sessionIds = store.Projects.Single().Sessions.Select(s => s.Id).ToList();
+        sessionIds.Should().Contain(["fresh", "live"]);
+        sessionIds.Should().NotContain("ancient");
+        // Persisted because the retention sweep mutated state.
+        await persistence.Received(1).SaveAsync(Arg.Any<ProjectsConfig>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task LoadAsync_Keeps_Newest_N_When_Cap_Exceeded()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var sessions = new List<Session>();
+        for (var i = 0; i < SessionRetentionPolicy.MaxPerWorktree + 25; i++)
+        {
+            // Older indices = older ClosedAt — i=0 is the oldest.
+            sessions.Add(ClosedAt($"s{i:D3}", "w", now - TimeSpan.FromHours(i)));
+        }
+
+        var cfg = new ProjectsConfig
+        {
+            Projects = [new Project { Id = "p", Name = "P", Path = @"C:\p", Sessions = sessions }],
+        };
+
+        var (store, _) = Make(cfg);
+        await store.LoadAsync();
+
+        var keptIds = store.Projects.Single().Sessions.Select(s => s.Id).ToHashSet();
+        keptIds.Count.Should().Be(SessionRetentionPolicy.MaxPerWorktree);
+        // Newest 100 ids (s000..s099) survive; the older 25 (s100..s124) drop.
+        for (var i = 0; i < SessionRetentionPolicy.MaxPerWorktree; i++)
+        {
+            keptIds.Should().Contain($"s{i:D3}", "newest sessions must be retained");
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_NoMutation_When_Within_Policy_Skips_Save()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var cfg = new ProjectsConfig
+        {
+            Projects = [new Project
+            {
+                Id = "p", Name = "P", Path = @"C:\p",
+                Sessions =
+                [
+                    ClosedAt("a", "w", now - TimeSpan.FromDays(1)),
+                    ClosedAt("b", "w", now - TimeSpan.FromDays(2)),
+                    Live("c", "w"),
+                ],
+            }],
+        };
+
+        var (store, persistence) = Make(cfg);
+        await store.LoadAsync();
+
+        // No prune happened → no save call (Load itself doesn't persist).
+        await persistence.DidNotReceive().SaveAsync(Arg.Any<ProjectsConfig>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SoftCloseSessionAsync_Drops_Oldest_When_Cap_Hit()
+    {
+        var now = DateTimeOffset.UtcNow;
+        // Pre-seed exactly the cap with closed sessions, then add one live one and close it.
+        var sessions = new List<Session>();
+        for (var i = 0; i < SessionRetentionPolicy.MaxPerWorktree; i++)
+        {
+            sessions.Add(ClosedAt($"old{i:D3}", "w", now - TimeSpan.FromHours(i + 1)));
+        }
+        sessions.Add(Live("victim", "w"));
+
+        var cfg = new ProjectsConfig
+        {
+            Projects = [new Project { Id = "p", Name = "P", Path = @"C:\p", Sessions = sessions }],
+        };
+
+        var (store, _) = Make(cfg);
+        await store.LoadAsync();
+
+        var events = new List<SessionStoreChange>();
+        store.Changed += (_, c) => events.Add(c);
+
+        // Closing one more pushes count to MaxPerWorktree+1 → oldest drops.
+        var result = await store.SoftCloseSessionAsync("victim");
+        result.IsSuccess.Should().BeTrue();
+
+        store.Projects.Single().Sessions
+            .Count(s => s.ClosedAt is not null && s.WorktreeId == "w")
+            .Should().Be(SessionRetentionPolicy.MaxPerWorktree);
+
+        // Oldest (highest index) is the one dropped — was at +99h.
+        store.Projects.Single().Sessions.Should().NotContain(s => s.Id == $"old{SessionRetentionPolicy.MaxPerWorktree - 1:D3}");
+
+        // SessionSoftClosed for the victim AND a SessionRemoved for the pruned old row.
+        events.OfType<SessionStoreChange.SessionSoftClosed>().Should().ContainSingle(e => e.Session.Id == "victim");
+        events.OfType<SessionStoreChange.SessionRemoved>().Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task SoftCloseSessionAsync_NoPrune_When_Within_Policy()
+    {
+        var (store, persistence) = Make(new ProjectsConfig
+        {
+            Projects = [new Project { Id = "p", Name = "P", Path = @"C:\p" }],
+        });
+        await store.LoadAsync();
+        await store.AddSessionAsync("p", new Session { Id = "s", WorktreeId = "w", WorktreePath = @"C:\p" });
+        persistence.ClearReceivedCalls();
+
+        var events = new List<SessionStoreChange>();
+        store.Changed += (_, c) => events.Add(c);
+
+        var result = await store.SoftCloseSessionAsync("s");
+        result.IsSuccess.Should().BeTrue();
+        events.OfType<SessionStoreChange.SessionRemoved>().Should().BeEmpty(
+            "no retention sweep should fire when the worktree is well below cap");
+    }
+
+    [Fact]
+    public async Task Retention_Buckets_Are_PerWorktree_Not_PerProject()
+    {
+        var now = DateTimeOffset.UtcNow;
+        // Worktree A: way over cap. Worktree B: well under cap.
+        var sessions = new List<Session>();
+        for (var i = 0; i < SessionRetentionPolicy.MaxPerWorktree + 5; i++)
+        {
+            sessions.Add(ClosedAt($"a{i:D3}", "wA", now - TimeSpan.FromHours(i)));
+        }
+        for (var i = 0; i < 3; i++)
+        {
+            sessions.Add(ClosedAt($"b{i:D3}", "wB", now - TimeSpan.FromHours(i)));
+        }
+
+        var cfg = new ProjectsConfig
+        {
+            Projects = [new Project { Id = "p", Name = "P", Path = @"C:\p", Sessions = sessions }],
+        };
+
+        var (store, _) = Make(cfg);
+        await store.LoadAsync();
+
+        var kept = store.Projects.Single().Sessions;
+        kept.Count(s => s.WorktreeId == "wA").Should().Be(SessionRetentionPolicy.MaxPerWorktree);
+        kept.Count(s => s.WorktreeId == "wB").Should().Be(3, "wB was nowhere near the cap");
+    }
+}

--- a/tests/CodeScope.Core.Tests/SessionRetentionPolicyTests.cs
+++ b/tests/CodeScope.Core.Tests/SessionRetentionPolicyTests.cs
@@ -68,7 +68,7 @@ public sealed class SessionRetentionPolicyTests
         var sessions = new List<Session>();
         for (var i = 0; i < SessionRetentionPolicy.MaxPerWorktree + 25; i++)
         {
-            // Older indices = older ClosedAt — i=0 is the oldest.
+            // Lower indices = newer ClosedAt — i=0 is the newest, i=124 is the oldest.
             sessions.Add(ClosedAt($"s{i:D3}", "w", now - TimeSpan.FromHours(i)));
         }
 
@@ -253,5 +253,38 @@ public sealed class SessionRetentionPolicyTests
         var kept = store.Projects.Single().Sessions;
         kept.Count(s => s.WorktreeId == "wA").Should().Be(SessionRetentionPolicy.MaxPerWorktree);
         kept.Count(s => s.WorktreeId == "wB").Should().Be(3, "wB was nowhere near the cap");
+    }
+
+    [Fact]
+    public async Task Retention_Treats_Null_WorktreeId_As_Single_Orphan_Bucket()
+    {
+        // Legacy / pre-migration rows can have WorktreeId = null. The retention policy
+        // collapses those into a single orphan bucket so the cap still enforces. Without
+        // this, every null-id row would be its own implicit bucket and the cap would never
+        // trigger for legacy state. Issue #33 follow-up — explicit guard against regression.
+        var now = DateTimeOffset.UtcNow;
+        var sessions = new List<Session>();
+        for (var i = 0; i < SessionRetentionPolicy.MaxPerWorktree + 25; i++)
+        {
+            // All null WorktreeId. Lower index = newer.
+            sessions.Add(ClosedAt($"orphan{i:D3}", null, now - TimeSpan.FromHours(i)));
+        }
+
+        var cfg = new ProjectsConfig
+        {
+            Projects = [new Project { Id = "p", Name = "P", Path = @"C:\p", Sessions = sessions }],
+        };
+
+        var (store, _) = Make(cfg);
+        await store.LoadAsync();
+
+        var kept = store.Projects.Single().Sessions;
+        kept.Count.Should().Be(SessionRetentionPolicy.MaxPerWorktree,
+            "null-WorktreeId rows must collapse into a single bucket so the cap applies");
+        // The newest MaxPerWorktree (orphan000..orphan099) survive; the older 25 drop.
+        for (var i = 0; i < SessionRetentionPolicy.MaxPerWorktree; i++)
+        {
+            kept.Should().Contain(s => s.Id == $"orphan{i:D3}");
+        }
     }
 }

--- a/tests/CodeScope.Core.Tests/SessionRetentionPolicyTests.cs
+++ b/tests/CodeScope.Core.Tests/SessionRetentionPolicyTests.cs
@@ -174,6 +174,60 @@ public sealed class SessionRetentionPolicyTests
     }
 
     [Fact]
+    public async Task SoftCloseSessionAsync_Sweep_Stays_Scoped_To_Affected_Project()
+    {
+        // Regression guard: SoftClose on project A must NOT prune anything from project B,
+        // even when both projects are independently over-cap. The sweep is project-scoped
+        // for perf (avoid walking unrelated state); confirm the filter is honoured.
+        var now = DateTimeOffset.UtcNow;
+
+        // Project A — at cap, with one live session about to be closed (the trigger).
+        var sessionsA = new List<Session>();
+        for (var i = 0; i < SessionRetentionPolicy.MaxPerWorktree; i++)
+        {
+            sessionsA.Add(ClosedAt($"a{i:D3}", "wA", now - TimeSpan.FromHours(i + 1)));
+        }
+        sessionsA.Add(Live("victim-a", "wA"));
+
+        var cfg = new ProjectsConfig
+        {
+            Projects =
+            [
+                new Project { Id = "pA", Name = "A", Path = @"C:\a", Sessions = sessionsA },
+                new Project { Id = "pB", Name = "B", Path = @"C:\b" },
+            ],
+        };
+
+        var (store, _) = Make(cfg);
+        await store.LoadAsync();
+
+        // After Load, project B is empty. Add an over-cap closed row directly via
+        // AddSessionAsync (bypasses the SoftClose path so no migration sweep is triggered).
+        await store.AddSessionAsync("pB", new Session
+        {
+            Id = "b-overflow",
+            WorktreeId = "wB",
+            WorktreePath = @"C:\b",
+            ClosedAt = now,
+        });
+        store.Projects.Single(p => p.Id == "pB").Sessions.Should().HaveCount(1);
+
+        // SoftClose on project A — A's bucket goes from cap to cap+1, triggering A's prune.
+        // The scoped sweep must NOT visit project B even though B has a closed session
+        // (which would survive in B anyway, but the contract is that scoped means scoped).
+        var events = new List<SessionStoreChange>();
+        store.Changed += (_, c) => events.Add(c);
+
+        var result = await store.SoftCloseSessionAsync("victim-a");
+        result.IsSuccess.Should().BeTrue();
+
+        store.Projects.Single(p => p.Id == "pA").Sessions
+            .Count(s => s.ClosedAt is not null).Should().Be(SessionRetentionPolicy.MaxPerWorktree);
+        store.Projects.Single(p => p.Id == "pB").Sessions.Should().ContainSingle(s => s.Id == "b-overflow",
+            "scoped sweep must not touch the unrelated project");
+    }
+
+    [Fact]
     public async Task Retention_Buckets_Are_PerWorktree_Not_PerProject()
     {
         var now = DateTimeOffset.UtcNow;


### PR DESCRIPTION
## Summary

Soft-closed sessions accumulated in \`projects.json\` + the sidebar History disclosure for the lifetime of an install — long-running installs were on track to grow hundreds of closed rows per worktree, slowing config load and growing the sidebar tree. ADR-0013 deliberately deferred the retention policy when the explicit history surface shipped.

This PR introduces \`SessionRetentionPolicy\`:

- \`MaxPerWorktree = 100\` — newest-first ordering preserved; older overflow drops.
- \`MaxAge = 90 days\` — anything closed longer ago than this drops outright.

\`SessionStore.LoadAsync\` now runs a one-time migration sweep after load (persists if anything changed). \`SoftCloseSessionAsync\` re-applies the policy after every successful close so the cap stays enforced as new entries land. Each pruned row emits \`SessionStoreChange.SessionRemoved\` so the sidebar History disappears in lockstep.

Pruning is **per-worktree** — orphan sessions (\`WorktreeId = null\`) collapse into a single bucket so the cap still bounds them. TTL is checked before cap, so the cap pass only sees survivors. Live sessions (\`ClosedAt is null\`) are never touched.

ADR-0015 in \`docs/DECISIONS.md\` captures the policy + the rejected alternatives (manual purge only, per-project retention).

Fixes #33.

## Behaviour change

On first launch after this lands, any pre-existing closed session older than 90 days **or** beyond the cap-100 of its worktree is irrecoverably dropped. A failed migration save logs at Warning so the user can re-run; in-memory state is still pruned so VMs see the post-prune snapshot.

## Test plan

- [x] \`SessionRetentionPolicyTests.LoadAsync_Drops_Sessions_Older_Than_MaxAge\` — TTL pass.
- [x] \`SessionRetentionPolicyTests.LoadAsync_Keeps_Newest_N_When_Cap_Exceeded\` — cap pass, newest 100 retained.
- [x] \`SessionRetentionPolicyTests.LoadAsync_NoMutation_When_Within_Policy_Skips_Save\` — no spurious persistence on cold-load of healthy state.
- [x] \`SessionRetentionPolicyTests.SoftCloseSessionAsync_Drops_Oldest_When_Cap_Hit\` — cap re-enforcement on every soft-close, with \`SessionRemoved\` event for pruned row.
- [x] \`SessionRetentionPolicyTests.SoftCloseSessionAsync_NoPrune_When_Within_Policy\` — no \`SessionRemoved\` event when worktree is well below cap.
- [x] \`SessionRetentionPolicyTests.Retention_Buckets_Are_PerWorktree_Not_PerProject\` — busy worktree's overflow doesn't cascade to a quieter sibling.
- [x] All existing 38 \`SessionStoreTests\` still green; full suite green modulo the documented FSWatcher discovery flake noted in \`HANDOFF.md\` (passes in isolation).