### PR TITLE
feat(rs): session restore — open tabs survive a restart

### DIFF
--- a/codescope-rs/core/src/layout.rs
+++ b/codescope-rs/core/src/layout.rs
@@ -37,6 +37,46 @@ pub struct LayoutState {
     /// group count matches; out-of-range falls back to 0. Mirrors
     /// `WorkspaceLayout.FocusedGroupIndex`.
     pub focused_group_index: usize,
+    /// Open tabs to rehydrate at next launch. Each entry binds a
+    /// terminal session to a group + active flag. We don't try to
+    /// restore the *running process* (the pty was killed at app
+    /// shutdown) — `auto_type` re-runs whatever command was used to
+    /// spawn the original tab so "New Claude session" comes back as
+    /// claude and plain shells come back as plain shells. Tabs
+    /// whose `working_directory` no longer exists are silently
+    /// dropped on rehydrate. Empty → no tabs at last save (fresh
+    /// install / migration from older layout.json), AppShell falls
+    /// back to a single cold-start tab.
+    pub open_tabs: Vec<RestoreTab>,
+}
+
+/// One tab worth of restore metadata. Light enough to round-trip
+/// cleanly — full C# `Session` parity (agent_session_id,
+/// last_opened timestamps, history bookkeeping) is out of scope
+/// until the projects.json side moves over.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RestoreTab {
+    /// Working directory the pty was spawned in. Missing this and
+    /// the user wakes up to a tab that ran in a different folder
+    /// than they remember.
+    pub working_directory: String,
+    /// Tab strip label. Free-form string the user originally saw —
+    /// usually `{project} · {branch}` or `{project} · {branch} · claude`.
+    pub title: String,
+    /// Optional command that was auto-typed at the prompt when this
+    /// tab spawned. `Some("claude")` for "New Claude session" rows;
+    /// `None` for plain shells. Re-runs at next launch so the agent
+    /// is back even though the pty itself is fresh.
+    #[serde(default)]
+    pub auto_type: Option<String>,
+    /// Index of the group this tab belongs to in `group_weights`'s
+    /// numbering. Restore clamps out-of-range values to 0.
+    pub group_index: usize,
+    /// Was this tab the active one in its group at save time?
+    /// Restore picks the first `true` per group; if none, the first
+    /// tab wins.
+    #[serde(default)]
+    pub active_in_group: bool,
 }
 
 impl Default for LayoutState {
@@ -47,6 +87,7 @@ impl Default for LayoutState {
             selected_project_id: None,
             group_weights: Vec::new(),
             focused_group_index: 0,
+            open_tabs: Vec::new(),
         }
     }
 }
@@ -108,6 +149,22 @@ mod tests {
             selected_project_id: Some("proj-1".into()),
             group_weights: vec![1.5, 1.0],
             focused_group_index: 1,
+            open_tabs: vec![
+                RestoreTab {
+                    working_directory: "C:\\repos\\foo".into(),
+                    title: "foo · main".into(),
+                    auto_type: None,
+                    group_index: 0,
+                    active_in_group: true,
+                },
+                RestoreTab {
+                    working_directory: "C:\\repos\\foo.worktrees\\branch-x".into(),
+                    title: "foo · branch-x · claude".into(),
+                    auto_type: Some("claude".into()),
+                    group_index: 1,
+                    active_in_group: true,
+                },
+            ],
         };
         state.save_to(&path).unwrap();
         let loaded = LayoutState::load_from(&path).unwrap();
@@ -115,6 +172,9 @@ mod tests {
         assert_eq!(loaded.selected_project_id.as_deref(), Some("proj-1"));
         assert_eq!(loaded.group_weights, vec![1.5, 1.0]);
         assert_eq!(loaded.focused_group_index, 1);
+        assert_eq!(loaded.open_tabs.len(), 2);
+        assert_eq!(loaded.open_tabs[1].auto_type.as_deref(), Some("claude"));
+        assert!(loaded.open_tabs[0].active_in_group);
     }
 
     #[test]

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -21,7 +21,7 @@ pub mod settings;
 pub mod theme;
 pub mod window_state;
 
