### PR TITLE
feat(rs): session restore — open tabs survive a restart

### DIFF
--- a/codescope-rs/core/src/layout.rs
+++ b/codescope-rs/core/src/layout.rs
@@ -37,6 +37,44 @@ pub struct LayoutState {
     /// group count matches; out-of-range falls back to 0. Mirrors
     /// `WorkspaceLayout.FocusedGroupIndex`.
     pub focused_group_index: usize,
+    /// Open tabs to rehydrate at next launch. Each entry binds a
+    /// terminal session to a group + active flag. We don't try to
+    /// restore the *running process* (the pty was killed at app
+    /// shutdown) — `auto_type` re-runs whatever command was used to
+    /// spawn the original tab so "New Claude session" comes back as
+    /// claude and plain shells come back as plain shells. Tabs
+    /// whose `working_directory` no longer exists are silently
+    /// dropped on rehydrate. Empty → no tabs at last save (fresh
+    /// install / migration from older layout.json), AppShell falls
+    /// back to a single cold-start tab.
+    pub open_tabs: Vec<RestoreTab>,
+}
+
+/// One tab worth of restore metadata. Light enough to round-trip
+/// cleanly — full C# `Session` parity (agent_session_id,
+/// last_opened timestamps, history bookkeeping) is out of scope
+/// until the projects.json side moves over.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RestoreTab {
+    /// Working directory the pty was spawned in.
+    pub working_directory: String,
+    /// Tab strip label. Free-form string the user originally saw —
+    /// usually `{project} · {branch}` or `{project} · {branch} · claude`.
+    pub title: String,
+    /// Optional command that was auto-typed at the prompt when this
+    /// tab spawned. `Some("claude")` for "New Claude session" rows;
+    /// `None` for plain shells. Re-runs at next launch so the agent
+    /// is back even though the pty itself is fresh.
+    #[serde(default)]
+    pub auto_type: Option<String>,
+    /// Index of the group this tab belongs to in `group_weights`'s
+    /// numbering. Restore clamps out-of-range values to 0.
+    pub group_index: usize,
+    /// Was this tab the active one in its group at save time?
+    /// Restore picks the first `true` per group; if none, the first
+    /// tab wins.
+    #[serde(default)]
+    pub active_in_group: bool,
 }
 
 impl Default for LayoutState {
@@ -47,6 +85,7 @@ impl Default for LayoutState {
             selected_project_id: None,
             group_weights: Vec::new(),
             focused_group_index: 0,
+            open_tabs: Vec::new(),
         }
     }
 }
@@ -108,6 +147,13 @@ mod tests {
             selected_project_id: Some("proj-1".into()),
             group_weights: vec![1.5, 1.0],
             focused_group_index: 1,
+            open_tabs: vec![RestoreTab {
+                working_directory: "C:\\repos\\foo".into(),
+                title: "foo · main · claude".into(),
+                auto_type: Some("claude".into()),
+                group_index: 0,
+                active_in_group: true,
+            }],
         };
         state.save_to(&path).unwrap();
         let loaded = LayoutState::load_from(&path).unwrap();
@@ -115,6 +161,9 @@ mod tests {
         assert_eq!(loaded.selected_project_id.as_deref(), Some("proj-1"));
         assert_eq!(loaded.group_weights, vec![1.5, 1.0]);
         assert_eq!(loaded.focused_group_index, 1);
+        assert_eq!(loaded.open_tabs.len(), 1);
+        assert_eq!(loaded.open_tabs[0].auto_type.as_deref(), Some("claude"));
+        assert!(loaded.open_tabs[0].active_in_group);
     }
 
     #[test]

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -21,7 +21,7 @@ pub mod settings;
 pub mod theme;
 pub mod window_state;
 
