### PR TITLE
feat(rs): worktree-backed sessions from the sidebar

### DIFF
--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -965,6 +965,7 @@ dependencies = [
  "gpui-terminal",
  "parking_lot",
  "portable-pty",
+ "uuid",
 ]
 
 [[package]]

--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -29,6 +29,7 @@ codescope-core = { path = "core" }
 portable-pty = "0.9"
 anyhow = "1"
 parking_lot = "0.12"
+uuid = { version = "1", features = ["v4"] }
 
 [profile.dev]
 opt-level = 1

--- a/codescope-rs/core/src/projects.rs
+++ b/codescope-rs/core/src/projects.rs
@@ -13,7 +13,7 @@
 //! because users can rename or relocate a worktree without breaking
 //! cross-references.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -76,6 +76,52 @@ impl Project {
             default_agent_id: None,
             sessions: Vec::new(),
             worktrees: Vec::new(),
+        }
+    }
+
+    /// Where new worktrees go for this project. Honours
+    /// `worktree_root` if set, otherwise falls back to
+    /// `"{path}.worktrees"` — matches the C# build's default and keeps
+    /// worktrees on the same volume as the primary tree (fast `git
+    /// worktree add` because the object database is shared).
+    pub fn worktree_root_path(&self) -> PathBuf {
+        match &self.worktree_root {
+            Some(root) => PathBuf::from(root),
+            None => PathBuf::from(format!("{}.worktrees", self.path)),
+        }
+    }
+
+    /// Absolute path of the worktree we'd create for a session on
+    /// `branch`. The branch name is used as the leaf folder name.
+    /// Slashes in branch names (`feature/foo`) become nested dirs,
+    /// which is what `git worktree add` does anyway.
+    pub fn worktree_path_for(&self, branch: &str) -> PathBuf {
+        self.worktree_root_path().join(branch)
+    }
+
+    /// Pick the next free `session-N` branch name. Walks both existing
+    /// `sessions` (closed-or-open records) and `worktrees` so we don't
+    /// clash with a branch that's still checked out somewhere. Starts
+    /// at `1` and counts up — gaps are fine, we just want uniqueness.
+    pub fn next_session_branch_name(&self) -> String {
+        let mut taken: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for s in &self.sessions {
+            if let Some(b) = s.branch.as_deref() {
+                taken.insert(b);
+            }
+        }
+        for w in &self.worktrees {
+            if let Some(b) = w.branch.as_deref() {
+                taken.insert(b);
+            }
+        }
+        let mut n: u32 = 1;
+        loop {
+            let candidate = format!("session-{n}");
+            if !taken.contains(candidate.as_str()) {
+                return candidate;
+            }
+            n += 1;
         }
     }
 }
