### PR TITLE
feat(rs): New session / New Claude session in sidebar menus

### DIFF
--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -129,10 +129,11 @@ impl AppShell {
         // focus inline.
         cx.subscribe_in(&sidebar, window, |this, _sidebar, event, window, cx| {
             match event {
-                SidebarEvent::OpenSession { working_directory, title } => {
+                SidebarEvent::OpenSession { working_directory, title, auto_type } => {
                     this.spawn_tab_in(
                         Some(working_directory.clone()),
                         Some(title.clone()),
+                        auto_type.clone(),
                         window,
                         cx,
                     );
@@ -212,13 +213,14 @@ impl AppShell {
     /// worktree clicks, post-create-worktree spawns) hand both in
     /// directly.
     fn spawn_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.spawn_tab_in(None, None, window, cx);
+        self.spawn_tab_in(None, None, None, window, cx);
     }
 
     fn spawn_tab_in(
         &mut self,
         working_directory: Option<std::path::PathBuf>,
         title_override: Option<SharedString>,
+        auto_type: Option<SharedString>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -294,9 +296,28 @@ impl AppShell {
             .unwrap_or_else(|| format!("Terminal {}", id + 1).into());
         let group_idx = self.focused_group;
         let group = &mut self.groups[group_idx];
+        // Capture the entity so an `auto_type` job can write to it
+        // without re-borrowing `self.groups` after the await point.
+        let terminal_for_autotype = terminal.clone();
         group.tabs.push(Tab { id, title, terminal });
         let new_idx = group.tabs.len() - 1;
         self.activate_tab(group_idx, new_idx, window, cx);
+
+        // Auto-type the requested command after a short settling
+        // delay so the shell has had time to print its prompt.
+        // Without the delay, the bytes can land before pwsh starts
+        // its REPL and get echoed into the banner instead of run.
+        if let Some(cmd) = auto_type {
+            cx.spawn(async move |_, cx| {
+                cx.background_executor().timer(Duration::from_millis(250)).await;
+                let _ = terminal_for_autotype.update(cx, |term, _cx| {
+                    let mut bytes = cmd.as_bytes().to_vec();
+                    bytes.push(b'\r');
+                    term.write_input(bytes);
+                });
+            })
+            .detach();
+        }
     }
 
     /// Close the tab at `(group_idx, tab_idx)`. When the group's last

--- a/codescope-rs/src/new_worktree_dialog.rs
+++ b/codescope-rs/src/new_worktree_dialog.rs
@@ -508,6 +508,7 @@ impl Sidebar {
                     cx.emit(crate::sidebar::SidebarEvent::OpenSession {
                         working_directory: std::path::PathBuf::from(&folder),
                         title: format!("{project_name} · {branch}").into(),
+                        auto_type: None,
                     });
                 }
             }

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -1106,26 +1106,38 @@ impl Sidebar {
                     .child(div().truncate().child(project_label)),
             )
             .child(div().h_px().bg(divider).my_1())
-            .child(item(
-                "wt-menu-open",
-                "Open session",
-                false,
-                Box::new(move |this, _window, cx| {
-                    cx.emit(SidebarEvent::OpenSession {
-                        working_directory: open_session_path.clone(),
-                        title: open_session_title.clone(),
-                        auto_type: None,
-                    });
-                    this.close_menu(cx);
-                }),
-            ))
+            .child({
+                let path_for_open = open_session_path.clone();
+                let title_for_open = open_session_title.clone();
+                item(
+                    "wt-menu-open",
+                    "Open session",
+                    false,
+                    Box::new(move |this, _window, cx| {
+                        cx.emit(SidebarEvent::OpenSession {
+                            working_directory: path_for_open.clone(),
+                            title: title_for_open.clone(),
+                            auto_type: None,
+                        });
+                        this.close_menu(cx);
+                    }),
+                )
+            })
             // "New Claude session" — same as Open session but auto-
             // types `claude` after the shell is up. Lands above the
             // Reveal/Copy/Remove rows so the agent-launch path stays
             // close to the plain Open session row.
+            //
+            // Title derives from the same `open_session_title` shape
+            // (`{project} · {branch}`) plus a ` · claude` suffix so
+            // multiple worktrees stay distinguishable in the tab strip
+            // when the user has agents running in several of them.
             .child({
                 let path = PathBuf::from(&worktree.path);
-                let title = SharedString::from(format!("{} · claude", project.name));
+                let title = SharedString::from(format!(
+                    "{} · claude",
+                    open_session_title.clone()
+                ));
                 item(
                     "wt-menu-new-claude",
                     "New Claude session",

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -88,6 +88,11 @@ pub enum SidebarEvent {
     OpenSession {
         working_directory: PathBuf,
         title: SharedString,
+        /// Optional command to auto-type at the shell prompt once the
+        /// pty has come up. Used by "New Claude session" / "New
+        /// Codex session" rows to launch the agent inline; `None`
+        /// just opens a plain shell. The host adds the trailing CR.
+        auto_type: Option<SharedString>,
     },
 }
 
@@ -738,6 +743,7 @@ impl Render for Sidebar {
                             cx.emit(SidebarEvent::OpenSession {
                                 working_directory: PathBuf::from(&wt_path_for_event),
                                 title: title_label.clone(),
+                                auto_type: None,
                             });
                         }),
                     )
@@ -895,6 +901,51 @@ impl Sidebar {
                     .child(div().text_color(ink).text_size(px(13.0)).truncate().child(header_label))
                     .child(div().child("project")),
             )
+            .child(div().h_px().bg(divider).my_1())
+            // "New session" rows fire `OpenSession` on the project's
+            // primary worktree path. Project name doubles as the tab
+            // title — the user can rename later. Two flavours:
+            //   • Plain "New session" — opens a shell at the project
+            //     root, no auto-typed command.
+            //   • "New Claude session" — opens a shell, then types
+            //     `claude` after the prompt is up. Mirrors the C#
+            //     build's `BuildAgentChoices` flow at the project
+            //     scope; we don't have the full agent picker yet so
+            //     this is the headline shortcut.
+            .child({
+                let project_path = project.path.clone();
+                let project_title: SharedString = project.name.clone().into();
+                item(
+                    "menu-new-session",
+                    "New session",
+                    false,
+                    Box::new(move |this, _window, cx| {
+                        cx.emit(SidebarEvent::OpenSession {
+                            working_directory: PathBuf::from(&project_path),
+                            title: project_title.clone(),
+                            auto_type: None,
+                        });
+                        this.close_menu(cx);
+                    }),
+                )
+            })
+            .child({
+                let project_path = project.path.clone();
+                let project_title: SharedString = project.name.clone().into();
+                item(
+                    "menu-new-claude",
+                    "New Claude session",
+                    false,
+                    Box::new(move |this, _window, cx| {
+                        cx.emit(SidebarEvent::OpenSession {
+                            working_directory: PathBuf::from(&project_path),
+                            title: project_title.clone(),
+                            auto_type: Some(claude_command().into()),
+                        });
+                        this.close_menu(cx);
+                    }),
+                )
+            })
             .child(div().h_px().bg(divider).my_1())
             .child(item(
                 "menu-new-worktree",
@@ -1063,10 +1114,32 @@ impl Sidebar {
                     cx.emit(SidebarEvent::OpenSession {
                         working_directory: open_session_path.clone(),
                         title: open_session_title.clone(),
+                        auto_type: None,
                     });
                     this.close_menu(cx);
                 }),
             ))
+            // "New Claude session" — same as Open session but auto-
+            // types `claude` after the shell is up. Lands above the
+            // Reveal/Copy/Remove rows so the agent-launch path stays
+            // close to the plain Open session row.
+            .child({
+                let path = PathBuf::from(&worktree.path);
+                let title = SharedString::from(format!("{} · claude", project.name));
+                item(
+                    "wt-menu-new-claude",
+                    "New Claude session",
+                    false,
+                    Box::new(move |this, _window, cx| {
+                        cx.emit(SidebarEvent::OpenSession {
+                            working_directory: path.clone(),
+                            title: title.clone(),
+                            auto_type: Some(claude_command().into()),
+                        });
+                        this.close_menu(cx);
+                    }),
+                )
+            })
             .child(div().h_px().bg(divider).my_1())
             .child({
                 let id_for_reveal = worktree_id.clone();
@@ -1278,6 +1351,17 @@ fn open_path_in_windows_terminal(path: &str) {
         let _ = path;
         eprintln!("info: 'Open in Windows Terminal' is Windows-only");
     }
+}
+
+/// The command we auto-type for "New Claude session". Bare `claude`
+/// — relies on the user's PATH to resolve it (npm-global on Windows,
+/// homebrew/npm on macOS, /usr/local/bin or similar on Linux). When
+/// it fails the user just sees a `command not found` in their shell
+/// and can install it from there. Mirrors the C# build's default
+/// agent invocation; the full agent picker (Codex / shell / custom)
+/// lands when the settings story does.
+fn claude_command() -> &'static str {
+    "claude"
 }
 
 /// Platform-appropriate label for the "Reveal in <native file browser>"

--- a/codescope-rs/terminal/src/view.rs
+++ b/codescope-rs/terminal/src/view.rs
@@ -153,20 +153,6 @@ impl TerminalView {
     /// palette matches whatever theme the [`Backend`] was spawned
     /// with. Callers that don't care about themes can keep using
     /// [`Self::new`] / [`Self::new_with_font`].
-    /// Write raw bytes to the pty as if the user had typed them.
-    /// Lets app shells inject startup commands (e.g. auto-type
-    /// `claude\r` after opening a tab) without going through the
-    /// keyboard pipeline. The bytes are queued on the backend; if the
-    /// shell hasn't started reading yet they wait there until it
-    /// does, so calling this immediately after `Backend::spawn` is
-    /// safe.
-    pub fn write_input<B>(&self, bytes: B)
-    where
-        B: Into<std::borrow::Cow<'static, [u8]>>,
-    {
-        self.backend.write_input(bytes);
-    }
-
     pub fn new_full(
         backend: Backend,
         palette: ColorPalette,
@@ -257,6 +243,27 @@ impl TerminalView {
             blink_phase,
             hovered_link: None,
         }
+    }
+
+    /// Write raw bytes to the pty as if the user had typed them.
+    /// Lets app shells inject startup commands (e.g. auto-type
+    /// `claude\r` after opening a tab) without going through the
+    /// keyboard pipeline.
+    ///
+    /// I/O-safe to call right after `Backend::spawn` — the bytes
+    /// queue on the slave side and the shell consumes them once it
+    /// starts reading. **UX-wise** that isn't always what you want:
+    /// pwsh on Windows prints a banner before its REPL starts
+    /// reading, and bytes that land before the prompt can get echoed
+    /// into the banner instead of executed. Callers that want the
+    /// command to run *as if* typed at the prompt should give the
+    /// shell a moment to settle (a short timer, or wait for the
+    /// first idle event from the backend) before calling this.
+    pub fn write_input<B>(&self, bytes: B)
+    where
+        B: Into<std::borrow::Cow<'static, [u8]>>,
+    {
+        self.backend.write_input(bytes);
     }
 
     /// Snap the cursor to its visible phase. Called whenever the user

--- a/codescope-rs/terminal/src/view.rs
+++ b/codescope-rs/terminal/src/view.rs
@@ -153,6 +153,20 @@ impl TerminalView {
     /// palette matches whatever theme the [`Backend`] was spawned
     /// with. Callers that don't care about themes can keep using
     /// [`Self::new`] / [`Self::new_with_font`].
+    /// Write raw bytes to the pty as if the user had typed them.
+    /// Lets app shells inject startup commands (e.g. auto-type
+    /// `claude\r` after opening a tab) without going through the
+    /// keyboard pipeline. The bytes are queued on the backend; if the
+    /// shell hasn't started reading yet they wait there until it
+    /// does, so calling this immediately after `Backend::spawn` is
+    /// safe.
+    pub fn write_input<B>(&self, bytes: B)
+    where
+        B: Into<std::borrow::Cow<'static, [u8]>>,
+    {
+        self.backend.write_input(bytes);
+    }
+
     pub fn new_full(
         backend: Backend,
         palette: ColorPalette,


### PR DESCRIPTION
## Summary
Adds agent-launch shortcuts to the project + worktree context menus, mirroring the C# build's \`BuildAgentChoices\` flow at the project / worktree scope.

| Row | Effect |
|---|---|
| **New session** | Opens a plain shell at the project / worktree root |
| **New Claude session** | Opens a shell, then types \`claude\` after a short settling delay so the agent launches inline |

These two are the headline shortcut today; the full agent picker (Codex / shell / custom) lands when the settings story does.

## Wiring
- \`SidebarEvent::OpenSession\` gains an optional \`auto_type: Option<SharedString>\` field.
- \`AppShell::spawn_tab_in\` captures the new \`Entity<TerminalView>\` before \`activate_tab\`, then schedules a 250 ms settle delay on the background executor before calling \`TerminalView::write_input\` to queue the command bytes.
- The 250 ms delay matters: without it pwsh's banner can land *after* the typed bytes and overwrite them, or the REPL hasn't started reading and the input gets echoed into the spawn output.
- \`TerminalView::write_input\` is a thin pass-through to \`Backend::write_input\` — exposed publicly so app shells can inject startup commands without going through the keyboard pipeline.

## Test plan
- [x] \`cargo build --bin window\` clean
- [x] \`cargo clippy --bin window --all-targets\` — no new warnings
- [x] \`cargo test --workspace\` — 51 passed (27 core + 15 dialog + 9 terminal mouse)
- [ ] Right-click a project → "New session" → tab opens at project root with empty shell
- [ ] Right-click a project → "New Claude session" → tab opens, \`claude\` runs at the prompt
- [ ] Right-click a worktree → "New Claude session" → tab opens at the worktree path with claude
- [ ] If \`claude\` isn't on PATH the user just sees \`command not found\` in their shell — no UI breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)