### PR TITLE
fix(rs): single-space tab titles around `·` (C# parity)

### DIFF
--- a/codescope-rs/src/new_worktree_dialog.rs
+++ b/codescope-rs/src/new_worktree_dialog.rs
@@ -209,9 +209,12 @@ impl Sidebar {
                 // user lands inside it immediately. Mirrors the C#
                 // dialog's `SpawnSession = true` default. The host
                 // (`AppShell`) catches the event and creates the tab.
+                // Single spaces around `·` to match the C# build's
+                // `$"{project.Name} · {branch}"` convention in
+                // `MainViewModel.RefreshTabTitlesForWorktree`.
                 cx.emit(crate::sidebar::SidebarEvent::OpenSession {
                     working_directory: std::path::PathBuf::from(&folder),
-                    title: format!("{project_name}  ·  {branch}").into(),
+                    title: format!("{project_name} · {branch}").into(),
                 });
             }
             Err(err) => {

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -551,8 +551,11 @@ impl Render for Sidebar {
                     })
                     .into();
                 let wt_path_for_event = wt.path.clone();
+                // Single spaces around `·` to match the C# build's
+                // `$"{project.Name} · {branch}"` convention in
+                // `MainViewModel.RefreshTabTitlesForWorktree`.
                 let title_label = SharedString::from(format!(
-                    "{}  ·  {}",
+                    "{} · {}",
                     project_name,
                     wt_label,
                 ));


### PR DESCRIPTION
## Summary

Addresses PR #63 review feedback (Copilot reviewer, comments 3213413541 / 3213413543).

The worktree-row click handler and the post-create-worktree spawn both formatted tab titles with double spaces around the middle dot — \`"{project}  ·  {branch}"\`. The C# build's \`MainViewModel.RefreshTabTitlesForWorktree\` uses \`\$"{project.Name} · {branch}"\` with single spaces, so tabs opened by the Rust port were visually inconsistent with the spec and would have read off when both ports run side-by-side in the dev / installed split.

Single spaces in both call sites now (\`sidebar.rs\` and \`new_worktree_dialog.rs\`), with a comment pointing back at the C# source so future drive-by edits don't drift away again.

## Test plan

- [x] \`cargo build\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)