@@ -241,6 +287,57 @@ mod tests {
     fn new_project_falls_back_when_path_has_no_leaf() {
         let p = Project::new("/".into());
         assert_eq!(p.name, "project");
+    }
+
+    #[test]
+    fn worktree_root_path_defaults_to_path_dot_worktrees() {
+        let p = Project::new("/repos/foo".into());
+        assert_eq!(p.worktree_root_path(), PathBuf::from("/repos/foo.worktrees"));
+    }
+
+    #[test]
+    fn worktree_root_path_honours_explicit_override() {
+        let mut p = Project::new("/repos/foo".into());
+        p.worktree_root = Some("/elsewhere/wt".into());
+        assert_eq!(p.worktree_root_path(), PathBuf::from("/elsewhere/wt"));
+    }
+
+    #[test]
+    fn worktree_path_for_joins_branch() {
+        let p = Project::new("/repos/foo".into());
+        assert_eq!(
+            p.worktree_path_for("session-1"),
+            PathBuf::from("/repos/foo.worktrees").join("session-1"),
+        );
+    }
+
+    #[test]
+    fn next_session_branch_name_starts_at_one() {
+        let p = Project::new("/repos/foo".into());
+        assert_eq!(p.next_session_branch_name(), "session-1");
+    }
+
+    #[test]
+    fn next_session_branch_name_skips_taken() {
+        let mut p = Project::new("/repos/foo".into());
+        p.worktrees.push(Worktree {
+            id: "w1".into(),
+            path: "/repos/foo.worktrees/session-1".into(),
+            branch: Some("session-1".into()),
+            is_primary: false,
+        });
+        p.sessions.push(Session {
+            id: "s2".into(),
+            worktree_path: "/repos/foo.worktrees/session-2".into(),
+            branch: Some("session-2".into()),
+            agent_id: None,
+            display_name: None,
+            worktree_id: None,
+            last_opened: None,
+            agent_session_id: None,
+            closed_at: None,
+        });
+        assert_eq!(p.next_session_branch_name(), "session-3");
     }
 
     #[test]

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -38,7 +38,7 @@ use gpui::{
 };
 use parking_lot::Mutex;
 
-use crate::sidebar::Sidebar;
+use crate::sidebar::{Sidebar, SidebarEvent};
 use crate::theme;
 
 /// How often the window-state debounce loop wakes up to check whether
@@ -92,6 +92,31 @@ impl AppShell {
         let sidebar = cx.new(|_| {
             Sidebar::new(projects, layout, theme.clone(), paths.clone())
         });
+
+        // Sidebar drives session lifecycle; we drive terminals + tabs.
+        // The `OpenSession` event is the single hand-off — sidebar
+        // builds the worktree and persists, we open a tab in it.
+        // `subscribe_in` (vs plain `subscribe`) gives the handler a
+        // `&mut Window`, which `spawn_tab_in` needs to focus the new
+        // tab's terminal.
+        cx.subscribe_in(
+            &sidebar,
+            window,
+            |this, _emitter, event, window, cx| match event {
+                SidebarEvent::OpenSession {
+                    working_directory,
+                    title,
+                } => {
+                    this.spawn_tab_in(
+                        Some(working_directory.clone()),
+                        Some(title.clone()),
+                        window,
+                        cx,
+                    );
+                }
+            },
+        )
+        .detach();
         let pending_window_save: Arc<Mutex<Option<PendingWindowSave>>> = Arc::new(Mutex::new(None));
 
         // Persist live window geometry. The observer fires for every
@@ -157,6 +182,26 @@ impl AppShell {
     /// projects yet) the shell starts in whatever cwd the binary
     /// inherited.
     fn spawn_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        // Pull project context from the sidebar — clone the path +
+        // name so we don't hold a borrow across `cx.new` further down.
+        let (working_directory, title) = match self.sidebar.read(cx).active_project() {
+            Some(p) => (Some(std::path::PathBuf::from(&p.path)), Some(p.name.clone().into())),
+            None => (None, None),
+        };
+        self.spawn_tab_in(working_directory, title, window, cx);
+    }
+
+    /// Same as [`Self::spawn_tab`] but with explicit cwd + tab title.
+    /// Used by the sidebar's session orchestration: a new worktree
+    /// becomes a new tab rooted in that worktree, titled
+    /// `{project}/{branch}`.
+    fn spawn_tab_in(
+        &mut self,
+        working_directory: Option<std::path::PathBuf>,
+        title: Option<SharedString>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let shell = std::env::var("CODESCOPE_SHELL")
             .ok()
             .map(|program| Shell::new(program, Vec::new()))
@@ -173,17 +218,6 @@ impl AppShell {
         env.insert("COLORTERM".into(), "truecolor".into());
         env.insert("TERM_PROGRAM".into(), "CodeScope".into());
         env.insert("TERM_PROGRAM_VERSION".into(), "0.0.1".into());
-
-        // Pull project context from the sidebar — clone the path +
-        // name so we don't hold a borrow across `cx.new` further down.
-        let active_project = self
-            .sidebar
-            .read(cx)
-            .active_project()
-            .map(|p| (p.path.clone(), p.name.clone()));
-        let working_directory = active_project
-            .as_ref()
-            .map(|(path, _)| std::path::PathBuf::from(path));
 
         // Build the terminal palette + cursor preset from the active
         // theme + settings. Cloned per spawn so each tab carries its
@@ -221,10 +255,7 @@ impl AppShell {
         let terminal = cx.new(|cx| TerminalView::new_full(backend, palette, font, cx));
         let id = self.next_id;
         self.next_id += 1;
-        let title: SharedString = match active_project {
-            Some((_, name)) => name.into(),
-            None => format!("Terminal {}", id + 1).into(),
-        };
+        let title: SharedString = title.unwrap_or_else(|| format!("Terminal {}", id + 1).into());
         self.tabs.push(Tab { id, title, terminal });
         let new_idx = self.tabs.len() - 1;
         self.activate_tab(new_idx, window, cx);

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -21,15 +21,32 @@
 //! └───────────────┘
 //! ```
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use codescope_core::{AppPaths, LayoutState, Project, ProjectsConfig, Theme};
+use codescope_core::{
+    AppPaths, LayoutState, Project, ProjectsConfig, Session, Theme, Worktree, git,
+};
 use gpui::{
-    Context, InteractiveElement, IntoElement, MouseButton, ParentElement, PathPromptOptions,
-    Render, SharedString, Styled, Window, div, px,
+    AnyElement, Context, EventEmitter, InteractiveElement, IntoElement, MouseButton,
+    ParentElement, PathPromptOptions, Render, SharedString, Styled, Window, div, px,
 };
 
 use crate::theme;
+
+/// Events the sidebar emits to the AppShell. Sidebar owns project /
+/// session persistence; AppShell owns terminals + tab strip. They meet
+/// here.
+#[derive(Clone, Debug)]
+pub enum SidebarEvent {
+    /// User asked us to open a session in `working_directory`. Could
+    /// be a freshly-created worktree or an existing one being
+    /// re-opened — the receiver doesn't need to care.
+    OpenSession {
+        working_directory: PathBuf,
+        title: SharedString,
+    },
+}
 
 /// Width of the sidebar pane. The C# build uses 240 with a
 /// resizable splitter; we keep it fixed for now and add the splitter
@@ -144,6 +161,82 @@ impl Sidebar {
         .detach();
     }
 
+    /// Spin up a brand-new session under the project at `idx`. Creates
+    /// a fresh worktree on a `session-N` branch (next free index),
+    /// records the worktree + session in `projects.json`, then asks
+    /// the AppShell to open a tab in the new worktree path.
+    ///
+    /// Synchronous for now: `git worktree add` is fast on a normal
+    /// repo (fractions of a second) and shifting it onto a background
+    /// task means juggling the `Project` clone across an await point.
+    /// Move it async when somebody complains about the tiny stutter.
+    pub fn new_session(&mut self, idx: usize, cx: &mut Context<Self>) {
+        let Some(project) = self.projects.projects.get(idx) else {
+            return;
+        };
+        let branch = project.next_session_branch_name();
+        let worktree_path = project.worktree_path_for(&branch);
+        let repo_path = PathBuf::from(&project.path);
+        let base = project.default_branch.clone();
+        let project_name = project.name.clone();
+
+        // Create the worktree on disk first. If git fails, leave both
+        // disk and projects.json untouched and surface the message.
+        if let Err(err) =
+            git::add_worktree(&repo_path, &worktree_path, &branch, Some(&base))
+        {
+            eprintln!("warning: git worktree add failed: {err:#}");
+            return;
+        }
+
+        // Persist the new Worktree + Session under the project,
+        // clone-then-save so a write failure rolls everything back.
+        let worktree_id = uuid::Uuid::new_v4().to_string();
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path_str = worktree_path.to_string_lossy().into_owned();
+        let mut next = self.projects.clone();
+        let project_mut = &mut next.projects[idx];
+        project_mut.worktrees.push(Worktree {
+            id: worktree_id.clone(),
+            path: worktree_path_str.clone(),
+            branch: Some(branch.clone()),
+            is_primary: false,
+        });
+        project_mut.sessions.push(Session {
+            id: session_id,
+            worktree_path: worktree_path_str.clone(),
+            branch: Some(branch.clone()),
+            agent_id: project_mut.default_agent_id.clone(),
+            display_name: None,
+            worktree_id: Some(worktree_id),
+            last_opened: Some(now_iso8601()),
+            agent_session_id: None,
+            closed_at: None,
+        });
+        if let Err(err) = next.save(&self.paths) {
+            eprintln!(
+                "warning: failed to save projects.json after creating worktree at {}: {err:#}",
+                worktree_path_str,
+            );
+            // The worktree is still on disk — leaving it there is the
+            // safer call (user can `git worktree remove` if needed)
+            // than racing to undo it and possibly leaving partial
+            // state. Surface the failure and bail.
+            return;
+        }
+        self.projects = next;
+
+        // Tell the AppShell to open a tab in the new worktree. Tab
+        // title combines project name + branch so multiple sessions
+        // on the same project stay distinguishable in the strip.
+        let title: SharedString = format!("{project_name}/{branch}").into();
+        cx.emit(SidebarEvent::OpenSession {
+            working_directory: worktree_path,
+            title,
+        });
+        cx.notify();
+    }
+
     /// Append a project at `path` and persist. Newly-added project
     /// becomes the selection — the user just chose it, so dropping
     /// them straight into it is what they expect.
@@ -241,7 +334,8 @@ impl Render for Sidebar {
             None
         };
 
-        let project_rows = rows.into_iter().map(|(idx, id, name)| {
+        let mut project_rows: Vec<AnyElement> = Vec::new();
+        for (idx, id, name) in rows {
             let active = selected == Some(idx);
             let bg = if active {
                 theme::frost_10(&theme)
@@ -261,29 +355,61 @@ impl Render for Sidebar {
             let frost_hover = theme::frost_10(&theme);
             let ink_hover = theme::ink(&theme);
 
-            div()
-                .id(("project", id_hash(&id)))
-                .h(px(32.0))
-                .flex()
-                .flex_row()
-                .items_center()
-                .pr_3()
-                .border_l_2()
-                .border_color(rail)
-                .pl(px(10.0)) // 12px - 2px border = 10
-                .bg(bg)
-                .text_color(text_color)
-                .text_size(px(13.0))
-                .cursor_pointer()
-                .hover(move |s| {
-                    if active { s } else { s.bg(frost_hover).text_color(ink_hover) }
-                })
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |this, _, _, cx| this.select(idx, cx)),
-                )
-                .child(div().flex_grow().truncate().child(name))
-        });
+            project_rows.push(
+                div()
+                    .id(("project", id_hash(&id)))
+                    .h(px(32.0))
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .pr_3()
+                    .border_l_2()
+                    .border_color(rail)
+                    .pl(px(10.0)) // 12px - 2px border = 10
+                    .bg(bg)
+                    .text_color(text_color)
+                    .text_size(px(13.0))
+                    .cursor_pointer()
+                    .hover(move |s| {
+                        if active { s } else { s.bg(frost_hover).text_color(ink_hover) }
+                    })
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _, _, cx| this.select(idx, cx)),
+                    )
+                    .child(div().flex_grow().truncate().child(name))
+                    .into_any_element(),
+            );
+
+            // "+ new session" affordance under the active project. Lives
+            // here (not in the heading) so the action is visually scoped
+            // to the project it operates on. Indented past the rail
+            // border so it reads as a child of the row above.
+            if active {
+                let frost_session = theme::frost_10(&theme);
+                let ink_session = theme::ink(&theme);
+                project_rows.push(
+                    div()
+                        .id(("new-session", id_hash(&id)))
+                        .h(px(28.0))
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .pl(px(24.0))
+                        .pr_3()
+                        .text_size(px(12.0))
+                        .text_color(theme::ink_ghost(&theme))
+                        .cursor_pointer()
+                        .hover(move |s| s.bg(frost_session).text_color(ink_session))
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| this.new_session(idx, cx)),
+                        )
+                        .child("+ new session")
+                        .into_any_element(),
+                );
+            }
+        }
 
         let mut body = div()
             .flex()
@@ -306,6 +432,47 @@ impl Render for Sidebar {
             .child(div().h_px().bg(theme::divider(&theme)))
             .child(body)
     }
+}
+
+impl EventEmitter<SidebarEvent> for Sidebar {}
+
+/// ISO 8601 / RFC 3339 UTC timestamp without sub-second precision —
+/// matches what the C# build writes for `lastOpened`. Bare-bones
+/// formatter (no `chrono` dep) because we only need to *write* it;
+/// nobody parses it back into a typed time on this side yet.
+fn now_iso8601() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Days-from-epoch arithmetic for a Z-suffixed UTC string. Good
+    // enough for a "when did the user last touch this" record; not
+    // a stand-in for real time math.
+    let days = (secs / 86_400) as i64;
+    let secs_of_day = secs % 86_400;
+    let h = secs_of_day / 3600;
+    let m = (secs_of_day % 3600) / 60;
+    let s = secs_of_day % 60;
+    let (y, mo, d) = days_to_ymd(days);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
+/// Days-since-1970-01-01 → (year, month, day). Civil-from-days, the
+/// algorithm from Howard Hinnant's date library — branch-free and
+/// correct for the full proleptic Gregorian range we care about.
+fn days_to_ymd(days: i64) -> (i32, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as i64; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    let y = (if m <= 2 { y + 1 } else { y }) as i32;
+    (y, m, d)
 }
 
 /// Cheap hash for use as a gpui element id derived from a string id.


