### PR TITLE
feat(rs): end-to-end worktree flow + git::list_branches + session 34 handoff

### DIFF
--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -16,13 +16,30 @@
 //! zero, so a UI dialog can surface "fatal: 'foo' is already checked
 //! out at '...'" without us having to guess the cause. We don't
 //! truncate — the failure modes in scope here (`worktree add/remove/
-//! list`) emit short messages, and clipping mid-sentence is worse
-//! UX than a slightly long line.
+//! list`, `for-each-ref`) emit short messages, and clipping mid-
+//! sentence is worse UX than a slightly long line.
 
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
 use anyhow::{Context, Result, anyhow};
+
+/// One row from `git for-each-ref refs/heads refs/remotes`. Surfaced
+/// to the "New worktree" dialog so the user can pick a base branch.
+/// Mirrors `NoScope.CodeScope.Core.Models.BranchInfo` from the C# build.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchInfo {
+    /// Short refname — e.g. `main`, `feat/csv`, `origin/main`.
+    pub name: String,
+    /// `true` when `name` lives under `refs/remotes/...`.
+    pub is_remote: bool,
+    /// 7-char commit sha the ref points at.
+    pub short_sha: String,
+    /// Committer date relative to now — e.g. `2 days ago`. Verbatim
+    /// from `%(committerdate:relative)` so the UI doesn't have to
+    /// parse and re-format.
+    pub relative_date: String,
+}
 
 /// One row from `git worktree list --porcelain`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,6 +86,57 @@ pub fn add_worktree(
         args.push(b);
     }
     run_git(repo, &args).map(|_| ())
+}
+
+/// `git for-each-ref` for both local heads and remotes — the union
+/// drives the base-branch picker in the "New worktree" dialog. Mirrors
+/// the C# `GitService.ListBranchesAsync`: format
+/// `<short_ref>|<short_sha>|<relative_date>`, `origin/HEAD` symbolic
+/// refs are dropped, and the final list is sorted alphabetically by
+/// `name` (case-insensitive) so locals and remotes interleave under a
+/// stable ordering — the dialog handles LOCAL/REMOTE grouping itself.
+pub fn list_branches(repo: &Path) -> Result<Vec<BranchInfo>> {
+    let mut all = Vec::new();
+    all.extend(for_each_ref(repo, false, "refs/heads")?);
+    all.extend(for_each_ref(repo, true, "refs/remotes")?);
+    all.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    Ok(all)
+}
+
+fn for_each_ref(repo: &Path, is_remote: bool, prefix: &str) -> Result<Vec<BranchInfo>> {
+    // `|` is not a valid refname character, so it's safe as a field
+    // separator (matches the C# build's choice for the same reason).
+    let format = "--format=%(refname:short)|%(objectname:short)|%(committerdate:relative)";
+    let output = run_git(repo, &["for-each-ref", format, prefix])?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut rows = Vec::new();
+    for raw in stdout.lines() {
+        let line = raw.trim_matches(|c: char| c == '\r' || c == ' ' || c == '\t' || c == '"');
+        if line.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.splitn(3, '|').collect();
+        if parts.len() < 3 {
+            continue;
+        }
+        let name = parts[0].trim();
+        // Skip the `<remote>/HEAD` symbolic row — it's not a real
+        // branch and showing it in a base-branch picker is just
+        // noise. On Windows git the same row sometimes shortens to
+        // `<remote>` (HEAD elided) so we also drop bare-remote rows
+        // (a real remote branch always has at least one `/` after
+        // the remote name).
+        if name.ends_with("/HEAD") || (is_remote && !name.contains('/')) {
+            continue;
+        }
+        rows.push(BranchInfo {
+            name: name.to_string(),
+            is_remote,
+            short_sha: parts[1].trim().to_string(),
+            relative_date: parts[2].trim().to_string(),
+        });
+    }
+    Ok(rows)
 }
 
 /// `git worktree remove <path>`. Set `force = true` to bypass dirty-
@@ -334,6 +402,47 @@ some-future-field foo bar\n";
         let wts = list_worktrees(&repo).expect("list after remove");
         assert_eq!(wts.len(), 1, "primary alone after remove");
         assert!(wts[0].is_primary);