-pub use layout::LayoutState;
+pub use layout::{LayoutState, RestoreTab};
 pub use paths::AppPaths;
 pub use projects::{Project, ProjectsConfig, Session, Worktree};
 pub use settings::{CursorSettings, FontSettings, Settings};

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -107,6 +107,14 @@ struct SplitterDrag {
     px_per_unit: f32,
 }
 
+/// Read the saved group weights out of a `LayoutState` snapshot.
+/// Wrapped as a helper so the constructor can also fall back to a
+/// single 1.0 weight when nothing's saved (first launch, fresh
+/// install, deleted layout.json).
+fn saved_group_weights(layout: &LayoutState) -> &[f32] {
+    layout.group_weights.as_slice()
+}
+
 /// Smallest weight we let either side of a drag go to. Below this the
 /// pane visibly disappears and the user can't get focus back to it
 /// without a Ctrl+Shift+W to remove the empty group. Mirrors C#'s
@@ -255,14 +263,53 @@ impl AppShell {
         })
         .detach();
 
+        // Rehydrate group layout from `layout.json`. We can restore
+        // the *shape* (column count + weights + focused index) even
+        // though session restore — which would refill each group's
+        // tab list — hasn't landed yet. So a saved 1.5/1.0 split
+        // comes back as two empty columns and the cold-start tab
+        // lands in whichever column was last focused. Empty siblings
+        // show the "press Ctrl+Shift+T" placeholder; the user can
+        // close them with Ctrl+Shift+W if they don't want them.
+        //
+        // Sanitise on the way in: drop any non-positive weights and
+        // anything wildly large to avoid a corrupt layout.json
+        // wedging the work area. `<= 0.0` weights would zero out
+        // their column with `flex-grow`, hiding the pane and giving
+        // no way to recover via the UI.
+        let mut sanitized_weights: Vec<f32> = saved_group_weights(&layout)
+            .iter()
+            .filter(|w| w.is_finite() && **w > 0.0 && **w < 1000.0)
+            .copied()
+            .collect();
+        if sanitized_weights.is_empty() {
+            sanitized_weights.push(1.0);
+        }
+        let group_count = sanitized_weights.len();
+        let mut groups: Vec<Group> = (0..group_count)
+            .map(|idx| Group {
+                id: idx as u64,
+                tabs: Vec::new(),
+                active_tab: 0,
+            })
+            .collect();
+        // Saved focus may be stale — clamp it into range so a config
+        // that lost groups since save still lands somewhere live.
+        let focused_group = layout
+            .focused_group_index
+            .min(groups.len().saturating_sub(1));
+        // Cold-start tab lands in the focused group only — siblings
+        // remain empty placeholders pending session restore.
+        let _ = &mut groups; // silence unused when group_count == 1
+
         let mut shell = Self {
-            groups: vec![Group { id: 0, tabs: Vec::new(), active_tab: 0 }],
-            focused_group: 0,
-            group_weights: vec![1.0],
+            groups,
+            focused_group,
+            group_weights: sanitized_weights,
             splitter_drag: None,
             paths: paths.clone(),
             layout,
-            next_group_id: 1,
+            next_group_id: group_count as u64,
             next_tab_id: 0,
             focus_handle,
             settings,

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -69,6 +69,15 @@ struct Tab {
     id: u64,
     title: SharedString,
     terminal: Entity<TerminalView>,
+    /// Working directory the pty was spawned in. Captured so a
+    /// session-restore round-trip can re-spawn the tab in the same
+    /// folder without going through the sidebar's active-project
+    /// fallback (which may have shifted since save).
+    working_directory: Option<std::path::PathBuf>,
+    /// Auto-typed command at spawn (None for plain shells, Some for
+    /// agent-launch tabs). Persisted so "New Claude session" comes
+    /// back as claude on restore.
+    auto_type: Option<SharedString>,
 }
 
 /// One column in the work area: a tab strip + the currently-selected
@@ -269,7 +278,7 @@ impl AppShell {
             theme,
             sidebar,
         };
-        shell.spawn_tab(window, cx);
+        shell.rehydrate_or_cold_start(window, cx);
         shell
     }
 
@@ -299,6 +308,7 @@ impl AppShell {
         };
         on_disk.group_weights = self.group_weights.clone();
         on_disk.focused_group_index = self.focused_group;
