### PR TITLE
feat: add Reveal context menu to tab strip

### DIFF
--- a/src/CodeScope.Ui/Views/ContextMenuFactory.cs
+++ b/src/CodeScope.Ui/Views/ContextMenuFactory.cs
@@ -1,0 +1,169 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Shapes;
+
+namespace NoScope.CodeScope.Ui.Views;
+
+/// <summary>
+/// Shared builders for the dynamic dark context menus used by the sidebar tree and
+/// the tab strip. The styling lives globally in <c>Styles/ContextMenuStyles.xaml</c>;
+/// this factory just produces MenuItems wired to the right icons, shortcuts, and
+/// header/group/danger Tag conventions those styles key off.
+/// </summary>
+internal static class ContextMenuFactory
+{
+    public static MenuItem BuildItem(string header, string iconKey, string? shortcut, Action onClick)
+    {
+        var mi = new MenuItem
+        {
+            Header = header,
+            Icon = IconFor(iconKey),
+            InputGestureText = shortcut ?? string.Empty,
+        };
+        mi.Click += (_, _) => onClick();
+        return mi;
+    }
+
+    public static MenuItem BuildGroupLabel(string text)
+        => new()
+        {
+            Header = text,
+            Tag = "group",
+        };
+
+    public static Separator BuildSeparator() => new();
+
+    public static MenuItem BuildContextHeader(string dotBrushKey, string title, string subtitle)
+    {
+        var grid = new Grid();
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var dot = new Ellipse
+        {
+            Width = 6,
+            Height = 6,
+            VerticalAlignment = VerticalAlignment.Center,
+            Fill = Application.Current?.TryFindResource(dotBrushKey) as Brush ?? Brushes.DeepSkyBlue,
+        };
+        Grid.SetColumn(dot, 0);
+        grid.Children.Add(dot);
+
+        var titleText = new TextBlock
+        {
+            Text = title,
+            Margin = new Thickness(8, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Center,
+            FontFamily = (FontFamily?)Application.Current?.TryFindResource("Fig.Font.Mono") ?? new FontFamily("Consolas"),
+            FontSize = 11,
+            Foreground = (Brush?)Application.Current?.TryFindResource("Text.Primary") ?? Brushes.White,
+        };
+        Grid.SetColumn(titleText, 1);
+        grid.Children.Add(titleText);
+
+        var subtitleText = new TextBlock
+        {
+            Text = subtitle,
+            VerticalAlignment = VerticalAlignment.Center,
+            FontSize = 10,
+            Foreground = (Brush?)Application.Current?.TryFindResource("Text.Faint") ?? Brushes.Gray,
+        };
+        Grid.SetColumn(subtitleText, 3);
+        grid.Children.Add(subtitleText);
+
+        return new MenuItem
+        {
+            Header = grid,
+            Tag = "header",
+        };
+    }
+
+    public static Path? IconFor(string geometryKey)
+    {
+        if (Application.Current?.TryFindResource(geometryKey) is not Geometry geom) { return null; }
+        var path = new Path
+        {
+            Data = geom,
+            Width = 14,
+            Height = 14,
+            Stretch = Stretch.None,
+            StrokeThickness = 1.4,
+            StrokeStartLineCap = PenLineCap.Round,
+            StrokeEndLineCap = PenLineCap.Round,
+            StrokeLineJoin = PenLineJoin.Round,
+            Fill = Brushes.Transparent,
+            SnapsToDevicePixels = true,
+        };
+        path.SetBinding(Shape.StrokeProperty, new Binding
+        {
+            RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor)
+            {
+                AncestorType = typeof(ContentPresenter),
+            },
+            Path = new PropertyPath("(0)", TextBlock.ForegroundProperty),
+            FallbackValue = Application.Current?.TryFindResource("Text.Secondary") ?? Brushes.Gainsboro,
+        });
+        return path;
+    }
+
+    /// <summary>
+    /// Returns true when the project at <paramref name="projectPath"/> has a configured
+    /// <c>[remote "origin"]</c>. Worktrees inherit the origin from their owning project's
+    /// .git config, which lives at the project root (not inside the worktree).
+    /// </summary>
+    public static bool HasOriginRemote(string? projectPath)
+    {
+        try
+        {
+            if (!TryGetGitConfigPath(projectPath, out var configPath) || configPath is null) { return false; }
+            var text = System.IO.File.ReadAllText(configPath);
+            return text.Contains("[remote \"origin\"]", StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryGetGitConfigPath(string? projectPath, out string? configPath)
+    {
+        configPath = null;
+        if (string.IsNullOrWhiteSpace(projectPath)) { return false; }
+
+        var gitPath = System.IO.Path.Combine(projectPath, ".git");
+
+        if (System.IO.Directory.Exists(gitPath))
+        {
+            var directConfigPath = System.IO.Path.Combine(gitPath, "config");
+            if (System.IO.File.Exists(directConfigPath))
+            {
+                configPath = directConfigPath;
+                return true;
+            }
+            return false;
+        }
+
+        if (!System.IO.File.Exists(gitPath)) { return false; }
+
+        var gitPointer = System.IO.File.ReadAllText(gitPath).Trim();
+        const string gitDirPrefix = "gitdir:";
+        if (!gitPointer.StartsWith(gitDirPrefix, StringComparison.OrdinalIgnoreCase)) { return false; }
+
+        var gitDir = gitPointer[gitDirPrefix.Length..].Trim();
+        if (string.IsNullOrWhiteSpace(gitDir)) { return false; }
+
+        var resolvedGitDir = System.IO.Path.IsPathRooted(gitDir)
+            ? gitDir
+            : System.IO.Path.GetFullPath(System.IO.Path.Combine(projectPath, gitDir));
+
+        var resolvedConfigPath = System.IO.Path.Combine(resolvedGitDir, "config");
+        if (!System.IO.File.Exists(resolvedConfigPath)) { return false; }
+
+        configPath = resolvedConfigPath;
+        return true;
+    }
+}

--- a/src/CodeScope.Ui/Views/GroupStripView.xaml
+++ b/src/CodeScope.Ui/Views/GroupStripView.xaml
@@ -65,14 +65,26 @@
                                 <!-- SessionTabViewModel.AutomationId — wpf-cli snapshots
                                      resolve to a:Tab_<displayName> instead of the VM type. -->
                                 <Setter Property="AutomationProperties.AutomationId" Value="{Binding AutomationId}" />
+                                <!-- Right-click context menu — placeholder is required for
+                                     ContextMenuOpening to fire; the handler in
+                                     GroupStripView.xaml.cs rebuilds the items per-tab on each
+                                     open (mirrors the sidebar's worktree Reveal block:
+                                     Reveal in Explorer / wt.exe / remote / Copy). -->
+                                <Setter Property="ContextMenu">
+                                    <Setter.Value>
+                                        <ContextMenu />
+                                    </Setter.Value>
+                                </Setter>
+                                <EventSetter Event="ContextMenuOpening" Handler="OnTabContextMenuOpening" />
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="ListBoxItem">
                                             <Grid MouseDown="OnTabMouseDown">
-                                                <!-- Right-click context menu (Rename / Duplicate / Close) was removed
-                                                     with issue #21: tab labels auto-follow the worktree's branch, so
-                                                     manual rename is gone, and Duplicate/Close are reachable from the
-                                                     sidebar tree menu (and Close from the tab's middle-click + ✕). -->
+                                                <!-- Right-click opens a Reveal context menu (built in
+                                                     GroupStripView.xaml.cs) with the worktree's
+                                                     Reveal-in-Explorer / Windows Terminal / remote /
+                                                     Copy bits. The Rename / Duplicate / Close items
+                                                     stay in the sidebar tree menu since #21. -->
                                                 <Border
                                                     x:Name="TabPill"
                                                     Background="Transparent"

--- a/src/CodeScope.Ui/Views/GroupStripView.xaml.cs
+++ b/src/CodeScope.Ui/Views/GroupStripView.xaml.cs
@@ -170,6 +170,109 @@ public partial class GroupStripView : UserControl
         }
     }
 
+    /// <summary>
+    /// Right-click on a tab opens a contextual menu mirroring the sidebar's worktree "Reveal"
+    /// section: Reveal in File Explorer / Open in Windows Terminal / Open remote / Copy
+    /// (path · branch · PR URL). The XAML setter wires an empty ContextMenu placeholder per
+    /// item so this event fires; we rebuild its Items each open so conditional rows (origin
+    /// remote, active PR, branch presence) reflect the current worktree state.
+    ///
+    /// Note: WPF shares a single ContextMenu instance across ListBoxItems that come from a
+    /// Style setter, but only one menu is ever open at a time, so the per-open rebuild is safe.
+    /// </summary>
+    private void OnTabContextMenuOpening(object sender, ContextMenuEventArgs e)
+    {
+        if (sender is not ListBoxItem { DataContext: SessionTabViewModel tab, ContextMenu: { } menu })
+        {
+            e.Handled = true;
+            return;
+        }
+
+        if (Application.Current?.MainWindow?.DataContext is not MainViewModel main || main.Sidebar is null)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        PopulateTabContextMenu(menu, tab, main.Sidebar);
+        if (menu.Items.Count == 0)
+        {
+            e.Handled = true;
+        }
+    }
+
+    private static void PopulateTabContextMenu(ContextMenu menu, SessionTabViewModel tab, SidebarViewModel sidebar)
+    {
+        menu.Items.Clear();
+
+        // Locate the worktree that owns this session — Sidebar.Projects is the source of truth
+        // since worktrees track their own Sessions list. Fall back to descriptor cwd if the
+        // session isn't attached to any worktree (shouldn't happen but keeps the menu safe).
+        ProjectViewModel? project = null;
+        WorktreeViewModel? worktree = null;
+        foreach (var p in sidebar.Projects)
+        {
+            foreach (var w in p.Worktrees)
+            {
+                if (w.Sessions.Any(s => s.Descriptor.Id == tab.Descriptor.Id))
+                {
+                    project = p;
+                    worktree = w;
+                    break;
+                }
+            }
+            if (worktree is not null) { break; }
+        }
+
+        var workingDir = worktree?.Path ?? tab.Descriptor.WorkingDirectory;
+        if (string.IsNullOrWhiteSpace(workingDir)) { return; }
+
+        var titleLabel = !string.IsNullOrWhiteSpace(tab.DisplayName) ? tab.DisplayName : tab.Descriptor.Title;
+        var subtitle = project?.Name ?? string.Empty;
+        menu.Items.Add(ContextMenuFactory.BuildContextHeader("Accent.Primary", titleLabel, subtitle));
+
+        menu.Items.Add(ContextMenuFactory.BuildGroupLabel("Reveal"));
+        menu.Items.Add(ContextMenuFactory.BuildItem(
+            "Reveal in File Explorer", "Ctx.Icon.Folder", null,
+            () => sidebar.RevealInExplorerCommand.Execute(workingDir)));
+        menu.Items.Add(ContextMenuFactory.BuildItem(
+            "Open in Windows Terminal", "Ctx.Icon.WinTerminal", null,
+            () => sidebar.OpenInWindowsTerminalCommand.Execute(workingDir)));
+
+        if (ContextMenuFactory.HasOriginRemote(project?.Path))
+        {
+            // OpenRemoteRepository resolves its target via ResolvePath, which only handles
+            // ProjectViewModel/WorktreeViewModel/string — pass the worktree (preferred) or
+            // a string path so the lookup hits a known branch.
+            menu.Items.Add(ContextMenuFactory.BuildItem(
+                "Open remote in browser", "Ctx.Icon.Link", null,
+                () => sidebar.OpenRemoteRepositoryCommand.Execute(worktree ?? (object)workingDir)));
+        }
+
+        // Copy → submenu. Path is always available; branch/PR rows depend on the resolved worktree.
+        var copyRoot = new MenuItem
+        {
+            Header = "Copy",
+            Icon = ContextMenuFactory.IconFor("Ctx.Icon.Clipboard"),
+        };
+        copyRoot.Items.Add(ContextMenuFactory.BuildItem(
+            "Path", "Ctx.Icon.ClipboardPath", "Ctrl+Alt+C",
+            () => sidebar.CopyPathCommand.Execute(workingDir)));
+        if (worktree is not null && !string.IsNullOrWhiteSpace(worktree.Worktree.Branch))
+        {
+            copyRoot.Items.Add(ContextMenuFactory.BuildItem(
+                "Branch name", "Ctx.Icon.Branch", null,
+                () => sidebar.CopyBranchCommand.Execute(worktree)));
+        }
+        if (worktree?.HasPullRequest == true)
+        {
+            copyRoot.Items.Add(ContextMenuFactory.BuildItem(
+                "PR URL", "Ctx.Icon.Link", null,
+                () => sidebar.CopyPullRequestUrlCommand.Execute(worktree)));
+        }
+        menu.Items.Add(copyRoot);
+    }
+
     // ── Drag source ─────────────────────────────────────────────
     private Point _dragOrigin;
     private SessionTabViewModel? _dragCandidate;

--- a/src/CodeScope.Ui/Views/GroupStripView.xaml.cs
+++ b/src/CodeScope.Ui/Views/GroupStripView.xaml.cs
@@ -239,11 +239,8 @@ public partial class GroupStripView : UserControl
             "Open in Windows Terminal", "Ctx.Icon.WinTerminal", null,
             () => sidebar.OpenInWindowsTerminalCommand.Execute(workingDir)));
 