+    }
+
+    #[test]
+    fn list_branches_returns_local_and_remote_sorted() {
+        let Some((_guard, repo, _wts)) = init_repo() else { return };
+        // Create a couple of locals and a fake remote so we can verify
+        // both groups come back. `git update-ref` lets us mint a
+        // `refs/remotes/origin/foo` without spinning up an actual
+        // remote — the seed commit's SHA is fine to point it at.
+        run(&repo, &["branch", "feat/x"]);
+        run(&repo, &["branch", "feat/y"]);
+        run(&repo, &["update-ref", "refs/remotes/origin/main", "HEAD"]);
+        run(&repo, &["update-ref", "refs/remotes/origin/feat/x", "HEAD"]);
+        // Symbolic origin/HEAD — must be dropped from the result.
+        run(&repo, &["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+
+        let branches = list_branches(&repo).expect("list");
+        let names: Vec<&str> = branches.iter().map(|b| b.name.as_str()).collect();
+        // Sorted alphabetically (case-insensitive). `origin/HEAD` is
+        // gone. Locals + remotes interleave under one ordering.
+        assert_eq!(
+            names,
+            vec!["feat/x", "feat/y", "main", "origin/feat/x", "origin/main"],
+            "branches: {names:?}"
+        );
+        // Local vs remote flag matches the prefix.
+        for b in &branches {
+            assert_eq!(b.is_remote, b.name.starts_with("origin/"), "{b:?}");
+            // Every row must have a non-empty short sha — without it
+            // the dialog footer can't render `<sha> · <date>`.
+            assert!(!b.short_sha.is_empty(), "{b:?}");
+        }
+    }
+
+    #[test]
+    fn list_branches_in_repo_with_only_main_returns_one_row() {
+        let Some((_guard, repo, _wts)) = init_repo() else { return };
+        let branches = list_branches(&repo).expect("list");
+        assert_eq!(branches.len(), 1);
+        assert_eq!(branches[0].name, "main");
+        assert!(!branches[0].is_remote);
     }
 
     #[test]

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -38,7 +38,7 @@ use gpui::{
 };
 use parking_lot::Mutex;
 
-use crate::sidebar::Sidebar;
+use crate::sidebar::{Sidebar, SidebarEvent};
 use crate::theme;
 
 /// How often the window-state debounce loop wakes up to check whether
@@ -92,6 +92,26 @@ impl AppShell {
         let sidebar = cx.new(|_| {
             Sidebar::new(projects, layout, theme.clone(), paths.clone())
         });
+
+        // Spawn a tab whenever the sidebar asks us to — fired by a
+        // worktree-row click in the project list and by a successful
+        // `submit_new_worktree_dialog`. `subscribe_in` (vs
+        // `subscribe`) is the variant that hands us `&mut Window`,
+        // which we need so the freshly-spawned terminal can grab
+        // focus inline.
+        cx.subscribe_in(&sidebar, window, |this, _sidebar, event, window, cx| {
+            match event {
+                SidebarEvent::OpenSession { working_directory, title } => {
+                    this.spawn_tab_in(
+                        Some(working_directory.clone()),
+                        Some(title.clone()),
+                        window,
+                        cx,
+                    );
+                }
+            }
+        })
+        .detach();
         let pending_window_save: Arc<Mutex<Option<PendingWindowSave>>> = Arc::new(Mutex::new(None));
 
         // Persist live window geometry. The observer fires for every
@@ -127,10 +147,10 @@ impl AppShell {
                         _ => None,
                     }
                 };
-                if let Some(p) = to_save {
-                    if let Err(err) = p.state.save(&paths_for_timer) {
-                        eprintln!("warning: failed to save window state: {err:#}");
-                    }
+                if let Some(p) = to_save
+                    && let Err(err) = p.state.save(&paths_for_timer)
+                {
+                    eprintln!("warning: failed to save window state: {err:#}");
                 }
             }
         })
