### PR TITLE
feat(rs): tab groups — split work area into side-by-side columns

### DIFF
--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -5,13 +5,18 @@
 //!
 //! ```text
 //! ┌────────────────────────────────────────────────────────┐
-//! │ tab strip (40px) — pill tabs · "+" · caption controls │  ← in titlebar
+//! │ brand · [strip g0] | [strip g1] · drag · ▭ ▢ ✕         │  ← 40 px titlebar row
 //! ├────────────────────────────────────────────────────────┤
-//! │                                                        │
-//! │              active TerminalView (size_full)           │
-//! │                                                        │
+//! │ side │  pane g0          │  pane g1                    │
+//! │ bar  │  (active term)    │  (active term)              │
 //! └────────────────────────────────────────────────────────┘
 //! ```
+//!
+//! Each top-level "group" is a tab strip + active terminal. Multiple
+//! groups sit side-by-side with the same weight per column on the
+//! tab-strip row and the body row, so clicking a strip section focuses
+//! the matching pane below. Groups mirror the C# build's
+//! `EditorGroupViewModel` flat list — no recursive split tree.
 //!
 //! Visuals follow `src/CodeScope.App/Styles/DesignTokens.xaml`:
 //! pure-black canvas, pure-white ink, single Framer Blue accent,
@@ -20,7 +25,8 @@
 //! Each tab owns its own [`Backend`] + [`TerminalView`]. Closing a
 //! tab drops the entity, which drops the backend, which sends
 //! `Msg::Shutdown` to the alacritty event loop and joins the worker
-//! thread.
+//! thread. When the last tab in a non-only group is closed the group
+//! itself collapses (mirroring `MainViewModel.CloseGroup`).
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -61,10 +67,32 @@ struct Tab {
     terminal: Entity<TerminalView>,
 }
 