-pub use layout::LayoutState;
+pub use layout::{LayoutState, RestoreTab};
 pub use paths::AppPaths;
 pub use projects::{Project, ProjectsConfig, Session, Worktree};
 pub use settings::{CursorSettings, FontSettings, Settings};

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -77,6 +77,15 @@ struct Tab {
     id: u64,
     title: SharedString,
     terminal: Entity<TerminalView>,
+    /// Working directory the pty was spawned in. Captured so a
+    /// session-restore round-trip can re-spawn the tab in the same
+    /// folder without going through the sidebar's active-project
+    /// fallback (which may have shifted since save).
+    working_directory: Option<std::path::PathBuf>,
+    /// Auto-typed command at spawn (None for plain shells, Some for
+    /// agent-launch tabs). Persisted so "New Claude session" comes
+    /// back as claude on restore.
+    auto_type: Option<SharedString>,
 }
 
 /// One column in the work area: a tab strip + the currently-selected
@@ -416,7 +425,7 @@ impl AppShell {
             theme,
             sidebar,
         };
-        shell.spawn_tab(window, cx);
+        shell.rehydrate_or_cold_start(window, cx);
         shell
     }
 
@@ -450,11 +459,97 @@ impl AppShell {
         on_disk.focused_group_index = self.focused_group;
         on_disk.sidebar_visible = self.sidebar_visible;
         on_disk.sidebar_width = self.sidebar_width;
+        on_disk.open_tabs = self.snapshot_open_tabs();
         if let Err(err) = on_disk.save(self.paths.as_ref()) {
             eprintln!("warning: failed to save layout.json: {err:#}");
             return;
         }
         self.layout = on_disk;
+    }
+
+    /// Build a `RestoreTab` for every currently-open tab. Tabs
+    /// without a known working directory are skipped — we'd have
+    /// nothing useful to spawn them with on rehydrate.
+    fn snapshot_open_tabs(&self) -> Vec<codescope_core::RestoreTab> {
+        let mut out = Vec::new();
+        for (g_idx, group) in self.groups.iter().enumerate() {
+            for (t_idx, tab) in group.tabs.iter().enumerate() {
+                let Some(ref wd) = tab.working_directory else { continue };
+                out.push(codescope_core::RestoreTab {
+                    working_directory: wd.to_string_lossy().into_owned(),
+                    title: tab.title.to_string(),
+                    auto_type: tab.auto_type.as_ref().map(|s| s.to_string()),
+                    group_index: g_idx,
+                    active_in_group: t_idx == group.active_tab,
+                });
+            }
+        }
+        out
+    }
+
+    /// Restore tabs from `LayoutState::open_tabs`, or fall back to
+    /// the cold-start spawn when nothing's saved. Builds on PR #74's
+    /// group-shape rehydration: by the time this runs the AppShell
+    /// already has N empty groups; we just put a tab back into each.
+    /// Tabs whose working directory no longer exists are silently
+    /// dropped; if everything is dropped (rare) we cold-start so the
+    /// user isn't left staring at empty groups.
+    fn rehydrate_or_cold_start(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let saved: Vec<codescope_core::RestoreTab> = self.layout.open_tabs.clone();
+        if saved.is_empty() {
+            self.spawn_tab(window, cx);
+            return;
+        }
+        let group_count = self.groups.len();
+        let mut active_by_group: Vec<Option<usize>> = vec![None; group_count];
+        let mut spawned_any = false;
+        for tab in saved.into_iter() {
+            let path = std::path::PathBuf::from(&tab.working_directory);
+            if !path.exists() {
+                eprintln!(
+                    "info: skipping restored tab — path no longer exists: {}",
+                    tab.working_directory
+                );
+                continue;
+            }
+            let group_idx = tab.group_index.min(group_count.saturating_sub(1));
+            // `spawn_tab_in` always lands in the focused group, so
+            // we move focus first then restore the saved focus
+            // index after the loop.
+            self.focused_group = group_idx;
+            let title = SharedString::from(tab.title);
+            let auto = tab.auto_type.map(SharedString::from);
+            self.spawn_tab_in(Some(path), Some(title), auto, window, cx);
+            spawned_any = true;
+            if tab.active_in_group {
+                let new_idx = self.groups[group_idx].tabs.len() - 1;
+                active_by_group[group_idx] = Some(new_idx);
+            }
+        }
+        if !spawned_any {
+            // Every saved path was missing — fall back to cold-start
+            // so the user gets *something*.
+            self.spawn_tab(window, cx);
+            return;
+        }
+        // Apply per-group active-tab selections.
+        for (g_idx, active) in active_by_group.iter().enumerate() {
+            if let Some(t_idx) = active
+                && let Some(group) = self.groups.get_mut(g_idx)
+                && *t_idx < group.tabs.len()
+            {
+                group.active_tab = *t_idx;
+            }
+        }
+        // Re-focus the saved focused group's active tab.
+        let focused = self
+            .layout
+            .focused_group_index
+            .min(self.groups.len().saturating_sub(1));
+        if !self.groups[focused].tabs.is_empty() {
+            let active = self.groups[focused].active_tab;
+            self.activate_tab(focused, active, window, cx);
+        }
     }
 
     fn focused_group(&self) -> &Group {
@@ -543,6 +638,11 @@ impl AppShell {
         };
         let font = build_font_config(&self.settings);
 
+        // Clone the resolved working directory before the SpawnConfig
+        // moves it — the Tab keeps its own copy so session-restore
+        // can re-spawn the pty in the same folder later, without
+        // re-resolving via the sidebar (which may have shifted).
+        let working_directory_for_tab = working_directory.clone();
         let backend = match Backend::spawn(SpawnConfig {
             shell,
             working_directory,
@@ -576,7 +676,13 @@ impl AppShell {
         // Capture the entity so an `auto_type` job can write to it
         // without re-borrowing `self.groups` after the await point.
         let terminal_for_autotype = terminal.clone();
-        group.tabs.push(Tab { id, title, terminal });
+        group.tabs.push(Tab {
+            id,
+            title,
+            terminal,
+            working_directory: working_directory_for_tab,
+            auto_type: auto_type.clone(),
+        });
         let new_idx = group.tabs.len() - 1;
         self.activate_tab(group_idx, new_idx, window, cx);
 


### PR DESCRIPTION
## Summary
Persists the user's open tabs to \`layout.json\` and rehydrates them on next launch. Builds on PRs #73 + #74 (group splitter / group rehydration) — the group shape comes back first, then each tab lands in the group it was saved to with the same active-tab selection.

The pty is fresh (it was killed at app shutdown), but \`auto_type\` re-runs the spawn-time command so "New Claude session" comes back as claude.

## Data shape
\`LayoutState\` gains \`open_tabs: Vec<RestoreTab>\`. \`RestoreTab\` carries:

- \`working_directory\` — pty cwd
- \`title\` — tab strip label (free-form, what the user originally saw)
- \`auto_type\` — Some("claude") for agent rows, None for plain shells
- \`group_index\` — which column the tab belongs to
- \`active_in_group\` — flag for the per-group selection

Light enough to round-trip cleanly. Full C# \`Session\` parity (\`agent_session_id\`, \`last_opened\` timestamps, history bookkeeping) is out of scope until the projects.json side moves over.

## Behaviour
- \`Tab\` gains \`working_directory\` + \`auto_type\` fields, recorded on spawn.
- \`save_layout\` snapshots all currently-open tabs into \`open_tabs\` after every spawn / close / move / activate.
- \`AppShell::new\` runs \`rehydrate_or_cold_start\` which walks \`open_tabs\`, drops entries whose path no longer exists, spawns each into the correct group (clamping out-of-range \`group_index\`), and applies the per-group active-tab flag.
- Empty \`open_tabs\` OR every saved path missing → falls through to cold-start so the user isn't staring at empty groups.

(Replaces #77 which had merge conflicts after #74-#76 landed; this is a clean branch on top of latest main.)

## Test plan
- [x] \`cargo build --bin window\` clean
- [x] \`cargo clippy --bin window --all-targets\` — no new warnings
- [x] \`cargo test --workspace\` — 52 passed (\`round_trip\` test now exercises \`open_tabs\` too)
- [ ] Open 3 tabs across 2 groups, close + reopen — same 3 tabs in the same groups
- [ ] One tab is "New Claude session" — comes back with claude running
- [ ] Manually delete one of the saved working directories before reopen — that tab silently drops, others come back
- [ ] Older \`layout.json\` (no \`open_tabs\` field) loads cleanly with single cold-start tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)