### PR TITLE
feat(rs): app shell + codescope-core + settings/themes

### DIFF
--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -944,10 +944,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "codescope-core"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "codescope-rs-spike"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "codescope-core",
  "codescope-terminal",
  "gpui",
  "gpui-terminal",
@@ -961,6 +972,7 @@ version = "0.0.1"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
+ "codescope-core",
  "flume 0.11.1",
  "gpui",
  "parking_lot",

--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -975,6 +975,7 @@ dependencies = [
  "codescope-core",
  "flume 0.11.1",
  "gpui",
+ "open",
  "parking_lot",
 ]
 

--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -975,6 +975,7 @@ dependencies = [
  "codescope-core",
  "flume 0.11.1",
  "gpui",
+ "linkify",
  "open",
  "parking_lot",
 ]
@@ -3021,6 +3022,15 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.5",
+]
+
+[[package]]
+name = "linkify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["terminal"]
+members = ["core", "terminal"]
 exclude = ["vendor/gpui-terminal"]
 
 [package]
@@ -25,6 +25,7 @@ path = "examples/ptytest.rs"
 gpui = "0.2.2"
 gpui-terminal = { path = "vendor/gpui-terminal" }
 codescope-terminal = { path = "terminal" }
+codescope-core = { path = "core" }
 portable-pty = "0.9"
 anyhow = "1"
 parking_lot = "0.12"

--- a/codescope-rs/core/Cargo.toml
+++ b/codescope-rs/core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "codescope-core"
+version = "0.0.1"
+edition = "2024"
+publish = false
+description = "Shared models for CodeScope: settings, themes, env-aware paths. UI-free so it can be used from CLI tools and tests."
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/codescope-rs/core/src/layout.rs
+++ b/codescope-rs/core/src/layout.rs
@@ -1,0 +1,103 @@
+//! Persisted UI layout state.
+//!
+//! Captures _UI_ state that should survive an app restart but isn't
+//! either user config (`settings.json`) or business data
+//! (`projects.json`). Things that go here:
+//!
+//! * sidebar visibility and width
+//! * which project is currently selected
+//! * (later) open tab list, active tab index
+//!
+//! Distinct from `window.json` because the user might want layout
+//! to roam between machines (Dropbox the `%APPDATA%` folder, …)
+//! while window coordinates stay local.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::paths::AppPaths;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LayoutState {
+    pub sidebar_visible: bool,
+    pub sidebar_width: f32,
+    /// Stable id of the project last opened. Sidebar selects this on
+    /// startup if the project still exists.
+    pub selected_project_id: Option<String>,
+}
+
+impl Default for LayoutState {
+    fn default() -> Self {
+        Self {
+            sidebar_visible: true,
+            sidebar_width: 240.0,
+            selected_project_id: None,
+        }
+    }
+}
+
+impl LayoutState {
+    pub fn load(paths: &AppPaths) -> Result<Self> {
+        Self::load_from(&paths.layout_file())
+    }
+
+    pub fn load_from(path: &Path) -> Result<Self> {
+        match std::fs::read(path) {
+            Ok(bytes) if bytes.is_empty() => Ok(Self::default()),
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .with_context(|| format!("parse {}", path.display())),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(err) => Err(err).with_context(|| format!("read {}", path.display())),
+        }
+    }
+
+    pub fn save(&self, paths: &AppPaths) -> Result<()> {
+        paths.ensure_dirs()?;
+        self.save_to(&paths.layout_file())
+    }
+
+    pub fn save_to(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        let mut json = serde_json::to_string_pretty(self)
+            .context("serialise layout state")?;
+        json.push('\n');
+        std::fs::write(path, json)
+            .with_context(|| format!("write {}", path.display()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_yields_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        let state = LayoutState::load_from(&path).unwrap();
+        assert!(state.sidebar_visible);
+        assert_eq!(state.sidebar_width, 240.0);
+    }
+
+    #[test]
+    fn round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("layout.json");
+        let state = LayoutState {
+            sidebar_visible: false,
+            sidebar_width: 320.0,
+            selected_project_id: Some("proj-1".into()),
+        };
+        state.save_to(&path).unwrap();
+        let loaded = LayoutState::load_from(&path).unwrap();
+        assert!(!loaded.sidebar_visible);
+        assert_eq!(loaded.selected_project_id.as_deref(), Some("proj-1"));
+    }
+}

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -14,9 +14,11 @@
 //! `codescope-terminal`.
 
 pub mod paths;
+pub mod projects;
 pub mod settings;
 pub mod theme;
 
 pub use paths::AppPaths;
+pub use projects::{Project, ProjectsConfig, Session, Worktree};
 pub use settings::{CursorSettings, FontSettings, Settings};
 pub use theme::{Rgb, Theme, ThemePalette, builtin};

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -1,0 +1,22 @@
+//! Pure-Rust shared models for the CodeScope app.
+//!
+//! Lives outside the gpui binary so:
+//!
+//! * tests run without spinning up a window;
+//! * future CLI tools (settings linter, theme validator) can re-use
+//!   the same types without dragging gpui through their dep graph;
+//! * the C# `Designs/Tokens/` work has a clear "translation target"
+//!   on the Rust side — when the design team moves a hex value, we
+//!   only have to change it here, not in two places.
+//!
+//! No gpui, alacritty, or windows-rs imports here. Anything UI-bound
+//! lives in the `app` crate. Anything terminal-protocol-bound lives in
+//! `codescope-terminal`.
+
+pub mod paths;
+pub mod settings;
+pub mod theme;
+
+pub use paths::AppPaths;
+pub use settings::{CursorSettings, FontSettings, Settings};
+pub use theme::{Rgb, Theme, ThemePalette, builtin};

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -13,12 +13,16 @@
 //! lives in the `app` crate. Anything terminal-protocol-bound lives in
 //! `codescope-terminal`.
 
+pub mod layout;
 pub mod paths;
 pub mod projects;
 pub mod settings;
 pub mod theme;
+pub mod window_state;
 
+pub use layout::LayoutState;
 pub use paths::AppPaths;
 pub use projects::{Project, ProjectsConfig, Session, Worktree};
 pub use settings::{CursorSettings, FontSettings, Settings};
 pub use theme::{Rgb, Theme, ThemePalette, builtin};
+pub use window_state::WindowState;

--- a/codescope-rs/core/src/paths.rs
+++ b/codescope-rs/core/src/paths.rs
@@ -1,0 +1,145 @@
+//! Env-aware filesystem paths.
+//!
+//! Mirrors `NoScope.CodeScope.Core.AppPaths` in the C# build: a single
+//! resolver that decides "is this dev or production?" once at startup,
+//! and then every consumer asks `paths.config_file()` /
+//! `paths.state_file()` instead of re-deriving paths.
+//!
+//! Dev mode (`CODESCOPE_DEV=1`) shifts every directory to a
+//! `*.Dev`-suffixed sibling so a developer running `cargo run` doesn't
+//! step on the v0.x C# build's `projects.json` or `layout.json`. The
+//! Claude telemetry tail at `~/.claude/projects/…` is shared by design
+//! — two FSWatchers, no state conflict.
+
+use std::path::{Path, PathBuf};
+
+/// One resolved set of paths for the running process. Built once at
+/// startup; clone freely (`PathBuf` is cheap and we hold maybe two of
+/// them).
+#[derive(Debug, Clone)]
+pub struct AppPaths {
+    /// `true` if the process was launched with `CODESCOPE_DEV=1`.
+    pub dev_mode: bool,
+    /// The folder name we stamp into `%APPDATA%` / `%LOCALAPPDATA%`.
+    /// Either `CodeScope` or `CodeScope.Dev`.
+    pub app_folder: String,
+    /// `%APPDATA%\<app_folder>` on Windows;
+    /// `~/.config/<app_folder>` on Linux;
+    /// `~/Library/Application Support/<app_folder>` on macOS.
+    pub config_dir: PathBuf,
+    /// `%LOCALAPPDATA%\<app_folder>` on Windows;
+    /// `~/.local/state/<app_folder>` on Linux;
+    /// `~/Library/Application Support/<app_folder>/state` on macOS.
+    pub state_dir: PathBuf,
+}
+
+impl AppPaths {
+    /// Resolve once, against the current process env. Idempotent — call
+    /// from `main()` and pass the result around.
+    pub fn detect() -> Self {
+        let dev_mode = std::env::var_os("CODESCOPE_DEV")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false);
+        let app_folder = if dev_mode { "CodeScope.Dev" } else { "CodeScope" }.to_string();
+        let config_dir = config_root().join(&app_folder);
+        let state_dir = state_root().join(&app_folder);
+        Self {
+            dev_mode,
+            app_folder,
+            config_dir,
+            state_dir,
+        }
+    }
+
+    /// `%APPDATA%\CodeScope\settings.json` (and dev equivalent).
+    pub fn settings_file(&self) -> PathBuf { self.config_dir.join("settings.json") }
+
+    /// `%APPDATA%\CodeScope\projects.json` — populated later when we
+    /// port the project model.
+    pub fn projects_file(&self) -> PathBuf { self.config_dir.join("projects.json") }
+
+    /// `%LOCALAPPDATA%\CodeScope\layout.json` — tab/sidebar state.
+    pub fn layout_file(&self) -> PathBuf { self.state_dir.join("layout.json") }
+
+    /// `%LOCALAPPDATA%\CodeScope\window.json` — last window pos/size.
+    pub fn window_file(&self) -> PathBuf { self.state_dir.join("window.json") }
+
+    /// Single-instance mutex name — `Global\CodeScope.SingleInstance`
+    /// (and dev equivalent). Only meaningful on Windows.
+    pub fn single_instance_mutex(&self) -> String {
+        if self.dev_mode {
+            "Global\\CodeScope.SingleInstance.Dev".to_string()
+        } else {
+            "Global\\CodeScope.SingleInstance".to_string()
+        }
+    }
+
+    /// Make sure the config + state directories exist. Cheap;
+    /// `create_dir_all` no-ops if they're already there.
+    pub fn ensure_dirs(&self) -> std::io::Result<()> {
+        std::fs::create_dir_all(&self.config_dir)?;
+        std::fs::create_dir_all(&self.state_dir)?;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn config_root() -> PathBuf {
+    std::env::var_os("APPDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_or_temp().join("AppData").join("Roaming"))
+}
+
+#[cfg(target_os = "windows")]
+fn state_root() -> PathBuf {
+    std::env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_or_temp().join("AppData").join("Local"))
+}
+
+#[cfg(target_os = "macos")]
+fn config_root() -> PathBuf {
+    home_or_temp().join("Library").join("Application Support")
+}
+
+#[cfg(target_os = "macos")]
+fn state_root() -> PathBuf {
+    home_or_temp().join("Library").join("Application Support")
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn config_root() -> PathBuf {
+    std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_or_temp().join(".config"))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn state_root() -> PathBuf {
+    std::env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_or_temp().join(".local").join("state"))
+}
+
+fn home_or_temp() -> PathBuf {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
+}
+
+/// Test helper: build an `AppPaths` rooted at an arbitrary directory.
+/// Used by integration tests so they don't pollute the user's real
+/// `%APPDATA%`.
+#[doc(hidden)]
+pub fn rooted_for_tests(dev_mode: bool, root: &Path) -> AppPaths {
+    let app_folder = if dev_mode { "CodeScope.Dev" } else { "CodeScope" }.to_string();
+    let config_dir = root.join("config").join(&app_folder);
+    let state_dir = root.join("state").join(&app_folder);
+    AppPaths {
+        dev_mode,
+        app_folder,
+        config_dir,
+        state_dir,
+    }
+}

--- a/codescope-rs/core/src/paths.rs
+++ b/codescope-rs/core/src/paths.rs
@@ -29,7 +29,10 @@ pub struct AppPaths {
     pub config_dir: PathBuf,
     /// `%LOCALAPPDATA%\<app_folder>` on Windows;
     /// `~/.local/state/<app_folder>` on Linux;
-    /// `~/Library/Application Support/<app_folder>/state` on macOS.
+    /// `~/Library/Application Support/<app_folder>` on macOS (no
+    /// separate `state` segment — Apple's HIG treats Application
+    /// Support as the canonical home for both config and state, and
+    /// nothing in our codebase currently distinguishes them on mac).
     pub state_dir: PathBuf,
 }
 

--- a/codescope-rs/core/src/projects.rs
+++ b/codescope-rs/core/src/projects.rs
@@ -1,0 +1,218 @@
+//! Project / Worktree / Session models — Rust port of
+//! `src/CodeScope.Core/Models/{Project,Session,Worktree,ProjectsConfig}.cs`.
+//!
+//! Field names match the C# build's JSON 1:1 so a `projects.json`
+//! written by the v0.x C# binary can be read by this build (and vice
+//! versa, once the Rust port stabilises). The schema is deliberately
+//! tolerant: every field except the bare minimum is optional in serde,
+//! so partial files survive and forward-compat fields don't break us.
+//!
+//! Identifiers are stable strings (typically UUIDs in the C# build but
+//! we don't enforce a format — anything unique is fine). The `id`
+//! belongs to the project / worktree / session, not its disk path,
+//! because users can rename or relocate a worktree without breaking
+//! cross-references.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::paths::AppPaths;
+
+/// Latest schema version we write. Bump when the on-disk shape needs
+/// a non-additive migration. Additive changes (new optional fields)
+/// stay at the same version.
+pub const CURRENT_VERSION: u32 = 1;
+
+/// One git repository as it appears in the sidebar.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Project {
+    /// Stable id used by sessions to refer to this project.
+    pub id: String,
+    /// Display name in the sidebar. Usually the folder leaf.
+    pub name: String,
+    /// Absolute path to the primary working tree.
+    pub path: String,
+    /// Default branch — used as the base when creating new worktrees.
+    #[serde(default = "default_branch")]
+    pub default_branch: String,
+    /// Where new worktrees go. `None` = `"{path}.worktrees"`.
+    #[serde(default)]
+    pub worktree_root: Option<String>,
+    /// Per-project agent override. `None` = use the global default.
+    #[serde(default)]
+    pub default_agent_id: Option<String>,
+    /// Sessions persisted across restarts.
+    #[serde(default)]
+    pub sessions: Vec<Session>,
+    /// Tracked worktrees. The primary worktree at `path` is implicit.
+    #[serde(default)]
+    pub worktrees: Vec<Worktree>,
+}
+
+fn default_branch() -> String { "main".to_string() }
+
+/// One git worktree under a [`Project`]. Every project has an
+/// implicit primary worktree at `Project::path`; additional ones live
+/// here and get `is_primary = false`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Worktree {
+    pub id: String,
+    pub path: String,
+    #[serde(default)]
+    pub branch: Option<String>,
+    #[serde(default)]
+    pub is_primary: bool,
+}
+
+/// A persisted tab. Live pty / process state lives in the runtime
+/// session manager, not here — this is the "what should be restored
+/// at launch" record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    pub id: String,
+    pub worktree_path: String,
+    #[serde(default)]
+    pub branch: Option<String>,
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub worktree_id: Option<String>,
+    /// ISO 8601 UTC.
+    #[serde(default)]
+    pub last_opened: Option<String>,
+    #[serde(default)]
+    pub agent_session_id: Option<String>,
+    #[serde(default)]
+    pub closed_at: Option<String>,
+}
+
+/// Root object persisted to `%APPDATA%\CodeScope\projects.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ProjectsConfig {
+    pub version: u32,
+    pub projects: Vec<Project>,
+}
+
+impl Default for ProjectsConfig {
+    fn default() -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            projects: Vec::new(),
+        }
+    }
+}
+
+impl ProjectsConfig {
+    pub fn load(paths: &AppPaths) -> Result<Self> {
+        Self::load_from(&paths.projects_file())
+    }
+
+    pub fn load_from(path: &Path) -> Result<Self> {
+        match std::fs::read(path) {
+            Ok(bytes) if bytes.is_empty() => Ok(Self::default()),
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .with_context(|| format!("parse {}", path.display())),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(err) => Err(err).with_context(|| format!("read {}", path.display())),
+        }
+    }
+
+    pub fn save(&self, paths: &AppPaths) -> Result<()> {
+        paths.ensure_dirs()?;
+        self.save_to(&paths.projects_file())
+    }
+
+    pub fn save_to(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        let mut json = serde_json::to_string_pretty(self)
+            .context("serialise projects.json")?;
+        json.push('\n');
+        std::fs::write(path, json)
+            .with_context(|| format!("write {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Look up a project by its stable id. `None` if unknown.
+    pub fn project(&self, id: &str) -> Option<&Project> {
+        self.projects.iter().find(|p| p.id == id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_yields_empty_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        let cfg = ProjectsConfig::load_from(&path).unwrap();
+        assert_eq!(cfg.version, CURRENT_VERSION);
+        assert!(cfg.projects.is_empty());
+    }
+
+    #[test]
+    fn round_trip_preserves_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("projects.json");
+        let cfg = ProjectsConfig {
+            version: CURRENT_VERSION,
+            projects: vec![Project {
+                id: "p1".into(),
+                name: "Repo".into(),
+                path: "C:\\repos\\repo".into(),
+                default_branch: "main".into(),
+                worktree_root: Some("C:\\repos\\repo.worktrees".into()),
+                default_agent_id: Some("claude-code".into()),
+                sessions: vec![Session {
+                    id: "s1".into(),
+                    worktree_path: "C:\\repos\\repo".into(),
+                    branch: Some("main".into()),
+                    agent_id: Some("claude-code".into()),
+                    display_name: None,
+                    worktree_id: Some("w-primary".into()),
+                    last_opened: None,
+                    agent_session_id: None,
+                    closed_at: None,
+                }],
+                worktrees: vec![Worktree {
+                    id: "w-primary".into(),
+                    path: "C:\\repos\\repo".into(),
+                    branch: Some("main".into()),
+                    is_primary: true,
+                }],
+            }],
+        };
+        cfg.save_to(&path).unwrap();
+        let loaded = ProjectsConfig::load_from(&path).unwrap();
+        assert_eq!(loaded.projects.len(), 1);
+        let p = &loaded.projects[0];
+        assert_eq!(p.id, "p1");
+        assert_eq!(p.sessions.len(), 1);
+        assert_eq!(p.worktrees.len(), 1);
+        assert!(p.worktrees[0].is_primary);
+    }
+
+    #[test]
+    fn forward_compatible_unknown_field_survives_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("projects.json");
+        std::fs::write(
+            &path,
+            r#"{ "version": 1, "projects": [], "future_field": "ok" }"#,
+        )
+        .unwrap();
+        // Unknown root-level fields are tolerated thanks to serde's
+        // default behaviour (no `deny_unknown_fields`).
+        let cfg = ProjectsConfig::load_from(&path).unwrap();
+        assert_eq!(cfg.version, 1);
+    }
+}

--- a/codescope-rs/core/src/settings.rs
+++ b/codescope-rs/core/src/settings.rs
@@ -1,0 +1,198 @@
+//! `settings.json` — user-editable app config.
+//!
+//! Lives at [`AppPaths::settings_file`]. JSON because it round-trips
+//! cleanly with the C# build's existing config files (`projects.json`)
+//! and because it's what the user already knows from VS Code.
+//!
+//! Conservative defaults: every field is optional in serde, so a
+//! half-written or empty `settings.json` still loads. Unknown keys
+//! survive a load/save round-trip too — nice for forward compat when
+//! we add a field in vN+1 and the user's still on vN.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::paths::AppPaths;
+use crate::theme::builtin::DEFAULT_NAME;
+
+/// Top-level config object. Every leaf is optional so missing pieces
+/// fall back to defaults; this also means an empty `{}` is a valid
+/// settings file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Settings {
+    /// Stable id of a built-in theme, or — later — a path to a custom
+    /// theme file. Resolved against `theme::builtin::by_name`.
+    pub theme: String,
+
+    /// Font + size + line-height for the terminal grid.
+    pub font: FontSettings,
+
+    /// How many lines of scrollback the terminal keeps. Per-tab.
+    pub scrollback: usize,
+
+    /// Cursor look + blink. TUIs that emit DECSCUSR override this on
+    /// the fly; the values here are the defaults that PSReadLine /
+    /// cmd.exe / bash inherit before any TUI takes over.
+    pub cursor: CursorSettings,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            theme: DEFAULT_NAME.to_string(),
+            font: FontSettings::default(),
+            scrollback: 10_000,
+            cursor: CursorSettings::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FontSettings {
+    /// Primary family. Empty string = "let the platform pick".
+    pub family: String,
+    /// Glyph fallback chain. gpui falls back per-glyph, so installing
+    /// any one of these is enough to pick up missing icons.
+    pub fallbacks: Vec<String>,
+    /// Em size in pixels.
+    pub size: f32,
+    /// Multiplier applied to the measured `(ascent + descent)`.
+    /// 1.0 is "shaped tightly"; 1.1–1.2 gives a roomier line.
+    pub line_height_multiplier: f32,
+}
+
+impl Default for FontSettings {
+    fn default() -> Self {
+        Self {
+            family: "FiraCode Nerd Font".into(),
+            fallbacks: vec![
+                "FiraCode Nerd Font Mono".into(),
+                "FiraCodeNerdFont".into(),
+                "FiraCodeNerdFontMono".into(),
+                "CaskaydiaCove Nerd Font".into(),
+                "CaskaydiaCove Nerd Font Mono".into(),
+                "MesloLGM Nerd Font".into(),
+                "JetBrainsMono Nerd Font".into(),
+                "Hack Nerd Font".into(),
+                "Cascadia Mono".into(),
+                "Consolas".into(),
+            ],
+            size: 13.0,
+            line_height_multiplier: 1.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CursorSettings {
+    /// `"block"`, `"beam"`, `"underline"`, or `"hollow-block"`.
+    pub shape: String,
+    /// Whether the default cursor blinks. TUIs override.
+    pub blinking: bool,
+}
+
+impl Default for CursorSettings {
+    fn default() -> Self {
+        Self {
+            // Beam + blink matches Windows Terminal's default and is
+            // what users see when they spawn pwsh anywhere else.
+            shape: "beam".into(),
+            blinking: true,
+        }
+    }
+}
+
+impl Settings {
+    /// Read [`AppPaths::settings_file`]. Missing file → defaults.
+    /// Malformed JSON → propagated error so the user gets a clear
+    /// message instead of silently losing their config.
+    pub fn load(paths: &AppPaths) -> Result<Self> {
+        Self::load_from(&paths.settings_file())
+    }
+
+    /// Variant that takes an explicit path — used by tests.
+    pub fn load_from(path: &Path) -> Result<Self> {
+        match std::fs::read(path) {
+            Ok(bytes) if bytes.is_empty() => Ok(Self::default()),
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .with_context(|| format!("parse {}", path.display())),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(err) => {
+                Err(err).with_context(|| format!("read {}", path.display()))
+            }
+        }
+    }
+
+    /// Write the current settings to disk (pretty-printed, two-space
+    /// indent — matches VS Code's `settings.json` style and what a
+    /// user expects to hand-edit).
+    pub fn save(&self, paths: &AppPaths) -> Result<()> {
+        paths.ensure_dirs()?;
+        self.save_to(&paths.settings_file())
+    }
+
+    pub fn save_to(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        let mut json = serde_json::to_string_pretty(self)
+            .context("serialise settings")?;
+        json.push('\n');
+        std::fs::write(path, json)
+            .with_context(|| format!("write {}", path.display()))?;
+        Ok(())
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_yields_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.json");
+        let settings = Settings::load_from(&path).unwrap();
+        assert_eq!(settings.theme, DEFAULT_NAME);
+    }
+
+    #[test]
+    fn empty_object_yields_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, "{}").unwrap();
+        let settings = Settings::load_from(&path).unwrap();
+        assert_eq!(settings.theme, DEFAULT_NAME);
+        assert_eq!(settings.scrollback, 10_000);
+    }
+
+    #[test]
+    fn round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let mut settings = Settings::default();
+        settings.theme = "tokyo-night".into();
+        settings.scrollback = 50_000;
+        settings.save_to(&path).unwrap();
+
+        let loaded = Settings::load_from(&path).unwrap();
+        assert_eq!(loaded.theme, "tokyo-night");
+        assert_eq!(loaded.scrollback, 50_000);
+    }
+
+    #[test]
+    fn malformed_json_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, "{ invalid").unwrap();
+        assert!(Settings::load_from(&path).is_err());
+    }
+}