@@ -152,11 +172,23 @@ impl AppShell {
     /// Open a fresh shell session and append it as a new tab. The new
     /// tab becomes the active one and the terminal grabs focus.
     ///
-    /// Working directory + tab title come from the sidebar's currently
-    /// selected project. Without a selection (cold launch, no
-    /// projects yet) the shell starts in whatever cwd the binary
-    /// inherited.
+    /// Without an explicit `working_directory` / `title`, working
+    /// directory + tab title come from the sidebar's currently
+    /// selected project (cold launch, "+ new tab" button). Callers
+    /// that already know which path to pin the terminal to (sidebar
+    /// worktree clicks, post-create-worktree spawns) hand both in
+    /// directly.
     fn spawn_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.spawn_tab_in(None, None, window, cx);
+    }
+
+    fn spawn_tab_in(
+        &mut self,
+        working_directory: Option<std::path::PathBuf>,
+        title_override: Option<SharedString>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let shell = std::env::var("CODESCOPE_SHELL")
             .ok()
             .map(|program| Shell::new(program, Vec::new()))
@@ -174,16 +206,19 @@ impl AppShell {
         env.insert("TERM_PROGRAM".into(), "CodeScope".into());
         env.insert("TERM_PROGRAM_VERSION".into(), "0.0.1".into());
 
-        // Pull project context from the sidebar — clone the path +
-        // name so we don't hold a borrow across `cx.new` further down.
+        // Resolve working directory + tab title. Explicit args win;
+        // otherwise pull project context from the sidebar — clone the
+        // path + name so we don't hold a borrow across `cx.new`.
         let active_project = self
             .sidebar
             .read(cx)
             .active_project()
             .map(|p| (p.path.clone(), p.name.clone()));
-        let working_directory = active_project
-            .as_ref()
-            .map(|(path, _)| std::path::PathBuf::from(path));
+        let working_directory = working_directory.or_else(|| {
+            active_project
+                .as_ref()
+                .map(|(path, _)| std::path::PathBuf::from(path))
+        });
 
         // Build the terminal palette + cursor preset from the active
         // theme + settings. Cloned per spawn so each tab carries its
@@ -221,10 +256,9 @@ impl AppShell {
         let terminal = cx.new(|cx| TerminalView::new_full(backend, palette, font, cx));
         let id = self.next_id;
         self.next_id += 1;
-        let title: SharedString = match active_project {
-            Some((_, name)) => name.into(),
-            None => format!("Terminal {}", id + 1).into(),
-        };
+        let title: SharedString = title_override
+            .or_else(|| active_project.map(|(_, name)| name.into()))
+            .unwrap_or_else(|| format!("Terminal {}", id + 1).into());
         self.tabs.push(Tab { id, title, terminal });
         let new_idx = self.tabs.len() - 1;
         self.activate_tab(new_idx, window, cx);
@@ -316,13 +350,13 @@ impl AppShell {
                 self.prev_tab(window, cx);
             }
             d if !mods.shift && d.len() == 1 => {
-                if let Some(n) = d.chars().next().and_then(|c| c.to_digit(10)) {
-                    if n >= 1 && n <= 9 {
-                        let idx = (n as usize) - 1;
-                        if idx < self.tabs.len() {
-                            cx.stop_propagation();
-                            self.activate_tab(idx, window, cx);
-                        }
+                if let Some(n) = d.chars().next().and_then(|c| c.to_digit(10))
+                    && (1..=9).contains(&n)
+                {
+                    let idx = (n as usize) - 1;
+                    if idx < self.tabs.len() {
+                        cx.stop_propagation();
+                        self.activate_tab(idx, window, cx);
                     }
                 }
             }

--- a/codescope-rs/src/new_worktree_dialog.rs
+++ b/codescope-rs/src/new_worktree_dialog.rs
@@ -171,6 +171,7 @@ impl Sidebar {
         let folder = state.folder.clone();
         let project_path = state.project_path.clone();
 
+        let project_name = state.project_name.clone();
         let result = codescope_core::git::add_worktree(
             Path::new(&project_path),
             Path::new(&folder),
@@ -181,8 +182,8 @@ impl Sidebar {
             Ok(()) => {
                 let new_wt = Worktree {
                     id: uuid::Uuid::new_v4().to_string(),
-                    path: folder,
-                    branch: Some(branch),
+                    path: folder.clone(),
+                    branch: Some(branch.clone()),
                     is_primary: false,
                 };
                 // Clone-then-save: a write failure leaves the in-
@@ -204,6 +205,14 @@ impl Sidebar {
                 }
                 self.replace_projects(next);
                 self.cancel_new_worktree_dialog(cx);
+                // Spawn a session pinned to the new worktree so the
+                // user lands inside it immediately. Mirrors the C#
+                // dialog's `SpawnSession = true` default. The host
+                // (`AppShell`) catches the event and creates the tab.
+                cx.emit(crate::sidebar::SidebarEvent::OpenSession {
+                    working_directory: std::path::PathBuf::from(&folder),
+                    title: format!("{project_name}  ·  {branch}").into(),
+                });
             }
             Err(err) => {
                 let msg = err.to_string();

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -23,14 +23,15 @@
 //! └───────────────┘
 //! ```
 
+use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
 
 use codescope_core::{AppPaths, LayoutState, Project, ProjectsConfig, Theme};
 use gpui::{
-    ClipboardItem, Context, Corner, InteractiveElement, IntoElement, MouseButton, MouseDownEvent,
-    ParentElement, PathPromptOptions, Pixels, Point, Render, SharedString, Styled, Window,
-    anchored, deferred, div, point, px,
+    ClipboardItem, Context, Corner, EventEmitter, InteractiveElement, IntoElement, MouseButton,
+    MouseDownEvent, ParentElement, PathPromptOptions, Pixels, Point, Render, SharedString, Styled,
+    Window, anchored, deferred, div, point, px,
 };
 
 use crate::new_worktree_dialog::NewWorktreeDialogState;
@@ -55,6 +56,34 @@ struct OpenMenu {
 /// Receives the active window so a row that opens a follow-on dialog
 /// (e.g. "New worktree…") can focus the dialog inline.
 type MenuItemAction = Box<dyn Fn(&mut Sidebar, &mut Window, &mut Context<Sidebar>) + 'static>;
+
+/// Events the sidebar emits up to its host (`AppShell`). Today there
+/// is just one — "open a session at this path" — fired when the user
+/// clicks a worktree row or right after the new-worktree dialog
+/// successfully creates one. Keeping the surface in an enum so adding
+/// more events (e.g. `OpenProjectFolder`) doesn't require changing
+/// the trait wiring.
+#[derive(Debug, Clone)]
+pub enum SidebarEvent {
+    /// Spawn a new tab whose terminal is pinned to `working_directory`,
+    /// using `title` for the tab strip. Title is just a label — the
+    /// host decides what to actually show (in practice the worktree
+    /// branch name suffixed with the project name).
+    OpenSession {
+        working_directory: PathBuf,
+        title: SharedString,
+    },
+}
+
+/// Owned snapshot of one non-primary worktree, captured before render
+/// loops over the project list, so each row's listener closure can
+/// `move` it without taking an outliving borrow on `self.projects`.
+#[derive(Clone)]
+struct WorktreeRowData {
+    id: String,
+    path: String,
+    branch: Option<String>,
+}
 
 pub struct Sidebar {
     projects: ProjectsConfig,
@@ -360,16 +389,42 @@ impl Sidebar {
     }
 }
 
+impl EventEmitter<SidebarEvent> for Sidebar {}
+
 impl Render for Sidebar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = self.theme.clone();
         let selected = self.selected;
-        let rows: Vec<_> = self
+        // Snapshot project + non-primary worktree metadata up front so
+        // each row's `cx.listener` closure can hold owned values
+        // without overlapping the immutable borrow `iter()` would
+        // otherwise extend across the rest of `render`. Primary
+        // worktrees are implicit at `Project::path`; we only emit
+        // child rows for the extras.
+        let rows: Vec<(usize, String, SharedString, String, Vec<WorktreeRowData>)> = self
             .projects
             .projects
             .iter()
             .enumerate()
-            .map(|(idx, p)| (idx, p.id.clone(), SharedString::from(p.name.clone())))
+            .map(|(idx, p)| {
+                let worktrees = p
+                    .worktrees
+                    .iter()
+                    .filter(|wt| !wt.is_primary)
+                    .map(|wt| WorktreeRowData {
+                        id: wt.id.clone(),
+                        path: wt.path.clone(),
+                        branch: wt.branch.clone(),
+                    })
+                    .collect();
+                (
+                    idx,
+                    p.id.clone(),
+                    SharedString::from(p.name.clone()),
+                    p.name.clone(),
+                    worktrees,
+                )
+            })
             .collect();
 
         let heading = div()
@@ -419,7 +474,13 @@ impl Render for Sidebar {
             None
         };
 
-        let project_rows = rows.into_iter().map(|(idx, id, name)| {
+        // Each project expands to one project row + zero or more
+        // worktree child rows. We collect a flat `Vec<AnyElement>`
+        // rather than a single iterator because the project + child
+        // rows are different element shapes and need to be flattened
+        // into a single `.children(...)` call.
+        let mut project_and_worktree_rows: Vec<gpui::AnyElement> = Vec::new();
+        for (idx, id, name, project_name, worktrees) in rows.into_iter() {
             let active = selected == Some(idx);
             let bg = if active {
                 theme::frost_10(&theme)
@@ -439,7 +500,7 @@ impl Render for Sidebar {
             let frost_hover = theme::frost_10(&theme);
             let ink_hover = theme::ink(&theme);
 
-            div()
+            let project_row = div()
                 .id(("project", id_hash(&id)))
                 .h(px(32.0))
                 .flex()
@@ -466,14 +527,68 @@ impl Render for Sidebar {
                         this.open_project_menu(idx, event.position, cx);
                     }),
                 )
-                .child(div().flex_grow().truncate().child(name))
-        });
+                .child(div().flex_grow().truncate().child(name));
+            project_and_worktree_rows.push(project_row.into_any_element());
+
+            // Non-primary worktree rows. Indented to make the parent /
+            // child relationship obvious; click emits `OpenSession`
+            // which the AppShell catches to spawn a tab pinned to the
+            // worktree's path.
+            for wt in worktrees {
+                let wt_label: SharedString = wt
+                    .branch
+                    .clone()
+                    .unwrap_or_else(|| {
+                        // Fallback when the worktree row in
+                        // `projects.json` predates branch tracking:
+                        // surface the folder leaf so the user still
+                        // sees something useful.
+                        std::path::Path::new(&wt.path)
+                            .file_name()
+                            .and_then(|s| s.to_str())
+                            .map(|s| s.to_string())
+                            .unwrap_or_else(|| wt.path.clone())
+                    })
+                    .into();
+                let wt_path_for_event = wt.path.clone();
+                let title_label = SharedString::from(format!(
+                    "{}  ·  {}",
+                    project_name,
+                    wt_label,
+                ));
+                let frost_hover = theme::frost_10(&theme);
+                let ink_hover = theme::ink(&theme);
+                let wt_row = div()
+                    .id(("worktree", id_hash(&wt.id)))
+                    .h(px(28.0))
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .pl(px(34.0)) // align under the project text past the rail + indent
+                    .pr_3()
+                    .text_color(theme::ink_ghost(&theme))
+                    .text_size(px(12.0))
+                    .cursor_pointer()
+                    .hover(move |s| s.bg(frost_hover).text_color(ink_hover))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |_, _, _, cx| {
+                            cx.emit(SidebarEvent::OpenSession {
+                                working_directory: PathBuf::from(&wt_path_for_event),
+                                title: title_label.clone(),
+                            });
+                        }),
+                    )
+                    .child(div().flex_grow().truncate().child(wt_label));
+                project_and_worktree_rows.push(wt_row.into_any_element());
+            }
+        }
 
         let mut body = div()
             .flex()
             .flex_col()
             .py_1()
-            .children(project_rows);
+            .children(project_and_worktree_rows);
         if let Some(es) = empty_state {
             body = body.child(es);
         }

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -9,16 +9,152 @@
 >
 > **The Rust port (`codescope-rs/`) is a 1:1 functional port of the C# CodeScope build (`src/CodeScope.App/`, `src/CodeScope.Core/`, `src/CodeScope.AgentCli/`).** Before implementing any feature on the Rust side, **read the equivalent C# code first** and mirror its behavior, button labels, dialogs, data shapes, and persistence layout. Functional parity is the goal — we are not redesigning. If a `HANDOFF.md` entry, README line, or "next entry point" disagrees with what the C# code actually does, the C# code wins; update the doc. Genuine platform-forced deviations (gpui vs WPF idiom) get a one-line comment and an entry in `docs/DECISIONS.md`. "Cleaner" or "more elegant" is not a reason on its own. (Reinforced in session 33 after PR #56 invented a non-existent UX.)
 
-**Last updated:** 2026-05-09 (session 33)
-**Branch:** `main` (PR #55 merged as `6cc89ee`; PR #56 closed without merge)
-**Head:** `6cc89ee` (main, in sync with origin)
+**Last updated:** 2026-05-09 (session 34)
+**Branch:** `main` (PRs #58–#62 merged this session)
+**Head:** main, in sync with origin (latest: PR #62 squash, then this session's bundle PR)
 **Release:** `v0.2.5` shipped — https://github.com/maui1911/CodeScope/releases/tag/v0.2.5
 **Build status:** ✅ C# untouched. Rust workspace builds clean
 (`cargo build --workspace --manifest-path codescope-rs/Cargo.toml`).
-27 unit tests across `codescope-core` (18) + `codescope-terminal`
-mouse-encoder (9). PR #54 merged to main as `7ffe4f3`; PR #55 as `6cc89ee`.
+Tests: `codescope-core` (27 incl. 6 new `git::` integration tests + 3
+new `projects::` round-trip tests) + `codescope-terminal` mouse-encoder
+(9) + `new_worktree_dialog` (7) — all passing. `cargo clippy` clean
+on `codescope-rs-spike` (drive-by fixes landed in this session).
 **Uncommitted work:** none.
 **Open issues:** none on GitHub.
+
+### Session 34 — camelCase, context menu, dialog, titlebar, tests, end-to-end worktree flow (PRs #58–#62 + bundle)
+
+The week's "next entry points" list (1–6 from session 33) is now
+mostly walked. Five small PRs landed sequentially with reviews
+addressed inline (Copilot reviewer flagged one issue per PR), then a
+single larger bundle PR closed out the worktree flow end-to-end.
+
+**Shipped (in merge order):**
+
+1. **PR #58 — camelCase round-trip on `projects.json`** (`599b8d3`).
+   `#[serde(rename_all = "camelCase")]` on `Project`, `Session`,
+   `Worktree`, `ProjectsConfig`. Opaque `agents: Vec<serde_json::Value>`
+   on the root so user agent-profile overrides survive a load/save
+   cycle while the Rust port doesn't consume them yet. Three new
+   tests pin the contract (C#-shape fixture, written-camelCase
+   assertion, agents round-trip). Review feedback: backwards-compat
+   for legacy snake_case Rust port files via per-field
+   `#[serde(alias = "<snake_case>")]` (`f8820cf`, also in #58) plus a
+   regression test (`loads_legacy_snake_case_fixture_without_data_loss`).
+2. **PR #59 — platform-correct labels in the project context menu**
+   (`3f01e2f`). The right-click menu itself piggybacked into PR #58
+   during a branch split (an earlier mistake), so #59 ended up
+   carrying just the platform fix. New `reveal_in_file_browser_label()`
+   helper picks the label per `cfg!(target_os = …)`; "Open in Windows
+   Terminal" row hidden off Windows via
+   `.children(cfg!(target_os = "windows").then(|| …))` so a `None`
+   yields zero children and the chain stays clean.
+3. **PR #60 — titlebar interactions** (`109e1ce`). Drag region
+   (`window_control_area(Drag)` + `start_window_move()`), double-
+   click toggles maximise via `zoom_window()`, three caption buttons
+   (Min/Max/Close, 46×40) with `WindowControlArea` annotations so
+   Windows snap-layouts and accessibility see real controls.
+4. **PR #61 — integration tests for `git::add_worktree` /
+   `remove_worktree`** (`27ceab1`). End-to-end against a real `git`
+   binary: per-test `TempDir` containing `<tmp>/repo/` and
+   `<tmp>/repo.worktrees/` (review feedback: the original draft
+   rooted under the OS-shared tempdir, which would have collided in
+   parallel and leaked outside the cleanup guard). Three tests
+   (add → list, add → remove → list, duplicate-branch error must
+   carry stderr).
+5. **PR #62 — "New worktree from branch…" dialog** (`6109eef`,
+   subagent-built). Trimmed first cut: branch input with auto-derived
+   folder under `<project>.worktrees/<sanitised-branch>`, HEAD as
+   implicit base, no spawn-toggle / base-picker / editable folder
+   yet. Modal rendered via `deferred(anchored().position(0,0).child(backdrop))`
+   with click-out-to-cancel and Escape/Enter handling; key chars come
+   from `event.keystroke.key_char`. New module
+   `codescope-rs/src/new_worktree_dialog.rs` with
+   `NewWorktreeDialogState` stashed on `Sidebar`. `Project::worktree_root_path()`
+   added to `codescope-core`. 7 new unit tests on the sanitiser +
+   folder derivation.
+6. **Bundle PR (this session, end-to-end worktree flow):** worktree
+   *child rows* now render under each project in the sidebar,
+   clicking one emits `SidebarEvent::OpenSession { working_directory,
+   title }` which `AppShell` catches via `cx.subscribe_in` and turns
+   into a fresh tab pinned to the worktree path. The new-worktree
+   dialog also emits the same event on successful create, matching
+   the C# build's `SpawnSession = true` default — the user lands
+   inside the new worktree immediately. New `git::list_branches`
+   (`for-each-ref refs/heads + refs/remotes`, mirrors C#'s
+   `GitService.ListBranchesAsync`; drops `<remote>/HEAD` symbolic
+   rows) + 2 integration tests. `spawn_tab` refactored to
+   `spawn_tab_in(working_directory, title_override, …)` so callers
+   can pin both. Drive-by clippy cleanup (`(1..=9).contains(&n)`,
+   collapsed nested `if let`).
+
+**Process notes (worth carrying forward):**
+- **PR splitting trap.** Stacking commits on the same local branch
+  and then trying to "split" by creating a sibling branch + rebase
+  works **only if you also reset the original branch** to drop the
+  cherry-picked commit. I missed that on the camelCase / context-menu
+  split, so PR #58 swallowed the context-menu commit and merged it to
+  main; PR #59 then needed a rebase that auto-detected the dup
+  ("patch contents already upstream"). Same dance had to happen for
+  PR #60 / #62 after their bases (deleted feature branches)
+  collapsed onto main. Lesson: after `git switch -c new-branch &&
+  rebase --onto …`, also `git switch original-branch && git reset
+  --hard origin/original-branch`. Or just use worktrees from the start.
+- **Branch-protection merging.** main has a protection rule that
+  blocks plain merges (`gh pr merge --squash`) and disallows
+  `--auto` for this repo. `--admin` overrides cleanly — the user
+  greenlit using it explicitly, the auto-mode classifier asked once
+  per session escalation. For the next session, default to `--admin`
+  on owner-merges of own PRs (with explicit per-session OK).
+- **Subagent task on PR #62 worked well.** Briefed with the C# spec
+  link, scoped to "trimmed first cut", isolation: worktree. Returned
+  a clean PR + a punch list of deferred items (Tab cycle, IME,
+  custom folder, base picker, spawn toggle). Worth doing again for
+  any feature that's >150 LOC and self-contained.
+
+**Suggested next entry points (priority order):**
+
+1. **Worktree dialog polish toward C# parity.** The deferred items
+   from PR #62's punch list — pair them with the new
+   `git::list_branches` API:
+   - **Base-branch dropdown** (filterable popup, LOCAL/REMOTE
+     groups, `(HEAD)` pinned). The C# spec is in
+     `src/CodeScope.Ui/Dialogs/NewWorktreeDialog.xaml.cs` lines
+     190–212. `list_branches` already returns the data.
+   - **Editable folder path** (live-syncs from branch but the user
+     can override). C# `BranchBox.TextChanged` handler is the model.
+   - **Spawn-session toggle** (defaults to true to match C# and the
+     bundle PR's behaviour; off = user just gets the worktree row).
+2. **Worktree row context menu.** "Remove worktree…",
+   "Reveal in <file browser>", "Copy path", "Restart session"
+   (later). Mirror `BuildWorktreeMenu` in
+   `src/CodeScope.Ui/Views/SidebarView.xaml.cs`.
+3. **Live theme reload.** Watch `settings.json` mtime via the
+   `notify` crate, reload, resolve theme by name, swap `Arc<Theme>`
+   on AppShell + Sidebar (the `apply_theme` plumbing already exists
+   on Sidebar; AppShell just needs the same).
+4. **Telemetry tail.** FSWatch on `~/.claude/projects/...` →
+   `running / idle / error` per session, drives sidebar status dots.
+   Heavy — multi-agent (Claude / Codex / OpenCode / Copilot / Pi),
+   each with its own session-discovery layer in C#. Probably its
+   own 1-2 session arc.
+5. **Sidebar splitter / collapse.** `LayoutState.sidebar_visible` /
+   `sidebar_width` are loaded but never re-saved because nothing
+   changes them. Add a thin draggable splitter on the right edge +
+   a collapse toggle in the heading.
+6. **`appears_transparent: true` quirks.** Verify on a non-
+   Windows host that the caption controls don't fight the native
+   chrome (we never tested on macOS / Linux).
+
+**Known small things (rolled forward from session 33):**
+- Backend's `hyperlink_at` is unused (snapshot handles it).
+- The "+ new tab" button still spawns in the *active project's*
+  primary path. After the worktree click flow lands, consider
+  making the "+" inherit the most-recent worktree of the active
+  project instead so users don't keep re-clicking a worktree row.
+- `codescope-terminal` has 8 preexisting clippy warnings (not
+  touched this session). Cleanup PR if anyone gets bored.
+
 
 ### Session 33 — worktree-on-new-session was wrong; rolled back; data-loss incident + recovery
 


### PR DESCRIPTION
## Summary

Bundles the next layer of polish on top of session 34's first wave (PRs #58–#62). The new-worktree dialog (#62) created worktrees on disk and appended them to \`projects.json\`, but the sidebar didn't render the result and creating one didn't open a session. This PR closes both gaps and lands the branch-listing API the dialog's future base-picker needs. Also includes the session 34 \`docs/HANDOFF.md\` update.

## What's in here

### Code (commit 1: \`feat(rs): end-to-end worktree flow + git::list_branches\`)

1. **\`codescope_core::git::list_branches\`** — mirrors C#'s \`GitService.ListBranchesAsync\`. \`for-each-ref refs/heads refs/remotes\` with format \`<short_ref>|<short_sha>|<relative_date>\`, \`<remote>/HEAD\` symbolic rows dropped, alphabetic sort. New \`BranchInfo\` struct matches \`Models.BranchInfo\` 1:1. Two integration tests against a real \`git\` binary.
2. **Worktree child rows** under each project in the sidebar (non-primary only — the primary IS the project root). 28 px height, indented 34 px. Label is the branch name (or folder leaf for legacy rows). Click → emit \`SidebarEvent::OpenSession\`.
3. **\`SidebarEvent\` enum + \`EventEmitter<SidebarEvent>\` on \`Sidebar\`.** Caught by \`AppShell\` via \`cx.subscribe_in(&sidebar, window, …)\` (the \`_in\` variant gives us \`&mut Window\`).
4. **\`spawn_tab_in(working_directory, title_override, …)\`** — \`spawn_tab\` refactored into a workhorse that takes either explicit args (worktree click, post-create spawn) or falls back to the active project's primary path (the "+ new tab" button on the tab strip).
5. **Auto-spawn after \`submit_new_worktree_dialog\`.** On a successful \`git worktree add\`, the dialog emits the same \`OpenSession\` event so the user lands inside the new worktree immediately. Mirrors the C# dialog's \`SpawnSession = true\` default.

Drive-by: \`(1..=9).contains(&n)\` and a collapsed nested \`if let\` in \`app.rs\`. \`codescope-rs-spike\` is now warning-free under \`cargo clippy --no-deps\`.

### Docs (commit 2: \`docs(handoff): session 34 …\`)

\`docs/HANDOFF.md\` updated with the full week-of-PRs entry: what shipped, two process lessons (PR splitting trap, branch-protection requires --admin on owner-merges), and a punch list of next entry points led by polishing the dialog toward C# parity (base-branch dropdown, editable folder, spawn toggle).

## Test plan

- [x] \`cargo build --workspace\` — clean.
- [x] \`cargo test --workspace\` — 27 (core, incl. 2 new \`list_branches\` tests) + 7 (new_worktree_dialog) + 9 (terminal mouse) all passing.
- [x] \`cargo clippy --workspace --no-deps\` — \`codescope-rs-spike\` warning-free; only the preexisting 8 warnings in \`codescope-terminal\` remain (untouched here).
- [ ] Manual smoke: create a worktree via the right-click menu → row appears in the sidebar under the project, terminal tab opens at the worktree path titled \`<Project> · <branch>\`. Click another worktree row → second tab opens at that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)