-        if (ContextMenuFactory.HasOriginRemote(project?.Path))
+        if (ContextMenuFactory.HasOriginRemote(workingDir))
         {
-            // OpenRemoteRepository resolves its target via ResolvePath, which only handles
-            // ProjectViewModel/WorktreeViewModel/string — pass the worktree (preferred) or
-            // a string path so the lookup hits a known branch.
             menu.Items.Add(ContextMenuFactory.BuildItem(
                 "Open remote in browser", "Ctx.Icon.Link", null,
                 () => sidebar.OpenRemoteRepositoryCommand.Execute(worktree ?? (object)workingDir)));

--- a/src/CodeScope.Ui/Views/SidebarView.xaml.cs
+++ b/src/CodeScope.Ui/Views/SidebarView.xaml.cs
@@ -541,16 +541,7 @@ public partial class SidebarView : UserControl
     }
 
     private static MenuItem BuildItem(string header, string iconKey, string? shortcut, Action onClick)
-    {
-        var mi = new MenuItem
-        {
-            Header = header,
-            Icon = IconFor(iconKey),
-            InputGestureText = shortcut ?? string.Empty,
-        };
-        mi.Click += (_, _) => onClick();
-        return mi;
-    }
+        => ContextMenuFactory.BuildItem(header, iconKey, shortcut, onClick);
 
     /// <summary>Icon-prefixed display name for a session inside the submenu (e.g. "✶ claude").</summary>
     private static string SessionMenuLabel(SessionTabViewModel s)