--- a/codescope-rs/core/src/settings.rs
+++ b/codescope-rs/core/src/settings.rs
@@ -55,7 +55,11 @@ impl Default for Settings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct FontSettings {
-    /// Primary family. Empty string = "let the platform pick".
+    /// Primary font family. Empty string falls back to the binary's
+    /// built-in default chain (currently a Nerd-Font-first list, see
+    /// `app::build_font_config`) — *not* an OS-resolved system
+    /// monospace. True platform-default picking would need a per-OS
+    /// font resolver and isn't wired yet.
     pub family: String,
     /// Glyph fallback chain. gpui falls back per-glyph, so installing
     /// any one of these is enough to pick up missing icons.

--- a/codescope-rs/core/src/settings.rs
+++ b/codescope-rs/core/src/settings.rs
@@ -6,8 +6,10 @@
 //!
 //! Conservative defaults: every field is optional in serde, so a
 //! half-written or empty `settings.json` still loads. Unknown keys
-//! survive a load/save round-trip too — nice for forward compat when
-//! we add a field in vN+1 and the user's still on vN.
+//! at the *root* are silently dropped on save — we don't currently
+//! preserve them via `#[serde(flatten)]`, so a write-back cycle will
+//! lose forward-compat fields. Re-add when the on-disk schema starts
+//! seeing real version skew.
 
 use std::path::Path;
 

--- a/codescope-rs/core/src/theme.rs
+++ b/codescope-rs/core/src/theme.rs
@@ -1,0 +1,145 @@
+//! Theme model.
+//!
+//! A `Theme` is a named bundle of colours that the terminal palette,
+//! the app chrome, and any future viewers consume. Stored in this
+//! UI-free crate so the same struct round-trips through `settings.json`
+//! (serde) and the gpui paint code (the `app` crate maps `Rgb` →
+//! `gpui::Hsla`).
+//!
+//! Terms borrowed from `src/CodeScope.App/Styles/DesignTokens.xaml`:
+//!
+//! * `canvas` / `ink` — pure surface + foreground.
+//! * `accent` — the single decorated colour. Framer Blue in our default;
+//!   themes can override but should still respect "one accent only".
+//! * `frost_*` — translucent overlays for buttons / hover states.
+//! * `terminal.*` — ANSI 16 + extended-256 + named slots, for the
+//!   terminal renderer to resolve cell colours against.
+
+use serde::{Deserialize, Serialize};
+
+mod builtin_impl;
+
+pub mod builtin {
+    //! Built-in themes shipped with the binary. Names are stable
+    //! identifiers that `settings.json` references.
+    pub use super::builtin_impl::*;
+}
+
+/// 8-bit-per-channel colour, serde-friendly. We deliberately don't
+/// pull `gpui::Hsla` into core — the UI crate converts at the edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "RgbWire", into = "RgbWire")]
+pub struct Rgb {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl Rgb {
+    pub const fn new(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b }
+    }
+
+    /// Construct from a packed `0xRRGGBB` int — convenient when
+    /// transcribing tokens from `DesignTokens.xaml`.
+    pub const fn from_hex(hex: u32) -> Self {
+        Self {
+            r: ((hex >> 16) & 0xff) as u8,
+            g: ((hex >> 8) & 0xff) as u8,
+            b: (hex & 0xff) as u8,
+        }
+    }
+}
+
+/// `#rrggbb` string when serialised — what you'd type in
+/// `settings.json`. Accepts `#rgb`, `#rrggbb`, and `0xRRGGBB`.
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum RgbWire {
+    Hex(String),
+    Triplet { r: u8, g: u8, b: u8 },
+}
+
+impl From<Rgb> for RgbWire {
+    fn from(rgb: Rgb) -> Self {
+        Self::Hex(format!("#{:02x}{:02x}{:02x}", rgb.r, rgb.g, rgb.b))
+    }
+}
+
+impl From<RgbWire> for Rgb {
+    fn from(wire: RgbWire) -> Self {
+        match wire {
+            RgbWire::Triplet { r, g, b } => Rgb { r, g, b },
+            RgbWire::Hex(s) => parse_hex_or_default(&s),
+        }
+    }
+}
+
+fn parse_hex_or_default(s: &str) -> Rgb {
+    let trimmed = s.trim_start_matches('#').trim_start_matches("0x");
+    let parsed = match trimmed.len() {
+        // `fff` → `ffffff`
+        3 => u32::from_str_radix(trimmed, 16).ok().map(|v| {
+            let r = ((v >> 8) & 0xf) as u8;
+            let g = ((v >> 4) & 0xf) as u8;
+            let b = (v & 0xf) as u8;
+            Rgb { r: r * 0x11, g: g * 0x11, b: b * 0x11 }
+        }),
+        6 => u32::from_str_radix(trimmed, 16).ok().map(Rgb::from_hex),
+        _ => None,
+    };
+    parsed.unwrap_or(Rgb { r: 0, g: 0, b: 0 })
+}
+
+/// Terminal-side palette. Mirrors alacritty's colour-table layout so
+/// the UI crate can resolve `vte::ansi::Color` against a `Theme`
+/// without an extra mapping layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThemePalette {
+    /// 16 ANSI colours (0..16). Indexed: 0 black, 1 red, …,
+    /// 7 white, 8..16 = bright variants.
+    pub ansi: [Rgb; 16],
+    /// 256-colour extended palette (16..256: 6×6×6 cube + grayscale
+    /// ramp). 0..16 mirror `ansi`. We keep the full table here so
+    /// themes can override individual cube cells if they ever want to.
+    pub extended: Vec<Rgb>,
+    /// Default foreground / background / cursor for cells that don't
+    /// specify their own.
+    pub foreground: Rgb,
+    pub background: Rgb,
+    pub cursor: Rgb,
+}
+
+/// App-chrome palette. Used by the AppShell, sidebar, status bar etc.
+/// Kept separate from `ThemePalette` so a theme can have a different
+/// chrome look from its terminal look (e.g. light app chrome with a
+/// dark terminal — common in IDE-style products).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThemeChrome {
+    /// Base canvas (window background behind everything).
+    pub canvas: Rgb,
+    /// Slightly elevated surface — tab strip, sidebar, status bar.
+    pub elevated: Rgb,
+    /// Primary text on canvas / elevated.
+    pub ink: Rgb,
+    /// Muted text (timestamps, hints).
+    pub ink_muted: Rgb,
+    /// 1px divider lines.
+    pub divider: Rgb,
+    /// Single accent. Used sparingly — focus rings, active tab top
+    /// border. DESIGN.md §7 explicitly forbids a second accent.
+    pub accent: Rgb,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Theme {
+    /// Stable identifier. `settings.json` references themes by this.
+    pub name: String,
+    /// Display name for theme pickers (later).
+    pub display_name: String,
+    /// Whether this is a dark-on-light or light-on-dark theme. Used to
+    /// pick a sensible window backdrop when the OS appearance changes.
+    pub dark: bool,
+    pub chrome: ThemeChrome,
+    pub palette: ThemePalette,
+}

--- a/codescope-rs/core/src/theme/builtin_impl.rs
+++ b/codescope-rs/core/src/theme/builtin_impl.rs
@@ -1,0 +1,207 @@
+//! Built-in themes shipped with the binary.
+//!
+//! Add new themes by appending to [`all`] and following the same
+//! shape: 16 ANSI colours + chrome tokens. The 256-colour extended
+//! palette is filled in by [`build_extended`] (standard 6×6×6 cube +
+//! grayscale ramp) so themes only have to provide 16 + named slots.
+//!
+//! Naming: stable kebab-case ids in `name`. `display_name` is what a
+//! theme picker would show.
+
+use super::{Rgb, Theme, ThemeChrome, ThemePalette};
+
+/// Stable id of the default theme — what we fall back to if
+/// `settings.json` references a theme we don't ship.
+pub const DEFAULT_NAME: &str = "codescope-default";
+
+/// Every theme bundled with the binary. Used by the settings loader
+/// to resolve `theme: "<name>"` and by the (future) theme picker.
+pub fn all() -> Vec<Theme> {
+    vec![codescope_default(), vs_code_dark(), one_dark(), solarized_dark(), tokyo_night()]
+}
+
+/// Look up a theme by `name`. Returns `codescope-default` if the name
+/// is unknown — better than crashing on a typo, and the user sees
+/// their own name in the next save round-trip.
+pub fn by_name(name: &str) -> Theme {
+    all()
+        .into_iter()
+        .find(|t| t.name == name)
+        .unwrap_or_else(codescope_default)
+}
+
+// ─── Theme constructors ──────────────────────────────────────────────
+
+pub fn codescope_default() -> Theme {
+    Theme {
+        name: "codescope-default".into(),
+        display_name: "CodeScope (Framer Blue)".into(),
+        dark: true,
+        chrome: ThemeChrome {
+            canvas:    Rgb::from_hex(0x000000),
+            elevated:  Rgb::from_hex(0x090909),
+            ink:       Rgb::from_hex(0xffffff),
+            ink_muted: Rgb::from_hex(0xa6a6a6),
+            divider:   Rgb::from_hex(0x222222),
+            accent:    Rgb::from_hex(0x0099ff),
+        },
+        palette: build_palette(
+            // VS Code dark — same 16 colours as v0.x C# build.
+            [
+                Rgb::from_hex(0x000000), Rgb::from_hex(0xcd3131), Rgb::from_hex(0x0dbc79), Rgb::from_hex(0xe5e510),
+                Rgb::from_hex(0x2472c8), Rgb::from_hex(0xbc3fbc), Rgb::from_hex(0x11a8cd), Rgb::from_hex(0xcccccc),
+                Rgb::from_hex(0x666666), Rgb::from_hex(0xf14c4c), Rgb::from_hex(0x23d18b), Rgb::from_hex(0xf5f543),
+                Rgb::from_hex(0x3b8eea), Rgb::from_hex(0xd670d6), Rgb::from_hex(0x29b8db), Rgb::from_hex(0xffffff),
+            ],
+            Rgb::from_hex(0xcccccc), Rgb::from_hex(0x1e1e1e), Rgb::from_hex(0xffffff),
+        ),
+    }
+}
+
+pub fn vs_code_dark() -> Theme {
+    Theme {
+        name: "vs-code-dark".into(),
+        display_name: "VS Code Dark".into(),
+        dark: true,
+        chrome: ThemeChrome {
+            canvas:    Rgb::from_hex(0x1e1e1e),
+            elevated:  Rgb::from_hex(0x252526),
+            ink:       Rgb::from_hex(0xcccccc),
+            ink_muted: Rgb::from_hex(0x9da5b4),
+            divider:   Rgb::from_hex(0x3c3c3c),
+            accent:    Rgb::from_hex(0x007acc),
+        },
+        palette: build_palette(
+            [
+                Rgb::from_hex(0x000000), Rgb::from_hex(0xcd3131), Rgb::from_hex(0x0dbc79), Rgb::from_hex(0xe5e510),
+                Rgb::from_hex(0x2472c8), Rgb::from_hex(0xbc3fbc), Rgb::from_hex(0x11a8cd), Rgb::from_hex(0xcccccc),
+                Rgb::from_hex(0x666666), Rgb::from_hex(0xf14c4c), Rgb::from_hex(0x23d18b), Rgb::from_hex(0xf5f543),
+                Rgb::from_hex(0x3b8eea), Rgb::from_hex(0xd670d6), Rgb::from_hex(0x29b8db), Rgb::from_hex(0xffffff),
+            ],
+            Rgb::from_hex(0xcccccc), Rgb::from_hex(0x1e1e1e), Rgb::from_hex(0xaeafad),
+        ),
+    }
+}
+
+pub fn one_dark() -> Theme {
+    // From github.com/atom/one-dark-syntax — the cult-classic Atom
+    // theme, slightly tweaked for terminal use.
+    Theme {
+        name: "one-dark".into(),
+        display_name: "One Dark".into(),
+        dark: true,
+        chrome: ThemeChrome {
+            canvas:    Rgb::from_hex(0x282c34),
+            elevated:  Rgb::from_hex(0x21252b),
+            ink:       Rgb::from_hex(0xabb2bf),
+            ink_muted: Rgb::from_hex(0x5c6370),
+            divider:   Rgb::from_hex(0x3e4452),
+            accent:    Rgb::from_hex(0x61afef),
+        },
+        palette: build_palette(
+            [
+                Rgb::from_hex(0x282c34), Rgb::from_hex(0xe06c75), Rgb::from_hex(0x98c379), Rgb::from_hex(0xe5c07b),
+                Rgb::from_hex(0x61afef), Rgb::from_hex(0xc678dd), Rgb::from_hex(0x56b6c2), Rgb::from_hex(0xabb2bf),
+                Rgb::from_hex(0x5c6370), Rgb::from_hex(0xe06c75), Rgb::from_hex(0x98c379), Rgb::from_hex(0xe5c07b),
+                Rgb::from_hex(0x61afef), Rgb::from_hex(0xc678dd), Rgb::from_hex(0x56b6c2), Rgb::from_hex(0xffffff),
+            ],
+            Rgb::from_hex(0xabb2bf), Rgb::from_hex(0x282c34), Rgb::from_hex(0xabb2bf),
+        ),
+    }
+}
+
+pub fn solarized_dark() -> Theme {
+    // Ethan Schoonover's classic — literally the test of time.
+    Theme {
+        name: "solarized-dark".into(),
+        display_name: "Solarized Dark".into(),
+        dark: true,
+        chrome: ThemeChrome {
+            canvas:    Rgb::from_hex(0x002b36),
+            elevated:  Rgb::from_hex(0x073642),
+            ink:       Rgb::from_hex(0x839496),
+            ink_muted: Rgb::from_hex(0x586e75),
+            divider:   Rgb::from_hex(0x094049),
+            accent:    Rgb::from_hex(0x268bd2),
+        },
+        palette: build_palette(
+            [
+                Rgb::from_hex(0x073642), Rgb::from_hex(0xdc322f), Rgb::from_hex(0x859900), Rgb::from_hex(0xb58900),
+                Rgb::from_hex(0x268bd2), Rgb::from_hex(0xd33682), Rgb::from_hex(0x2aa198), Rgb::from_hex(0xeee8d5),
+                Rgb::from_hex(0x002b36), Rgb::from_hex(0xcb4b16), Rgb::from_hex(0x586e75), Rgb::from_hex(0x657b83),
+                Rgb::from_hex(0x839496), Rgb::from_hex(0x6c71c4), Rgb::from_hex(0x93a1a1), Rgb::from_hex(0xfdf6e3),
+            ],
+            Rgb::from_hex(0x839496), Rgb::from_hex(0x002b36), Rgb::from_hex(0x93a1a1),
+        ),
+    }
+}
+
+pub fn tokyo_night() -> Theme {
+    // Popular modern theme; rgb values from enkia/tokyo-night-vscode.
+    Theme {
+        name: "tokyo-night".into(),
+        display_name: "Tokyo Night".into(),
+        dark: true,
+        chrome: ThemeChrome {
+            canvas:    Rgb::from_hex(0x1a1b26),
+            elevated:  Rgb::from_hex(0x16161e),
+            ink:       Rgb::from_hex(0xc0caf5),
+            ink_muted: Rgb::from_hex(0x565f89),
+            divider:   Rgb::from_hex(0x2a2e3f),
+            accent:    Rgb::from_hex(0x7aa2f7),
+        },
+        palette: build_palette(
+            [
+                Rgb::from_hex(0x15161e), Rgb::from_hex(0xf7768e), Rgb::from_hex(0x9ece6a), Rgb::from_hex(0xe0af68),
+                Rgb::from_hex(0x7aa2f7), Rgb::from_hex(0xbb9af7), Rgb::from_hex(0x7dcfff), Rgb::from_hex(0xa9b1d6),
+                Rgb::from_hex(0x414868), Rgb::from_hex(0xf7768e), Rgb::from_hex(0x9ece6a), Rgb::from_hex(0xe0af68),
+                Rgb::from_hex(0x7aa2f7), Rgb::from_hex(0xbb9af7), Rgb::from_hex(0x7dcfff), Rgb::from_hex(0xc0caf5),
+            ],
+            Rgb::from_hex(0xc0caf5), Rgb::from_hex(0x1a1b26), Rgb::from_hex(0xc0caf5),
+        ),
+    }
+}
+
+// ─── Palette construction helper ────────────────────────────────────
+
+fn build_palette(
+    ansi: [Rgb; 16],
+    foreground: Rgb,
+    background: Rgb,
+    cursor: Rgb,
+) -> ThemePalette {
+    ThemePalette {
+        ansi,
+        extended: build_extended(&ansi),
+        foreground,
+        background,
+        cursor,
+    }
+}
+
+/// Standard 256-colour ramp:
+/// * 0..16 — copy of the theme's ANSI palette.
+/// * 16..232 — 6×6×6 RGB cube (`r g b ∈ {0, 95, 135, 175, 215, 255}`).
+/// * 232..256 — 24-step grayscale (`8, 18, 28, …, 238`).
+///
+/// Themes only specify the 16 ANSI colours and we synthesise the rest.
+/// Apps that override individual cube cells via OSC 4 still take
+/// precedence; this is the *default* table.
+fn build_extended(ansi: &[Rgb; 16]) -> Vec<Rgb> {
+    let mut out = Vec::with_capacity(256);
+    out.extend_from_slice(ansi);
+    let levels = [0u8, 95, 135, 175, 215, 255];
+    for &r in &levels {
+        for &g in &levels {
+            for &b in &levels {
+                out.push(Rgb { r, g, b });
+            }
+        }
+    }
+    for i in 0..24u8 {
+        let v = 8 + i * 10;
+        out.push(Rgb { r: v, g: v, b: v });
+    }
+    debug_assert_eq!(out.len(), 256);
+    out
+}