-pub struct AppShell {
+/// One column in the work area: a tab strip + the currently-selected
+/// tab's terminal. Mirrors `EditorGroupViewModel` from the C# build —
+/// flat list, no recursion. The group's identity is its `id` so we can
+/// stamp gpui element ids that survive across renders without going
+/// through the index (which shifts when a sibling group collapses).
+struct Group {
+    id: u64,
     tabs: Vec<Tab>,
+    /// Local tab index inside this group. Each group has its own
+    /// active tab — focusing one group doesn't change another's
+    /// selection.
     active_tab: usize,
-    next_id: u64,
+}
+
+pub struct AppShell {
+    /// Flat list of tab groups laid out left-to-right. Always at
+    /// least one entry — `close_tab` collapses an emptied group only
+    /// when there are siblings to fall back on, and `close_focused_group`
+    /// quits the app when invoked on the only remaining group.
+    groups: Vec<Group>,
+    /// Index into `groups` of the currently-focused column. Keyboard
+    /// shortcuts (Ctrl+T, Ctrl+\, Ctrl+W, Ctrl+1..9) target this
+    /// group; click on any pane / tab strip section moves the focus.
+    focused_group: usize,
+    next_group_id: u64,
+    next_tab_id: u64,
     focus_handle: FocusHandle,
     /// Loaded user settings. Cloned into each new tab spawn so a
     /// future "reload settings" can swap this without disturbing
@@ -157,9 +185,10 @@ impl AppShell {
         .detach();
 
         let mut shell = Self {
-            tabs: Vec::new(),
-            active_tab: 0,
-            next_id: 0,
+            groups: vec![Group { id: 0, tabs: Vec::new(), active_tab: 0 }],
+            focused_group: 0,
+            next_group_id: 1,
+            next_tab_id: 0,
             focus_handle,
             settings,
             theme,
@@ -167,6 +196,10 @@ impl AppShell {
         };
         shell.spawn_tab(window, cx);
         shell
+    }
+
+    fn focused_group(&self) -> &Group {
+        &self.groups[self.focused_group]
     }
 
     /// Open a fresh shell session and append it as a new tab. The new
@@ -254,62 +287,152 @@ impl AppShell {
         };
 
         let terminal = cx.new(|cx| TerminalView::new_full(backend, palette, font, cx));
-        let id = self.next_id;
-        self.next_id += 1;
+        let id = self.next_tab_id;
+        self.next_tab_id += 1;
         let title: SharedString = title_override
             .or_else(|| active_project.map(|(_, name)| name.into()))
             .unwrap_or_else(|| format!("Terminal {}", id + 1).into());
-        self.tabs.push(Tab { id, title, terminal });
-        let new_idx = self.tabs.len() - 1;
-        self.activate_tab(new_idx, window, cx);
+        let group_idx = self.focused_group;
+        let group = &mut self.groups[group_idx];
+        group.tabs.push(Tab { id, title, terminal });
+        let new_idx = group.tabs.len() - 1;
+        self.activate_tab(group_idx, new_idx, window, cx);
     }
 
-    fn close_tab(&mut self, idx: usize, window: &mut Window, cx: &mut Context<Self>) {
-        if idx >= self.tabs.len() {
+    /// Close the tab at `(group_idx, tab_idx)`. When the focused
+    /// group's last tab closes we collapse the group entirely (provided
+    /// at least one sibling remains); when no groups remain we quit.
+    fn close_tab(
+        &mut self,
+        group_idx: usize,
+        tab_idx: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(group) = self.groups.get_mut(group_idx) else { return };
+        if tab_idx >= group.tabs.len() {
             return;
         }
-        self.tabs.remove(idx);
-        if self.tabs.is_empty() {
-            // Last tab closed — quit the app.
-            cx.quit();
+        group.tabs.remove(tab_idx);
+        if group.tabs.is_empty() {
+            // Empty group — collapse if there are siblings, otherwise
+            // quit (mirrors `close_tab` on the singleton group before
+            // multi-group support).
+            if self.groups.len() == 1 {
+                cx.quit();
+                return;
+            }
+            self.groups.remove(group_idx);
+            // If we just removed the focused group (or anything to its
+            // left), shift the focus index left so it still points at
+            // a real entry. Then re-focus the new focused group's
+            // active tab so the terminal regains keyboard input.
+            if self.focused_group >= self.groups.len() {
+                self.focused_group = self.groups.len() - 1;
+            } else if group_idx <= self.focused_group && self.focused_group > 0 {
+                self.focused_group -= 1;
+            }
+            let active = self.groups[self.focused_group].active_tab;
+            self.activate_tab(self.focused_group, active, window, cx);
             return;
         }
-        if self.active_tab >= self.tabs.len() {
-            self.active_tab = self.tabs.len() - 1;
-        } else if self.active_tab > idx {
-            self.active_tab -= 1;
+        // Group still has tabs — slide the active index left if we
+        // closed at or before it.
+        let group = &mut self.groups[group_idx];
+        if group.active_tab >= group.tabs.len() {
+            group.active_tab = group.tabs.len() - 1;
+        } else if group.active_tab > tab_idx {
+            group.active_tab -= 1;
         }
-        self.activate_tab(self.active_tab, window, cx);
+        let new_active = group.active_tab;
+        self.activate_tab(group_idx, new_active, window, cx);
     }
 
-    fn activate_tab(&mut self, idx: usize, window: &mut Window, cx: &mut Context<Self>) {
-        if idx >= self.tabs.len() {
+    /// Activate `(group_idx, tab_idx)`. Sets focused group, marks the
+    /// tab as the group's active one, and routes keyboard focus to the
+    /// terminal so typing lands in the right pty without an extra
+    /// click.
+    fn activate_tab(
+        &mut self,
+        group_idx: usize,
+        tab_idx: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(group) = self.groups.get_mut(group_idx) else { return };
+        if tab_idx >= group.tabs.len() {
             return;
         }
-        self.active_tab = idx;
-        let handle = self.tabs[idx].terminal.read(cx).focus_handle(cx);
+        group.active_tab = tab_idx;
+        self.focused_group = group_idx;
+        let handle = self.groups[group_idx].tabs[tab_idx].terminal.read(cx).focus_handle(cx);
         handle.focus(window);
         cx.notify();
     }
 
     fn next_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.tabs.is_empty() {
+        let group_idx = self.focused_group;
+        let group = &self.groups[group_idx];
+        if group.tabs.is_empty() {
             return;
         }
-        let next = (self.active_tab + 1) % self.tabs.len();
-        self.activate_tab(next, window, cx);
+        let next = (group.active_tab + 1) % group.tabs.len();
+        self.activate_tab(group_idx, next, window, cx);
     }
 
     fn prev_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.tabs.is_empty() {
+        let group_idx = self.focused_group;
+        let group = &self.groups[group_idx];
+        if group.tabs.is_empty() {
             return;
         }
-        let prev = if self.active_tab == 0 {
-            self.tabs.len() - 1
+        let prev = if group.active_tab == 0 {
+            group.tabs.len() - 1
         } else {
-            self.active_tab - 1
+            group.active_tab - 1
         };
-        self.activate_tab(prev, window, cx);
+        self.activate_tab(group_idx, prev, window, cx);
+    }
+
+    /// Append a new empty group to the right of the focused one and
+    /// move focus to it. Mirrors `MainViewModel.SplitRight` (Ctrl+\ in
+    /// the C# build). The new group has no tabs — the caller usually
+    /// follows up with `spawn_tab`, or the user does via Ctrl+T / the
+    /// `+` button on the new strip.
+    fn split_right(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let id = self.next_group_id;
+        self.next_group_id += 1;
+        let insert_at = self.focused_group + 1;
+        self.groups.insert(
+            insert_at,
+            Group { id, tabs: Vec::new(), active_tab: 0 },
+        );
+        self.focused_group = insert_at;
+        // Drop keyboard focus back on AppShell's root handle so the
+        // next typed character isn't routed to a now-stale terminal
+        // (the previously focused group's). Once the user types Ctrl+T
+        // / clicks +, `activate_tab` will rehome focus.
+        self.focus_handle.focus(window);
+        cx.notify();
+    }
+
+    /// Move focus to the group at `idx`. Routes keyboard focus to the
+    /// group's currently-active tab so typing resumes in the right
+    /// terminal. No-op when the index is out of range or the group is
+    /// empty (an empty group has no terminal to focus — we still set
+    /// `focused_group` so a subsequent Ctrl+T lands in this column).
+    fn focus_group(&mut self, idx: usize, window: &mut Window, cx: &mut Context<Self>) {
+        if idx >= self.groups.len() {
+            return;
+        }
+        if self.groups[idx].tabs.is_empty() {
+            self.focused_group = idx;
+            self.focus_handle.focus(window);
+            cx.notify();
+            return;
+        }
+        let active = self.groups[idx].active_tab;
+        self.activate_tab(idx, active, window, cx);
     }
 
     fn on_key_down(
@@ -339,7 +462,18 @@ impl AppShell {
             }
             "w" if mods.shift => {
                 cx.stop_propagation();
-                self.close_tab(self.active_tab, window, cx);
+                let g = self.focused_group;
+                let t = self.focused_group().active_tab;
+                self.close_tab(g, t, window, cx);
+            }
+            // Ctrl+\ — split the focused group to the right. Matches
+            // the C# binding (`SplitRightCommand`). Backslash is a
+            // single-key chord on US/most layouts, so we hit it here
+            // alongside the shifted variant in case of layouts that
+            // treat the bare key as a different glyph.
+            "\\" => {
+                cx.stop_propagation();
+                self.split_right(window, cx);
             }
             "tab" if !mods.shift => {
                 cx.stop_propagation();
@@ -354,9 +488,10 @@ impl AppShell {
                     && (1..=9).contains(&n)
                 {
                     let idx = (n as usize) - 1;
-                    if idx < self.tabs.len() {
+                    let group_idx = self.focused_group;
+                    if idx < self.groups[group_idx].tabs.len() {
                         cx.stop_propagation();
-                        self.activate_tab(idx, window, cx);
+                        self.activate_tab(group_idx, idx, window, cx);
                     }
                 }
             }
@@ -378,116 +513,36 @@ impl Render for AppShell {
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let theme = self.theme.clone();
-        // Snapshot the data we need into owned values up front. Lets us
-        // hand each `cx.listener` its own mutable borrow without
-        // overlapping with the immutable borrow `self.tabs.iter()`
-        // would otherwise hold.
-        let active_idx = self.active_tab;
-        let tab_meta: Vec<(usize, u64, SharedString)> = self
-            .tabs
+        // Snapshot per-group + per-tab metadata up front so each
+        // `cx.listener` closure can hold owned values without
+        // overlapping the immutable borrow `self.groups.iter()` would
+        // otherwise extend across the rest of `render`.
+        let focused_group_idx = self.focused_group;
+        let groups_meta: Vec<GroupRenderData> = self
+            .groups
             .iter()
             .enumerate()
-            .map(|(idx, tab)| (idx, tab.id, tab.title.clone()))
+            .map(|(g_idx, group)| GroupRenderData {
+                group_idx: g_idx,
+                group_id: group.id,
+                active_tab: group.active_tab,
+                is_focused: g_idx == focused_group_idx,
+                tabs: group
+                    .tabs
+                    .iter()
+                    .enumerate()
+                    .map(|(t_idx, tab)| TabRenderData {
+                        tab_idx: t_idx,
+                        tab_id: tab.id,
+                        title: tab.title.clone(),
+                    })
+                    .collect(),
+                active_terminal: group
+                    .tabs
+                    .get(group.active_tab)
+                    .map(|t| t.terminal.clone()),
+            })
             .collect();
-        let active_terminal = self
-            .tabs
-            .get(self.active_tab)
-            .map(|t| t.terminal.clone());
-
-        let tabs = tab_meta.into_iter().map(|(idx, id, title)| {
-            let active = idx == active_idx;
-            // Active tab: canvas-coloured "card" punched into the
-            // elevated strip, plus a 2 px accent top border — the
-            // same shape the C# tab strip uses. Inactive tabs sit
-            // transparent on the strip and only fill on hover.
-            let bg = if active { theme::canvas(&theme) } else { gpui::transparent_black() };
-            let text_color = if active { theme::ink(&theme) } else { theme::ink_dim(&theme) };
-            let top_border = if active { theme::accent(&theme) } else { gpui::transparent_black() };
-            let frost_10 = theme::frost_10(&theme);
-            let frost_20 = theme::frost_20(&theme);
-            let ink = theme::ink(&theme);
-            let ink_ghost = theme::ink_ghost(&theme);
-            let status_dot = if active { theme::status_running() } else { theme::ink_ghost(&theme) };
-
-            div()
-                .id(("tab", id))
-                .h_full()
-                .min_w(px(140.0))
-                .max_w(px(240.0))
-                .flex()
-                .flex_row()
-                .items_center()
-                .gap_2()
-                .px_3()
-                .border_t_2()
-                .border_color(top_border)
-                .bg(bg)
-                .text_color(text_color)
-                .hover(move |s| {
-                    if active { s } else { s.bg(frost_10).text_color(ink) }
-                })
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |this, _, window, cx| {
-                        this.activate_tab(idx, window, cx);
-                    }),
-                )
-                // Status dot — green = active session, dim = inactive.
-                // Cheap visual hook even before we wire real status.
-                .child(
-                    div()
-                        .w(px(8.0))
-                        .h(px(8.0))
-                        .rounded_full()
-                        .bg(status_dot),
-                )
-                .child(div().flex_grow().truncate().child(title))
-                .child(
-                    div()
-                        .id(("close", idx as u64))
-                        .w(px(20.0))
-                        .h(px(20.0))
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .rounded_full()
-                        .text_color(ink_ghost)
-                        .hover(move |s| s.bg(frost_20).text_color(ink))
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |this, _, window, cx| {
-                                cx.stop_propagation();
-                                this.close_tab(idx, window, cx);
-                            }),
-                        )
-                        .child("×"),
-                )
-        });
-
-        let new_tab_frost = theme::frost_10(&theme);
-        let new_tab_accent = theme::accent(&theme);
-        // `h(40)` instead of `h_full()` because the strip's flex-row
-        // doesn't always resolve `h_full` to the parent's 40 px before
-        // hit-testing happens — the button looked the right size but
-        // its hit area collapsed to 0, killing both hover and click.
-        let new_tab_button = div()
-            .id("new-tab")
-            .h(px(40.0))
-            .w(px(40.0))
-            .flex()
-            .items_center()
-            .justify_center()
-            .text_color(theme::ink_dim(&theme))
-            .text_size(px(18.0))
-            .cursor_pointer()
-            .hover(move |s| s.bg(new_tab_frost).text_color(new_tab_accent))
-            .on_mouse_down(
-                MouseButton::Left,
-                cx.listener(|this, _, window, cx| {
-                    this.spawn_tab(window, cx);
-                }),
-            )
-            .child("+");
 
         // The drag region fills the gap between the "+" button and the
         // caption controls so the user can grab the bar to move the
@@ -602,6 +657,39 @@ impl Render for AppShell {
                     ),
             );
 
+        // Build the per-group strip sections + per-group panes in one
+        // pass so the tab strip and the body row stay in lock-step (a
+        // group is one column; both layers must agree on which group
+        // is in which column).
+        let group_count = groups_meta.len();
+        let mut strip_sections: Vec<gpui::AnyElement> = Vec::with_capacity(group_count * 2);
+        let mut group_panes: Vec<gpui::AnyElement> = Vec::with_capacity(group_count * 2);
+        for (col_idx, gmeta) in groups_meta.into_iter().enumerate() {
+            if col_idx > 0 {
+                // 1 px column divider mirrors the C# build's
+                // `GridSplitter` chrome — strictly visual today; drag
+                // handling lands in the next PR alongside per-group
+                // weight persistence.
+                strip_sections.push(
+                    div()
+                        .w_px()
+                        .h_full()
+                        .bg(theme::divider(&theme))
+                        .into_any_element(),
+                );
+                group_panes.push(
+                    div()
+                        .w_px()
+                        .h_full()
+                        .bg(theme::divider(&theme))
+                        .into_any_element(),
+                );
+            }
+            let (strip, pane) = self.render_group(&theme, &gmeta, cx);
+            strip_sections.push(strip.into_any_element());
+            group_panes.push(pane.into_any_element());
+        }
+
         let tab_strip = div()
             .h(px(40.0))
             .flex()
@@ -610,27 +698,34 @@ impl Render for AppShell {
             .border_color(theme::divider(&theme))
             .bg(theme::elevated(&theme))
             .child(brand_mark)
-            .children(tabs)
-            .child(new_tab_button)
+            // Per-group strip sections share the available width
+            // equally for now (each is `flex_grow`). Per-group weight
+            // sliders + drag-resize land in the follow-up PR.
+            .child(
+                div()
+                    .flex_grow()
+                    .flex()
+                    .flex_row()
+                    .h_full()
+                    .children(strip_sections),
+            )
             .child(drag_region)
             .child(minimize_btn)
             .child(maximize_btn)
             .child(close_btn);
 
-        let body = if let Some(terminal) = active_terminal {
-            div().size_full().child(terminal).into_any_element()
-        } else {
-            // No tabs left — usually we've just quit, but render a
-            // black void in the meantime so we never flash.
-            div().size_full().into_any_element()
-        };
+        let work_area = div()
+            .flex_grow()
+            .flex()
+            .flex_row()
+            .children(group_panes);
 
         let main_row = div()
             .flex_grow()
             .flex()
             .flex_row()
             .child(self.sidebar.clone())
-            .child(div().flex_grow().child(body));
+            .child(work_area);
 
         div()
             .key_context("AppShell")
@@ -643,6 +738,218 @@ impl Render for AppShell {
             .text_color(theme::ink(&theme))
             .child(tab_strip)
             .child(main_row)
+    }
+}
+
+/// Frame-local snapshot for one tab inside a group. Owned strings so
+/// the listener closures can `move` the title without keeping a borrow
+/// on `self.groups`.
+struct TabRenderData {
+    tab_idx: usize,
+    tab_id: u64,
+    title: SharedString,
+}
+
+/// Frame-local snapshot for one group. We snapshot `Entity<TerminalView>`
+/// for the active tab so the body row can render it without
+/// re-borrowing `self.groups` after `groups_meta` is moved into the
+/// per-group render loop.
+struct GroupRenderData {
+    group_idx: usize,
+    group_id: u64,
+    active_tab: usize,
+    is_focused: bool,
+    tabs: Vec<TabRenderData>,
+    active_terminal: Option<Entity<TerminalView>>,
+}
+
+impl AppShell {
+    /// Build one group's tab strip section + body pane. Returned as a
+    /// pair so `render` can interleave dividers between adjacent
+    /// groups while keeping the strip and the pane below it in the
+    /// same column.
+    fn render_group(
+        &self,
+        theme: &Arc<Theme>,
+        gmeta: &GroupRenderData,
+        cx: &mut Context<Self>,
+    ) -> (gpui::Stateful<gpui::Div>, gpui::Stateful<gpui::Div>) {
+        let group_idx = gmeta.group_idx;
+        let group_id = gmeta.group_id;
+        let active_tab = gmeta.active_tab;
+        let is_focused = gmeta.is_focused;
+        let frost_10 = theme::frost_10(theme);
+        let frost_20 = theme::frost_20(theme);
+        let canvas = theme::canvas(theme);
+        let elevated = theme::elevated(theme);
+        let ink = theme::ink(theme);
+        let ink_dim = theme::ink_dim(theme);
+        let ink_ghost = theme::ink_ghost(theme);
+        let accent = theme::accent(theme);
+        let divider = theme::divider(theme);
+
+        let tabs = gmeta.tabs.iter().map(|tmeta| {
+            let tab_idx = tmeta.tab_idx;
+            let tab_id = tmeta.tab_id;
+            let title = tmeta.title.clone();
+            let active = tab_idx == active_tab && is_focused;
+            // Tab styling follows the same shape as the single-group
+            // version — active tab gets a canvas-coloured "card" with
+            // an accent top border. In an unfocused group the active
+            // tab still shows as the selected card (so the user sees
+            // which tab will resume on focus) but without the accent
+            // top border.
+            let card = tab_idx == active_tab;
+            let bg = if card { canvas } else { gpui::transparent_black() };
+            let text_color = if active { ink } else { ink_dim };
+            let top_border = if active { accent } else { gpui::transparent_black() };
+            let status_dot = if active {
+                theme::status_running()
+            } else {
+                ink_ghost
+            };
+            div()
+                .id(("tab", tab_id))
+                .h_full()
+                .min_w(px(140.0))
+                .max_w(px(240.0))
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_2()
+                .px_3()
+                .border_t_2()
+                .border_color(top_border)
+                .bg(bg)
+                .text_color(text_color)
+                .hover(move |s| {
+                    if active { s } else { s.bg(frost_10).text_color(ink) }
+                })
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, window, cx| {
+                        this.activate_tab(group_idx, tab_idx, window, cx);
+                    }),
+                )
+                .child(
+                    div()
+                        .w(px(8.0))
+                        .h(px(8.0))
+                        .rounded_full()
+                        .bg(status_dot),
+                )
+                .child(div().flex_grow().truncate().child(title))
+                .child(
+                    div()
+                        .id(("close", tab_id))
+                        .w(px(20.0))
+                        .h(px(20.0))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded_full()
+                        .text_color(ink_ghost)
+                        .hover(move |s| s.bg(frost_20).text_color(ink))
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _, window, cx| {
+                                cx.stop_propagation();
+                                this.close_tab(group_idx, tab_idx, window, cx);
+                            }),
+                        )
+                        .child("×"),
+                )
+        });
+
+        // Per-strip "+" button — same height/width as the cold-start
+        // singleton's, but lives inside the strip section so each group
+        // gets its own. Click spawns into *this* group regardless of
+        // which one is currently focused.
+        let new_tab_frost = frost_10;
+        let new_tab_accent = accent;
+        let new_tab_button = div()
+            .id(("new-tab", group_id))
+            .h(px(40.0))
+            .w(px(40.0))
+            .flex()
+            .items_center()
+            .justify_center()
+            .text_color(ink_dim)
+            .text_size(px(18.0))
+            .cursor_pointer()
+            .hover(move |s| s.bg(new_tab_frost).text_color(new_tab_accent))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, window, cx| {
+                    // Spawning routes through the currently-focused
+                    // group, so focus this one first to make the click
+                    // do what the user expects (spawn here, not
+                    // wherever focus happened to be).
+                    this.focus_group(group_idx, window, cx);
+                    this.spawn_tab(window, cx);
+                }),
+            )
+            .child("+");
+
+        // Strip section: tabs + "+" button. Click anywhere in the
+        // remaining whitespace focuses the group so the next Ctrl+T
+        // lands here. The trailing `flex_grow` filler captures the
+        // empty area to the right of the rightmost tab.
+        let strip = div()
+            .id(("group-strip", group_id))
+            .h_full()
+            .flex_grow()
+            .flex()
+            .flex_row()
+            .bg(elevated)
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, window, cx| {
+                    this.focus_group(group_idx, window, cx);
+                }),
+            )
+            .children(tabs)
+            .child(new_tab_button)
+            // Empty trailing region — gives the user something to
+            // click for "focus this group" without hitting a tab.
+            .child(div().flex_grow().h_full());
+
+        // Pane: active tab's terminal, or a black void when the group
+        // has no tabs (split-right + Ctrl+T-not-yet-pressed). 2 px
+        // accent rail at the top of the focused group's pane mirrors
+        // the C# `EditorGroupView` `IsFocused` cue.
+        let rail_color = if is_focused { accent } else { divider };
+        let body_inner: gpui::AnyElement = if let Some(term) = gmeta.active_terminal.as_ref() {
+            div().size_full().child(term.clone()).into_any_element()
+        } else {
+            div()
+                .size_full()
+                .flex()
+                .items_center()
+                .justify_center()
+                .text_color(ink_ghost)
+                .text_size(px(12.0))
+                .child("Empty group · press Ctrl+Shift+T to open a tab")
+                .into_any_element()
+        };
+        let pane = div()
+            .id(("group-pane", group_id))
+            .h_full()
+            .flex_grow()
+            .flex()
+            .flex_col()
+            .border_t_2()
+            .border_color(rail_color)
+            .bg(canvas)
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, window, cx| {
+                    this.focus_group(group_idx, window, cx);
+                }),
+            )
+            .child(body_inner);
+
+        (strip, pane)
     }
 }
 

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -44,7 +44,7 @@ use gpui::{
 };
 use parking_lot::Mutex;
 