@@ -568,114 +559,15 @@ public partial class SidebarView : UserControl
         };
 
     /// <summary>Mono small-caps section label (SESSION / GIT / REVEAL). Non-interactive.</summary>
-    private static MenuItem BuildGroupLabel(string text)
-        => new()
-        {
-            Header = text,
-            Tag = "group",
-        };
+    private static MenuItem BuildGroupLabel(string text) => ContextMenuFactory.BuildGroupLabel(text);
 
     /// <summary>Contextual header row: status dot + branch + repo (muted, right-aligned).</summary>
     private static MenuItem BuildContextHeader(string dotBrushKey, string branch, string repo)
-    {
-        var grid = new Grid();
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        => ContextMenuFactory.BuildContextHeader(dotBrushKey, branch, repo);
 
-        var dot = new Ellipse
-        {
-            Width = 6,
-            Height = 6,
-            VerticalAlignment = VerticalAlignment.Center,
-            Fill = Application.Current?.TryFindResource(dotBrushKey) as Brush ?? Brushes.DeepSkyBlue,
-        };
-        Grid.SetColumn(dot, 0);
-        grid.Children.Add(dot);
+    private static Separator BuildSeparator() => ContextMenuFactory.BuildSeparator();
 
-        var branchText = new TextBlock
-        {
-            Text = branch,
-            Margin = new Thickness(8, 0, 0, 0),
-            VerticalAlignment = VerticalAlignment.Center,
-            FontFamily = (FontFamily?)Application.Current?.TryFindResource("Fig.Font.Mono") ?? new FontFamily("Consolas"),
-            FontSize = 11,
-            Foreground = (Brush?)Application.Current?.TryFindResource("Text.Primary") ?? Brushes.White,
-        };
-        Grid.SetColumn(branchText, 1);
-        grid.Children.Add(branchText);
-
-        var repoText = new TextBlock
-        {
-            Text = repo,
-            VerticalAlignment = VerticalAlignment.Center,
-            FontSize = 10,
-            Foreground = (Brush?)Application.Current?.TryFindResource("Text.Faint") ?? Brushes.Gray,
-        };
-        Grid.SetColumn(repoText, 3);
-        grid.Children.Add(repoText);
-
-        return new MenuItem
-        {
-            Header = grid,
-            Tag = "header",
-        };
-    }
-
-    private static Separator BuildSeparator() => new();
-
-    private static bool TryGetGitConfigPath(string? projectPath, out string? configPath)
-    {
-        configPath = null;
-        if (string.IsNullOrWhiteSpace(projectPath)) { return false; }
-
-        var gitPath = System.IO.Path.Combine(projectPath, ".git");
-
-        if (System.IO.Directory.Exists(gitPath))
-        {
-            var directConfigPath = System.IO.Path.Combine(gitPath, "config");
-            if (System.IO.File.Exists(directConfigPath))
-            {
-                configPath = directConfigPath;
-                return true;
-            }
-            return false;
-        }
-
-        if (!System.IO.File.Exists(gitPath)) { return false; }
-
-        var gitPointer = System.IO.File.ReadAllText(gitPath).Trim();
-        const string gitDirPrefix = "gitdir:";
-        if (!gitPointer.StartsWith(gitDirPrefix, StringComparison.OrdinalIgnoreCase)) { return false; }
-
-        var gitDir = gitPointer[gitDirPrefix.Length..].Trim();
-        if (string.IsNullOrWhiteSpace(gitDir)) { return false; }
-
-        var resolvedGitDir = System.IO.Path.IsPathRooted(gitDir)
-            ? gitDir
-            : System.IO.Path.GetFullPath(System.IO.Path.Combine(projectPath, gitDir));
-
-        var resolvedConfigPath = System.IO.Path.Combine(resolvedGitDir, "config");
-        if (!System.IO.File.Exists(resolvedConfigPath)) { return false; }
-
-        configPath = resolvedConfigPath;
-        return true;
-    }
-
-    private static bool HasOriginRemote(string? projectPath)
-    {
-        try
-        {
-            if (!TryGetGitConfigPath(projectPath, out var configPath) || configPath is null) { return false; }
-            var text = System.IO.File.ReadAllText(configPath);
-            return text.Contains("[remote \"origin\"]", StringComparison.Ordinal);
-        }
-        catch
-        {
-            return false;
-        }
-    }
+    private static bool HasOriginRemote(string? projectPath) => ContextMenuFactory.HasOriginRemote(projectPath);
 
     /// <summary>Runs <paramref name="action"/> with the main-window view-model if present.
     /// Replaces the `Application.Current?.MainWindow?.DataContext is MainViewModel main` guard