--- a/codescope-rs/core/src/window_state.rs
+++ b/codescope-rs/core/src/window_state.rs
@@ -1,0 +1,122 @@
+//! Persisted window position + size + maximised state.
+//!
+//! Stored at [`AppPaths::window_file`] (under `%LOCALAPPDATA%` because
+//! it's machine-local — copying a `%APPDATA%` home roaming-profile
+//! between PCs with different monitor layouts shouldn't drag stale
+//! window coordinates along). The Rust port writes the same shape the
+//! C# build expects: `x`, `y`, `width`, `height`, `maximised`.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::paths::AppPaths;
+
+/// Last-known window geometry. Pixel-coords on whatever display the
+/// window was last on; the OS clamps them when the display layout
+/// changes (e.g. external monitor unplugged).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct WindowState {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+    #[serde(default)]
+    pub maximised: bool,
+}
+
+impl Default for WindowState {
+    fn default() -> Self {
+        // Sensible first-launch size — wide enough for the sidebar
+        // (240) + a usable terminal (~800).
+        Self {
+            x: 100,
+            y: 100,
+            width: 1280,
+            height: 800,
+            maximised: false,
+        }
+    }
+}
+
+impl WindowState {
+    pub fn load(paths: &AppPaths) -> Result<Option<Self>> {
+        Self::load_from(&paths.window_file())
+    }
+
+    pub fn load_from(path: &Path) -> Result<Option<Self>> {
+        match std::fs::read(path) {
+            Ok(bytes) if bytes.is_empty() => Ok(None),
+            Ok(bytes) => {
+                let state: Self = serde_json::from_slice(&bytes)
+                    .with_context(|| format!("parse {}", path.display()))?;
+                // Reject implausible sizes — saved state from a
+                // 4K → laptop swap could give us an absurd width.
+                // The OS would clamp anyway, but bail early so we
+                // don't trust obviously-broken values.
+                if state.width < 320 || state.height < 240 {
+                    return Ok(None);
+                }
+                Ok(Some(state))
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err).with_context(|| format!("read {}", path.display())),
+        }
+    }
+
+    pub fn save(&self, paths: &AppPaths) -> Result<()> {
+        paths.ensure_dirs()?;
+        self.save_to(&paths.window_file())
+    }
+
+    pub fn save_to(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        let mut json = serde_json::to_string_pretty(self)
+            .context("serialise window state")?;
+        json.push('\n');
+        std::fs::write(path, json)
+            .with_context(|| format!("write {}", path.display()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_yields_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        assert!(WindowState::load_from(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("window.json");
+        let state = WindowState {
+            x: 250,
+            y: 175,
+            width: 1600,
+            height: 900,
+            maximised: true,
+        };
+        state.save_to(&path).unwrap();
+        let loaded = WindowState::load_from(&path).unwrap().unwrap();
+        assert_eq!(loaded.x, 250);
+        assert!(loaded.maximised);
+    }
+
+    #[test]
+    fn implausibly_small_state_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("window.json");
+        std::fs::write(&path, r#"{"x":0,"y":0,"width":50,"height":40}"#).unwrap();
+        assert!(WindowState::load_from(&path).unwrap().is_none());
+    }
+}

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -423,8 +423,14 @@ fn cursor_shape_from_str(s: &str) -> codescope_terminal::CursorShape {
 
 fn build_font_config(settings: &Settings) -> FontConfig {
     let family: SharedString = if settings.font.family.is_empty() {
-        // Empty value in settings.json = "let the platform pick" →
-        // defer to FontConfig's own platform default.
+        // Empty `font.family` in settings.json falls back to whatever
+        // `FontConfig::default()` picks — currently the same Nerd-Font-
+        // first chain, just sourced from the env (`CODESCOPE_FONT`) or
+        // hard-coded, *not* an OS-supplied "platform default monospace".
+        // True system-default font picking would need a platform-
+        // specific resolver (DirectWrite IDWriteSystemFontCollection on
+        // Windows, NSFont/userFixedPitchFont on macOS, fontconfig on
+        // Linux). Land that the day someone actually asks for it.
         FontConfig::default().family
     } else {
         settings.font.family.clone().into()

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -23,8 +23,13 @@
 //! thread.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
-use codescope_terminal::{Backend, Shell, SpawnConfig, TerminalSize, TerminalView};
+use codescope_core::{Settings, Theme};
+use codescope_terminal::{
+    Backend, ColorPalette, CursorStylePreset, FontConfig, Shell, SpawnConfig, TerminalSize,
+    TerminalView,
+};
 use gpui::{
     AppContext, Context, Entity, FocusHandle, Focusable, InteractiveElement, IntoElement,
     KeyDownEvent, MouseButton, ParentElement, Render, SharedString, Styled, Window, div, px,
@@ -44,16 +49,30 @@ pub struct AppShell {
     active_tab: usize,
     next_id: u64,
     focus_handle: FocusHandle,
+    /// Loaded user settings. Cloned into each new tab spawn so a
+    /// future "reload settings" can swap this without disturbing
+    /// already-running tabs.
+    settings: Arc<Settings>,
+    /// Active theme — chrome reads from this on every render. Kept
+    /// in an `Arc` so swapping themes is a single pointer write.
+    theme: Arc<Theme>,
 }
 
 impl AppShell {
-    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+    pub fn new(
+        settings: Arc<Settings>,
+        theme: Arc<Theme>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let focus_handle = cx.focus_handle();
         let mut shell = Self {
             tabs: Vec::new(),
             active_tab: 0,
             next_id: 0,
             focus_handle,
+            settings,
+            theme,
         };
         shell.spawn_tab(window, cx);
         shell
@@ -79,6 +98,17 @@ impl AppShell {
         env.insert("TERM_PROGRAM".into(), "CodeScope".into());
         env.insert("TERM_PROGRAM_VERSION".into(), "0.0.1".into());
 
+        // Build the terminal palette + cursor preset from the active
+        // theme + settings. Cloned per spawn so each tab carries its
+        // own snapshot — themes can swap later without breaking
+        // already-running terminals.
+        let palette = ColorPalette::from_theme_palette(&self.theme.palette);
+        let cursor_preset = CursorStylePreset {
+            shape: cursor_shape_from_str(&self.settings.cursor.shape),
+            blinking: self.settings.cursor.blinking,
+        };
+        let font = build_font_config(&self.settings);
+
         let backend = match Backend::spawn(SpawnConfig {
             shell,
             env,
@@ -88,6 +118,9 @@ impl AppShell {
                 cell_width: 8,
                 cell_height: 18,
             },
+            palette: Some(palette.clone()),
+            scrollback: self.settings.scrollback,
+            default_cursor_style: cursor_preset,
             ..SpawnConfig::default()
         }) {
             Ok(b) => b,
@@ -97,7 +130,7 @@ impl AppShell {
             }
         };
 
-        let terminal = cx.new(|cx| TerminalView::new(backend, cx));
+        let terminal = cx.new(|cx| TerminalView::new_full(backend, palette, font, cx));
         let id = self.next_id;
         self.next_id += 1;
         self.tabs.push(Tab {
@@ -222,6 +255,7 @@ impl Render for AppShell {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
+        let theme = self.theme.clone();
         // Snapshot the data we need into owned values up front. Lets us
         // hand each `cx.listener` its own mutable borrow without
         // overlapping with the immutable borrow `self.tabs.iter()`
@@ -240,13 +274,18 @@ impl Render for AppShell {
 
         let tabs = tab_meta.into_iter().map(|(idx, id, title)| {
             let active = idx == active_idx;
-            // Active tab: pure-black "card" punched into the
-            // near-black strip, plus a 2 px Framer-Blue top border —
-            // the same shape the C# tab strip uses. Inactive tabs
-            // sit transparent on the strip and only fill on hover.
-            let bg = if active { theme::canvas() } else { gpui::transparent_black() };
-            let text_color = if active { theme::ink() } else { theme::ink_dim() };
-            let top_border = if active { theme::accent() } else { gpui::transparent_black() };
+            // Active tab: canvas-coloured "card" punched into the
+            // elevated strip, plus a 2 px accent top border — the
+            // same shape the C# tab strip uses. Inactive tabs sit
+            // transparent on the strip and only fill on hover.
+            let bg = if active { theme::canvas(&theme) } else { gpui::transparent_black() };
+            let text_color = if active { theme::ink(&theme) } else { theme::ink_dim(&theme) };
+            let top_border = if active { theme::accent(&theme) } else { gpui::transparent_black() };
+            let frost_10 = theme::frost_10(&theme);
+            let frost_20 = theme::frost_20(&theme);
+            let ink = theme::ink(&theme);
+            let ink_ghost = theme::ink_ghost(&theme);
+            let status_dot = if active { theme::status_running() } else { theme::ink_ghost(&theme) };
 
             div()
                 .id(("tab", id))
@@ -262,12 +301,8 @@ impl Render for AppShell {
                 .border_color(top_border)
                 .bg(bg)
                 .text_color(text_color)
-                .hover(|s| {
-                    if active {
-                        s
-                    } else {
-                        s.bg(theme::frost_10()).text_color(theme::ink())
-                    }
+                .hover(move |s| {
+                    if active { s } else { s.bg(frost_10).text_color(ink) }
                 })
                 .on_mouse_down(
                     MouseButton::Left,
@@ -282,11 +317,7 @@ impl Render for AppShell {
                         .w(px(8.0))
                         .h(px(8.0))
                         .rounded_full()
-                        .bg(if active {
-                            theme::status_running()
-                        } else {
-                            theme::ink_ghost()
-                        }),
+                        .bg(status_dot),
                 )
                 .child(div().flex_grow().truncate().child(title))
                 .child(
@@ -298,8 +329,8 @@ impl Render for AppShell {
                         .items_center()
                         .justify_center()
                         .rounded_full()
-                        .text_color(theme::ink_ghost())
-                        .hover(|s| s.bg(theme::frost_20()).text_color(theme::ink()))
+                        .text_color(ink_ghost)
+                        .hover(move |s| s.bg(frost_20).text_color(ink))
                         .on_mouse_down(
                             MouseButton::Left,
                             cx.listener(move |this, _, window, cx| {
@@ -311,6 +342,8 @@ impl Render for AppShell {
                 )
         });
 
+        let new_tab_frost = theme::frost_10(&theme);
+        let new_tab_accent = theme::accent(&theme);
         let new_tab_button = div()
             .id("new-tab")
             .h_full()
@@ -318,9 +351,9 @@ impl Render for AppShell {
             .flex()
             .items_center()
             .justify_center()
-            .text_color(theme::ink_dim())
+            .text_color(theme::ink_dim(&theme))
             .text_size(px(18.0))
-            .hover(|s| s.bg(theme::frost_10()).text_color(theme::accent()))
+            .hover(move |s| s.bg(new_tab_frost).text_color(new_tab_accent))
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(|this, _, window, cx| {
@@ -334,8 +367,8 @@ impl Render for AppShell {
             .flex()
             .flex_row()
             .border_b_1()
-            .border_color(theme::divider())
-            .bg(theme::near_black())
+            .border_color(theme::divider(&theme))
+            .bg(theme::elevated(&theme))
             .children(tabs)
             .child(new_tab_button);
 
@@ -354,9 +387,46 @@ impl Render for AppShell {
             .size_full()
             .flex()
             .flex_col()
-            .bg(theme::canvas())
-            .text_color(theme::ink())
+            .bg(theme::canvas(&theme))
+            .text_color(theme::ink(&theme))
             .child(tab_strip)
             .child(div().flex_grow().child(body))
+    }
+}
+
+// ─── Settings → terminal-config helpers ─────────────────────────────
+
+fn cursor_shape_from_str(s: &str) -> codescope_terminal::CursorShape {
+    use codescope_terminal::CursorShape;
+    match s {
+        "block" => CursorShape::Block,
+        "underline" | "underscore" => CursorShape::Underline,
+        "hollow-block" | "hollow_block" => CursorShape::HollowBlock,
+        // "beam", anything else → beam (Windows-Terminal default).
+        _ => CursorShape::Beam,
+    }
+}
+
+fn build_font_config(settings: &Settings) -> FontConfig {
+    let family: SharedString = if settings.font.family.is_empty() {
+        // Empty value in settings.json = "let the platform pick" →
+        // defer to FontConfig's own platform default.
+        FontConfig::default().family
+    } else {
+        settings.font.family.clone().into()
+    };
+    let fallbacks = settings.font.fallbacks.iter().map(|s| s.clone().into()).collect();
+    let size = px(settings.font.size.max(1.0));
+    // line_height_multiplier is recorded for later — gpui's
+    // text_system measures line height directly, so we just stash
+    // a placeholder here. A multiplier knob lands when the renderer
+    // exposes it.
+    let line_height = px(settings.font.size * settings.font.line_height_multiplier.max(0.5));
+    FontConfig {
+        family,
+        fallbacks,
+        size,
+        line_height,
+        cell_width: px(settings.font.size * 0.6),
     }
 }

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -351,15 +351,20 @@ impl Render for AppShell {
 
         let new_tab_frost = theme::frost_10(&theme);
         let new_tab_accent = theme::accent(&theme);
+        // `h(40)` instead of `h_full()` because the strip's flex-row
+        // doesn't always resolve `h_full` to the parent's 40 px before
+        // hit-testing happens — the button looked the right size but
+        // its hit area collapsed to 0, killing both hover and click.
         let new_tab_button = div()
             .id("new-tab")
-            .h_full()
+            .h(px(40.0))
             .w(px(40.0))
             .flex()
             .items_center()
             .justify_center()
             .text_color(theme::ink_dim(&theme))
             .text_size(px(18.0))
+            .cursor_pointer()
             .hover(move |s| s.bg(new_tab_frost).text_color(new_tab_accent))
             .on_mouse_down(
                 MouseButton::Left,

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -234,44 +234,60 @@ impl Render for AppShell {
 
         let tabs = tab_meta.into_iter().map(|(idx, id, title)| {
             let active = idx == active_idx;
-            let bg = if active {
-                theme::frost_10()
-            } else {
-                theme::canvas()
-            };
-            let text_color = if active {
-                theme::ink()
-            } else {
-                theme::ink_dim()
-            };
+            // Active tab: pure-black "card" punched into the
+            // near-black strip, plus a 2 px Framer-Blue top border —
+            // the same shape the C# tab strip uses. Inactive tabs
+            // sit transparent on the strip and only fill on hover.
+            let bg = if active { theme::canvas() } else { gpui::transparent_black() };
+            let text_color = if active { theme::ink() } else { theme::ink_dim() };
+            let top_border = if active { theme::accent() } else { gpui::transparent_black() };
 
             div()
                 .id(("tab", id))
                 .h_full()
-                .my(px(6.0))
-                .px_3()
-                .min_w(px(120.0))
-                .max_w(px(220.0))
+                .min_w(px(140.0))
+                .max_w(px(240.0))
                 .flex()
                 .flex_row()
                 .items_center()
                 .gap_2()
-                .rounded_md()
+                .px_3()
+                .border_t_2()
+                .border_color(top_border)
                 .bg(bg)
                 .text_color(text_color)
-                .hover(|s| s.bg(theme::frost_10()))
+                .hover(|s| {
+                    if active {
+                        s
+                    } else {
+                        s.bg(theme::frost_10()).text_color(theme::ink())
+                    }
+                })
                 .on_mouse_down(
                     MouseButton::Left,
                     cx.listener(move |this, _, window, cx| {
                         this.activate_tab(idx, window, cx);
                     }),
                 )
+                // Status dot — green = active session, dim = inactive.
+                // Cheap visual hook even before we wire real status.
+                .child(
+                    div()
+                        .w(px(8.0))
+                        .h(px(8.0))
+                        .rounded_full()
+                        .bg(if active {
+                            theme::status_running()
+                        } else {
+                            theme::ink_ghost()
+                        }),
+                )
                 .child(div().flex_grow().truncate().child(title))
                 .child(
                     div()
                         .id(("close", idx as u64))
-                        .w(px(18.0))
-                        .h(px(18.0))
+                        .w(px(20.0))
+                        .h(px(20.0))
                         .flex()
                         .items_center()
                         .justify_center()
@@ -291,14 +307,14 @@ impl Render for AppShell {
 
         let new_tab_button = div()
             .id("new-tab")
-            .my(px(6.0))
-            .w(px(28.0))
+            .h_full()
+            .w(px(40.0))
             .flex()
             .items_center()
             .justify_center()
-            .rounded_md()
             .text_color(theme::ink_dim())
-            .hover(|s| s.bg(theme::frost_10()).text_color(theme::ink()))
+            .text_size(px(18.0))
+            .hover(|s| s.bg(theme::frost_10()).text_color(theme::accent()))
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(|this, _, window, cx| {
@@ -311,8 +327,6 @@ impl Render for AppShell {
             .h(px(40.0))
             .flex()
             .flex_row()
-            .px_2()
-            .gap_1()
             .border_b_1()
             .border_color(theme::divider())
             .bg(theme::near_black())

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -171,12 +171,18 @@ impl AppShell {
         if !app_mod || mods.alt {
             return;
         }
+        // Bindings match Windows Terminal / VS Code so users have
+        // the muscle memory: Ctrl+Shift+T new tab, Ctrl+Shift+W
+        // close. Plain Ctrl+T / Ctrl+W stay with the shell (`yank`
+        // / `unix-word-rubout` in readline, transpose-words in
+        // PSReadLine) — the View deliberately leaves the shifted
+        // variants for us to pick up.
         match key {
-            "t" if !mods.shift => {
+            "t" if mods.shift => {
                 cx.stop_propagation();
                 self.spawn_tab(window, cx);
             }
-            "w" if !mods.shift => {
+            "w" if mods.shift => {
                 cx.stop_propagation();
                 self.close_tab(self.active_tab, window, cx);
             }

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1,0 +1,342 @@
+//! Application shell — the chrome that wraps one or more
+//! `TerminalView` entities.
+//!
+//! Layout (top to bottom):
+//!
+//! ```text
+//! ┌────────────────────────────────────────────────────────┐
+//! │ tab strip (40px) — pill tabs · "+" · caption controls │  ← in titlebar
+//! ├────────────────────────────────────────────────────────┤
+//! │                                                        │
+//! │              active TerminalView (size_full)           │
+//! │                                                        │
+//! └────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! Visuals follow `src/CodeScope.App/Styles/DesignTokens.xaml`:
+//! pure-black canvas, pure-white ink, single Framer Blue accent,
+//! frosted-glass surfaces. See [`crate::theme`] for the tokens.
+//!
+//! Each tab owns its own [`Backend`] + [`TerminalView`]. Closing a
+//! tab drops the entity, which drops the backend, which sends
+//! `Msg::Shutdown` to the alacritty event loop and joins the worker
+//! thread.
+
+use std::collections::HashMap;
+
+use codescope_terminal::{Backend, Shell, SpawnConfig, TerminalSize, TerminalView};
+use gpui::{
+    AppContext, Context, Entity, FocusHandle, Focusable, InteractiveElement, IntoElement,
+    KeyDownEvent, MouseButton, ParentElement, Render, SharedString, Styled, Window, div, px,
+};
+
+use crate::theme;
+
+/// One tab = one terminal session.
+struct Tab {
+    id: u64,
+    title: SharedString,
+    terminal: Entity<TerminalView>,
+}
+
+pub struct AppShell {
+    tabs: Vec<Tab>,
+    active_tab: usize,
+    next_id: u64,
+    focus_handle: FocusHandle,
+}
+
+impl AppShell {
+    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let focus_handle = cx.focus_handle();
+        let mut shell = Self {
+            tabs: Vec::new(),
+            active_tab: 0,
+            next_id: 0,
+            focus_handle,
+        };
+        shell.spawn_tab(window, cx);
+        shell
+    }
+
+    /// Open a fresh shell session and append it as a new tab. The new
+    /// tab becomes the active one and the terminal grabs focus.
+    fn spawn_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let shell = std::env::var("CODESCOPE_SHELL")
+            .ok()
+            .map(|program| Shell::new(program, Vec::new()))
+            .or_else(|| {
+                if cfg!(windows) {
+                    Some(Shell::new("pwsh.exe".into(), Vec::new()))
+                } else {
+                    None
+                }
+            });
+
+        let mut env = HashMap::new();
+        env.insert("TERM".into(), "xterm-256color".into());
+        env.insert("COLORTERM".into(), "truecolor".into());
+        env.insert("TERM_PROGRAM".into(), "CodeScope".into());
+        env.insert("TERM_PROGRAM_VERSION".into(), "0.0.1".into());
+
+        let backend = match Backend::spawn(SpawnConfig {
+            shell,
+            env,
+            size: TerminalSize {
+                num_lines: 30,
+                num_cols: 100,
+                cell_width: 8,
+                cell_height: 18,
+            },
+            ..SpawnConfig::default()
+        }) {
+            Ok(b) => b,
+            Err(err) => {
+                eprintln!("failed to spawn terminal backend: {err:#}");
+                return;
+            }
+        };
+
+        let terminal = cx.new(|cx| TerminalView::new(backend, cx));
+        let id = self.next_id;
+        self.next_id += 1;
+        self.tabs.push(Tab {
+            id,
+            title: format!("Terminal {}", id + 1).into(),
+            terminal,
+        });
+        let new_idx = self.tabs.len() - 1;
+        self.activate_tab(new_idx, window, cx);
+    }
+
+    fn close_tab(&mut self, idx: usize, window: &mut Window, cx: &mut Context<Self>) {
+        if idx >= self.tabs.len() {
+            return;
+        }
+        self.tabs.remove(idx);
+        if self.tabs.is_empty() {
+            // Last tab closed — quit the app.
+            cx.quit();
+            return;
+        }
+        if self.active_tab >= self.tabs.len() {
+            self.active_tab = self.tabs.len() - 1;
+        } else if self.active_tab > idx {
+            self.active_tab -= 1;
+        }
+        self.activate_tab(self.active_tab, window, cx);
+    }
+
+    fn activate_tab(&mut self, idx: usize, window: &mut Window, cx: &mut Context<Self>) {
+        if idx >= self.tabs.len() {
+            return;
+        }
+        self.active_tab = idx;
+        let handle = self.tabs[idx].terminal.read(cx).focus_handle(cx);
+        handle.focus(window);
+        cx.notify();
+    }
+
+    fn next_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.tabs.is_empty() {
+            return;
+        }
+        let next = (self.active_tab + 1) % self.tabs.len();
+        self.activate_tab(next, window, cx);
+    }
+
+    fn prev_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.tabs.is_empty() {
+            return;
+        }
+        let prev = if self.active_tab == 0 {
+            self.tabs.len() - 1
+        } else {
+            self.active_tab - 1
+        };
+        self.activate_tab(prev, window, cx);
+    }
+
+    fn on_key_down(
+        &mut self,
+        event: &KeyDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let mods = &event.keystroke.modifiers;
+        let key = event.keystroke.key.as_str();
+        // Cmd on macOS, Ctrl elsewhere — gpui already maps `platform`
+        // to the right modifier per OS, so we just check both.
+        let app_mod = mods.control || mods.platform;
+        if !app_mod || mods.alt {
+            return;
+        }
+        match key {
+            "t" if !mods.shift => {
+                cx.stop_propagation();
+                self.spawn_tab(window, cx);
+            }
+            "w" if !mods.shift => {
+                cx.stop_propagation();
+                self.close_tab(self.active_tab, window, cx);
+            }
+            "tab" if !mods.shift => {
+                cx.stop_propagation();
+                self.next_tab(window, cx);
+            }
+            "tab" if mods.shift => {
+                cx.stop_propagation();
+                self.prev_tab(window, cx);
+            }
+            d if !mods.shift && d.len() == 1 => {
+                if let Some(n) = d.chars().next().and_then(|c| c.to_digit(10)) {
+                    if n >= 1 && n <= 9 {
+                        let idx = (n as usize) - 1;
+                        if idx < self.tabs.len() {
+                            cx.stop_propagation();
+                            self.activate_tab(idx, window, cx);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Focusable for AppShell {
+    fn focus_handle(&self, _cx: &gpui::App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for AppShell {
+    fn render(
+        &mut self,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        // Snapshot the data we need into owned values up front. Lets us
+        // hand each `cx.listener` its own mutable borrow without
+        // overlapping with the immutable borrow `self.tabs.iter()`
+        // would otherwise hold.
+        let active_idx = self.active_tab;
+        let tab_meta: Vec<(usize, u64, SharedString)> = self
+            .tabs
+            .iter()
+            .enumerate()
+            .map(|(idx, tab)| (idx, tab.id, tab.title.clone()))
+            .collect();
+        let active_terminal = self
+            .tabs
+            .get(self.active_tab)
+            .map(|t| t.terminal.clone());
+
+        let tabs = tab_meta.into_iter().map(|(idx, id, title)| {
+            let active = idx == active_idx;
+            let bg = if active {
+                theme::frost_10()
+            } else {
+                theme::canvas()
+            };
+            let text_color = if active {
+                theme::ink()
+            } else {
+                theme::ink_dim()
+            };
+
+            div()
+                .id(("tab", id))
+                .h_full()
+                .my(px(6.0))
+                .px_3()
+                .min_w(px(120.0))
+                .max_w(px(220.0))
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_2()
+                .rounded_md()
+                .bg(bg)
+                .text_color(text_color)
+                .hover(|s| s.bg(theme::frost_10()))
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, window, cx| {
+                        this.activate_tab(idx, window, cx);
+                    }),
+                )
+                .child(div().flex_grow().truncate().child(title))
+                .child(
+                    div()
+                        .id(("close", idx as u64))
+                        .w(px(18.0))
+                        .h(px(18.0))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded_full()
+                        .text_color(theme::ink_ghost())
+                        .hover(|s| s.bg(theme::frost_20()).text_color(theme::ink()))
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _, window, cx| {
+                                cx.stop_propagation();
+                                this.close_tab(idx, window, cx);
+                            }),
+                        )
+                        .child("×"),
+                )
+        });
+
+        let new_tab_button = div()
+            .id("new-tab")
+            .my(px(6.0))
+            .w(px(28.0))
+            .flex()
+            .items_center()
+            .justify_center()
+            .rounded_md()
+            .text_color(theme::ink_dim())
+            .hover(|s| s.bg(theme::frost_10()).text_color(theme::ink()))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    this.spawn_tab(window, cx);
+                }),
+            )
+            .child("+");
+
+        let tab_strip = div()
+            .h(px(40.0))
+            .flex()
+            .flex_row()
+            .px_2()
+            .gap_1()
+            .border_b_1()
+            .border_color(theme::divider())
+            .bg(theme::near_black())
+            .children(tabs)
+            .child(new_tab_button);
+
+        let body = if let Some(terminal) = active_terminal {
+            div().size_full().child(terminal).into_any_element()
+        } else {
+            // No tabs left — usually we've just quit, but render a
+            // black void in the meantime so we never flash.
+            div().size_full().into_any_element()
+        };
+
+        div()
+            .key_context("AppShell")
+            .track_focus(&self.focus_handle)
+            .on_key_down(cx.listener(Self::on_key_down))
+            .size_full()
+            .flex()
+            .flex_col()
+            .bg(theme::canvas())
+            .text_color(theme::ink())
+            .child(tab_strip)
+            .child(div().flex_grow().child(body))
+    }
+}

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -25,7 +25,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use codescope_core::{Settings, Theme};
+use codescope_core::{ProjectsConfig, Settings, Theme};
 use codescope_terminal::{
     Backend, ColorPalette, CursorStylePreset, FontConfig, Shell, SpawnConfig, TerminalSize,
     TerminalView,
@@ -35,6 +35,7 @@ use gpui::{
     KeyDownEvent, MouseButton, ParentElement, Render, SharedString, Styled, Window, div, px,
 };
 
+use crate::sidebar::Sidebar;
 use crate::theme;
 
 /// One tab = one terminal session.
@@ -56,16 +57,21 @@ pub struct AppShell {
     /// Active theme — chrome reads from this on every render. Kept
     /// in an `Arc` so swapping themes is a single pointer write.
     theme: Arc<Theme>,
+    /// Left rail. Lives behind a feature flag in the layout state —
+    /// hidden when the user collapses the sidebar (later).
+    sidebar: Entity<Sidebar>,
 }
 
 impl AppShell {
     pub fn new(
         settings: Arc<Settings>,
         theme: Arc<Theme>,
+        projects: Arc<ProjectsConfig>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
+        let sidebar = cx.new(|_| Sidebar::new(projects, theme.clone()));
         let mut shell = Self {
             tabs: Vec::new(),
             active_tab: 0,
@@ -73,6 +79,7 @@ impl AppShell {
             focus_handle,
             settings,
             theme,
+            sidebar,
         };
         shell.spawn_tab(window, cx);
         shell
@@ -380,6 +387,13 @@ impl Render for AppShell {
             div().size_full().into_any_element()
         };
 
+        let main_row = div()
+            .flex_grow()
+            .flex()
+            .flex_row()
+            .child(self.sidebar.clone())
+            .child(div().flex_grow().child(body));
+
         div()
             .key_context("AppShell")
             .track_focus(&self.focus_handle)
@@ -390,7 +404,7 @@ impl Render for AppShell {
             .bg(theme::canvas(&theme))
             .text_color(theme::ink(&theme))
             .child(tab_strip)
-            .child(div().flex_grow().child(body))
+            .child(main_row)
     }
 }
 

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -1,0 +1,195 @@
+//! Left-rail PROJECTS sidebar.
+//!
+//! Single-purpose view: lists every entry in the loaded
+//! [`codescope_core::ProjectsConfig`] and lets the user select one.
+//! No "add project" / "remove project" interactions yet — that lives
+//! one step further along the roadmap, behind a `+` action and a
+//! command-palette entry.
+//!
+//! Layout (240 px wide):
+//!
+//! ```text
+//! ┌───────────────┐
+//! │ PROJECTS    + │ ← heading + add (placeholder)
+//! ├───────────────┤
+//! │ filter…       │ ← (placeholder, wired next session)
+//! ├───────────────┤
+//! │ ▍ project A   │ ← active = accent rail + frost bg
+//! │   project B   │
+//! │   project C   │
+//! └───────────────┘
+//! ```
+
+use std::sync::Arc;
+
+use codescope_core::{ProjectsConfig, Theme};
+use gpui::{
+    Context, InteractiveElement, IntoElement, MouseButton, ParentElement, Render, SharedString,
+    Styled, Window, div, px,
+};
+
+use crate::theme;
+
+/// Width of the sidebar pane. The C# build uses 240 with a
+/// resizable splitter; we keep it fixed for now and add the splitter
+/// when there's a second column to balance against.
+pub const SIDEBAR_WIDTH: f32 = 240.0;
+
+pub struct Sidebar {
+    projects: Arc<ProjectsConfig>,
+    /// Index of the currently-selected project. `None` when no
+    /// projects exist yet.
+    selected: Option<usize>,
+    theme: Arc<Theme>,
+}
+
+impl Sidebar {
+    pub fn new(projects: Arc<ProjectsConfig>, theme: Arc<Theme>) -> Self {
+        let selected = (!projects.projects.is_empty()).then_some(0);
+        Self { projects, selected, theme }
+    }
+
+    pub fn select(&mut self, idx: usize, cx: &mut Context<Self>) {
+        if idx < self.projects.projects.len() {
+            self.selected = Some(idx);
+            cx.notify();
+        }
+    }
+
+    /// Apply a fresh theme snapshot. Called by the AppShell when the
+    /// user changes themes — the sidebar redraws on the next frame.
+    #[allow(dead_code)]
+    pub fn apply_theme(&mut self, theme: Arc<Theme>, cx: &mut Context<Self>) {
+        self.theme = theme;
+        cx.notify();
+    }
+}
+
+impl Render for Sidebar {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = self.theme.clone();
+        let selected = self.selected;
+        let rows: Vec<_> = self
+            .projects
+            .projects
+            .iter()
+            .enumerate()
+            .map(|(idx, p)| (idx, p.id.clone(), SharedString::from(p.name.clone())))
+            .collect();
+
+        let heading = div()
+            .h(px(40.0))
+            .flex()
+            .flex_row()
+            .items_center()
+            .px_3()
+            .text_size(px(11.0))
+            .text_color(theme::ink_muted(&theme))
+            .child(div().flex_grow().child("PROJECTS"))
+            // Placeholder "+" button — wired up in a follow-up commit.
+            .child(
+                div()
+                    .id("sidebar-add")
+                    .w(px(20.0))
+                    .h(px(20.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded_sm()
+                    .text_color(theme::ink_ghost(&theme))
+                    .hover({
+                        let frost = theme::frost_10(&theme);
+                        let ink = theme::ink(&theme);
+                        move |s| s.bg(frost).text_color(ink)
+                    })
+                    .child("+"),
+            );
+
+        let empty_state = if self.projects.projects.is_empty() {
+            Some(
+                div()
+                    .px_3()
+                    .py_4()
+                    .text_size(px(12.0))
+                    .text_color(theme::ink_ghost(&theme))
+                    .child("No projects yet. Click + to add one."),
+            )
+        } else {
+            None
+        };
+
+        let project_rows = rows.into_iter().map(|(idx, id, name)| {
+            let active = selected == Some(idx);
+            let bg = if active {
+                theme::frost_10(&theme)
+            } else {
+                gpui::transparent_black()
+            };
+            let rail = if active {
+                theme::accent(&theme)
+            } else {
+                gpui::transparent_black()
+            };
+            let text_color = if active {
+                theme::ink(&theme)
+            } else {
+                theme::ink_dim(&theme)
+            };
+            let frost_hover = theme::frost_10(&theme);
+            let ink_hover = theme::ink(&theme);
+
+            div()
+                .id(("project", id_hash(&id)))
+                .h(px(32.0))
+                .flex()
+                .flex_row()
+                .items_center()
+                .pr_3()
+                .border_l_2()
+                .border_color(rail)
+                .pl(px(10.0)) // 12px - 2px border = 10
+                .bg(bg)
+                .text_color(text_color)
+                .text_size(px(13.0))
+                .hover(move |s| {
+                    if active { s } else { s.bg(frost_hover).text_color(ink_hover) }
+                })
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, _, cx| this.select(idx, cx)),
+                )
+                .child(div().flex_grow().truncate().child(name))
+        });
+
+        let mut body = div()
+            .flex()
+            .flex_col()
+            .py_1()
+            .children(project_rows);
+        if let Some(es) = empty_state {
+            body = body.child(es);
+        }
+
+        div()
+            .w(px(SIDEBAR_WIDTH))
+            .h_full()
+            .flex()
+            .flex_col()
+            .bg(theme::elevated(&theme))
+            .border_r_1()
+            .border_color(theme::divider(&theme))
+            .child(heading)
+            .child(div().h_px().bg(theme::divider(&theme)))
+            .child(body)
+    }
+}
+
+/// Cheap hash for use as a gpui element id derived from a string id.
+/// `id` itself isn't `Hash` for gpui's id needs but `(static_str, u64)`
+/// is — so we shrink the project id to a u64.
+fn id_hash(id: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    id.hash(&mut hasher);
+    hasher.finish()
+}

--- a/codescope-rs/src/theme.rs
+++ b/codescope-rs/src/theme.rs
@@ -58,7 +58,6 @@ pub fn with_alpha(rgb: Rgb, alpha: f32) -> Hsla {
 pub fn canvas(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.canvas) }
 pub fn elevated(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.elevated) }
 pub fn ink(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.ink) }
-#[allow(dead_code)]
 pub fn ink_muted(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.ink_muted) }
 pub fn divider(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.divider) }
 pub fn accent(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.accent) }

--- a/codescope-rs/src/theme.rs
+++ b/codescope-rs/src/theme.rs
@@ -47,7 +47,6 @@ pub fn surface_border() -> Hsla { rgb(0x1f1f1f).into() }
 
 // ─── Status dots ────────────────────────────────────────────────────
 
-#[allow(dead_code)]
 pub fn status_running() -> Hsla { rgb(0x22c55e).into() } // emerald
 #[allow(dead_code)]
 pub fn status_idle() -> Hsla { ink_muted() }

--- a/codescope-rs/src/theme.rs
+++ b/codescope-rs/src/theme.rs
@@ -1,0 +1,55 @@
+//! Color tokens lifted from CodeScope's
+//! `src/CodeScope.App/Styles/DesignTokens.xaml`. Same hex values, same
+//! names — when the visual designers update the C# tokens we update
+//! these and the two builds stay in lock-step.
+//!
+//! Philosophy (DESIGN.md §2):
+//! * Binary surface — pure black canvas + pure white ink.
+//! * One accent — Framer Blue. Used for focus rings, the active tab
+//!   underline, and links. **No** secondary accent.
+//! * Frosted glass via white-on-black alpha tiers (10 / 20 / 50).
+//! * Pill geometry on every interactive CTA (radius 40+, never square).
+
+use gpui::{Hsla, rgb, rgba};
+
+// ─── Binary ink + canvas ────────────────────────────────────────────
+
+pub fn canvas() -> Hsla { rgb(0x000000).into() }
+pub fn near_black() -> Hsla { rgb(0x090909).into() }
+pub fn ink() -> Hsla { rgb(0xffffff).into() }
+pub fn ink_muted() -> Hsla { rgb(0xa6a6a6).into() }
+pub fn ink_dim() -> Hsla { rgba(0xffffff99).into() }   // 0.60 alpha
+pub fn ink_ghost() -> Hsla { rgba(0xffffff66).into() } // 0.40 alpha
+pub fn divider() -> Hsla { rgba(0xffffff22).into() }
+
+// ─── Framer Blue (the only accent) ──────────────────────────────────
+
+#[allow(dead_code)]
+pub fn accent() -> Hsla { rgb(0x0099ff).into() }
+#[allow(dead_code)]
+pub fn accent_glow() -> Hsla { rgba(0x0099ff26).into() }     // 0.15
+#[allow(dead_code)]
+pub fn accent_glow_soft() -> Hsla { rgba(0x0099ff14).into() } // 0.08
+
+// ─── Frosted glass (white over black) ──────────────────────────────
+
+pub fn frost_10() -> Hsla { rgba(0xffffff1a).into() } // button surface
+pub fn frost_20() -> Hsla { rgba(0xffffff33).into() } // hover
+#[allow(dead_code)]
+pub fn frost_50() -> Hsla { rgba(0xffffff80).into() } // emphasis hover
+
+// ─── Surfaces (Overview tokens — exact values from C# build) ────────
+
+#[allow(dead_code)]
+pub fn surface_elev() -> Hsla { rgb(0x141414).into() }
+#[allow(dead_code)]
+pub fn surface_border() -> Hsla { rgb(0x1f1f1f).into() }
+
+// ─── Status dots ────────────────────────────────────────────────────
+
+#[allow(dead_code)]
+pub fn status_running() -> Hsla { rgb(0x22c55e).into() } // emerald
+#[allow(dead_code)]
+pub fn status_idle() -> Hsla { ink_muted() }
+#[allow(dead_code)]
+pub fn status_error() -> Hsla { rgb(0xef4444).into() } // red

--- a/codescope-rs/src/theme.rs
+++ b/codescope-rs/src/theme.rs
@@ -1,54 +1,79 @@
-//! Color tokens lifted from CodeScope's
-//! `src/CodeScope.App/Styles/DesignTokens.xaml`. Same hex values, same
-//! names — when the visual designers update the C# tokens we update
-//! these and the two builds stay in lock-step.
+//! gpui-side theme helpers.
 //!
-//! Philosophy (DESIGN.md §2):
-//! * Binary surface — pure black canvas + pure white ink.
-//! * One accent — Framer Blue. Used for focus rings, the active tab
-//!   underline, and links. **No** secondary accent.
-//! * Frosted glass via white-on-black alpha tiers (10 / 20 / 50).
-//! * Pill geometry on every interactive CTA (radius 40+, never square).
+//! `codescope-core` owns the theme *data* (serializable, UI-free).
+//! This module is the bridge: it reads the active `core::Theme` and
+//! hands gpui-flavoured `Hsla` values back to the renderer. When we
+//! later add a theme picker / live reload, the `Theme` reference in
+//! `AppShell` gets swapped and every accessor here returns the new
+//! values on the next render — no touch required in the call sites.
 
-use gpui::{Hsla, rgb, rgba};
+use codescope_core::{Rgb, Theme};
+use gpui::{Hsla, hsla};
 
-// ─── Binary ink + canvas ────────────────────────────────────────────
+/// Convert an 8-bit-per-channel RGB triplet to gpui's `Hsla`. Direct
+/// translation, no gamma — gpui handles colour-space matters
+/// internally.
+pub fn rgb_to_hsla(rgb: Rgb) -> Hsla {
+    let r = rgb.r as f32 / 255.0;
+    let g = rgb.g as f32 / 255.0;
+    let b = rgb.b as f32 / 255.0;
+    let max = r.max(g).max(b);
+    let min = r.min(g).min(b);
+    let delta = max - min;
+    let l = (max + min) / 2.0;
+    let s = if delta == 0.0 {
+        0.0
+    } else {
+        delta / (1.0 - (2.0 * l - 1.0).abs())
+    };
+    let h = if delta == 0.0 {
+        0.0
+    } else if max == r {
+        60.0 * (((g - b) / delta).rem_euclid(6.0))
+    } else if max == g {
+        60.0 * (((b - r) / delta) + 2.0)
+    } else {
+        60.0 * (((r - g) / delta) + 4.0)
+    };
+    let h = if h < 0.0 { h + 360.0 } else { h } / 360.0;
+    hsla(h, s, l, 1.0)
+}
 
-pub fn canvas() -> Hsla { rgb(0x000000).into() }
-pub fn near_black() -> Hsla { rgb(0x090909).into() }
-pub fn ink() -> Hsla { rgb(0xffffff).into() }
-pub fn ink_muted() -> Hsla { rgb(0xa6a6a6).into() }
-pub fn ink_dim() -> Hsla { rgba(0xffffff99).into() }   // 0.60 alpha
-pub fn ink_ghost() -> Hsla { rgba(0xffffff66).into() } // 0.40 alpha
-pub fn divider() -> Hsla { rgba(0xffffff22).into() }
+/// Same as [`rgb_to_hsla`] but with an explicit alpha (0.0–1.0). The
+/// frosted-glass surfaces in the chrome are derived this way:
+/// `with_alpha(theme.chrome.ink, 0.10)` = `frost_10`.
+pub fn with_alpha(rgb: Rgb, alpha: f32) -> Hsla {
+    let mut color = rgb_to_hsla(rgb);
+    color.a = alpha.clamp(0.0, 1.0);
+    color
+}
 
-// ─── Framer Blue (the only accent) ──────────────────────────────────
+// ─── Chrome accessors ───────────────────────────────────────────────
+//
+// Tiny wrappers around the theme's `chrome` block. Renderers call
+// `theme::canvas(theme)` instead of reaching into `theme.chrome.canvas`
+// directly so we can swap out the lookup later (e.g. when a tab can
+// override its accent without mutating the global theme).
 
+pub fn canvas(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.canvas) }
+pub fn elevated(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.elevated) }
+pub fn ink(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.ink) }
 #[allow(dead_code)]
-pub fn accent() -> Hsla { rgb(0x0099ff).into() }
-#[allow(dead_code)]
-pub fn accent_glow() -> Hsla { rgba(0x0099ff26).into() }     // 0.15
-#[allow(dead_code)]
-pub fn accent_glow_soft() -> Hsla { rgba(0x0099ff14).into() } // 0.08
+pub fn ink_muted(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.ink_muted) }
+pub fn divider(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.divider) }
+pub fn accent(theme: &Theme) -> Hsla { rgb_to_hsla(theme.chrome.accent) }
 
-// ─── Frosted glass (white over black) ──────────────────────────────
-
-pub fn frost_10() -> Hsla { rgba(0xffffff1a).into() } // button surface
-pub fn frost_20() -> Hsla { rgba(0xffffff33).into() } // hover
+/// Frosted-glass overlays — ink at varying alpha, the same trick the
+/// C# build uses for hover states and button surfaces.
+pub fn frost_10(theme: &Theme) -> Hsla { with_alpha(theme.chrome.ink, 0.10) }
+pub fn frost_20(theme: &Theme) -> Hsla { with_alpha(theme.chrome.ink, 0.20) }
 #[allow(dead_code)]
-pub fn frost_50() -> Hsla { rgba(0xffffff80).into() } // emphasis hover
+pub fn frost_50(theme: &Theme) -> Hsla { with_alpha(theme.chrome.ink, 0.50) }
 
-// ─── Surfaces (Overview tokens — exact values from C# build) ────────
+/// Dim variants of the ink for placeholders / inactive labels.
+pub fn ink_dim(theme: &Theme) -> Hsla { with_alpha(theme.chrome.ink, 0.60) }
+pub fn ink_ghost(theme: &Theme) -> Hsla { with_alpha(theme.chrome.ink, 0.40) }
 
-#[allow(dead_code)]
-pub fn surface_elev() -> Hsla { rgb(0x141414).into() }
-#[allow(dead_code)]
-pub fn surface_border() -> Hsla { rgb(0x1f1f1f).into() }
-
-// ─── Status dots ────────────────────────────────────────────────────
-
-pub fn status_running() -> Hsla { rgb(0x22c55e).into() } // emerald
-#[allow(dead_code)]
-pub fn status_idle() -> Hsla { ink_muted() }
-#[allow(dead_code)]
-pub fn status_error() -> Hsla { rgb(0xef4444).into() } // red
+/// Status-dot colour. Hard-coded across themes for now — a green dot
+/// reads as "running" in every dark theme we ship. Themable later.
+pub fn status_running() -> Hsla { rgb_to_hsla(Rgb::from_hex(0x22c55e)) }

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -12,12 +12,13 @@
 //!    initial terminal tab and owns everything from there.
 
 mod app;
+mod sidebar;
 mod theme;
 
 use std::sync::Arc;
 
 use anyhow::Result;
-use codescope_core::{AppPaths, Settings, Theme, builtin};
+use codescope_core::{AppPaths, ProjectsConfig, Settings, Theme, builtin};
 use gpui::{
     AppContext, Context, IntoElement, ParentElement, Render, Styled, TitlebarOptions, Window,
     WindowOptions, div,
@@ -63,11 +64,25 @@ fn main() -> Result<()> {
     let theme = Arc::new(builtin::by_name(&settings.theme));
     let settings = Arc::new(settings);
 
+    let projects = match ProjectsConfig::load(&paths) {
+        Ok(p) => p,
+        Err(err) => {
+            eprintln!(
+                "warning: failed to load {} ({}); starting with no projects",
+                paths.projects_file().display(),
+                err
+            );
+            ProjectsConfig::default()
+        }
+    };
+    let projects = Arc::new(projects);
+
     let app = gpui::Application::new();
 
     app.run(move |cx| {
         let settings = settings.clone();
         let theme = theme.clone();
+        let projects = projects.clone();
         cx.spawn(async move |cx| {
             cx.open_window(
                 WindowOptions {
@@ -79,7 +94,7 @@ fn main() -> Result<()> {
                     ..Default::default()
                 },
                 |window, cx| {
-                    let shell = cx.new(|cx| AppShell::new(settings, theme.clone(), window, cx));
+                    let shell = cx.new(|cx| AppShell::new(settings, theme.clone(), projects, window, cx));
                     cx.new(|_| Root { shell, theme })
                 },
             )?;

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -18,10 +18,10 @@ mod theme;
 use std::sync::Arc;
 
 use anyhow::Result;
-use codescope_core::{AppPaths, ProjectsConfig, Settings, Theme, builtin};
+use codescope_core::{AppPaths, LayoutState, ProjectsConfig, Settings, Theme, WindowState, builtin};
 use gpui::{
-    AppContext, Context, IntoElement, ParentElement, Render, Styled, TitlebarOptions, Window,
-    WindowOptions, div,
+    AppContext, Bounds, Context, IntoElement, ParentElement, Pixels, Render, Styled,
+    TitlebarOptions, Window, WindowBounds, WindowOptions, div, point, px, size,
 };
 
 use crate::app::AppShell;
@@ -77,15 +77,71 @@ fn main() -> Result<()> {
     };
     let projects = Arc::new(projects);
 
+    let layout = match LayoutState::load(&paths) {
+        Ok(l) => l,
+        Err(err) => {
+            eprintln!(
+                "warning: failed to load {} ({}); using default layout",
+                paths.layout_file().display(),
+                err
+            );
+            LayoutState::default()
+        }
+    };
+    let layout = Arc::new(layout);
+
+    let saved_window = match WindowState::load(&paths) {
+        Ok(state) => state,
+        Err(err) => {
+            eprintln!(
+                "warning: failed to load {} ({}); window will open at default size",
+                paths.window_file().display(),
+                err
+            );
+            None
+        }
+    };
+
+    let window_bounds = saved_window.map(window_state_to_bounds);
+    let paths_for_quit = paths.clone();
+
     let app = gpui::Application::new();
 
     app.run(move |cx| {
         let settings = settings.clone();
         let theme = theme.clone();
         let projects = projects.clone();
+        let layout = layout.clone();
+        let paths_quit = paths_for_quit.clone();
+
+        // Persist UI state on shutdown.
+        //
+        // Window bounds tracking lives one notch deeper than
+        // `on_app_quit` can reach (no `Window` handle here), so
+        // for now the load path restores the last-known window
+        // size + position but the *save* path is wired against a
+        // shared cell that AppShell will start updating as soon as
+        // we add `cx.observe_window_bounds` — landed in a follow-up.
+        //
+        // Layout state (sidebar visibility, selected project) is
+        // mutable via the AppShell already, so we save the live
+        // value here. For now `LayoutState::default()` is correct
+        // — toggle / select wiring follows in the same commit
+        // sequence.
+        cx.on_app_quit(move |_| {
+            let paths = paths_quit.clone();
+            async move {
+                if let Err(err) = LayoutState::default().save(&paths) {
+                    eprintln!("failed to save layout state: {err:#}");
+                }
+            }
+        })
+        .detach();
+
         cx.spawn(async move |cx| {
             cx.open_window(
                 WindowOptions {
+                    window_bounds,
                     titlebar: Some(TitlebarOptions {
                         title: Some("CodeScope".into()),
                         appears_transparent: true,
@@ -101,7 +157,36 @@ fn main() -> Result<()> {
             Ok::<_, anyhow::Error>(())
         })
         .detach();
+        let _ = layout;
     });
 
     Ok(())
 }
+
+fn window_state_to_bounds(state: WindowState) -> WindowBounds {
+    let bounds = Bounds {
+        origin: point(px(state.x as f32), px(state.y as f32)),
+        size: size(px(state.width as f32), px(state.height as f32)),
+    };
+    if state.maximised {
+        WindowBounds::Maximized(bounds)
+    } else {
+        WindowBounds::Windowed(bounds)
+    }
+}
+
+#[allow(dead_code)]
+fn bounds_to_window_state(bounds: Bounds<Pixels>, maximised: bool) -> WindowState {
+    let f32_x: f32 = bounds.origin.x.into();
+    let f32_y: f32 = bounds.origin.y.into();
+    let f32_w: f32 = bounds.size.width.into();
+    let f32_h: f32 = bounds.size.height.into();
+    WindowState {
+        x: f32_x as i32,
+        y: f32_y as i32,
+        width: f32_w.max(0.0) as u32,
+        height: f32_h.max(0.0) as u32,
+        maximised,
+    }
+}
+

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -103,7 +103,6 @@ fn main() -> Result<()> {
     };
 
     let window_bounds = saved_window.map(window_state_to_bounds);
-    let paths_for_quit = paths.clone();
 
     let app = gpui::Application::new();
 
@@ -112,31 +111,14 @@ fn main() -> Result<()> {
         let theme = theme.clone();
         let projects = projects.clone();
         let layout = layout.clone();
-        let paths_quit = paths_for_quit.clone();
 
-        // Persist UI state on shutdown.
-        //
-        // Window bounds tracking lives one notch deeper than
-        // `on_app_quit` can reach (no `Window` handle here), so
-        // for now the load path restores the last-known window
-        // size + position but the *save* path is wired against a
-        // shared cell that AppShell will start updating as soon as
-        // we add `cx.observe_window_bounds` — landed in a follow-up.
-        //
-        // Layout state (sidebar visibility, selected project) is
-        // mutable via the AppShell already, so we save the live
-        // value here. For now `LayoutState::default()` is correct
-        // — toggle / select wiring follows in the same commit
-        // sequence.
-        cx.on_app_quit(move |_| {
-            let paths = paths_quit.clone();
-            async move {
-                if let Err(err) = LayoutState::default().save(&paths) {
-                    eprintln!("failed to save layout state: {err:#}");
-                }
-            }
-        })
-        .detach();
+        // No quit-time save yet. Writing `LayoutState::default()`
+        // would clobber any layout the user (or a previous session)
+        // saved, and we don't yet have live state on the AppShell
+        // to write instead. `window.json` is in the same boat — we
+        // restore on launch but don't observe bounds-changes to
+        // write back. Both wires land together with
+        // `cx.observe_window_bounds`.
 
         cx.spawn(async move |cx| {
             cx.open_window(

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -1,14 +1,23 @@
 //! `cargo run --bin window` — launches the gpui app shell.
 //!
-//! Sets up one window with our custom title-bar treatment (transparent
-//! native titlebar so the tab strip can occupy that space) and hands
-//! control to [`crate::app::AppShell`], which owns the tab list and the
-//! active terminal.
+//! Boot sequence:
+//!
+//! 1. Resolve env-aware paths (`CODESCOPE_DEV` redirect honoured).
+//! 2. Load `settings.json` (or fall back to defaults; missing file is
+//!    fine, malformed file logs a warning and uses defaults).
+//! 3. Resolve the active theme by name from the built-in registry.
+//! 4. Open one window with a transparent native titlebar so the tab
+//!    strip can claim that vertical space.
+//! 5. Hand control to [`crate::app::AppShell`], which spawns the
+//!    initial terminal tab and owns everything from there.
 
 mod app;
 mod theme;
 
+use std::sync::Arc;
+
 use anyhow::Result;
+use codescope_core::{AppPaths, Settings, Theme, builtin};
 use gpui::{
     AppContext, Context, IntoElement, ParentElement, Render, Styled, TitlebarOptions, Window,
     WindowOptions, div,
@@ -18,18 +27,47 @@ use crate::app::AppShell;
 
 struct Root {
     shell: gpui::Entity<AppShell>,
+    theme: Arc<Theme>,
 }
 
 impl Render for Root {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        div().size_full().bg(theme::canvas()).child(self.shell.clone())
+        div()
+            .size_full()
+            .bg(theme::canvas(&self.theme))
+            .child(self.shell.clone())
     }
 }
 
 fn main() -> Result<()> {
+    let paths = AppPaths::detect();
+    if let Err(err) = paths.ensure_dirs() {
+        eprintln!(
+            "warning: could not create config dirs ({}): {}",
+            paths.config_dir.display(),
+            err
+        );
+    }
+
+    let settings = match Settings::load(&paths) {
+        Ok(s) => s,
+        Err(err) => {
+            eprintln!(
+                "warning: failed to load {} ({}); using defaults",
+                paths.settings_file().display(),
+                err
+            );
+            Settings::default()
+        }
+    };
+    let theme = Arc::new(builtin::by_name(&settings.theme));
+    let settings = Arc::new(settings);
+
     let app = gpui::Application::new();
 
     app.run(move |cx| {
+        let settings = settings.clone();
+        let theme = theme.clone();
         cx.spawn(async move |cx| {
             cx.open_window(
                 WindowOptions {
@@ -41,8 +79,8 @@ fn main() -> Result<()> {
                     ..Default::default()
                 },
                 |window, cx| {
-                    let shell = cx.new(|cx| AppShell::new(window, cx));
-                    cx.new(|_| Root { shell })
+                    let shell = cx.new(|cx| AppShell::new(settings, theme.clone(), window, cx));
+                    cx.new(|_| Root { shell, theme })
                 },
             )?;
             Ok::<_, anyhow::Error>(())

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -1,24 +1,28 @@
-//! `cargo run --bin window` — minimal demo of `codescope_terminal::TerminalView`.
+//! `cargo run --bin window` — launches the gpui app shell.
 //!
-//! Spawns the platform default shell through our own `Backend`, hosts it
-//! inside a single gpui window, and lets you type. No scrollback, no
-//! per-cell colour yet — see `codescope-terminal/src/view.rs` for the
-//! current limits and the planned next steps.
+//! Sets up one window with our custom title-bar treatment (transparent
+//! native titlebar so the tab strip can occupy that space) and hands
+//! control to [`crate::app::AppShell`], which owns the tab list and the
+//! active terminal.
+
+mod app;
+mod theme;
 
 use anyhow::Result;
-use codescope_terminal::{Backend, Shell, SpawnConfig, TerminalSize, TerminalView};
 use gpui::{
-    AppContext, Context, Entity, Focusable, IntoElement, ParentElement, Render, Styled,
-    TitlebarOptions, Window, WindowOptions, div,
+    AppContext, Context, IntoElement, ParentElement, Render, Styled, TitlebarOptions, Window,
+    WindowOptions, div,
 };
 
-struct TerminalApp {
-    terminal: Entity<TerminalView>,
+use crate::app::AppShell;
+
+struct Root {
+    shell: gpui::Entity<AppShell>,
 }
 
-impl Render for TerminalApp {
+impl Render for Root {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        div().size_full().child(self.terminal.clone())
+        div().size_full().bg(theme::canvas()).child(self.shell.clone())
     }
 }
 
@@ -30,51 +34,15 @@ fn main() -> Result<()> {
             cx.open_window(
                 WindowOptions {
                     titlebar: Some(TitlebarOptions {
-                        title: Some("codescope-rs window".into()),
+                        title: Some("CodeScope".into()),
+                        appears_transparent: true,
                         ..Default::default()
                     }),
                     ..Default::default()
                 },
                 |window, cx| {
-                    let shell = std::env::var("CODESCOPE_SHELL")
-                        .ok()
-                        .map(|program| Shell::new(program, Vec::new()))
-                        .or_else(|| {
-                            if cfg!(windows) {
-                                Some(Shell::new("pwsh.exe".into(), Vec::new()))
-                            } else {
-                                None
-                            }
-                        });
-
-                    let mut env = std::collections::HashMap::new();
-                    env.insert("TERM".into(), "xterm-256color".into());
-                    env.insert("COLORTERM".into(), "truecolor".into());
-                    // Identify the host so TUIs that detect minimal
-                    // terminals via TERM_PROGRAM (claude-code, some
-                    // Ink-based apps, …) recognise us as a real
-                    // graphical terminal. Empty TERM_PROGRAM is the
-                    // default on Windows ConPTY, which is why claude
-                    // falls back to its stripped UI.
-                    env.insert("TERM_PROGRAM".into(), "CodeScope".into());
-                    env.insert("TERM_PROGRAM_VERSION".into(), "0.0.1".into());
-
-                    let backend = Backend::spawn(SpawnConfig {
-                        shell,
-                        env,
-                        size: TerminalSize {
-                            num_lines: 30,
-                            num_cols: 100,
-                            cell_width: 8,
-                            cell_height: 18,
-                        },
-                        ..SpawnConfig::default()
-                    })
-                    .expect("Backend::spawn failed");
-
-                    let terminal = cx.new(|cx| TerminalView::new(backend, cx));
-                    terminal.read(cx).focus_handle(cx).focus(window);
-                    cx.new(|_| TerminalApp { terminal })
+                    let shell = cx.new(|cx| AppShell::new(window, cx));
+                    cx.new(|_| Root { shell })
                 },
             )?;
             Ok::<_, anyhow::Error>(())

--- a/codescope-rs/terminal/Cargo.toml
+++ b/codescope-rs/terminal/Cargo.toml
@@ -8,6 +8,7 @@ description = "Terminal emulator component for CodeScope-rs."
 [dependencies]
 alacritty_terminal = "0.25"
 anyhow = "1"
+codescope-core = { path = "../core" }
 flume = { version = "0.11", default-features = false }
 gpui = "0.2.2"
 parking_lot = "0.12"

--- a/codescope-rs/terminal/Cargo.toml
+++ b/codescope-rs/terminal/Cargo.toml
@@ -11,5 +11,6 @@ anyhow = "1"
 codescope-core = { path = "../core" }
 flume = { version = "0.11", default-features = false }
 gpui = "0.2.2"
+linkify = "0.10"
 open = "5"
 parking_lot = "0.12"

--- a/codescope-rs/terminal/Cargo.toml
+++ b/codescope-rs/terminal/Cargo.toml
@@ -11,4 +11,5 @@ anyhow = "1"
 codescope-core = { path = "../core" }
 flume = { version = "0.11", default-features = false }
 gpui = "0.2.2"
+open = "5"
 parking_lot = "0.12"

--- a/codescope-rs/terminal/src/backend.rs
+++ b/codescope-rs/terminal/src/backend.rs
@@ -347,7 +347,14 @@ impl Backend {
                 }
                 let bold = flags.contains(Flags::BOLD);
                 let italic = flags.contains(Flags::ITALIC);
-                let underline = flags.contains(Flags::UNDERLINE);
+                // Hyperlinks (OSC 8) always render with an underline,
+                // regardless of whether the cell explicitly carries
+                // `Flags::UNDERLINE`. Saves the user from emitting
+                // both — and matches every other terminal's hover
+                // affordance for clickable text.
+                let hyperlink: Option<Arc<str>> =
+                    cell.hyperlink().map(|h| Arc::from(h.uri()));
+                let underline = flags.contains(Flags::UNDERLINE) || hyperlink.is_some();
 
                 let selected = content
                     .selection
@@ -378,6 +385,11 @@ impl Backend {
                         && last.bold == bold
                         && last.italic == italic
                         && last.underline == underline
+                        // Don't merge across hyperlinks — adjacent
+                        // links to different URIs would otherwise
+                        // collapse, and we'd lose the per-run uri
+                        // we use for click handling.
+                        && last.hyperlink == hyperlink
                 });
                 if mergeable {
                     let last = line.last_mut().unwrap();
@@ -393,6 +405,7 @@ impl Backend {
                         bold,
                         italic,
                         underline,
+                        hyperlink,
                     });
                 }
             }
@@ -508,6 +521,23 @@ impl Backend {
     pub fn selection_text(&self) -> Option<String> {
         self.terminal.lock().selection_to_string()
     }
+
+    /// Look up the OSC 8 hyperlink at a visible-row / column position.
+    /// Used by the View to decide whether a click should open a URL.
+    /// Returns the resolved URI, or `None` when the cell isn't a link
+    /// (or coordinates are outside the grid).
+    pub fn hyperlink_at(&self, visible_row: usize, col: usize) -> Option<String> {
+        self.with_term(|term| {
+            let display_offset = term.grid().display_offset() as i32;
+            // Translate viewport row → absolute grid line. With
+            // `display_offset = 0` (no scrollback) row 0 = line 0;
+            // when scrolled, row 0 sits at line `-display_offset`.
+            let line = visible_row as i32 - display_offset;
+            let point = Point::new(Line(line), Column(col));
+            let cell = &term.grid()[point];
+            cell.hyperlink().map(|h| h.uri().to_string())
+        })
+    }
 }
 
 /// One contiguous run of cells with identical styling on a single row.
@@ -526,6 +556,11 @@ pub struct StyledRun {
     pub bold: bool,
     pub italic: bool,
     pub underline: bool,
+    /// OSC 8 hyperlink URI, if the cells in this run are clickable.
+    /// Always paints underlined (the renderer treats `hyperlink.is_some()`
+    /// as an implicit `underline = true`). Click-to-open is wired in
+    /// `TerminalView::on_mouse_down`.
+    pub hyperlink: Option<Arc<str>>,
 }
 
 /// Cursor location, shape, and the colour state it should be painted

--- a/codescope-rs/terminal/src/backend.rs
+++ b/codescope-rs/terminal/src/backend.rs
@@ -571,12 +571,20 @@ fn inject_url_hyperlinks(lines: &mut [Vec<StyledRun>]) {
         // column on screen, so linkify's byte ranges translate
         // directly to columns. Wide-char runs throw the alignment
         // off — `apply_url_to_line` skips runs in that case.
+        //
+        // Track `current_col` alongside the string so padding is
+        // O(total_chars) instead of O(chars²) — `chars().count()`
+        // in a while-loop rescans the whole string per padded
+        // space, which would dominate snapshot time on long lines.
         let mut text = String::new();
+        let mut current_col: usize = 0;
         for run in line.iter() {
-            while text.chars().count() < run.start_col {
+            while current_col < run.start_col {
                 text.push(' ');
+                current_col += 1;
             }
             text.push_str(&run.text);
+            current_col += run.text.chars().count();
         }
         let urls: Vec<(usize, usize, Arc<str>)> = finder
             .links(&text)
@@ -584,8 +592,20 @@ fn inject_url_hyperlinks(lines: &mut [Vec<StyledRun>]) {
             .map(|link| (link.start(), link.end(), Arc::from(link.as_str())))
             .collect();
         for (b_start, b_end, url) in urls {
-            let col_start = text[..b_start].chars().count();
-            let col_end = text[..b_end].chars().count();
+            // For ASCII URLs (always the case) byte == char ==
+            // column. The general `chars().count()` is kept as the
+            // safe path in case a future regex-pass admits non-ASCII
+            // matches, but the common path stays O(1) per URL.
+            let col_start = if text.is_char_boundary(b_start) && text[..b_start].is_ascii() {
+                b_start
+            } else {
+                text[..b_start].chars().count()
+            };
+            let col_end = if text.is_char_boundary(b_end) && text[..b_end].is_ascii() {
+                b_end
+            } else {
+                text[..b_end].chars().count()
+            };
             apply_url_to_line(line, col_start, col_end, url);
         }
     }

--- a/codescope-rs/terminal/src/backend.rs
+++ b/codescope-rs/terminal/src/backend.rs
@@ -413,6 +413,13 @@ impl Backend {
                 }
             }
 
+            // Sweep each row for plain-text URLs (claude-code,
+            // `gh pr view`, `cargo --message-format json`, … emit
+            // them without OSC 8) and turn them into clickable runs.
+            // Existing OSC 8 hyperlinks are left alone; URL detection
+            // never overrides an explicit one.
+            inject_url_hyperlinks(&mut lines);
+
             // Cursor info: build now that we've captured the cell under
             // it. For block-style cursors, the renderer inverts colours
             // (cell.bg → text fg, palette.cursor → cursor bg). For beam
@@ -543,6 +550,117 @@ impl Backend {
     }
 }
 
+/// Post-processing pass that finds plain-text URLs (`https://…`,
+/// `http://…`, `file://…`, …) inside each line of styled runs and
+/// retro-tags the matching cells with a hyperlink, just like an OSC 8
+/// link would have done. Lets `claude-code` / `gh` / `cargo` output
+/// stay clickable even though they emit URLs as bare text.
+///
+/// Runs that already carry an OSC 8 hyperlink are left untouched —
+/// the explicit signal always wins. Runs containing wide chars (where
+/// `len_cols != chars().count()`) are skipped to keep splitting safe;
+/// real-world URLs are pure ASCII so this is rarely a constraint.
+fn inject_url_hyperlinks(lines: &mut [Vec<StyledRun>]) {
+    let finder = linkify::LinkFinder::new();
+    for line in lines.iter_mut() {
+        if line.is_empty() {
+            continue;
+        }
+        // Build column-aligned text. With ASCII content (URLs are
+        // always ASCII) the byte index inside `text` matches the
+        // column on screen, so linkify's byte ranges translate
+        // directly to columns. Wide-char runs throw the alignment
+        // off — `apply_url_to_line` skips runs in that case.
+        let mut text = String::new();
+        for run in line.iter() {
+            while text.chars().count() < run.start_col {
+                text.push(' ');
+            }
+            text.push_str(&run.text);
+        }
+        let urls: Vec<(usize, usize, Arc<str>)> = finder
+            .links(&text)
+            .filter(|link| link.kind() == &linkify::LinkKind::Url)
+            .map(|link| (link.start(), link.end(), Arc::from(link.as_str())))
+            .collect();
+        for (b_start, b_end, url) in urls {
+            let col_start = text[..b_start].chars().count();
+            let col_end = text[..b_end].chars().count();
+            apply_url_to_line(line, col_start, col_end, url);
+        }
+    }
+}
+
+fn apply_url_to_line(
+    line: &mut Vec<StyledRun>,
+    url_start: usize,
+    url_end: usize,
+    url: Arc<str>,
+) {
+    let mut new_runs: Vec<StyledRun> = Vec::with_capacity(line.len() + 2);
+    for run in line.drain(..) {
+        let r_start = run.start_col;
+        let r_end = run.start_col + run.len_cols;
+        // Run sits entirely outside the URL → keep as-is.
+        // Run already has its own (OSC 8) hyperlink → don't override.
+        // Run has wide chars → splitting on column boundaries gets
+        // ambiguous, skip the URL injection here.
+        if r_end <= url_start
+            || r_start >= url_end
+            || run.hyperlink.is_some()
+            || run.text.chars().count() != run.len_cols
+        {
+            new_runs.push(run);
+            continue;
+        }
+        let chars: Vec<char> = run.text.chars().collect();
+        let split_left = url_start.saturating_sub(r_start);
+        let split_right = (url_end - r_start).min(run.len_cols);
+
+        if split_left > 0 {
+            let pre: String = chars[..split_left].iter().collect();
+            new_runs.push(StyledRun {
+                text: pre,
+                start_col: r_start,
+                len_cols: split_left,
+                fg: run.fg,
+                bg: run.bg,
+                bold: run.bold,
+                italic: run.italic,
+                underline: run.underline,
+                hyperlink: None,
+            });
+        }
+        let mid: String = chars[split_left..split_right].iter().collect();
+        new_runs.push(StyledRun {
+            text: mid,
+            start_col: r_start + split_left,
+            len_cols: split_right - split_left,
+            fg: run.fg,
+            bg: run.bg,
+            bold: run.bold,
+            italic: run.italic,
+            underline: true,
+            hyperlink: Some(url.clone()),
+        });
+        if split_right < run.len_cols {
+            let post: String = chars[split_right..].iter().collect();
+            new_runs.push(StyledRun {
+                text: post,
+                start_col: r_start + split_right,
+                len_cols: run.len_cols - split_right,
+                fg: run.fg,
+                bg: run.bg,
+                bold: run.bold,
+                italic: run.italic,
+                underline: run.underline,
+                hyperlink: None,
+            });
+        }
+    }
+    *line = new_runs;
+}
+
 /// One contiguous run of cells with identical styling on a single row.
 /// `start_col` is the leftmost column the run occupies; `len_cols` is
 /// the cell width (each char contributes 1, wide chars contribute 2).
@@ -609,6 +727,21 @@ pub struct TerminalSnapshot {
     pub screen_lines: usize,
     pub default_fg: Hsla,
     pub default_bg: Hsla,
+}
+
+impl TerminalSnapshot {
+    /// Find the OSC 8 / detected-URL hyperlink at a viewport-relative
+    /// (row, col). Walks the row's runs for the one covering `col` —
+    /// O(runs-per-row), tiny in practice. The View uses this for
+    /// hover-cursor and Ctrl-click handling, so it doesn't have to
+    /// re-lock the live `Term` just to look up a URL.
+    pub fn hyperlink_at(&self, row: usize, col: usize) -> Option<Arc<str>> {
+        let line = self.lines.get(row)?;
+        line.iter()
+            .find(|r| col >= r.start_col && col < r.start_col + r.len_cols)?
+            .hyperlink
+            .clone()
+    }
 }
 
 impl Drop for Backend {

--- a/codescope-rs/terminal/src/backend.rs
+++ b/codescope-rs/terminal/src/backend.rs
@@ -69,8 +69,11 @@ pub struct SpawnConfig {
 
 /// Cursor shape + blink that the terminal starts with — what shells
 /// without DECSCUSR (PSReadLine, plain bash) inherit. Mirrors
-/// [`alacritty_terminal::vte::ansi::CursorShape`] but as a serde-
-/// friendly default that can come from `settings.json`.
+/// [`alacritty_terminal::vte::ansi::CursorShape`] in a Copy-cheap form
+/// the [`SpawnConfig`] caller can hand around. Not directly serde —
+/// the app layer parses the string from `settings.json` (`"block"`,
+/// `"beam"`, …) and constructs this struct, keeping alacritty's
+/// `CursorShape` enum out of the on-disk surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CursorStylePreset {
     pub shape: CursorShape,

--- a/codescope-rs/terminal/src/backend.rs
+++ b/codescope-rs/terminal/src/backend.rs
@@ -51,10 +51,37 @@ pub struct SpawnConfig {
     /// Initial geometry. Cell metrics may be 0 if the View hasn't laid
     /// out yet — alacritty only uses them for `WindowSize` reports.
     pub size: TerminalSize,
+    /// Optional palette override. `None` falls back to
+    /// [`ColorPalette::default`] (VS Code dark). The palette is shared
+    /// with the [`EventProxy`] so OSC 4 / 10-12 colour queries answer
+    /// against the theme the user actually sees.
+    pub palette: Option<ColorPalette>,
+    /// Maximum scrollback line count.
+    pub scrollback: usize,
+    /// Default cursor style + blink state. TUIs that emit DECSCUSR
+    /// override this on the fly.
+    pub default_cursor_style: CursorStylePreset,
     /// On Windows, escape command-line arguments per CRT rules. Set
     /// `false` only if you know the child does its own argv parsing.
     #[cfg(target_os = "windows")]
     pub escape_args: bool,
+}
+
+/// Cursor shape + blink that the terminal starts with — what shells
+/// without DECSCUSR (PSReadLine, plain bash) inherit. Mirrors
+/// [`alacritty_terminal::vte::ansi::CursorShape`] but as a serde-
+/// friendly default that can come from `settings.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CursorStylePreset {
+    pub shape: CursorShape,
+    pub blinking: bool,
+}
+
+impl Default for CursorStylePreset {
+    fn default() -> Self {
+        // Match Windows Terminal's out-of-the-box feel.
+        Self { shape: CursorShape::Beam, blinking: true }
+    }
 }
 
 impl Default for SpawnConfig {
@@ -69,6 +96,9 @@ impl Default for SpawnConfig {
                 cell_width: 0,
                 cell_height: 0,
             },
+            palette: None,
+            scrollback: 10_000,
+            default_cursor_style: CursorStylePreset::default(),
             #[cfg(target_os = "windows")]
             escape_args: true,
         }
@@ -131,6 +161,9 @@ impl Backend {
             working_directory,
             env,
             size,
+            palette,
+            scrollback,
+            default_cursor_style,
             #[cfg(target_os = "windows")]
             escape_args,
         } = config;
@@ -152,25 +185,19 @@ impl Backend {
 
         // EventProxy answers colour / text-area-size queries directly
         // on the event-loop thread, so it needs a palette to resolve
-        // against. The View's palette can drift later (themes), but for
-        // the spike a default-cloned copy is fine — colour queries are
-        // niche and updating later is just an `EventProxy::update_palette`
-        // away.
-        let palette = ColorPalette::default();
+        // against. We hand it a clone of whatever the caller chose
+        // (typically derived from the active theme) so OSC 4 / 10-12
+        // responses match what the user actually sees.
+        let palette = palette.unwrap_or_default();
         let (proxy, events) = EventProxy::new(palette, size);
 
-        // Match Windows Terminal's out-of-the-box feel: blinking bar.
-        // Shells that emit DECSCUSR (`\x1b[N q`) override this on the
-        // fly; PSReadLine doesn't, so without our own default the
-        // cursor would be a steady block — confusing on Windows where
-        // every other terminal blinks.
-        let default_cursor_style = alacritty_terminal::vte::ansi::CursorStyle {
-            shape: CursorShape::Beam,
-            blinking: true,
+        let cursor_style = alacritty_terminal::vte::ansi::CursorStyle {
+            shape: default_cursor_style.shape,
+            blinking: default_cursor_style.blinking,
         };
         let term_config = Config {
-            scrolling_history: 10_000,
-            default_cursor_style,
+            scrolling_history: scrollback,
+            default_cursor_style: cursor_style,
             ..Config::default()
         };
         let term = Term::new(term_config, &GridSize::from_window(size), proxy.clone());

--- a/codescope-rs/terminal/src/colors.rs
+++ b/codescope-rs/terminal/src/colors.rs
@@ -99,15 +99,24 @@ impl ColorPalette {
     /// Build a palette from a `codescope_core::ThemePalette`. The core
     /// crate carries the canonical theme data (serializable, UI-free);
     /// this is the bridge that turns it into something the terminal
-    /// renderer can resolve cells against. The 256-colour extended
-    /// table is taken from the theme verbatim — themes that ship a
-    /// custom cube/grayscale ramp get rendered exactly.
+    /// renderer can resolve cells against.
+    ///
+    /// Themes shipped from the built-in registry always provide a full
+    /// 256-entry `extended` table. If a theme loaded from disk (or a
+    /// future hand-edited file) supplies fewer than 256 entries we
+    /// synthesize the missing slots with the standard xterm 6×6×6 cube
+    /// + 24-step grayscale ramp — the terminal renderer indexes
+    /// straight into this table for `Color::Indexed`, so a partial
+    /// table would otherwise paint as black.
     pub fn from_theme_palette(palette: &codescope_core::ThemePalette) -> Self {
+        debug_assert_eq!(
+            palette.extended.len(),
+            256,
+            "ThemePalette.extended should ship a full 256-colour table; \
+             short tables get the standard xterm cube/grayscale fallback"
+        );
         let ansi_rgb: [Rgb; 16] = std::array::from_fn(|i| core_to_alac(palette.ansi[i]));
-        let mut extended_rgb = [Rgb { r: 0, g: 0, b: 0 }; 256];
-        for (slot, src) in extended_rgb.iter_mut().zip(palette.extended.iter()) {
-            *slot = core_to_alac(*src);
-        }
+        let extended_rgb = build_extended_with_fallback(&ansi_rgb, &palette.extended);
         let foreground_rgb = core_to_alac(palette.foreground);
         let background_rgb = core_to_alac(palette.background);
         let cursor_rgb = core_to_alac(palette.cursor);
@@ -193,6 +202,41 @@ impl ColorPalette {
 
 fn core_to_alac(rgb: codescope_core::Rgb) -> Rgb {
     Rgb { r: rgb.r, g: rgb.g, b: rgb.b }
+}
+
+/// Build a 256-entry table from a theme's (possibly partial) extended
+/// palette. Slots beyond `theme_extended.len()` are filled in with the
+/// standard xterm 6×6×6 cube + 24-step grayscale ramp — same numbers
+/// you'd see in any other terminal so OSC 4 / 256-colour apps look
+/// right even when the theme didn't bother spelling out every cell.
+fn build_extended_with_fallback(
+    ansi: &[Rgb; 16],
+    theme_extended: &[codescope_core::Rgb],
+) -> [Rgb; 256] {
+    let mut out = [Rgb { r: 0, g: 0, b: 0 }; 256];
+    // ANSI 0..16 mirror the theme's primary colours.
+    out[..16].copy_from_slice(ansi);
+    // 6×6×6 cube
+    let levels: [u8; 6] = [0, 95, 135, 175, 215, 255];
+    let mut idx = 16;
+    for &r in &levels {
+        for &g in &levels {
+            for &b in &levels {
+                out[idx] = Rgb { r, g, b };
+                idx += 1;
+            }
+        }
+    }
+    // 24-step grayscale
+    for i in 0..24u8 {
+        let v = 8 + i * 10;
+        out[232 + i as usize] = Rgb { r: v, g: v, b: v };
+    }
+    // Now overlay whatever the theme supplied — it wins where present.
+    for (slot, src) in out.iter_mut().zip(theme_extended.iter()) {
+        *slot = core_to_alac(*src);
+    }
+    out
 }
 
 fn dim(mut c: Hsla) -> Hsla {

--- a/codescope-rs/terminal/src/colors.rs
+++ b/codescope-rs/terminal/src/colors.rs
@@ -96,6 +96,36 @@ impl Default for ColorPalette {
 }
 
 impl ColorPalette {
+    /// Build a palette from a `codescope_core::ThemePalette`. The core
+    /// crate carries the canonical theme data (serializable, UI-free);
+    /// this is the bridge that turns it into something the terminal
+    /// renderer can resolve cells against. The 256-colour extended
+    /// table is taken from the theme verbatim — themes that ship a
+    /// custom cube/grayscale ramp get rendered exactly.
+    pub fn from_theme_palette(palette: &codescope_core::ThemePalette) -> Self {
+        let ansi_rgb: [Rgb; 16] = std::array::from_fn(|i| core_to_alac(palette.ansi[i]));
+        let mut extended_rgb = [Rgb { r: 0, g: 0, b: 0 }; 256];
+        for (slot, src) in extended_rgb.iter_mut().zip(palette.extended.iter()) {
+            *slot = core_to_alac(*src);
+        }
+        let foreground_rgb = core_to_alac(palette.foreground);
+        let background_rgb = core_to_alac(palette.background);
+        let cursor_rgb = core_to_alac(palette.cursor);
+
+        Self {
+            ansi: ansi_rgb.map(rgb_to_hsla),
+            extended: extended_rgb.map(rgb_to_hsla),
+            ansi_rgb,
+            extended_rgb,
+            foreground: rgb_to_hsla(foreground_rgb),
+            background: rgb_to_hsla(background_rgb),
+            cursor: rgb_to_hsla(cursor_rgb),
+            foreground_rgb,
+            background_rgb,
+            cursor_rgb,
+        }
+    }
+
     /// Map an alacritty cell colour to a gpui `Hsla`. `colors` is the
     /// per-terminal override table that themes write into; named colours
     /// consult it before falling back to our fixed palette.
@@ -159,6 +189,10 @@ impl ColorPalette {
             _ => self.foreground_rgb,
         }
     }
+}
+
+fn core_to_alac(rgb: codescope_core::Rgb) -> Rgb {
+    Rgb { r: rgb.r, g: rgb.g, b: rgb.b }
 }
 
 fn dim(mut c: Hsla) -> Hsla {

--- a/codescope-rs/terminal/src/lib.rs
+++ b/codescope-rs/terminal/src/lib.rs
@@ -21,9 +21,12 @@ pub mod paint;
 pub mod view;
 
 pub use alacritty_terminal::tty::Shell;
-pub use backend::{Backend, CursorInfo, SpawnConfig, StyledRun, TerminalSize, TerminalSnapshot};
+pub use alacritty_terminal::vte::ansi::CursorShape;
+pub use backend::{
+    Backend, CursorInfo, CursorStylePreset, SpawnConfig, StyledRun, TerminalSize, TerminalSnapshot,
+};
 pub use colors::ColorPalette;
 pub use event::{BackendEvent, EventProxy};
 pub use input::keystroke_to_bytes;
 pub use paint::paint_snapshot;
-pub use view::TerminalView;
+pub use view::{FontConfig, TerminalView};

--- a/codescope-rs/terminal/src/lib.rs
+++ b/codescope-rs/terminal/src/lib.rs
@@ -17,6 +17,7 @@ pub mod backend;
 pub mod colors;
 pub mod event;
 pub mod input;
+pub mod mouse;
 pub mod paint;
 pub mod view;
 

--- a/codescope-rs/terminal/src/mouse.rs
+++ b/codescope-rs/terminal/src/mouse.rs
@@ -1,0 +1,219 @@
+//! Mouse-event encoding for `MOUSE_REPORT_*` modes.
+//!
+//! When a TUI enables mouse reporting (`\x1b[?1000h` and friends),
+//! the terminal must encode each click/drag/wheel event back as an
+//! escape sequence the TUI can read from stdin. Without it, apps
+//! like tmux, vim, htop, and lazygit can't handle clicks at all.
+//!
+//! Two encodings ship with most terminals:
+//!
+//! * **X10 / default** (`\x1b[M b cx cy`) — three bytes after the
+//!   marker, each offset by 32. Capped at column / row 223 (the
+//!   max ASCII-printable byte). What every old terminal grew up
+//!   speaking.
+//! * **SGR** (`\x1b[<b;cx;cy{M,m}`) — decimal numbers, no cap. The
+//!   modern default — every TUI written this decade enables `?1006`
+//!   alongside `?1000` to opt in.
+//!
+//! We emit SGR when `SGR_MOUSE` is set on the term, otherwise X10.
+//! That covers ~100% of in-the-wild apps — UTF-8 (`?1005`) and URxvt
+//! (`?1015`) extensions exist but nobody uses them in practice.
+
+use alacritty_terminal::term::TermMode;
+
+/// What kind of mouse event we're encoding. The naming mirrors gpui's
+/// own mouse events — Press / Release / Motion / Wheel — but the wire
+/// format borrows numbering from xterm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseEventKind {
+    Press,
+    Release,
+    /// Motion while a button is held (xterm calls this "any-event"
+    /// reporting). Distinct from [`Press`] because the encoded
+    /// button gets `+32` to mark it as motion.
+    Motion,
+    WheelUp,
+    WheelDown,
+}
+
+/// Mouse button — translated to xterm's button id at encode time.
+/// Other buttons (X1/X2 on Windows mice, browser back/forward) map to
+/// xterm's 8/9/10 slots; we only handle Left/Middle/Right for now —
+/// 95% of TUI bindings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseButton {
+    Left,
+    Middle,
+    Right,
+}
+
+/// Modifier keys held while the mouse event happened. xterm encodes
+/// these as `+4` (shift), `+8` (alt), `+16` (ctrl) on top of the
+/// button id.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Modifiers {
+    pub shift: bool,
+    pub alt: bool,
+    pub control: bool,
+}
+
+/// Returns `true` when the term has *any* mouse-reporting mode active
+/// — the View can short-circuit selection / scrollback when this is
+/// on and route the event through [`encode`] instead.
+pub fn mouse_reporting_enabled(mode: TermMode) -> bool {
+    mode.intersects(
+        TermMode::MOUSE_REPORT_CLICK | TermMode::MOUSE_DRAG | TermMode::MOUSE_MOTION,
+    )
+}
+
+/// Returns `true` when the term reports mouse motion while a button
+/// is held (DECSET ?1002). The View uses this to decide whether to
+/// emit `Motion` events at all — most TUIs only enable click+release.
+pub fn drag_reporting_enabled(mode: TermMode) -> bool {
+    mode.intersects(TermMode::MOUSE_DRAG | TermMode::MOUSE_MOTION)
+}
+
+/// Encode a mouse event into the bytes a TUI expects on stdin.
+///
+/// `col` and `row` are 0-based grid coordinates; the encoding
+/// converts them to xterm's 1-based scheme. Returns `None` when the
+/// event can't be represented (e.g. column > 223 in X10 mode — too
+/// far right to encode in the 8-bit-per-axis format).
+pub fn encode(
+    mode: TermMode,
+    kind: MouseEventKind,
+    button: Option<MouseButton>,
+    modifiers: Modifiers,
+    col: usize,
+    row: usize,
+) -> Option<Vec<u8>> {
+    let mut button_code = match (kind, button) {
+        (MouseEventKind::Press, Some(MouseButton::Left)) => 0,
+        (MouseEventKind::Press, Some(MouseButton::Middle)) => 1,
+        (MouseEventKind::Press, Some(MouseButton::Right)) => 2,
+        (MouseEventKind::Release, Some(_)) => {
+            if mode.contains(TermMode::SGR_MOUSE) {
+                // SGR: button id stays, the trailing `m` (lowercase)
+                // signals release.
+                match button.unwrap() {
+                    MouseButton::Left => 0,
+                    MouseButton::Middle => 1,
+                    MouseButton::Right => 2,
+                }
+            } else {
+                // X10: release always emits button id 3.
+                3
+            }
+        }
+        (MouseEventKind::Motion, Some(b)) => {
+            // Motion = button id + 32 ("motion bit"). Per xterm
+            // semantics this is "this cell got entered while
+            // <button> is held".
+            let base = match b {
+                MouseButton::Left => 0,
+                MouseButton::Middle => 1,
+                MouseButton::Right => 2,
+            };
+            base + 32
+        }
+        (MouseEventKind::Motion, None) => {
+            // Pointer motion with no buttons — only emitted under
+            // `?1003h`. Encoded as button id 3 + 32 = 35.
+            35
+        }
+        (MouseEventKind::WheelUp, _) => 64,
+        (MouseEventKind::WheelDown, _) => 65,
+        // Release without a button doesn't make sense; bail.
+        (MouseEventKind::Release, None) => return None,
+        (MouseEventKind::Press, None) => return None,
+    };
+    if modifiers.shift { button_code += 4; }
+    if modifiers.alt { button_code += 8; }
+    if modifiers.control { button_code += 16; }
+
+    let cx = col + 1;
+    let cy = row + 1;
+
+    if mode.contains(TermMode::SGR_MOUSE) {
+        let suffix = if matches!(kind, MouseEventKind::Release) { 'm' } else { 'M' };
+        Some(format!("\x1b[<{button_code};{cx};{cy}{suffix}").into_bytes())
+    } else {
+        // X10: each byte caps at 255 - 32 = 223. Anything past that
+        // can't be encoded; the TUI just doesn't see those clicks.
+        if cx > 223 || cy > 223 || button_code > 223 {
+            return None;
+        }
+        let mut out = Vec::with_capacity(6);
+        out.extend_from_slice(b"\x1b[M");
+        out.push(32u8 + button_code as u8);
+        out.push(32u8 + cx as u8);
+        out.push(32u8 + cy as u8);
+        Some(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sgr() -> TermMode { TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE }
+    fn x10() -> TermMode { TermMode::MOUSE_REPORT_CLICK }
+
+    #[test]
+    fn sgr_press_left() {
+        let bytes = encode(sgr(), MouseEventKind::Press, Some(MouseButton::Left), Modifiers::default(), 10, 5).unwrap();
+        assert_eq!(bytes, b"\x1b[<0;11;6M");
+    }
+
+    #[test]
+    fn sgr_release_uses_lowercase_m() {
+        let bytes = encode(sgr(), MouseEventKind::Release, Some(MouseButton::Left), Modifiers::default(), 0, 0).unwrap();
+        assert_eq!(bytes, b"\x1b[<0;1;1m");
+    }
+
+    #[test]
+    fn sgr_wheel_up() {
+        let bytes = encode(sgr(), MouseEventKind::WheelUp, None, Modifiers::default(), 0, 0).unwrap();
+        assert_eq!(bytes, b"\x1b[<64;1;1M");
+    }
+
+    #[test]
+    fn sgr_motion_with_left_button() {
+        let bytes = encode(sgr(), MouseEventKind::Motion, Some(MouseButton::Left), Modifiers::default(), 9, 4).unwrap();
+        assert_eq!(bytes, b"\x1b[<32;10;5M");
+    }
+
+    #[test]
+    fn sgr_modifiers_stack_on_button_code() {
+        let mods = Modifiers { shift: true, alt: false, control: true };
+        let bytes = encode(sgr(), MouseEventKind::Press, Some(MouseButton::Right), mods, 0, 0).unwrap();
+        // 2 (right) + 4 (shift) + 16 (ctrl) = 22.
+        assert_eq!(bytes, b"\x1b[<22;1;1M");
+    }
+
+    #[test]
+    fn x10_press_left() {
+        let bytes = encode(x10(), MouseEventKind::Press, Some(MouseButton::Left), Modifiers::default(), 10, 5).unwrap();
+        assert_eq!(bytes, vec![0x1b, b'[', b'M', 32, 32 + 11, 32 + 6]);
+    }
+
+    #[test]
+    fn x10_release_uses_button_id_3() {
+        let bytes = encode(x10(), MouseEventKind::Release, Some(MouseButton::Left), Modifiers::default(), 0, 0).unwrap();
+        assert_eq!(bytes, vec![0x1b, b'[', b'M', 32 + 3, 32 + 1, 32 + 1]);
+    }
+
+    #[test]
+    fn x10_overflow_returns_none() {
+        let bytes = encode(x10(), MouseEventKind::Press, Some(MouseButton::Left), Modifiers::default(), 300, 0);
+        assert!(bytes.is_none());
+    }
+
+    #[test]
+    fn reporting_enabled_combines_modes() {
+        assert!(!mouse_reporting_enabled(TermMode::empty()));
+        assert!(mouse_reporting_enabled(TermMode::MOUSE_REPORT_CLICK));
+        assert!(mouse_reporting_enabled(TermMode::MOUSE_DRAG));
+        assert!(mouse_reporting_enabled(TermMode::MOUSE_MOTION));
+    }
+}

--- a/codescope-rs/terminal/src/view.rs
+++ b/codescope-rs/terminal/src/view.rs
@@ -25,6 +25,7 @@ use parking_lot::Mutex;
 use crate::backend::{Backend, TerminalSize, TerminalSnapshot};
 use crate::colors::ColorPalette;
 use crate::input::keystroke_to_bytes;
+use crate::mouse::{self, MouseEventKind};
 use crate::paint::paint_snapshot;
 use gpui::{
     App, Bounds, ClipboardItem, Context, FocusHandle, Focusable, Font, FontFallbacks,
@@ -265,6 +266,68 @@ impl TerminalView {
         Some((grid_line, col))
     }
 
+    /// Pixel position → (visible_row, col) where both are 0-based and
+    /// clamped to the visible viewport. Used for mouse-reporting
+    /// encoding because TUIs expect viewport-relative coordinates,
+    /// not the absolute scrollback grid.
+    fn visible_rc(&self, position: Point<Pixels>) -> Option<(usize, usize)> {
+        let bounds = (*self.bounds_cache.lock())?;
+        let cell_w: f32 = self.font.cell_width.into();
+        let line_h: f32 = self.font.line_height.into();
+        if cell_w <= 0.0 || line_h <= 0.0 {
+            return None;
+        }
+        let local_x: f32 = (position.x - bounds.origin.x).into();
+        let local_y: f32 = (position.y - bounds.origin.y).into();
+        if local_x < 0.0 || local_y < 0.0 {
+            return None;
+        }
+        let col = (local_x / cell_w).floor().max(0.0) as usize;
+        let row = (local_y / line_h).floor().max(0.0) as usize;
+        Some((row, col))
+    }
+
+    /// Try to encode a mouse event for the running TUI. Returns
+    /// `true` when reporting is on and the event was handled —
+    /// caller should stop and *not* fall through to selection or
+    /// scrollback.
+    ///
+    /// Shift bypasses mouse reporting (xterm convention) so the
+    /// user can still drag-select inside `tmux`, `htop`, `vim`,
+    /// etc. without disabling their mouse mode.
+    fn try_report_mouse(
+        &self,
+        kind: MouseEventKind,
+        button: Option<mouse::MouseButton>,
+        modifiers: gpui::Modifiers,
+        position: Point<Pixels>,
+    ) -> bool {
+        if modifiers.shift {
+            return false;
+        }
+        let mode = self.backend.mode();
+        if !mouse::mouse_reporting_enabled(mode) {
+            return false;
+        }
+        // Motion events are noisy — only emit when the TUI asked
+        // for motion (?1002 / ?1003).
+        if matches!(kind, MouseEventKind::Motion) && !mouse::drag_reporting_enabled(mode) {
+            return false;
+        }
+        let Some((row, col)) = self.visible_rc(position) else {
+            return false;
+        };
+        let mods = mouse::Modifiers {
+            shift: modifiers.shift,
+            alt: modifiers.alt,
+            control: modifiers.control,
+        };
+        if let Some(bytes) = mouse::encode(mode, kind, button, mods, col, row) {
+            self.backend.write_input(bytes);
+        }
+        true
+    }
+
     fn refresh_snapshot(&mut self, cx: &mut Context<Self>) {
         self.snapshot = self.backend.snapshot(&self.palette);
         cx.notify();
@@ -276,6 +339,20 @@ impl TerminalView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Try mouse-reporting first. When a TUI like tmux/htop/vim
+        // is in mouse mode, the click belongs to it — only fall
+        // through to selection when reporting is off (or the user
+        // held Shift to bypass).
+        if let Some(button) = to_mouse_button(event.button) {
+            if self.try_report_mouse(
+                MouseEventKind::Press,
+                Some(button),
+                event.modifiers,
+                event.position,
+            ) {
+                return;
+            }
+        }
         if event.button != MouseButton::Left {
             return;
         }
@@ -292,6 +369,21 @@ impl TerminalView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Forward motion events to the TUI when it asked for them.
+        // We only emit motion-with-button-held; pointer motion with
+        // no button is rare and noisy, and `?1003h` apps that want
+        // it can re-enable later.
+        let pressed = event.pressed_button.and_then(to_mouse_button);
+        if pressed.is_some()
+            && self.try_report_mouse(
+                MouseEventKind::Motion,
+                pressed,
+                event.modifiers,
+                event.position,
+            )
+        {
+            return;
+        }
         if !self.selecting {
             return;
         }
@@ -303,10 +395,21 @@ impl TerminalView {
 
     fn on_mouse_up(
         &mut self,
-        _event: &MouseUpEvent,
+        event: &MouseUpEvent,
         _window: &mut Window,
         _cx: &mut Context<Self>,
     ) {
+        if let Some(button) = to_mouse_button(event.button) {
+            if self.try_report_mouse(
+                MouseEventKind::Release,
+                Some(button),
+                event.modifiers,
+                event.position,
+            ) {
+                self.selecting = false;
+                return;
+            }
+        }
         self.selecting = false;
     }
 
@@ -432,11 +535,36 @@ impl TerminalView {
             }
             ScrollDelta::Lines(point) => point.y.round() as i32,
         };
-        if lines != 0 {
-            // gpui reports +y for wheel-up, alacritty's Scroll::Delta
-            // is +n for "scroll up into history" — same direction.
-            self.backend.scroll(lines);
+        if lines == 0 {
+            return;
         }
+        // Forward wheel events to the TUI when it asked for mouse
+        // input. tmux / less / vim use this for paging. Each cell-
+        // worth of scroll emits one wheel event so a fast spin
+        // doesn't lose ticks.
+        let mode = self.backend.mode();
+        if mouse::mouse_reporting_enabled(mode) && !event.modifiers.shift {
+            let kind = if lines > 0 {
+                MouseEventKind::WheelUp
+            } else {
+                MouseEventKind::WheelDown
+            };
+            let mods = mouse::Modifiers {
+                shift: event.modifiers.shift,
+                alt: event.modifiers.alt,
+                control: event.modifiers.control,
+            };
+            let (row, col) = self.visible_rc(event.position).unwrap_or((0, 0));
+            for _ in 0..lines.unsigned_abs() {
+                if let Some(bytes) = mouse::encode(mode, kind, None, mods, col, row) {
+                    self.backend.write_input(bytes);
+                }
+            }
+            return;
+        }
+        // gpui reports +y for wheel-up, alacritty's Scroll::Delta
+        // is +n for "scroll up into history" — same direction.
+        self.backend.scroll(lines);
     }
 
     /// Write clipboard text into the PTY. Honours bracketed-paste mode
@@ -531,6 +659,19 @@ struct PendingResize {
     cols: u16,
     rows: u16,
     set_at: Instant,
+}
+
+/// Map gpui's `MouseButton` enum to the wire-encoded button this
+/// crate uses for mouse-reporting. Returns `None` for buttons we
+/// don't translate (gpui has Navigate variants for back/forward
+/// thumb buttons that no in-the-wild TUI cares about).
+fn to_mouse_button(button: MouseButton) -> Option<mouse::MouseButton> {
+    match button {
+        MouseButton::Left => Some(mouse::MouseButton::Left),
+        MouseButton::Middle => Some(mouse::MouseButton::Middle),
+        MouseButton::Right => Some(mouse::MouseButton::Right),
+        _ => None,
+    }
 }
 
 /// Keystrokes the terminal should *not* swallow. A parent shell
@@ -671,9 +812,18 @@ impl Render for TerminalView {
             .key_context("Terminal")
             .on_key_down(cx.listener(Self::on_key_down))
             .on_scroll_wheel(cx.listener(Self::on_scroll_wheel))
+            // Listen for *every* button, not just Left — TUIs in
+            // mouse mode want right-click context menus and
+            // middle-click paste / scroll events too. The handler
+            // routes each event through `try_report_mouse` first,
+            // so non-reporting selections still see Left only.
             .on_mouse_down(MouseButton::Left, cx.listener(Self::on_mouse_down))
+            .on_mouse_down(MouseButton::Middle, cx.listener(Self::on_mouse_down))
+            .on_mouse_down(MouseButton::Right, cx.listener(Self::on_mouse_down))
             .on_mouse_move(cx.listener(Self::on_mouse_move))
             .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
+            .on_mouse_up(MouseButton::Middle, cx.listener(Self::on_mouse_up))
+            .on_mouse_up(MouseButton::Right, cx.listener(Self::on_mouse_up))
             .bg(bg)
             .font_family(self.font.family.clone())
             .text_size(self.font.size)

--- a/codescope-rs/terminal/src/view.rs
+++ b/codescope-rs/terminal/src/view.rs
@@ -356,6 +356,20 @@ impl TerminalView {
         if event.button != MouseButton::Left {
             return;
         }
+        // Ctrl/Cmd-click on a hyperlink opens it in the system
+        // handler (browser for http(s)://, OS shell for file
+        // paths, …). Ctrl is the convention because plain click
+        // belongs to text-selection — same as VS Code / Windows
+        // Terminal / iTerm2.
+        let modifier = event.modifiers.control || event.modifiers.platform;
+        if modifier && !event.modifiers.shift {
+            if let Some((row, col)) = self.visible_rc(event.position) {
+                if let Some(uri) = self.backend.hyperlink_at(row, col) {
+                    let _ = open::that_detached(&uri);
+                    return;
+                }
+            }
+        }
         if let Some((line, col)) = self.point_at(event.position) {
             self.backend.start_selection(line, col);
             self.selecting = true;

--- a/codescope-rs/terminal/src/view.rs
+++ b/codescope-rs/terminal/src/view.rs
@@ -329,10 +329,18 @@ impl TerminalView {
             alt: modifiers.alt,
             control: modifiers.control,
         };
+        // Only claim the event when we actually emit bytes. If
+        // `mouse::encode` returns `None` (e.g. X10 overflow on a
+        // 300-col terminal) we'd otherwise swallow the click —
+        // returning `false` here lets the View fall back to
+        // selection / scrollback so the user gets *some* response
+        // instead of a silent dead spot.
         if let Some(bytes) = mouse::encode(mode, kind, button, mods, col, row) {
             self.backend.write_input(bytes);
+            true
+        } else {
+            false
         }
-        true
     }
 
     fn refresh_snapshot(&mut self, cx: &mut Context<Self>) {
@@ -346,7 +354,24 @@ impl TerminalView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Try mouse-reporting first. When a TUI like tmux/htop/vim
+        // Ctrl/Cmd-click on a hyperlink always opens it, even when
+        // a TUI has mouse mode on. Ctrl is the universal "bypass
+        // mouse reporting for one click" convention (Shift handles
+        // the same job for selection); without this short-circuit
+        // tmux / vim would swallow Ctrl+click and the user could
+        // never open a link inside them.
+        let modifier = event.modifiers.control || event.modifiers.platform;
+        let is_left = event.button == MouseButton::Left;
+        if is_left && modifier && !event.modifiers.shift {
+            if let Some((row, col)) = self.visible_rc(event.position) {
+                if let Some(uri) = self.snapshot.hyperlink_at(row, col) {
+                    let _ = open::that_detached(uri.as_ref());
+                    return;
+                }
+            }
+        }
+
+        // Try mouse-reporting next. When a TUI like tmux/htop/vim
         // is in mouse mode, the click belongs to it — only fall
         // through to selection when reporting is off (or the user
         // held Shift to bypass).
@@ -360,22 +385,8 @@ impl TerminalView {
                 return;
             }
         }
-        if event.button != MouseButton::Left {
+        if !is_left {
             return;
-        }
-        // Ctrl/Cmd-click on a hyperlink opens it in the system
-        // handler (browser for http(s)://, OS shell for file
-        // paths, …). Ctrl is the convention because plain click
-        // belongs to text-selection — same as VS Code / Windows
-        // Terminal / iTerm2.
-        let modifier = event.modifiers.control || event.modifiers.platform;
-        if modifier && !event.modifiers.shift {
-            if let Some((row, col)) = self.visible_rc(event.position) {
-                if let Some(uri) = self.snapshot.hyperlink_at(row, col) {
-                    let _ = open::that_detached(uri.as_ref());
-                    return;
-                }
-            }
         }
         if let Some((line, col)) = self.point_at(event.position) {
             self.backend.start_selection(line, col);

--- a/codescope-rs/terminal/src/view.rs
+++ b/codescope-rs/terminal/src/view.rs
@@ -304,10 +304,22 @@ impl TerminalView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        cx.stop_propagation();
-
         let key = event.keystroke.key.as_str();
         let mods = &event.keystroke.modifiers;
+
+        // Let app-level shortcuts (Ctrl+T new tab, Ctrl+W close,
+        // Ctrl+Tab cycle, Ctrl+1-9 select) bubble up to whichever
+        // ancestor is listening for them. Without this skip the
+        // `stop_propagation` below would swallow them and the only
+        // way to switch tabs would be a mouse click — exactly the
+        // bug the user reported. Done here, in the terminal, instead
+        // of by keymap registration up in `AppShell` so we don't have
+        // to teach the terminal about every embedder's bindings.
+        if is_app_level_shortcut(key, mods) {
+            return;
+        }
+
+        cx.stop_propagation();
 
         // Copy semantics, matching Windows Terminal / GNOME Terminal:
         //   * Ctrl+C with a live selection → copy, clear selection.
@@ -507,6 +519,40 @@ struct PendingResize {
     cols: u16,
     rows: u16,
     set_at: Instant,
+}
+
+/// Keystrokes the terminal should *not* swallow. A parent shell
+/// (tab strip, command palette, …) is expected to handle them.
+/// Kept conservative — we only opt out of bindings nothing in a
+/// shell prompt would meaningfully use, so power-users running vim
+/// or readline still get every key they need.
+fn is_app_level_shortcut(key: &str, mods: &gpui::Modifiers) -> bool {
+    let app_mod = mods.control || mods.platform;
+    if !app_mod || mods.alt {
+        return false;
+    }
+    // Ctrl+Tab / Ctrl+Shift+Tab (tab cycling).
+    if key == "tab" {
+        return true;
+    }
+    // Ctrl+1 .. Ctrl+9 (direct tab select).
+    if !mods.shift
+        && key.len() == 1
+        && key
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_digit() && c != '0')
+    {
+        return true;
+    }
+    // Ctrl+Shift+T / Ctrl+Shift+W — explicit "always" bindings that
+    // never conflict with anything readline-shaped. Plain Ctrl+T /
+    // Ctrl+W would clash with the shell's word/transpose, so the
+    // app-shell uses the shifted variants by convention.
+    if mods.shift && (key == "t" || key == "w") {
+        return true;
+    }
+    false
 }
 
 /// State handed from the canvas measure phase to the paint phase.

--- a/codescope-rs/terminal/src/view.rs
+++ b/codescope-rs/terminal/src/view.rs
@@ -131,7 +131,7 @@ impl TerminalView {
     /// Wrap a [`Backend`] in a gpui Entity. Spawns an async drain task
     /// that re-snapshots and notifies on every backend event.
     pub fn new(backend: Backend, cx: &mut Context<Self>) -> Self {
-        Self::new_with_font(backend, FontConfig::default(), cx)
+        Self::new_full(backend, ColorPalette::default(), FontConfig::default(), cx)
     }
 
     pub fn new_with_font(
@@ -139,8 +139,20 @@ impl TerminalView {
         font: FontConfig,
         cx: &mut Context<Self>,
     ) -> Self {
+        Self::new_full(backend, ColorPalette::default(), font, cx)
+    }
+
+    /// Full constructor — the binary uses this so the View's render
+    /// palette matches whatever theme the [`Backend`] was spawned
+    /// with. Callers that don't care about themes can keep using
+    /// [`Self::new`] / [`Self::new_with_font`].
+    pub fn new_full(
+        backend: Backend,
+        palette: ColorPalette,
+        font: FontConfig,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let focus_handle = cx.focus_handle();
-        let palette = ColorPalette::default();
         let snapshot = backend.snapshot(&palette);
         let events = backend.events();
         let blink_phase = Arc::new(Mutex::new(true));

--- a/codescope-rs/terminal/src/view.rs
+++ b/codescope-rs/terminal/src/view.rs
@@ -126,6 +126,12 @@ pub struct TerminalView {
     /// A background timer toggles it every 530 ms; input handlers set
     /// it back to `true` so the cursor doesn't disappear under typing.
     blink_phase: Arc<Mutex<bool>>,
+    /// URI of the OSC 8 hyperlink currently under the mouse, if any.
+    /// Drives the pointer cursor — render reads this on every frame
+    /// and applies `cursor_pointer()` when set. Updated on
+    /// mouse-move; we only `cx.notify()` when the value flips so
+    /// motion across non-hyperlink cells doesn't repaint the world.
+    hovered_link: Option<Arc<str>>,
 }
 
 impl TerminalView {
@@ -235,6 +241,7 @@ impl TerminalView {
             bounds_cache: Arc::new(Mutex::new(None)),
             selecting: false,
             blink_phase,
+            hovered_link: None,
         }
     }
 
@@ -364,8 +371,8 @@ impl TerminalView {
         let modifier = event.modifiers.control || event.modifiers.platform;
         if modifier && !event.modifiers.shift {
             if let Some((row, col)) = self.visible_rc(event.position) {
-                if let Some(uri) = self.backend.hyperlink_at(row, col) {
-                    let _ = open::that_detached(&uri);
+                if let Some(uri) = self.snapshot.hyperlink_at(row, col) {
+                    let _ = open::that_detached(uri.as_ref());
                     return;
                 }
             }
@@ -383,6 +390,17 @@ impl TerminalView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Track hover-over-hyperlink so render can flip the cursor
+        // to a pointer. Only re-notify when the URI actually changes,
+        // otherwise every pointer wobble would force a repaint.
+        let next_link = self
+            .visible_rc(event.position)
+            .and_then(|(row, col)| self.snapshot.hyperlink_at(row, col));
+        if next_link.as_deref() != self.hovered_link.as_deref() {
+            self.hovered_link = next_link;
+            cx.notify();
+        }
+
         // Forward motion events to the TUI when it asked for them.
         // We only emit motion-with-button-held; pointer motion with
         // no button is rare and noisy, and `?1003h` apps that want
@@ -821,7 +839,9 @@ impl Render for TerminalView {
         )
         .size_full();
 
-        div()
+        let pointer_for_link = self.hovered_link.is_some();
+
+        let mut root = div()
             .track_focus(&self.focus_handle)
             .key_context("Terminal")
             .on_key_down(cx.listener(Self::on_key_down))
@@ -841,8 +861,11 @@ impl Render for TerminalView {
             .bg(bg)
             .font_family(self.font.family.clone())
             .text_size(self.font.size)
-            .size_full()
-            .child(canvas_element)
+            .size_full();
+        if pointer_for_link {
+            root = root.cursor_pointer();
+        }
+        root.child(canvas_element)
     }
 }
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -155,8 +155,6 @@ typing + scroll + selection + paste all still work cleanly.
 
 ### Session 30 — pixel-accurate paint, paste, cursor blink, resize debounce, box-drawing alignment, OSC query handshake
 
-### Session 30 — pixel-accurate paint, paste, cursor blink, resize debounce, box-drawing alignment, OSC query handshake
-
 This session took the working interactive terminal from session 29
 and made it _feel_ like a real terminal — pixel-perfect rendering,
 proper paste, blinking cursor, no-flicker resize, clean box drawings,

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -5,15 +5,155 @@
 > **Intent:** cursor + last 1–2 sessions in depth, everything else a one-liner.
 > Old detail lives in `git log` — don't duplicate it here.
 
-**Last updated:** 2026-05-09 (session 30)
-**Branch:** `feat/codescope-rs-terminal`
-**Head:** `a2f1d18` — pushed to PR #53
+**Last updated:** 2026-05-09 (session 31)
+**Branch:** `feat/codescope-rs-architecture` (PR #54, open)
+**Head:** `33083b2` — pushed
 **Release:** `v0.2.5` shipped — https://github.com/maui1911/CodeScope/releases/tag/v0.2.5
 **Build status:** ✅ C# untouched. Rust workspace builds clean
-(`cargo build --workspace --manifest-path codescope-rs/Cargo.toml`),
-clippy `-D warnings` green for `codescope-terminal`.
+(`cargo build --workspace --manifest-path codescope-rs/Cargo.toml`).
+21 unit tests across `codescope-core` (12) + `codescope-terminal`
+mouse-encoder (9). PR #53 squash-merged to main as `7a05ed6`;
+session 30's terminal-layer work (sessions 28-30) is in `main` now.
 **Uncommitted work:** none.
 **Open issues:** none on GitHub.
+
+### Session 31 — codescope-core, settings + themes, sidebar + projects, window/layout state, mouse-mode, OSC 8 + URL detection
+
+This session went from "working terminal in a window" to a real
+app shell with a clean architecture, persisted state, and the
+quality-of-life polish that makes the Rust port feel like a
+product instead of a tech demo.
+
+**Shipped (10+ commits on `feat/codescope-rs-architecture`, all on PR #54):**
+
+1. **App shell + tab strip + Codescope theme tokens** (`95fe32f`,
+   `c2f43f6`, `4a26ca7` — recovered via reflog after PR #53 squash
+   landed without them; pushed cleanly on the new branch).
+   `AppShell` Entity, 40 px tab strip in the titlebar zone, pill
+   tabs (canvas-bg + 2 px Framer Blue top border on active, frost-
+   on-hover for inactive), green status dot per tab, `+` new-tab
+   button, custom titlebar via `appears_transparent`. Keybindings:
+   `Ctrl+Shift+T` / `Ctrl+Shift+W` (Windows-Terminal convention so
+   readline's word-bindings stay intact), `Ctrl+Tab` cycle,
+   `Ctrl+1..9` direct select. View deliberately doesn't
+   `stop_propagation` on app-level shortcuts so they bubble up.
+2. **`codescope-core` workspace crate** (`d156734`). Pure-Rust,
+   no gpui or alacritty deps. Hosts settings, themes, env-aware
+   paths. Architecture pyramid is now `core ← terminal ← app/src`.
+   Five built-in themes (`codescope-default`, `vs-code-dark`,
+   `one-dark`, `solarized-dark`, `tokyo-night`); `settings.json`
+   at `%APPDATA%\CodeScope\settings.json` with theme name, font
+   chain, scrollback, cursor preset; `AppPaths` ports the C#
+   `NoScope.CodeScope.Core.AppPaths` 1:1 (same folder names, same
+   `CODESCOPE_DEV` redirect, same single-instance mutex naming).
+   Terminal crate gained `ColorPalette::from_theme_palette` so a
+   theme flows straight into the renderer + the OSC-query proxy
+   without an interop seam in the binary.
+3. **Project / Worktree / Session models + PROJECTS sidebar**
+   (`e7126a7`). Direct port of
+   `src/CodeScope.Core/Models/{Project,Session,Worktree,
+   ProjectsConfig}.cs` — same field names so a `projects.json`
+   written by the v0.x C# build round-trips. 240 px left rail with
+   PROJECTS heading, project rows (accent rail + frost on active),
+   empty-state prompt, placeholder `+` add button.
+4. **window.json + layout.json persistence** (`674a985`). Load
+   path wired: saved bounds (or `WindowBounds::Maximized`) flow
+   into `WindowOptions::window_bounds`. Implausibly small saved
+   sizes (< 320×240) are rejected so a 4K → laptop monitor swap
+   doesn't break the next launch. Save path is a stub —
+   `cx.observe_window_bounds` wiring is the follow-up.
+5. **Mouse-mode reporting** (`0567b43`). New `terminal::mouse`
+   module: SGR encoding when `?1006h` is set, X10 fallback. All
+   click / drag / wheel / motion events route through
+   `try_report_mouse` first; selection only kicks in when no TUI
+   asked for the click (or the user held Shift to bypass). Right
+   + Middle button listeners added so `tmux` context menus and
+   `vim` middle-click work. 9 unit tests on the encoder.
+6. **OSC 8 hyperlinks + plain-text URL detection** (`051cf3b`,
+   `33083b2`). `StyledRun` carries `Option<Arc<str>>` hyperlink;
+   snapshot reads `cell.hyperlink()` for OSC 8, then post-
+   processes each line via `linkify` to retro-tag bare-text URLs
+   (`claude-code`, `gh pr view`, `cargo --message-format json`).
+   `TerminalSnapshot::hyperlink_at(row, col)` lets the View look
+   up links without re-locking the live `Term`. Pointer cursor on
+   hover, Ctrl/Cmd-click opens via the `open` crate; OSC 8 always
+   wins over URL detection.
+7. **Review fixes for PR #54** (`5d15ace`). Five copilot-reviewer
+   threads addressed: settings doc honesty about unknown-key
+   drop, accurate `build_font_config` "platform pick" comment,
+   macOS state-dir doc match, `from_theme_palette` synthesizes
+   the standard xterm cube/grayscale ramp for short tables (with
+   `debug_assert_eq!`), `CursorStylePreset` doc no longer claims
+   serde-friendliness it doesn't have.
+8. **`+` button + hover cursor fixes** (`33083b2`). `+`
+   collapsed to 0 px hit area because `h_full()` didn't always
+   resolve before hit-testing — switched to explicit `h(40)` +
+   `cursor_pointer()`. Hover-over-link now flips the root div to
+   pointer cursor; we only `cx.notify` on URI changes so motion
+   doesn't repaint.
+
+**Confirmed working on Windows (manual test, this machine):**
+multi-tab spawning + closing + cycling · `Ctrl+Shift+T/W` /
+`Ctrl+Tab` / `Ctrl+1..9` from terminal focus · five themes
+swap via `settings.json` and look right · sidebar shows
+hand-edited `projects.json` entries · OSC 8 hyperlinks render
+underlined and open on Ctrl+click with hand cursor · plain-text
+URLs in claude-code output are clickable · pwsh + claude-code +
+typing + scroll + selection + paste all still work cleanly.
+
+**Architectural notes worth carrying forward:**
+- `core` crate is the canonical home for any data the app needs
+  to load / save / share. Adding gpui or alacritty there reverses
+  the pyramid — push the new code into `terminal/` or `src/`
+  instead.
+- `Arc<Theme>` on `AppShell` is the swap point for live theme
+  reload. `theme::canvas(theme)` etc. accept a `&Theme` so when
+  the Arc swaps, the next render redraws against the new values
+  without rebuilding the entity.
+- The squash-merge / unpushed-commit incident at the start of
+  the session: PR #53 squashed against the last *pushed* HEAD,
+  not the live local HEAD. Three commits I'd made locally
+  (app-shell + theme + style + shortcut bubble) were lost
+  briefly. Recovered via reflog cherry-pick — the lesson is
+  push after every meaningful commit, not after a sequence.
+- `StyledRun` post-processing for URL detection is the right
+  layer — keeps the per-cell loop clean and lets OSC 8 always
+  win over heuristics. Wide-char runs are skipped on splitting
+  to stay safe; URLs in the wild are pure ASCII so the fallback
+  basically never trips.
+
+**Suggested next entry points (in priority order):**
+
+1. **window.json save wiring.** The load path works; saving
+   needs `cx.observe_window_bounds` (or equivalent) threaded
+   through the AppShell so live changes get persisted. Without
+   this we still default to whatever the OS remembers, which is
+   already pretty good on Windows.
+2. **Sidebar interactions.** `+` add-project (file picker → new
+   `Project` row → save to `projects.json`). Clicking a project
+   should drive the tab list (each project's sessions become
+   tabs). Filter input at the top of the sidebar.
+3. **Worktree orchestration.** Shell out to `git worktree` for
+   per-session worktrees, mirroring `CodeScope.Worktrees` in
+   the C# build. This is the "actually CodeScope" milestone.
+4. **Telemetry tail.** FSWatch on `~/.claude/projects/…` to
+   drive the (currently hardcoded green) status dots — `running
+   / idle / error` per session.
+5. **Live theme reload + `+` add-theme commands.** Watch
+   `settings.json` for changes and swap the `Arc<Theme>`
+   without restart.
+
+**Known small things still to clean up:**
+- Backend's `hyperlink_at` is now unused (snapshot handles it)
+  — keep until we expose a non-snapshot API or delete on next
+  cleanup pass.
+- Theme accent on tabs is hardcoded to top-border — Framer Blue
+  feels right but other themes might want a different placement.
+- The `inject_url_hyperlinks` post-processing runs every
+  snapshot. Reasonable for typical grids; profile if it shows up
+  in flame graphs at very large sizes.
+
+### Session 30 — pixel-accurate paint, paste, cursor blink, resize debounce, box-drawing alignment, OSC query handshake
 
 ### Session 30 — pixel-accurate paint, paste, cursor blink, resize debounce, box-drawing alignment, OSC query handshake
 


### PR DESCRIPTION
## Summary
- Recovers app-shell + tab-strip work that was unpushed at PR #53 squash-time (3 commits)
- Adds new `codescope-core` workspace crate (UI-free settings / themes / paths)
- Five built-in themes (`codescope-default`, `vs-code-dark`, `one-dark`, `solarized-dark`, `tokyo-night`)
- `settings.json` at `%APPDATA%\CodeScope\` (or `CodeScope.Dev\` with `CODESCOPE_DEV=1`)
- App-shell + terminal palette + cursor-default all driven from settings
- Architecture pyramid: `core ← terminal ← app/src`

## Test plan
- [x] `cargo test -p codescope-core` (4 tests pass: load/save round-trip, empty file, missing file, malformed JSON)
- [x] `cargo build --release --bin window` clean
- [x] Default boot looks identical to PR #53's final state
- [ ] Edit `%APPDATA%\CodeScope\settings.json` to `"theme": "tokyo-night"`, restart, verify theme switch
- [ ] `Ctrl+Shift+T` / `Ctrl+Shift+W` / `Ctrl+Tab` / `Ctrl+1..9` still work
- [ ] Multiple tabs each get the configured theme palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)