+        on_disk.open_tabs = self.snapshot_open_tabs();
         if let Err(err) = on_disk.save(self.paths.as_ref()) {
             eprintln!("warning: failed to save layout.json: {err:#}");
             return;
@@ -306,8 +316,114 @@ impl AppShell {
         self.layout = on_disk;
     }
 
+    /// Build a `RestoreTab` for every currently-open tab. Tabs
+    /// without a known working directory are skipped — we'd have
+    /// nothing useful to restore them in. The resulting list goes
+    /// straight into `LayoutState::open_tabs`.
+    fn snapshot_open_tabs(&self) -> Vec<codescope_core::RestoreTab> {
+        let mut out = Vec::new();
+        for (g_idx, group) in self.groups.iter().enumerate() {
+            for (t_idx, tab) in group.tabs.iter().enumerate() {
+                let Some(ref wd) = tab.working_directory else { continue };
+                out.push(codescope_core::RestoreTab {
+                    working_directory: wd.to_string_lossy().into_owned(),
+                    title: tab.title.to_string(),
+                    auto_type: tab.auto_type.as_ref().map(|s| s.to_string()),
+                    group_index: g_idx,
+                    active_in_group: t_idx == group.active_tab,
+                });
+            }
+        }
+        out
+    }
+
     fn focused_group(&self) -> &Group {
         &self.groups[self.focused_group]
+    }
+
+    /// Restore tabs from the persisted `LayoutState::open_tabs`, or
+    /// fall back to a single cold-start tab when there's nothing to
+    /// restore. Called once at the end of `AppShell::new`. Each tab
+    /// goes back into the group it was saved to (clamped into
+    /// range), and the active-in-group flag drives the per-group
+    /// selection. After restore we focus the *globally* focused
+    /// group's active tab so keyboard input lands somewhere live.
+    ///
+    /// Tabs whose `working_directory` no longer exists are silently
+    /// dropped — the user gets a fresh group with whatever survived.
+    /// If everything is dropped (rare: every saved path was deleted),
+    /// we fall through to the cold-start path so the user isn't
+    /// left staring at empty groups.
+    fn rehydrate_or_cold_start(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let saved: Vec<codescope_core::RestoreTab> = self.layout.open_tabs.clone();
+        if saved.is_empty() {
+            self.spawn_tab(window, cx);
+            return;
+        }
+
+        // Group by `group_index`, dropping non-existent paths and
+        // clamping out-of-range groups into 0..groups.len().
+        let group_count = self.groups.len();
+        let mut active_by_group: Vec<Option<usize>> = vec![None; group_count];
+        let mut spawned_any = false;
+        for tab in saved.into_iter() {
+            let path = std::path::PathBuf::from(&tab.working_directory);
+            if !path.exists() {
+                eprintln!(
+                    "info: skipping restored tab — path no longer exists: {}",
+                    tab.working_directory
+                );
+                continue;
+            }
+            let group_idx = tab.group_index.min(group_count.saturating_sub(1));
+            // Spawn into the requested group by temporarily moving
+            // focus there. `spawn_tab_in` always lands in the
+            // currently-focused group, so we can't address other
+            // groups directly without focus-stomping. We restore the
+            // intended `focused_group` after the loop.
+            self.focused_group = group_idx;
+            let title = SharedString::from(tab.title);
+            let auto = tab.auto_type.map(SharedString::from);
+            self.spawn_tab_in(Some(path), Some(title), auto, window, cx);
+            spawned_any = true;
+            if tab.active_in_group {
+                let new_idx = self.groups[group_idx].tabs.len() - 1;
+                active_by_group[group_idx] = Some(new_idx);
+            }
+        }
+
+        if !spawned_any {
+            // Every restore candidate's path was missing — fall back
+            // to the cold-start spawn so the user gets *something*.
+            self.spawn_tab(window, cx);
+            return;
+        }
+
+        // Apply per-group active selections. `spawn_tab_in` left each
+        // group's `active_tab` pointing at its last-spawned, which
+        // for groups without an explicit active_in_group flag is
+        // the right answer (matches the legacy "newest tab wins"
+        // behaviour); for groups with a flag we override.
+        for (g_idx, active) in active_by_group.iter().enumerate() {
+            if let Some(t_idx) = active
+                && let Some(group) = self.groups.get_mut(g_idx)
+                && *t_idx < group.tabs.len()
+            {
+                group.active_tab = *t_idx;
+            }
+        }
+
+        // Re-focus the saved focused group's active tab so keyboard
+        // input lands on the user's actual last-active terminal,
+        // not whichever tab spawn happened to land last.
+        let focused = self
+            .layout
+            .focused_group_index
+            .min(self.groups.len().saturating_sub(1));
+        if !self.groups[focused].tabs.is_empty() {
+            let active = self.groups[focused].active_tab;
+            self.activate_tab(focused, active, window, cx);
+        }
     }
 
     /// Open a fresh shell session and append it as a new tab. The new
@@ -373,6 +489,11 @@ impl AppShell {
         };
         let font = build_font_config(&self.settings);
 
+        // Clone the resolved working directory before the SpawnConfig
+        // moves it — the Tab keeps its own copy so session-restore
+        // can re-spawn the pty in the same folder later, without
+        // re-resolving via the sidebar (which may have shifted).
+        let working_directory_for_tab = working_directory.clone();
         let backend = match Backend::spawn(SpawnConfig {
             shell,
             working_directory,
@@ -406,7 +527,13 @@ impl AppShell {
         // Capture the entity so an `auto_type` job can write to it
         // without re-borrowing `self.groups` after the await point.
         let terminal_for_autotype = terminal.clone();
-        group.tabs.push(Tab { id, title, terminal });
+        group.tabs.push(Tab {
+            id,
+            title,
+            terminal,
+            working_directory: working_directory_for_tab,
+            auto_type: auto_type.clone(),
+        });
         let new_idx = group.tabs.len() - 1;
         self.activate_tab(group_idx, new_idx, window, cx);
 


### PR DESCRIPTION
## Summary
Persists the user's open tabs to \`layout.json\` and rehydrates them on next launch. Builds on PR #74 (group rehydration) — the group shape comes back first, then each tab lands in the group it was saved to with the same active-tab selection.

The pty itself is fresh (it was killed at app shutdown), but \`auto_type\` re-runs the spawn-time command so "New Claude session" comes back as claude.

**Depends on PR #74** for the group-shape rehydration. Merged that branch in here so this PR stands alone if reviewed first; will conflict-clean on top of #74's merge.

## Data shape
\`\`\`jsonc
// layout.json
{
  ...
  "open_tabs": [
    {
      "working_directory": "C:\\repos\\foo",
      "title": "foo · main",
      "auto_type": null,
      "group_index": 0,
      "active_in_group": true
    },
    {
      "working_directory": "C:\\repos\\foo.worktrees\\branch-x",
      "title": "foo · branch-x · claude",
      "auto_type": "claude",
      "group_index": 1,
      "active_in_group": true
    }
  ]
}
\`\`\`

\`RestoreTab\` is light enough to round-trip cleanly. Full C# \`Session\` parity (\`agent_session_id\`, last-opened timestamps, history bookkeeping) is out of scope until the projects.json side moves over.

## Behaviour
- \`Tab\` gains \`working_directory: Option<PathBuf>\` and \`auto_type: Option<SharedString>\`. \`spawn_tab_in\` records both.
- \`save_layout\` writes a snapshot of all currently-open tabs into \`layout.open_tabs\` after every spawn/close/move/activate (existing call sites already trigger \`save_layout\`).
- \`AppShell::new\` runs \`rehydrate_or_cold_start\` instead of \`spawn_tab\`. It walks \`layout.open_tabs\`, drops entries whose path no longer exists, spawns each into the correct group (clamping out-of-range \`group_index\`), and applies the per-group active-tab flag.
- If every entry's path is missing → falls through to the cold-start spawn so the user isn't staring at empty groups.
- Empty \`open_tabs\` (fresh install or older layout.json) → cold-start spawn as before.

## Test plan
- [x] \`cargo build --bin window\` clean
- [x] \`cargo clippy --bin window --all-targets\` — no new warnings
- [x] \`cargo test --workspace\` — 52 passed (\`round_trip\` test now exercises \`open_tabs\` too)
- [ ] Open 3 tabs across 2 groups, close + reopen — same 3 tabs in the same groups
- [ ] One tab is "New Claude session" — comes back with claude running
- [ ] Manually delete one of the saved working directories before reopen — that tab silently drops, others come back
- [ ] Older \`layout.json\` (no \`open_tabs\` field) loads cleanly with single cold-start tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)