### PR DESCRIPTION
## Summary

Wires `core::git` into the sidebar so a click creates a fresh worktree + session and opens a tab in it.

- **+ new session** affordance under the active project. Click =
  - `git worktree add` on `session-N` (next free index)
  - persist Worktree + Session to `projects.json` (clone-then-save)
  - emit `SidebarEvent::OpenSession`; AppShell opens a tab via `subscribe_in`
- Tab title `{project}/{branch}` so multiple sessions on the same project stay distinguishable
- Worktree path = `{project.path}.worktrees/{branch}`, honouring `worktree_root` override
- Failure modes: git failure bails before persistence; persistence failure leaves the worktree on disk (user can `git worktree remove`)
- Refactor: `AppShell::spawn_tab` now thin wrapper around `spawn_tab_in(cwd, title, …)` — keyboard/+ button uses active project, sidebar event uses worktree path

## Test plan

- [x] `cargo test -p codescope-core` — 23 passing (5 new helpers)
- [x] `cargo build` — clean, no warnings
- [ ] Click "+ new session" on the active project → worktree appears at `{path}.worktrees/session-1`, projects.json grows, new tab opens in that path with title `{project}/session-1`
- [ ] Click again → `session-2` (uniqueness honoured)
- [ ] Click on a project where the repo isn't a git repo → error logged, no state changed
- [ ] Existing tab "+" / Ctrl+Shift+T still spawn in the active project's *primary* path (not a worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)