### PR TITLE
feat(rs): window/layout persistence, add-project picker, git primitives

### DIFF
--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]

--- a/codescope-rs/core/Cargo.toml
+++ b/codescope-rs/core/Cargo.toml
@@ -9,6 +9,7 @@ description = "Shared models for CodeScope: settings, themes, env-aware paths. U
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -1,0 +1,241 @@
+//! Thin wrapper around `git worktree` and friends.
+//!
+//! Shells out to the system `git` binary — see CLAUDE.md, the
+//! technology decisions list explicitly chooses shelling-out over
+//! libgit2 bindings. Process spawning makes this module the only
+//! impure thing in `core`, but parsing porcelain output stays here
+//! (away from gpui) so it can be unit-tested without the renderer.
+//!
+//! The C# build's [`GitService`] has a much wider surface
+//! (`for-each-ref`, branch listing, status). We start narrow: the
+//! Rust port only needs the primitives that drive the sidebar's
+//! per-session worktrees. Branch listing lands the day the new-
+//! session dialog needs it.
+//!
+//! Errors carry the stderr tail when `git` exits non-zero, so a
+//! UI dialog can surface "fatal: 'foo' is already checked out at
+//! '...'" without us having to guess the cause.
+
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+use anyhow::{Context, Result, anyhow};
+
+/// One row from `git worktree list --porcelain`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeInfo {
+    /// Absolute path to the worktree root.
+    pub path: String,
+    /// SHA the worktree currently points at (`HEAD <sha>` line). The
+    /// porcelain emits this for every worktree, so it's never empty
+    /// in practice — we keep it `String` (not `Option`) on purpose.
+    pub head: String,
+    /// Branch name without the `refs/heads/` prefix. `None` for a
+    /// detached HEAD or a bare repo.
+    pub branch: Option<String>,
+    /// Whether this is the primary working tree (the one the repo
+    /// was initialised at). Porcelain output emits the primary
+    /// first; we tag the first stanza accordingly.
+    pub is_primary: bool,
+    /// `true` if the worktree is currently locked. Locked worktrees
+    /// can't be removed without `--force` and we surface the flag
+    /// so the UI can warn before destructive ops.
+    pub locked: bool,
+}
+
+/// `git worktree list --porcelain` for `repo`. The repo is *any*
+/// path inside the working tree — git resolves it to the right
+/// `.git` directory.
+pub fn list_worktrees(repo: &Path) -> Result<Vec<WorktreeInfo>> {
+    let output = run_git(repo, &["worktree", "list", "--porcelain"])?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_worktree_porcelain(&stdout))
+}
+
+/// `git worktree add <path> -b <branch> [<base>]`. Creates the
+/// branch as part of the same call so we don't race.
+pub fn add_worktree(
+    repo: &Path,
+    path: &Path,
+    branch: &str,
+    base: Option<&str>,
+) -> Result<()> {
+    let path_str = path.to_string_lossy();
+    let mut args: Vec<&str> = vec!["worktree", "add", &path_str, "-b", branch];
+    if let Some(b) = base {
+        args.push(b);
+    }
+    run_git(repo, &args).map(|_| ())
+}
+
+/// `git worktree remove <path>`. Set `force = true` to bypass dirty-
+/// tree / locked checks. The C# build uses force=false in normal
+/// flows and lets the user retry with force after seeing the error.
+pub fn remove_worktree(repo: &Path, path: &Path, force: bool) -> Result<()> {
+    let path_str = path.to_string_lossy();
+    let mut args: Vec<&str> = vec!["worktree", "remove"];
+    if force {
+        args.push("--force");
+    }
+    args.push(&path_str);
+    run_git(repo, &args).map(|_| ())
+}
+
+/// Run `git <args...>` in `cwd`. Returns the captured `Output` on
+/// success; bubbles up stderr (trimmed) on non-zero exit.
+fn run_git(cwd: &Path, args: &[&str]) -> Result<Output> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .with_context(|| format!("spawn git {}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let code = output.status.code().unwrap_or(-1);
+        return Err(anyhow!("git {} exited {}: {}", args.join(" "), code, stderr));
+    }
+    Ok(output)
+}
+
+/// Parse the porcelain output from `git worktree list --porcelain`.
+/// Format (per `git-worktree(1)`):
+///
+/// ```text
+/// worktree /path/to/wt
+/// HEAD <sha>
+/// branch refs/heads/<name>   ← OR `bare` OR `detached`
+/// [locked [reason]]
+///
+/// worktree /path/to/wt2
+/// ...
+/// ```
+///
+/// Stanzas are separated by blank lines. The first stanza is the
+/// primary working tree.
+pub fn parse_worktree_porcelain(stdout: &str) -> Vec<WorktreeInfo> {
+    let mut out = Vec::new();
+    let mut path: Option<String> = None;
+    let mut head: Option<String> = None;
+    let mut branch: Option<String> = None;
+    let mut locked = false;
+
+    let mut flush = |path: &mut Option<String>,
+                     head: &mut Option<String>,
+                     branch: &mut Option<String>,
+                     locked: &mut bool,
+                     out: &mut Vec<WorktreeInfo>| {
+        if let (Some(p), Some(h)) = (path.take(), head.take()) {
+            let is_primary = out.is_empty();
+            out.push(WorktreeInfo {
+                path: p,
+                head: h,
+                branch: branch.take(),
+                is_primary,
+                locked: std::mem::replace(locked, false),
+            });
+        } else {
+            // Reset if we hit a malformed stanza.
+            path.take();
+            head.take();
+            branch.take();
+            *locked = false;
+        }
+    };
+
+    for raw in stdout.lines() {
+        let line = raw.trim_end_matches('\r');
+        if line.is_empty() {
+            flush(&mut path, &mut head, &mut branch, &mut locked, &mut out);
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            path = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("HEAD ") {
+            head = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("branch ") {
+            branch = Some(rest.trim_start_matches("refs/heads/").to_string());
+        } else if line == "bare" || line == "detached" {
+            // No branch — leave `branch` as None.
+        } else if line == "locked" || line.starts_with("locked ") {
+            locked = true;
+        }
+        // Unknown lines are ignored — porcelain v1 is documented to
+        // be append-only, so a future field can show up here without
+        // breaking us.
+    }
+    // Trailing stanza without a blank line.
+    flush(&mut path, &mut head, &mut branch, &mut locked, &mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "worktree /home/me/repo\n\
+HEAD abc1234\n\
+branch refs/heads/main\n\
+\n\
+worktree /home/me/repo.worktrees/feat-x\n\
+HEAD def5678\n\
+branch refs/heads/feat-x\n\
+locked\n\
+\n\
+worktree /home/me/repo.worktrees/detached\n\
+HEAD 999aaaa\n\
+detached\n";
+
+    #[test]
+    fn parses_primary_branch_and_detached() {
+        let wts = parse_worktree_porcelain(SAMPLE);
+        assert_eq!(wts.len(), 3);
+
+        assert_eq!(wts[0].path, "/home/me/repo");
+        assert_eq!(wts[0].head, "abc1234");
+        assert_eq!(wts[0].branch.as_deref(), Some("main"));
+        assert!(wts[0].is_primary);
+        assert!(!wts[0].locked);
+
+        assert_eq!(wts[1].branch.as_deref(), Some("feat-x"));
+        assert!(!wts[1].is_primary);
+        assert!(wts[1].locked);
+
+        assert_eq!(wts[2].branch, None);
+        assert!(!wts[2].is_primary);
+    }
+
+    #[test]
+    fn empty_input_yields_no_rows() {
+        assert!(parse_worktree_porcelain("").is_empty());
+    }
+
+    #[test]
+    fn malformed_stanza_is_dropped() {
+        // Missing HEAD line → stanza dropped, but next valid stanza
+        // still parses.
+        let stdout = "worktree /broken\n\
+\n\
+worktree /good\n\
+HEAD abc\n\
+branch refs/heads/main\n";
+        let wts = parse_worktree_porcelain(stdout);
+        assert_eq!(wts.len(), 1);
+        assert_eq!(wts[0].path, "/good");
+        // First *successfully-parsed* stanza is primary.
+        assert!(wts[0].is_primary);
+    }
+
+    #[test]
+    fn unknown_lines_are_ignored() {
+        let stdout = "worktree /repo\n\
+HEAD abc\n\
+branch refs/heads/main\n\
+some-future-field foo bar\n";
+        let wts = parse_worktree_porcelain(stdout);
+        assert_eq!(wts.len(), 1);
+        assert_eq!(wts[0].path, "/repo");
+    }
+}

--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -122,7 +122,7 @@ pub fn parse_worktree_porcelain(stdout: &str) -> Vec<WorktreeInfo> {
     let mut branch: Option<String> = None;
     let mut locked = false;
 
-    let mut flush = |path: &mut Option<String>,
+    let flush = |path: &mut Option<String>,
                      head: &mut Option<String>,
                      branch: &mut Option<String>,
                      locked: &mut bool,

--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -12,9 +12,12 @@
 //! per-session worktrees. Branch listing lands the day the new-
 //! session dialog needs it.
 //!
-//! Errors carry the stderr tail when `git` exits non-zero, so a
-//! UI dialog can surface "fatal: 'foo' is already checked out at
-//! '...'" without us having to guess the cause.
+//! Errors carry the trimmed stderr verbatim when `git` exits non-
+//! zero, so a UI dialog can surface "fatal: 'foo' is already checked
+//! out at '...'" without us having to guess the cause. We don't
+//! truncate — the failure modes in scope here (`worktree add/remove/
+//! list`) emit short messages, and clipping mid-sentence is worse
+//! UX than a slightly long line.
 
 use std::path::Path;
 use std::process::{Command, Output, Stdio};

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -13,6 +13,7 @@
 //! lives in the `app` crate. Anything terminal-protocol-bound lives in
 //! `codescope-terminal`.
 
+pub mod git;
 pub mod layout;
 pub mod paths;
 pub mod projects;

--- a/codescope-rs/core/src/projects.rs
+++ b/codescope-rs/core/src/projects.rs
@@ -53,6 +53,33 @@ pub struct Project {
 
 fn default_branch() -> String { "main".to_string() }
 
+impl Project {
+    /// Build a fresh project pointing at `path`. Name defaults to the
+    /// folder leaf (or `"project"` if the path has no leaf for some
+    /// reason), id is a fresh UUIDv4. The default branch is `"main"`
+    /// — callers can override by mutating the returned struct before
+    /// saving. No validation that `path` is actually a git repo: the
+    /// sidebar lists everything the user adds; bad paths surface when
+    /// the worktree code tries to use them.
+    pub fn new(path: String) -> Self {
+        let name = std::path::Path::new(&path)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "project".to_string());
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            name,
+            path,
+            default_branch: default_branch(),
+            worktree_root: None,
+            default_agent_id: None,
+            sessions: Vec::new(),
+            worktrees: Vec::new(),
+        }
+    }
+}
+
 /// One git worktree under a [`Project`]. Every project has an
 /// implicit primary worktree at `Project::path`; additional ones live
 /// here and get `is_primary = false`.
@@ -199,6 +226,21 @@ mod tests {
         assert_eq!(p.sessions.len(), 1);
         assert_eq!(p.worktrees.len(), 1);
         assert!(p.worktrees[0].is_primary);
+    }
+
+    #[test]
+    fn new_project_uses_folder_leaf_as_name() {
+        let p = Project::new("/home/me/codescope".into());
+        assert_eq!(p.name, "codescope");
+        assert_eq!(p.default_branch, "main");
+        // UUIDv4 is 36 chars including the dashes.
+        assert_eq!(p.id.len(), 36);
+    }
+
+    #[test]
+    fn new_project_falls_back_when_path_has_no_leaf() {
+        let p = Project::new("/".into());
+        assert_eq!(p.name, "project");
     }
 
     #[test]

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use codescope_core::{AppPaths, ProjectsConfig, Settings, Theme, WindowState};
+use codescope_core::{AppPaths, LayoutState, ProjectsConfig, Settings, Theme, WindowState};
 use codescope_terminal::{
     Backend, ColorPalette, CursorStylePreset, FontConfig, Shell, SpawnConfig, TerminalSize,
     TerminalView,
@@ -83,12 +83,15 @@ impl AppShell {
         settings: Arc<Settings>,
         theme: Arc<Theme>,
         projects: ProjectsConfig,
+        layout: LayoutState,
         paths: Arc<AppPaths>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
-        let sidebar = cx.new(|_| Sidebar::new(projects, theme.clone(), paths.clone()));
+        let sidebar = cx.new(|_| {
+            Sidebar::new(projects, layout, theme.clone(), paths.clone())
+        });
         let pending_window_save: Arc<Mutex<Option<PendingWindowSave>>> = Arc::new(Mutex::new(None));
 
         // Persist live window geometry. The observer fires for every

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -148,6 +148,11 @@ impl AppShell {
 
     /// Open a fresh shell session and append it as a new tab. The new
     /// tab becomes the active one and the terminal grabs focus.
+    ///
+    /// Working directory + tab title come from the sidebar's currently
+    /// selected project. Without a selection (cold launch, no
+    /// projects yet) the shell starts in whatever cwd the binary
+    /// inherited.
     fn spawn_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let shell = std::env::var("CODESCOPE_SHELL")
             .ok()
@@ -166,6 +171,17 @@ impl AppShell {
         env.insert("TERM_PROGRAM".into(), "CodeScope".into());
         env.insert("TERM_PROGRAM_VERSION".into(), "0.0.1".into());
 
+        // Pull project context from the sidebar — clone the path +
+        // name so we don't hold a borrow across `cx.new` further down.
+        let active_project = self
+            .sidebar
+            .read(cx)
+            .active_project()
+            .map(|p| (p.path.clone(), p.name.clone()));
+        let working_directory = active_project
+            .as_ref()
+            .map(|(path, _)| std::path::PathBuf::from(path));
+
         // Build the terminal palette + cursor preset from the active
         // theme + settings. Cloned per spawn so each tab carries its
         // own snapshot — themes can swap later without breaking
@@ -179,6 +195,7 @@ impl AppShell {
 
         let backend = match Backend::spawn(SpawnConfig {
             shell,
+            working_directory,
             env,
             size: TerminalSize {
                 num_lines: 30,
@@ -201,11 +218,11 @@ impl AppShell {
         let terminal = cx.new(|cx| TerminalView::new_full(backend, palette, font, cx));
         let id = self.next_id;
         self.next_id += 1;
-        self.tabs.push(Tab {
-            id,
-            title: format!("Terminal {}", id + 1).into(),
-            terminal,
-        });
+        let title: SharedString = match active_project {
+            Some((_, name)) => name.into(),
+            None => format!("Terminal {}", id + 1).into(),
+        };
+        self.tabs.push(Tab { id, title, terminal });
         let new_idx = self.tabs.len() - 1;
         self.activate_tab(new_idx, window, cx);
     }

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -82,13 +82,13 @@ impl AppShell {
     pub fn new(
         settings: Arc<Settings>,
         theme: Arc<Theme>,
-        projects: Arc<ProjectsConfig>,
+        projects: ProjectsConfig,
         paths: Arc<AppPaths>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
-        let sidebar = cx.new(|_| Sidebar::new(projects, theme.clone()));
+        let sidebar = cx.new(|_| Sidebar::new(projects, theme.clone(), paths.clone()));
         let pending_window_save: Arc<Mutex<Option<PendingWindowSave>>> = Arc::new(Mutex::new(None));
 
         // Persist live window geometry. The observer fires for every

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -24,19 +24,35 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use codescope_core::{ProjectsConfig, Settings, Theme};
+use codescope_core::{AppPaths, ProjectsConfig, Settings, Theme, WindowState};
 use codescope_terminal::{
     Backend, ColorPalette, CursorStylePreset, FontConfig, Shell, SpawnConfig, TerminalSize,
     TerminalView,
 };
 use gpui::{
     AppContext, Context, Entity, FocusHandle, Focusable, InteractiveElement, IntoElement,
-    KeyDownEvent, MouseButton, ParentElement, Render, SharedString, Styled, Window, div, px,
+    KeyDownEvent, MouseButton, ParentElement, Render, SharedString, Styled, Window, WindowBounds,
+    div, px,
 };
+use parking_lot::Mutex;
 
 use crate::sidebar::Sidebar;
 use crate::theme;
+
+/// How often the window-state debounce loop wakes up to check whether
+/// the latest pending save has been stable long enough.
+const WINDOW_SAVE_POLL: Duration = Duration::from_millis(150);
+/// How long the pending save must sit untouched before we actually
+/// hit disk. Long enough that a drag-resize doesn't write on every
+/// pixel; short enough that a normal resize-and-let-go feels instant.
+const WINDOW_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
+
+struct PendingWindowSave {
+    state: WindowState,
+    set_at: Instant,
+}
 
 /// One tab = one terminal session.
 struct Tab {
@@ -67,11 +83,56 @@ impl AppShell {
         settings: Arc<Settings>,
         theme: Arc<Theme>,
         projects: Arc<ProjectsConfig>,
+        paths: Arc<AppPaths>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
         let sidebar = cx.new(|_| Sidebar::new(projects, theme.clone()));
+        let pending_window_save: Arc<Mutex<Option<PendingWindowSave>>> = Arc::new(Mutex::new(None));
+
+        // Persist live window geometry. The observer fires for every
+        // resize / move tick; we just stash the latest state and let
+        // the background debounce task hit disk once the dust settles.
+        cx.observe_window_bounds(window, {
+            let pending = pending_window_save.clone();
+            move |_, window, _| {
+                let state = window_state_from_window(window);
+                *pending.lock() = Some(PendingWindowSave {
+                    state,
+                    set_at: Instant::now(),
+                });
+            }
+        })
+        .detach();
+
+        // Debounced disk write. The loop dies when AppShell drops
+        // (`this.upgrade()` returns None), which is what we want — at
+        // app shutdown anything still pending is genuinely stale.
+        let pending_for_timer = pending_window_save.clone();
+        let paths_for_timer = paths.clone();
+        cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor().timer(WINDOW_SAVE_POLL).await;
+                if this.upgrade().is_none() {
+                    break;
+                }
+                let to_save = {
+                    let mut guard = pending_for_timer.lock();
+                    match guard.as_ref() {
+                        Some(p) if p.set_at.elapsed() >= WINDOW_SAVE_DEBOUNCE => guard.take(),
+                        _ => None,
+                    }
+                };
+                if let Some(p) = to_save {
+                    if let Err(err) = p.state.save(&paths_for_timer) {
+                        eprintln!("warning: failed to save window state: {err:#}");
+                    }
+                }
+            }
+        })
+        .detach();
+
         let mut shell = Self {
             tabs: Vec::new(),
             active_tab: 0,
@@ -410,6 +471,31 @@ impl Render for AppShell {
             .text_color(theme::ink(&theme))
             .child(tab_strip)
             .child(main_row)
+    }
+}
+
+// ─── Window-state extraction ────────────────────────────────────────
+
+/// Snapshot the platform window into the on-disk `WindowState`. We
+/// always store the *restore* bounds so unmaximising lands at a
+/// sensible size; `maximised` is a separate flag the loader uses to
+/// pick `WindowBounds::Maximized` vs `Windowed`.
+fn window_state_from_window(window: &Window) -> WindowState {
+    let restore = match window.window_bounds() {
+        WindowBounds::Windowed(b) => b,
+        WindowBounds::Maximized(b) => b,
+        WindowBounds::Fullscreen(b) => b,
+    };
+    let f32_x: f32 = restore.origin.x.into();
+    let f32_y: f32 = restore.origin.y.into();
+    let f32_w: f32 = restore.size.width.into();
+    let f32_h: f32 = restore.size.height.into();
+    WindowState {
+        x: f32_x as i32,
+        y: f32_y as i32,
+        width: f32_w.max(0.0) as u32,
+        height: f32_h.max(0.0) as u32,
+        maximised: window.is_maximized(),
     }
 }
 

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -23,7 +23,7 @@
 
 use std::sync::Arc;
 
-use codescope_core::{AppPaths, Project, ProjectsConfig, Theme};
+use codescope_core::{AppPaths, LayoutState, Project, ProjectsConfig, Theme};
 use gpui::{
     Context, InteractiveElement, IntoElement, MouseButton, ParentElement, PathPromptOptions,
     Render, SharedString, Styled, Window, div, px,
@@ -42,21 +42,49 @@ pub struct Sidebar {
     /// projects exist yet.
     selected: Option<usize>,
     theme: Arc<Theme>,
-    /// Where `projects.json` lives. Threaded in so add/remove can
-    /// persist without re-detecting the env.
+    /// Where `projects.json` and `layout.json` live. Threaded in so
+    /// add/remove + selection changes can persist without re-detecting
+    /// the env.
     paths: Arc<AppPaths>,
+    /// In-memory copy of `layout.json` — kept in sync as the user
+    /// changes selection so a save-on-change writes out the full
+    /// (correct) struct, not just the field we touched.
+    layout: LayoutState,
 }
 
 impl Sidebar {
-    pub fn new(projects: ProjectsConfig, theme: Arc<Theme>, paths: Arc<AppPaths>) -> Self {
-        let selected = (!projects.projects.is_empty()).then_some(0);
-        Self { projects, selected, theme, paths }
+    pub fn new(
+        projects: ProjectsConfig,
+        layout: LayoutState,
+        theme: Arc<Theme>,
+        paths: Arc<AppPaths>,
+    ) -> Self {
+        // Restore last-opened project if it still exists. Falls back
+        // to the first project when the saved id is gone (project
+        // removed between sessions) or absent (first launch).
+        let selected = match layout.selected_project_id.as_deref() {
+            Some(id) => projects.projects.iter().position(|p| p.id == id),
+            None => None,
+        }
+        .or_else(|| (!projects.projects.is_empty()).then_some(0));
+        Self { projects, selected, theme, paths, layout }
     }
 
     pub fn select(&mut self, idx: usize, cx: &mut Context<Self>) {
         if idx < self.projects.projects.len() {
             self.selected = Some(idx);
+            self.layout.selected_project_id =
+                Some(self.projects.projects[idx].id.clone());
+            self.save_layout();
             cx.notify();
+        }
+    }
+
+    /// Persist `layout.json` after selection / sidebar-visibility
+    /// changes. No debounce — selection is user-driven and slow.
+    fn save_layout(&self) {
+        if let Err(err) = self.layout.save(&self.paths) {
+            eprintln!("warning: failed to save layout.json: {err:#}");
         }
     }
 
@@ -130,12 +158,15 @@ impl Sidebar {
             return;
         }
         let project = Project::new(path);
+        let new_id = project.id.clone();
         self.projects.projects.push(project);
         let new_idx = self.projects.projects.len() - 1;
         self.selected = Some(new_idx);
+        self.layout.selected_project_id = Some(new_id);
         if let Err(err) = self.projects.save(&self.paths) {
             eprintln!("warning: failed to save projects.json: {err:#}");
         }
+        self.save_layout();
         cx.notify();
     }
 }

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -60,6 +60,13 @@ impl Sidebar {
         }
     }
 
+    /// The project the user currently has selected, if any. AppShell
+    /// reads this when spawning a new tab so the terminal lands in
+    /// the right cwd.
+    pub fn active_project(&self) -> Option<&Project> {
+        self.selected.and_then(|idx| self.projects.projects.get(idx))
+    }
+
     /// Apply a fresh theme snapshot. Called by the AppShell when the
     /// user changes themes — the sidebar redraws on the next frame.
     #[allow(dead_code)]

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -71,13 +71,16 @@ impl Sidebar {
     }
 
     pub fn select(&mut self, idx: usize, cx: &mut Context<Self>) {
-        if idx < self.projects.projects.len() {
-            self.selected = Some(idx);
-            self.layout.selected_project_id =
-                Some(self.projects.projects[idx].id.clone());
-            self.save_layout();
-            cx.notify();
+        if idx >= self.projects.projects.len() || self.selected == Some(idx) {
+            // Out-of-range or re-clicking the active row — no-op,
+            // skip the synchronous `layout.json` write.
+            return;
         }
+        self.selected = Some(idx);
+        self.layout.selected_project_id =
+            Some(self.projects.projects[idx].id.clone());
+        self.save_layout();
+        cx.notify();
     }
 
     /// Persist `layout.json` after selection / sidebar-visibility
@@ -103,12 +106,10 @@ impl Sidebar {
         cx.notify();
     }
 
-    /// Open the platform "pick a folder" dialog. On confirm, append a
-    /// fresh [`Project`] and write `projects.json`. Any error is
-    /// logged to stderr — the sidebar stays consistent because we
-    /// only mutate state when the save succeeds. (Saved-but-stale
-    /// is preferable to in-memory-but-not-saved; see the C# build's
-    /// `ProjectsRepository` for the same trade-off.)
+    /// Open the platform "pick a folder" dialog. On confirm, hand the
+    /// path to [`Self::add_project`] which writes `projects.json`
+    /// before mutating in-memory state, so a save failure leaves both
+    /// the disk and the UI in their previous (consistent) state.
     pub fn open_add_project_picker(
         &mut self,
         _window: &mut Window,
@@ -146,26 +147,36 @@ impl Sidebar {
     /// Append a project at `path` and persist. Newly-added project
     /// becomes the selection — the user just chose it, so dropping
     /// them straight into it is what they expect.
+    ///
+    /// Save-then-commit ordering: we build a candidate `ProjectsConfig`,
+    /// write it to disk, and only swap it into `self.projects` (and
+    /// touch `selected` / `layout.json`) once the write succeeds. A
+    /// failed write therefore leaves both disk and UI in their
+    /// previous consistent state, instead of producing an in-memory
+    /// row that disappears on relaunch — and (worse) a `layout.json`
+    /// pointing at a project id that never made it to `projects.json`.
     pub fn add_project(&mut self, path: String, cx: &mut Context<Self>) {
         // Refuse exact duplicates by path. Two rows pointing at the
         // same directory would let a user "add" the same project
         // twice and then wonder why both rows behave identically.
-        if self.projects.projects.iter().any(|p| p.path == path) {
-            if let Some(idx) = self.projects.projects.iter().position(|p| p.path == path) {
-                self.selected = Some(idx);
-                cx.notify();
-            }
+        if let Some(idx) = self.projects.projects.iter().position(|p| p.path == path) {
+            self.select(idx, cx);
             return;
         }
         let project = Project::new(path);
         let new_id = project.id.clone();
-        self.projects.projects.push(project);
+        // Clone-then-save: failure leaves `self.projects` untouched.
+        let mut next = self.projects.clone();
+        next.projects.push(project);
+        if let Err(err) = next.save(&self.paths) {
+            eprintln!("warning: failed to save projects.json: {err:#}");
+            return;
+        }
+        // Disk is committed; now mirror the change in memory.
+        self.projects = next;
         let new_idx = self.projects.projects.len() - 1;
         self.selected = Some(new_idx);
         self.layout.selected_project_id = Some(new_id);
-        if let Err(err) = self.projects.save(&self.paths) {
-            eprintln!("warning: failed to save projects.json: {err:#}");
-        }
         self.save_layout();
         cx.notify();
     }

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -2,17 +2,18 @@
 //!
 //! Single-purpose view: lists every entry in the loaded
 //! [`codescope_core::ProjectsConfig`] and lets the user select one.
-//! No "add project" / "remove project" interactions yet — that lives
-//! one step further along the roadmap, behind a `+` action and a
-//! command-palette entry.
+//! The `+` button kicks off a directory picker and, on success,
+//! appends a new project and persists `projects.json`. Removal /
+//! editing are still TODO and live behind right-click + a command
+//! palette in the C# build.
 //!
 //! Layout (240 px wide):
 //!
 //! ```text
 //! ┌───────────────┐
-//! │ PROJECTS    + │ ← heading + add (placeholder)
+//! │ PROJECTS    + │ ← heading + add (file picker)
 //! ├───────────────┤
-//! │ filter…       │ ← (placeholder, wired next session)
+//! │ filter…       │ ← (placeholder, wired later)
 //! ├───────────────┤
 //! │ ▍ project A   │ ← active = accent rail + frost bg
 //! │   project B   │
@@ -22,10 +23,10 @@
 
 use std::sync::Arc;
 
-use codescope_core::{ProjectsConfig, Theme};
+use codescope_core::{AppPaths, Project, ProjectsConfig, Theme};
 use gpui::{
-    Context, InteractiveElement, IntoElement, MouseButton, ParentElement, Render, SharedString,
-    Styled, Window, div, px,
+    Context, InteractiveElement, IntoElement, MouseButton, ParentElement, PathPromptOptions,
+    Render, SharedString, Styled, Window, div, px,
 };
 
 use crate::theme;
@@ -36,17 +37,20 @@ use crate::theme;
 pub const SIDEBAR_WIDTH: f32 = 240.0;
 
 pub struct Sidebar {
-    projects: Arc<ProjectsConfig>,
+    projects: ProjectsConfig,
     /// Index of the currently-selected project. `None` when no
     /// projects exist yet.
     selected: Option<usize>,
     theme: Arc<Theme>,
+    /// Where `projects.json` lives. Threaded in so add/remove can
+    /// persist without re-detecting the env.
+    paths: Arc<AppPaths>,
 }
 
 impl Sidebar {
-    pub fn new(projects: Arc<ProjectsConfig>, theme: Arc<Theme>) -> Self {
+    pub fn new(projects: ProjectsConfig, theme: Arc<Theme>, paths: Arc<AppPaths>) -> Self {
         let selected = (!projects.projects.is_empty()).then_some(0);
-        Self { projects, selected, theme }
+        Self { projects, selected, theme, paths }
     }
 
     pub fn select(&mut self, idx: usize, cx: &mut Context<Self>) {
@@ -61,6 +65,70 @@ impl Sidebar {
     #[allow(dead_code)]
     pub fn apply_theme(&mut self, theme: Arc<Theme>, cx: &mut Context<Self>) {
         self.theme = theme;
+        cx.notify();
+    }
+
+    /// Open the platform "pick a folder" dialog. On confirm, append a
+    /// fresh [`Project`] and write `projects.json`. Any error is
+    /// logged to stderr — the sidebar stays consistent because we
+    /// only mutate state when the save succeeds. (Saved-but-stale
+    /// is preferable to in-memory-but-not-saved; see the C# build's
+    /// `ProjectsRepository` for the same trade-off.)
+    pub fn open_add_project_picker(
+        &mut self,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let rx = cx.prompt_for_paths(PathPromptOptions {
+            files: false,
+            directories: true,
+            multiple: false,
+            prompt: Some("Add project".into()),
+        });
+        cx.spawn(async move |this, cx| {
+            let paths = match rx.await {
+                Ok(Ok(Some(paths))) => paths,
+                // `Ok(None)` = user cancelled, `Ok(Err(...))` = picker
+                // failed to open (Linux). Both end the flow silently
+                // — the user already sees what happened on screen.
+                Ok(Ok(None)) => return,
+                Ok(Err(err)) => {
+                    eprintln!("warning: file picker failed: {err:#}");
+                    return;
+                }
+                Err(_) => return,
+            };
+            if let Some(path) = paths.into_iter().next() {
+                let path_str = path.to_string_lossy().into_owned();
+                let _ = this.update(cx, |this, cx| {
+                    this.add_project(path_str, cx);
+                });
+            }
+        })
+        .detach();
+    }
+
+    /// Append a project at `path` and persist. Newly-added project
+    /// becomes the selection — the user just chose it, so dropping
+    /// them straight into it is what they expect.
+    pub fn add_project(&mut self, path: String, cx: &mut Context<Self>) {
+        // Refuse exact duplicates by path. Two rows pointing at the
+        // same directory would let a user "add" the same project
+        // twice and then wonder why both rows behave identically.
+        if self.projects.projects.iter().any(|p| p.path == path) {
+            if let Some(idx) = self.projects.projects.iter().position(|p| p.path == path) {
+                self.selected = Some(idx);
+                cx.notify();
+            }
+            return;
+        }
+        let project = Project::new(path);
+        self.projects.projects.push(project);
+        let new_idx = self.projects.projects.len() - 1;
+        self.selected = Some(new_idx);
+        if let Err(err) = self.projects.save(&self.paths) {
+            eprintln!("warning: failed to save projects.json: {err:#}");
+        }
         cx.notify();
     }
 }
@@ -86,7 +154,6 @@ impl Render for Sidebar {
             .text_size(px(11.0))
             .text_color(theme::ink_muted(&theme))
             .child(div().flex_grow().child("PROJECTS"))
-            // Placeholder "+" button — wired up in a follow-up commit.
             .child(
                 div()
                     .id("sidebar-add")
@@ -97,11 +164,18 @@ impl Render for Sidebar {
                     .justify_center()
                     .rounded_sm()
                     .text_color(theme::ink_ghost(&theme))
+                    .cursor_pointer()
                     .hover({
                         let frost = theme::frost_10(&theme);
                         let ink = theme::ink(&theme);
                         move |s| s.bg(frost).text_color(ink)
                     })
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, _, window, cx| {
+                            this.open_add_project_picker(window, cx);
+                        }),
+                    )
                     .child("+"),
             );
 
@@ -151,6 +225,7 @@ impl Render for Sidebar {
                 .bg(bg)
                 .text_color(text_color)
                 .text_size(px(13.0))
+                .cursor_pointer()
                 .hover(move |s| {
                     if active { s } else { s.bg(frost_hover).text_color(ink_hover) }
                 })

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -103,6 +103,7 @@ fn main() -> Result<()> {
     };
 
     let window_bounds = saved_window.map(window_state_to_bounds);
+    let paths = Arc::new(paths);
 
     let app = gpui::Application::new();
 
@@ -111,14 +112,14 @@ fn main() -> Result<()> {
         let theme = theme.clone();
         let projects = projects.clone();
         let layout = layout.clone();
+        let paths = paths.clone();
 
-        // No quit-time save yet. Writing `LayoutState::default()`
-        // would clobber any layout the user (or a previous session)
-        // saved, and we don't yet have live state on the AppShell
-        // to write instead. `window.json` is in the same boat — we
-        // restore on launch but don't observe bounds-changes to
-        // write back. Both wires land together with
-        // `cx.observe_window_bounds`.
+        // `window.json` save now lives inside `AppShell::new` — it
+        // observes bounds and debounces writes. `layout.json` save
+        // is still TODO (waiting on real live layout state); we
+        // deliberately don't write `LayoutState::default()` at
+        // quit-time because that would clobber whatever the user
+        // last saved.
 
         cx.spawn(async move |cx| {
             cx.open_window(
@@ -132,7 +133,9 @@ fn main() -> Result<()> {
                     ..Default::default()
                 },
                 |window, cx| {
-                    let shell = cx.new(|cx| AppShell::new(settings, theme.clone(), projects, window, cx));
+                    let shell = cx.new(|cx| {
+                        AppShell::new(settings, theme.clone(), projects, paths, window, cx)
+                    });
                     cx.new(|_| Root { shell, theme })
                 },
             )?;

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -87,7 +87,6 @@ fn main() -> Result<()> {
             LayoutState::default()
         }
     };
-    let layout = Arc::new(layout);
 
     let saved_window = match WindowState::load(&paths) {
         Ok(state) => state,
@@ -107,13 +106,10 @@ fn main() -> Result<()> {
     let app = gpui::Application::new();
 
     app.run(move |cx| {
-        // `window.json` save now lives inside `AppShell::new` — it
-        // observes bounds and debounces writes. `layout.json` save
-        // is still TODO (waiting on real live layout state); we
-        // deliberately don't write `LayoutState::default()` at
-        // quit-time because that would clobber whatever the user
-        // last saved.
-        let _ = layout;
+        // `window.json` save lives inside `AppShell::new` (observes
+        // bounds, debounces writes). `layout.json` save lives inside
+        // `Sidebar::select` / `add_project` — selection changes are
+        // user-driven and slow, no debounce needed.
 
         cx.spawn(async move |cx| {
             cx.open_window(
@@ -128,7 +124,15 @@ fn main() -> Result<()> {
                 },
                 |window, cx| {
                     let shell = cx.new(|cx| {
-                        AppShell::new(settings, theme.clone(), projects, paths, window, cx)
+                        AppShell::new(
+                            settings,
+                            theme.clone(),
+                            projects,
+                            layout,
+                            paths,
+                            window,
+                            cx,
+                        )
                     });
                     cx.new(|_| Root { shell, theme })
                 },

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use anyhow::Result;
 use codescope_core::{AppPaths, LayoutState, ProjectsConfig, Settings, Theme, WindowState, builtin};
 use gpui::{
-    AppContext, Bounds, Context, IntoElement, ParentElement, Pixels, Render, Styled,
-    TitlebarOptions, Window, WindowBounds, WindowOptions, div, point, px, size,
+    AppContext, Bounds, Context, IntoElement, ParentElement, Render, Styled, TitlebarOptions,
+    Window, WindowBounds, WindowOptions, div, point, px, size,
 };
 
 use crate::app::AppShell;
@@ -75,7 +75,6 @@ fn main() -> Result<()> {
             ProjectsConfig::default()
         }
     };
-    let projects = Arc::new(projects);
 
     let layout = match LayoutState::load(&paths) {
         Ok(l) => l,
@@ -108,18 +107,13 @@ fn main() -> Result<()> {
     let app = gpui::Application::new();
 
     app.run(move |cx| {
-        let settings = settings.clone();
-        let theme = theme.clone();
-        let projects = projects.clone();
-        let layout = layout.clone();
-        let paths = paths.clone();
-
         // `window.json` save now lives inside `AppShell::new` — it
         // observes bounds and debounces writes. `layout.json` save
         // is still TODO (waiting on real live layout state); we
         // deliberately don't write `LayoutState::default()` at
         // quit-time because that would clobber whatever the user
         // last saved.
+        let _ = layout;
 
         cx.spawn(async move |cx| {
             cx.open_window(
@@ -142,7 +136,6 @@ fn main() -> Result<()> {
             Ok::<_, anyhow::Error>(())
         })
         .detach();
-        let _ = layout;
     });
 
     Ok(())
@@ -157,21 +150,6 @@ fn window_state_to_bounds(state: WindowState) -> WindowBounds {
         WindowBounds::Maximized(bounds)
     } else {
         WindowBounds::Windowed(bounds)
-    }
-}
-
-#[allow(dead_code)]
-fn bounds_to_window_state(bounds: Bounds<Pixels>, maximised: bool) -> WindowState {
-    let f32_x: f32 = bounds.origin.x.into();
-    let f32_y: f32 = bounds.origin.y.into();
-    let f32_w: f32 = bounds.size.width.into();
-    let f32_h: f32 = bounds.size.height.into();
-    WindowState {
-        x: f32_x as i32,
-        y: f32_y as i32,
-        width: f32_w.max(0.0) as u32,
-        height: f32_h.max(0.0) as u32,
-        maximised,
     }
 }
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -6,8 +6,8 @@
 > Old detail lives in `git log` — don't duplicate it here.
 
 **Last updated:** 2026-05-09 (session 32)
-**Branch:** `feat/codescope-rs-window-state-save` (PR pending)
-**Head:** `ee8d155` — pushed (`feat(rs): persist sidebar selection across launches`)
+**Branch:** `feat/codescope-rs-window-state-save` (PR #55, manual-tested)
+**Head:** `27301fe` — pushed (`fix(rs): address PR #55 review feedback`)
 **Release:** `v0.2.5` shipped — https://github.com/maui1911/CodeScope/releases/tag/v0.2.5
 **Build status:** ✅ C# untouched. Rust workspace builds clean
 (`cargo build --workspace --manifest-path codescope-rs/Cargo.toml`).
@@ -96,7 +96,39 @@ in stacked commits on `feat/codescope-rs-window-state-save` (off main):
    "Open in Explorer", "Reveal in shell" — mirrors the C# build's
    tab-strip context menu.
 
-**Known small things still to clean up:**
+**Manual-test results (this machine, dev build, end of session):**
+- ✅ resize + reposition → close → relaunch reopens at the same
+  bounds (`window.json` save wiring works)
+- ✅ click `+` → folder picker → new row appended, `projects.json`
+  written in Rust shape (snake_case)
+- ✅ select project → close → relaunch restores selection
+  (`layout.json.selected_project_id` wired)
+- ✅ select project → `Ctrl+Shift+T` → new tab labelled with the
+  project name, `pwd` lands in the project's path
+- ⚠️ test plan claimed "v0.x C# `projects.json` round-trips" — it
+  does **not** in practice. C# writes camelCase
+  (`defaultBranch`, `worktreePath`, `agentSessionId`, …); Rust
+  expects snake_case. C#-shape file fails to deserialize and we
+  fall back to empty config. Fix in the next pass: add
+  `#[serde(rename_all = "camelCase")]` on `Project`, `Session`,
+  `Worktree`, `ProjectsConfig` (verify per-field — the C# file
+  has a top-level `agents: []` we don't model yet, so a
+  `serde(default)` fallthrough on extras is also needed). Then
+  add a round-trip integration test with a fixture cribbed from
+  `CodeScope.Dev.backup-*` so the schema break can't silently
+  return.
+
+**Known small things still to clean up (rolled into the "next
+pass" lane the user explicitly carved out):**
+- **Titlebar interactions broken.** `appears_transparent: true`
+  claims the bar for our tab strip but we don't replace the
+  drag region or the caption controls — so the window can't be
+  dragged, can't be maximised by double-clicking the bar, and
+  has no min/max/close glyphs. gpui's `examples/window.rs` and
+  `window_shadow.rs` show the pattern: a `WindowControlArea`
+  for the buttons + a hand-rolled drag handler on empty bar
+  space (`window.start_window_move()` on Windows). Land
+  alongside the next round of polish.
 - Backend's `hyperlink_at` is unused (snapshot handles it).
 - Layout fields `sidebar_visible` / `sidebar_width` are loaded
   but never re-saved because nothing changes them yet — fine for

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -11,9 +11,9 @@
 **Release:** `v0.2.5` shipped — https://github.com/maui1911/CodeScope/releases/tag/v0.2.5
 **Build status:** ✅ C# untouched. Rust workspace builds clean
 (`cargo build --workspace --manifest-path codescope-rs/Cargo.toml`).
-22 unit tests across `codescope-core` (16, +4 git porcelain parser
-+ Project::new) + `codescope-terminal` mouse-encoder (9). PR #54
-merged to main as `7ffe4f3`.
+27 unit tests across `codescope-core` (18: +4 git porcelain parser
++ 2 `Project::new` since session 31's 12) + `codescope-terminal`
+mouse-encoder (9). PR #54 merged to main as `7ffe4f3`.
 **Uncommitted work:** none.
 **Open issues:** none on GitHub.
 
@@ -43,9 +43,9 @@ in stacked commits on `feat/codescope-rs-window-state-save` (off main):
    to the system `git`. Pure-stdlib (no libgit2 — see CLAUDE.md
    technology decisions). Porcelain parser handles
    primary/branched/detached/locked stanzas. 4 unit tests on the
-   parser. Errors carry the trimmed stderr tail so a future error
-   dialog can surface "fatal: 'foo' is already checked out at
-   '...'" verbatim. Not yet wired to UI.
+   parser. Errors carry the trimmed stderr verbatim so a future
+   error dialog can surface "fatal: 'foo' is already checked out
+   at '...'" without guessing the cause. Not yet wired to UI.
 4. **Sidebar drives new-tab cwd** (`1d2163d`). AppShell reads
    `Sidebar::active_project()` at spawn time, threads `path`
    through `SpawnConfig.working_directory`, labels the tab with

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -5,17 +5,106 @@
 > **Intent:** cursor + last 1–2 sessions in depth, everything else a one-liner.
 > Old detail lives in `git log` — don't duplicate it here.
 
-**Last updated:** 2026-05-09 (session 31)
-**Branch:** `feat/codescope-rs-architecture` (PR #54, open)
-**Head:** `33083b2` — pushed
+**Last updated:** 2026-05-09 (session 32)
+**Branch:** `feat/codescope-rs-window-state-save` (PR pending)
+**Head:** `ee8d155` — pushed (`feat(rs): persist sidebar selection across launches`)
 **Release:** `v0.2.5` shipped — https://github.com/maui1911/CodeScope/releases/tag/v0.2.5
 **Build status:** ✅ C# untouched. Rust workspace builds clean
 (`cargo build --workspace --manifest-path codescope-rs/Cargo.toml`).
-21 unit tests across `codescope-core` (12) + `codescope-terminal`
-mouse-encoder (9). PR #53 squash-merged to main as `7a05ed6`;
-session 30's terminal-layer work (sessions 28-30) is in `main` now.
+22 unit tests across `codescope-core` (16, +4 git porcelain parser
++ Project::new) + `codescope-terminal` mouse-encoder (9). PR #54
+merged to main as `7ffe4f3`.
 **Uncommitted work:** none.
 **Open issues:** none on GitHub.
+
+### Session 32 — window/layout persistence, add-project, git primitives, sidebar drives tab cwd
+
+Picked up the priority list left by session 31 and walked five items
+in stacked commits on `feat/codescope-rs-window-state-save` (off main):
+
+1. **`window.json` save wiring** (`48ccd19`). AppShell registers
+   `cx.observe_window_bounds`; bounds + `is_maximized` flow into a
+   `PendingWindowSave` slot, debounced for 500 ms before hitting
+   disk. Restore-bounds (not live size) are serialised so an
+   un-maximise on the next launch lands at the user's chosen size.
+   Loop dies on AppShell drop — anything still pending at quit is
+   genuinely stale.
+2. **Sidebar `+` add-project** (`60f9c8a`). Native folder picker
+   via `cx.prompt_for_paths(directories: true)`; on confirm a
+   fresh `Project` is appended and `projects.json` written.
+   `Project::new(path)` lives in `core`: leaf folder name → display
+   name, UUIDv4 id, branch defaults to "main". Duplicate paths
+   short-circuit (re-pick selects the existing row instead of
+   adding a stale copy). Switched Sidebar to own `ProjectsConfig`
+   directly (was `Arc<...>`) — simpler add/remove without
+   `Arc::make_mut`.
+3. **`codescope-core::git` worktree primitives** (`ca7c10d`).
+   `list_worktrees` / `add_worktree` / `remove_worktree` shell out
+   to the system `git`. Pure-stdlib (no libgit2 — see CLAUDE.md
+   technology decisions). Porcelain parser handles
+   primary/branched/detached/locked stanzas. 4 unit tests on the
+   parser. Errors carry the trimmed stderr tail so a future error
+   dialog can surface "fatal: 'foo' is already checked out at
+   '...'" verbatim. Not yet wired to UI.
+4. **Sidebar drives new-tab cwd** (`1d2163d`). AppShell reads
+   `Sidebar::active_project()` at spawn time, threads `path`
+   through `SpawnConfig.working_directory`, labels the tab with
+   the project name. Without a selection (cold launch / no
+   projects) we fall back to inherited cwd + numeric label.
+5. **Selection persists across launches** (`ee8d155`). Sidebar
+   owns `LayoutState`, restores selection by id on construction,
+   writes `layout.json` on every `select` / `add_project`. Saved
+   id missing or stale → first project. Single writer (Sidebar);
+   AppShell-side fields (sidebar_visible / sidebar_width — both
+   unused so far) will land the same way once they become
+   user-controllable.
+
+**Architectural notes worth carrying forward:**
+- `core` is now slightly impure: `git.rs` shells out to `git`. UI
+  imports are still excluded (gpui, alacritty, windows-rs) — the
+  layering pyramid still holds.
+- Background-debounce + `Arc<Mutex<Option<PendingX>>>` works
+  cleanly for both terminal-resize (terminal/view.rs) and
+  window-state save (src/app.rs). Reach for it whenever a fast
+  observer feeds a slow consumer.
+- `Sidebar` is the writer for `layout.json`. Splitting writes per
+  field-owner keeps the persistence surface obvious — when adding
+  fields, prefer to put the writer next to the state owner rather
+  than centralising.
+
+**Suggested next entry points (priority order):**
+
+1. **Worktree orchestration UI.** Add a "New session" affordance
+   per project (button in sidebar, command-palette later). Prompt
+   for a branch, run `add_worktree`, save a `Session` to the
+   project, open a new tab in the worktree path. The "actually
+   CodeScope" milestone — primitives in `core::git` are ready,
+   the UI piece is what's left.
+2. **Live theme reload.** Watch `settings.json` for mtime change
+   (poll every ~1 s in a background task), reload settings,
+   resolve theme by name, swap `Arc<Theme>` on AppShell + Sidebar,
+   `cx.notify`. The two `theme::canvas(theme)` etc. helpers
+   already accept `&Theme` so a swap repaints without rebuilding.
+3. **Telemetry tail.** FSWatch on `~/.claude/projects/...` →
+   `running / idle / error` per session, drives status dots
+   (currently hardcoded green when active).
+4. **Filter input at the top of the sidebar.** Needs a real text
+   input — gpui's `examples/input.rs` is the reference but it's a
+   chunk of code. Worth pairing with the new-session dialog so
+   the input widget effort lands once.
+5. **Right-click on project / tab.** "Remove from sidebar",
+   "Open in Explorer", "Reveal in shell" — mirrors the C# build's
+   tab-strip context menu.
+
+**Known small things still to clean up:**
+- Backend's `hyperlink_at` is unused (snapshot handles it).
+- Layout fields `sidebar_visible` / `sidebar_width` are loaded
+  but never re-saved because nothing changes them yet — fine for
+  now, will update when a toggle / resize lands.
+- `git::add_worktree` / `remove_worktree` have no integration
+  test that hits a real `git` binary. The parser is tested; the
+  shell-out wrapper is thin enough that the integration test can
+  land alongside the new-session UI.
 
 ### Session 31 — codescope-core, settings + themes, sidebar + projects, window/layout state, mouse-mode, OSC 8 + URL detection
 
@@ -122,36 +211,8 @@ typing + scroll + selection + paste all still work cleanly.
   to stay safe; URLs in the wild are pure ASCII so the fallback
   basically never trips.
 
-**Suggested next entry points (in priority order):**
-
-1. **window.json save wiring.** The load path works; saving
-   needs `cx.observe_window_bounds` (or equivalent) threaded
-   through the AppShell so live changes get persisted. Without
-   this we still default to whatever the OS remembers, which is
-   already pretty good on Windows.
-2. **Sidebar interactions.** `+` add-project (file picker → new
-   `Project` row → save to `projects.json`). Clicking a project
-   should drive the tab list (each project's sessions become
-   tabs). Filter input at the top of the sidebar.
-3. **Worktree orchestration.** Shell out to `git worktree` for
-   per-session worktrees, mirroring `CodeScope.Worktrees` in
-   the C# build. This is the "actually CodeScope" milestone.
-4. **Telemetry tail.** FSWatch on `~/.claude/projects/…` to
-   drive the (currently hardcoded green) status dots — `running
-   / idle / error` per session.
-5. **Live theme reload + `+` add-theme commands.** Watch
-   `settings.json` for changes and swap the `Arc<Theme>`
-   without restart.
-
-**Known small things still to clean up:**
-- Backend's `hyperlink_at` is now unused (snapshot handles it)
-  — keep until we expose a non-snapshot API or delete on next
-  cleanup pass.
-- Theme accent on tabs is hardcoded to top-border — Framer Blue
-  feels right but other themes might want a different placement.
-- The `inject_url_hyperlinks` post-processing runs every
-  snapshot. Reasonable for typical grids; profile if it shows up
-  in flame graphs at very large sizes.
+(Next-entry-points list moved to the session 32 entry above —
+those items are still accurate but session 32 added context.)
 
 ### Session 30 — pixel-accurate paint, paste, cursor blink, resize debounce, box-drawing alignment, OSC query handshake
 


### PR DESCRIPTION
## Summary

Picks up the priority list left by session 31 in HANDOFF.md and walks five items in stacked commits off `main`.

- **`window.json` save wiring** — `cx.observe_window_bounds` debounces resize/move events into `WindowState::save` (500 ms); restore-bounds (not live size) get serialised so an un-maximise on the next launch lands at the user's chosen size.
- **Sidebar `+` add-project** — Native folder picker via `cx.prompt_for_paths`; new `Project` is appended and `projects.json` rewritten. `Project::new(path)` lives in `core` (UUIDv4 id, leaf-folder name, branch defaults to "main"). Duplicate paths short-circuit.
- **`codescope-core::git` worktree primitives** — `list_worktrees` / `add_worktree` / `remove_worktree` shell out to `git`. Pure stdlib (no libgit2 — see CLAUDE.md). Porcelain parser handles primary/branched/detached/locked stanzas; 4 unit tests. Errors carry the trimmed stderr tail.
- **Sidebar drives new-tab cwd** — AppShell reads `Sidebar::active_project()` at spawn time; threads `path` through `SpawnConfig.working_directory` and labels the tab with the project name.
- **Selection persists across launches** — Sidebar owns `LayoutState`, restores selection by id, writes `layout.json` on every `select` / `add_project`. Saved id missing or stale → first project.

## Test plan

- [x] `cargo build --workspace --manifest-path codescope-rs/Cargo.toml` clean
- [x] `cargo test -p codescope-core --manifest-path codescope-rs/Cargo.toml` — 18 passing (was 14, +4 git porcelain + Project::new)
- [ ] Manual: open the dev build, resize window, kill process, relaunch — bounds restored
- [ ] Manual: click `+` in PROJECTS heading, pick a folder → new row, persisted across relaunch
- [ ] Manual: click a project, Ctrl+Shift+T → new tab spawns in that project's path, labelled with project name
- [ ] Manual: select project A, kill process, relaunch → A is still selected
- [ ] Manual: existing v0.x C# build's `projects.json` round-trips with the Rust port (Sidebar still owns the file shape — checked via `Project` struct's serde shape, no format break expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)