### PR TITLE
fix(rs): platform-correct labels in the project context menu

### DIFF
--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -544,16 +544,23 @@ impl Sidebar {
             .child(div().h_px().bg(divider).my_1())
             .child(item(
                 "menu-reveal",
-                "Reveal in File Explorer",
+                reveal_in_file_browser_label(),
                 false,
                 Box::new(move |this, cx| this.reveal_in_explorer(idx, cx)),
             ))
-            .child(item(
-                "menu-wt",
-                "Open in Windows Terminal",
-                false,
-                Box::new(move |this, cx| this.open_in_windows_terminal(idx, cx)),
-            ))
+            // "Open in Windows Terminal" is genuinely Windows-only —
+            // `wt.exe` doesn't exist on macOS / Linux. Hide the row
+            // entirely on other platforms instead of shipping a
+            // misleading no-op. `.children(Option<_>)` yields 0 or 1
+            // child without splitting the chain.
+            .children(cfg!(target_os = "windows").then(|| {
+                item(
+                    "menu-wt",
+                    "Open in Windows Terminal",
+                    false,
+                    Box::new(move |this, cx| this.open_in_windows_terminal(idx, cx)),
+                )
+            }))
             .child(item(
                 "menu-copy-path",
                 "Copy path",
@@ -586,6 +593,24 @@ impl Sidebar {
                 .snap_to_window_with_margin(px(8.0))
                 .child(menu_body),
         )
+    }
+}
+
+/// Platform-appropriate label for the "Reveal in <native file browser>"
+/// menu row. Mirrors the underlying spawn target in
+/// [`Sidebar::reveal_in_explorer`] (`explorer.exe` / `open` /
+/// `xdg-open`) so the UI matches what actually happens. The C# build
+/// is Windows-only and uses "Reveal in File Explorer" verbatim — we
+/// keep that string on Windows and pick a native equivalent
+/// elsewhere instead of shipping a Windows-centric label on macOS /
+/// Linux.
+fn reveal_in_file_browser_label() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "Reveal in File Explorer"
+    } else if cfg!(target_os = "macos") {
+        "Reveal in Finder"
+    } else {
+        "Reveal in File Manager"
     }
 }
 


### PR DESCRIPTION
> **Note:** Originally this PR also contained the right-click context menu itself, but those commits were accidentally included in PR #58 during a branch split and merged to main as part of #58. After rebasing onto current main, the only commit left here is the platform-label fix that was added in response to PR #58 review feedback (Copilot reviewer, comments 3213302117 and 3213302121).

## Summary

The \`Reveal in File Explorer\` and \`Open in Windows Terminal\` rows in the sidebar context menu were rendered with hard-coded Windows-centric labels on every platform. The \`Reveal\` row's underlying spawn target was already platform-dispatched (\`explorer.exe\` / \`open\` / \`xdg-open\`) but the label always said "File Explorer", and the \`Open in Windows Terminal\` row was always rendered but logged a "Windows-only" notice and did nothing on macOS / Linux.

Two fixes:

1. New \`reveal_in_file_browser_label()\` helper picks the platform label that matches the underlying spawn:
   - Windows → "Reveal in File Explorer" (verbatim from the C# build)
   - macOS → "Reveal in Finder"
   - else → "Reveal in File Manager"

   \`cfg!()\` is const-folded at compile time so the right string is baked into the binary on each target.

2. The \`Open in Windows Terminal\` row is now hidden entirely off Windows via \`.children(cfg!(target_os = "windows").then(|| …))\`. \`Option<E>\` impls \`IntoIterator<Item = E>\` so a \`None\` yields zero children and the chain stays clean.

## Test plan

- [x] \`cargo build\` — clean.
- [x] \`cargo clippy\` — no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)