@@ -686,37 +578,8 @@ public partial class SidebarView : UserControl
     }
 
     /// <summary>Resolve an `Ctx.Icon.*` <see cref="StreamGeometry"/> resource into a Path element
-    /// sized for MenuItem.Icon (14×14, stroked 1.4px, no fill). <see cref="Path.Stroke"/> is bound
-    /// to the enclosing <see cref="ContentPresenter"/>'s <c>TextBlock.Foreground</c> attached
-    /// property so the Item/Danger/SubHeader/Primary templates can swap the icon colour by setting
-    /// that property on IconHost (hover → Accent.Primary, danger → Ctx.Danger, etc).</summary>
-    private static Path? IconFor(string geometryKey)
-    {
-        if (Application.Current?.TryFindResource(geometryKey) is not Geometry geom) { return null; }
-        var path = new Path
-        {
-            Data = geom,
-            Width = 14,
-            Height = 14,
-            Stretch = Stretch.None,
-            StrokeThickness = 1.4,
-            StrokeStartLineCap = PenLineCap.Round,
-            StrokeEndLineCap = PenLineCap.Round,
-            StrokeLineJoin = PenLineJoin.Round,
-            Fill = Brushes.Transparent,
-            SnapsToDevicePixels = true,
-        };
-        path.SetBinding(Path.StrokeProperty, new Binding
-        {
-            RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor)
-            {
-                AncestorType = typeof(ContentPresenter),
-            },
-            Path = new PropertyPath("(0)", TextBlock.ForegroundProperty),
-            FallbackValue = Application.Current?.TryFindResource("Text.Secondary") ?? Brushes.Gainsboro,
-        });
-        return path;
-    }
+    /// sized for MenuItem.Icon (14×14, stroked 1.4px, no fill).</summary>
+    private static Path? IconFor(string geometryKey) => ContextMenuFactory.IconFor(geometryKey);
 
     /// <summary>
     /// Brush key for the worktree context-menu header dot. Tracks the same two-state agent