-use crate::sidebar::{Sidebar, SidebarEvent};
+use crate::sidebar::{SIDEBAR_WIDTH, Sidebar, SidebarEvent};
 use crate::theme;
 
 /// How often the window-state debounce loop wakes up to check whether
@@ -299,9 +299,15 @@ impl AppShell {
         self.activate_tab(group_idx, new_idx, window, cx);
     }
 
-    /// Close the tab at `(group_idx, tab_idx)`. When the focused
-    /// group's last tab closes we collapse the group entirely (provided
-    /// at least one sibling remains); when no groups remain we quit.
+    /// Close the tab at `(group_idx, tab_idx)`. When the group's last
+    /// tab closes we collapse the group entirely (provided at least
+    /// one sibling remains); when no groups remain we quit.
+    ///
+    /// Closing a tab in an *unfocused* group keeps focus where it was
+    /// (mirrors C# `MainViewModel.CloseTabAsync` — the user clicked an
+    /// "x" on a sibling, they didn't ask to switch contexts). Auto-
+    /// collapsing a focused group that becomes empty does refocus the
+    /// fallback group so typing keeps landing somewhere.
     fn close_tab(
         &mut self,
         group_idx: usize,
@@ -313,20 +319,20 @@ impl AppShell {
         if tab_idx >= group.tabs.len() {
             return;
         }
+        let was_focused_group = self.focused_group == group_idx;
         group.tabs.remove(tab_idx);
         if group.tabs.is_empty() {
             // Empty group — collapse if there are siblings, otherwise
-            // quit (mirrors `close_tab` on the singleton group before
-            // multi-group support).
+            // quit.
             if self.groups.len() == 1 {
                 cx.quit();
                 return;
             }
             self.groups.remove(group_idx);
-            // If we just removed the focused group (or anything to its
-            // left), shift the focus index left so it still points at
-            // a real entry. Then re-focus the new focused group's
-            // active tab so the terminal regains keyboard input.
+            // If the focused group was at or after `group_idx`, slide
+            // its index left so it keeps pointing at the same group.
+            // Re-focus the (possibly new) focused group so keyboard
+            // input lands somewhere live.
             if self.focused_group >= self.groups.len() {
                 self.focused_group = self.groups.len() - 1;
             } else if group_idx <= self.focused_group && self.focused_group > 0 {
@@ -344,8 +350,15 @@ impl AppShell {
         } else if group.active_tab > tab_idx {
             group.active_tab -= 1;
         }
-        let new_active = group.active_tab;
-        self.activate_tab(group_idx, new_active, window, cx);
+        if was_focused_group {
+            let new_active = group.active_tab;
+            self.activate_tab(group_idx, new_active, window, cx);
+        } else {
+            // Closing a tab in a sibling group — adjust its `active_tab`
+            // (already done above) and redraw, but leave keyboard focus
+            // on the user's actually-focused group.
+            cx.notify();
+        }
     }
 
     /// Activate `(group_idx, tab_idx)`. Sets focused group, marks the
@@ -392,6 +405,24 @@ impl AppShell {
             group.active_tab - 1
         };
         self.activate_tab(group_idx, prev, window, cx);
+    }
+
+    /// Drop the focused group entirely. Pre-condition: the group is
+    /// empty (caller checks) and there's at least one sibling. After
+    /// removal we land focus on the previous (or first remaining)
+    /// group's active tab so typing keeps working without an extra
+    /// click. Mirrors `MainViewModel.CloseGroup`.
+    fn close_focused_group(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        debug_assert!(self.focused_group < self.groups.len());
+        debug_assert!(self.groups[self.focused_group].tabs.is_empty());
+        debug_assert!(self.groups.len() > 1);
+        let removed = self.focused_group;
+        self.groups.remove(removed);
+        if self.focused_group >= self.groups.len() {
+            self.focused_group = self.groups.len() - 1;
+        }
+        let active = self.groups[self.focused_group].active_tab;
+        self.activate_tab(self.focused_group, active, window, cx);
     }
 
     /// Append a new empty group to the right of the focused one and
@@ -463,8 +494,21 @@ impl AppShell {
             "w" if mods.shift => {
                 cx.stop_propagation();
                 let g = self.focused_group;
-                let t = self.focused_group().active_tab;
-                self.close_tab(g, t, window, cx);
+                let group = self.focused_group();
+                if group.tabs.is_empty() {
+                    // Empty focused group — collapse it so the user
+                    // can undo an accidental split right without
+                    // having to spawn a tab first. Mirrors the
+                    // `tab is null` branch of `MainViewModel.CloseTabAsync`.
+                    // No-op when this is the only group; the user has
+                    // to close their last tab to quit.
+                    if self.groups.len() > 1 {
+                        self.close_focused_group(window, cx);
+                    }
+                } else {
+                    let t = group.active_tab;
+                    self.close_tab(g, t, window, cx);
+                }
             }
             // Ctrl+\ — split the focused group to the right. Matches
             // the C# binding (`SplitRightCommand`). Backslash is a
@@ -690,6 +734,24 @@ impl Render for AppShell {
             group_panes.push(pane.into_any_element());
         }
 
+        // Sidebar-width spacer between the 40 px brand mark and the
+        // first strip section so each strip column starts at the same
+        // x-coordinate as the matching pane below — without this, the
+        // strip dividers slide left of the work-area dividers and the
+        // user sees mis-aligned columns. The spacer also serves as
+        // titlebar drag region above the sidebar (window-control area
+        // + start_window_move) so the user can grab the bar there.
+        let sidebar_spacer_w = px(SIDEBAR_WIDTH) - px(40.0);
+        let sidebar_spacer = div()
+            .id("titlebar-sidebar-spacer")
+            .w(sidebar_spacer_w)
+            .h(px(40.0))
+            .window_control_area(WindowControlArea::Drag)
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|_, _, window, _| window.start_window_move()),
+            );
+
         let tab_strip = div()
             .h(px(40.0))
             .flex()
@@ -698,6 +760,7 @@ impl Render for AppShell {
             .border_color(theme::divider(&theme))
             .bg(theme::elevated(&theme))
             .child(brand_mark)
+            .child(sidebar_spacer)
             // Per-group strip sections share the available width
             // equally for now (each is `flex_grow`). Per-group weight
             // sliders + drag-resize land in the follow-up PR.


### PR DESCRIPTION
## Summary
- Adds C#-parity tab groups to the Rust port: the work area is now a flat horizontal list of `Group`s (mirrors `EditorGroupViewModel`), each with its own tab strip (column-aligned with the matching pane below) and its own active tab.
- **Ctrl+\** splits the focused group to the right (`MainViewModel.SplitRight`). Closing the last tab in a non-only group auto-collapses the column. Click any strip / pane to focus that group.
- Default cold-start behavior is unchanged: one group, one tab, identical to before. Multi-group only shows up after the user explicitly splits.

## Out of scope (follow-ups)
- **PR2** — drag-resize the divider (`group_weights` + `LayoutState` persistence)
- **PR3** — drag a tab across groups without ConPTY teardown (needs a view-pool akin to `SessionViewHostPool`)

I deliberately bundled the model refactor + Split Right into one PR so the on-disk persistence and the cross-group reparent each land on top of a stable foundation, not on top of an in-flight refactor.

## Refactor scope
- `Tab` unchanged.
- `AppShell.tabs: Vec<Tab>` → `AppShell.groups: Vec<Group>` (`Group { id, tabs, active_tab }`); added `focused_group` + `next_group_id`.
- All existing tab ops now take `(group_idx, tab_idx)` so a sibling group's selection isn't disturbed when keyboard focus moves.
- New `render_group()` returns the `(strip_section, pane)` pair for one column; `render()` interleaves them with 1 px dividers and keeps the strip/pane columns in lock-step.
- Focus model: clicking a group's pane or strip routes through `focus_group()`, which forwards to `activate_tab()` so the active terminal regains keyboard input.

## UI behavior — needs user verification
I built and ran the dev binary cleanly but can't drive the GUI from here. Please sanity-check:

## Test plan
- [x] `cargo build --bin window` clean
- [x] `cargo clippy --bin window --all-targets` — no new warnings (one pre-existing `items_after_test_module` from `new_worktree_dialog.rs` remains)
- [x] `cargo test --workspace` — 51 passed (27 core + 15 dialog + 9 terminal mouse)
- [ ] Cold start: one group, one tab — identical to the previous build
- [ ] Ctrl+\ adds an empty column to the right of the focused one; placeholder text "Empty group · press Ctrl+Shift+T to open a tab" shows in the new pane
- [ ] Click into the empty group → Ctrl+Shift+T spawns a tab there
- [ ] Click any tab strip section / pane on the **left** group → its accent-rail focus marker lights up, Ctrl+1..9 / Ctrl+Tab target it
- [ ] Per-group "+" button spawns into that specific group regardless of where focus was
- [ ] Ctrl+Shift+W on the last tab in a non-only group collapses the column entirely; on the only group it quits the app