### PR DESCRIPTION
## Summary
- Adds a right-click context menu to tabs in the group tab strip, mirroring the **Reveal** block from the sidebar's worktree menu (Reveal in File Explorer / Open in Windows Terminal / Open remote in browser / Copy → Path · Branch · PR URL).
- Extracts the dark-menu helpers (`BuildItem`, `BuildGroupLabel`, `BuildContextHeader`, `BuildSeparator`, `IconFor`, `HasOriginRemote`) from `SidebarView` into a new shared `ContextMenuFactory` so both views share styling and icon resolution.
- All actions reuse the existing `SidebarViewModel` relay commands (`RevealInExplorerCommand`, `OpenInWindowsTerminalCommand`, `OpenRemoteRepositoryCommand`, `CopyPathCommand`, `CopyBranchCommand`, `CopyPullRequestUrlCommand`) — no new path or git logic.

## Implementation notes
- The tab `ListBoxItem` style sets a placeholder `<ContextMenu/>` so WPF fires `ContextMenuOpening`; the handler clears the menu's items and rebuilds them per-open against the live worktree (so conditional rows for `origin` remote, active PR, and branch presence reflect current state).
- The owning worktree is resolved by scanning `MainViewModel.Sidebar.Projects` for the worktree whose `Sessions` contains the tab's session id.
- Dev-mode separation is unaffected — no new on-disk state.

## Test plan
- [ ] Right-click a tab whose worktree has no origin remote → no "Open remote in browser" row.
- [ ] Right-click a tab on a worktree with a configured origin → "Open remote in browser" appears.
- [ ] Right-click a tab whose worktree has an open PR → Copy submenu shows "PR URL".
- [ ] "Reveal in File Explorer" opens the worktree path in Explorer.
- [ ] "Open in Windows Terminal" opens `wt.exe -d <worktree path>` (or pwsh fallback).
- [ ] "Copy → Path" / "Copy → Branch name" land the right strings on the clipboard.
- [ ] Sidebar tree context menu (worktree / project / session / history rows) still renders identically — refactor preserves behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)