### PR TITLE
fix(rs): PR #82 review — security + error handling + docs

### DIFF
--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -46,6 +46,7 @@ windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_Shell",
 ] }
 
 [target.'cfg(windows)'.build-dependencies]

--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -147,8 +147,14 @@ pub fn pull_ff_only(repo: &Path) -> Result<()> {
 }
 
 /// `git config --get remote.origin.url`. Returns the trimmed URL
-/// string, or `Ok(None)` when the remote isn't configured (so
-/// "Open remote in browser" can hide itself instead of erroring).
+/// string, or `Ok(None)` when the remote isn't configured. Other
+/// failure modes (not a git repo, unreadable config, …) bubble up
+/// as `Err` so callers can distinguish "no origin" from "something
+/// is wrong" — collapsing both into `Ok(None)` would mis-report
+/// genuine errors as "no remote" and silently hide them.
+///
+/// Exit-code conventions: `git config --get` returns 1 specifically
+/// for "key not found"; anything else is a real error.
 pub fn remote_origin_url(repo: &Path) -> Result<Option<String>> {
     let output = Command::new("git")
         .args(["config", "--get", "remote.origin.url"])
@@ -158,13 +164,23 @@ pub fn remote_origin_url(repo: &Path) -> Result<Option<String>> {
         .stderr(Stdio::piped())
         .output()
         .with_context(|| "spawn git config")?;
-    if !output.status.success() {
-        // `git config --get` exits 1 when the key is missing — that's
-        // expected (no origin), not an error.
-        return Ok(None);
+    match output.status.code() {
+        Some(0) => {
+            let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if url.is_empty() { Ok(None) } else { Ok(Some(url)) }
+        }
+        // 1 = "the key was not found"; treat as "no origin".
+        Some(1) => Ok(None),
+        // Anything else (128 = not in a git directory, 129 = bad args,
+        // …) is a real error worth surfacing.
+        Some(code) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(anyhow!("git config --get remote.origin.url exited {code}: {stderr}"))
+        }
+        None => Err(anyhow!(
+            "git config --get remote.origin.url terminated by signal"
+        )),
     }
-    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if url.is_empty() { Ok(None) } else { Ok(Some(url)) }
 }
 
 /// Convert a git remote URL (HTTPS or SSH) into a browser URL.
@@ -540,6 +556,38 @@ some-future-field foo bar\n";
         assert_eq!(branches[0].name, "main");
         assert!(!branches[0].is_remote);
     }
+
+    #[test]
+    fn remote_origin_url_returns_none_when_unset() {
+        let Some((_guard, repo, _wts)) = init_repo() else { return };
+        // `init_repo` doesn't configure a remote — this should be the
+        // canonical "no origin" case.
+        let result = remote_origin_url(&repo).expect("call ok");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn remote_origin_url_returns_configured_value() {
+        let Some((_guard, repo, _wts)) = init_repo() else { return };
+        run(
+            &repo,
+            &[
+                "config",
+                "remote.origin.url",
+                "git@github.com:foo/bar.git",
+            ],
+        );
+        let result = remote_origin_url(&repo).expect("call ok");
+        assert_eq!(result.as_deref(), Some("git@github.com:foo/bar.git"));
+    }
+
+    // Note: there's no integration test for the error path (e.g.
+    // a corrupt config file) because reproducing one reliably
+    // across hosts is awkward — `git config --get` outside a repo
+    // can succeed with `Ok(None)` if global config is reachable but
+    // doesn't have the key. The exit-code branching in the source
+    // is small enough that the doc + visual review serves better
+    // than a flaky integration test would.
 
     #[test]
     fn add_worktree_existing_branch_returns_stderr_error() {

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -391,10 +391,12 @@ impl Sidebar {
         self.close_menu(cx);
     }
 
-    /// Copy the branch name of a non-primary worktree to the system
-    /// clipboard. The menu row gates itself on `branch.is_some()` so
-    /// this only runs for tracked-branch worktrees, but we double-
-    /// check anyway. Mirrors C#'s `CopyBranchCommand`.
+    /// Copy the worktree's branch name to the system clipboard. The
+    /// menu row gates itself on `branch.is_some()` so this only
+    /// surfaces when the worktree has a tracked branch (detached
+    /// worktrees skip the row), but we double-check inside in case
+    /// the row is reused from a future entry point. Mirrors C#'s
+    /// `CopyBranchCommand`.
     fn copy_worktree_branch(
         &mut self,
         project_idx: usize,
@@ -445,8 +447,16 @@ impl Sidebar {
     }
 
     /// Resolve the worktree's project remote URL, normalise it to
-    /// a browser URL, and open it via the OS handler. Hidden /
-    /// silent if there's no `origin` remote. Mirrors C#'s
+    /// a browser URL, and open it via the OS handler.
+    ///
+    /// **No-op when there's no `origin` remote** — we log to stderr
+    /// and silently return; the menu row stays visible so the user
+    /// gets a friendly explanation rather than a hidden affordance
+    /// that flickers based on async probe state. The C# build
+    /// gates the row up-front via `HasOriginRemote`; doing the
+    /// equivalent here would require a sync `.git/config` scan on
+    /// every render. We can revisit when there's a project-level
+    /// "git capabilities" cache to back it. Mirrors C#'s
     /// `OpenRemoteRepositoryCommand`.
     fn open_worktree_remote_in_browser(
         &mut self,
@@ -1515,19 +1525,29 @@ fn reveal_path_in_file_browser(path: &str) {
     }
 }
 
-/// Open an HTTP(S) URL in the user's default browser. Uses the
-/// platform-native handler — `start <url>` style on Windows,
-/// `open` on macOS, `xdg-open` on Linux. Detached so a slow
-/// browser launch doesn't stall the UI thread.
+/// Open an HTTP(S) URL in the user's default browser. On Windows
+/// we route through `ShellExecuteW` (via `win32_titlebar::shell_open_url`)
+/// rather than `cmd /C start` — the latter would let any `&` / `|`
+/// in the URL be interpreted as command separators by `cmd.exe`,
+/// which is a command-injection risk for a URL we got out of
+/// `git config`. macOS uses `open`, Linux uses `xdg-open`; both
+/// pass arguments verbatim without shell parsing.
 fn open_url_in_browser(url: &str) {
     #[cfg(target_os = "windows")]
-    let result = Command::new("cmd").args(["/C", "start", "", url]).spawn();
+    {
+        crate::win32_titlebar::shell_open_url(url);
+    }
     #[cfg(target_os = "macos")]
-    let result = Command::new("open").arg(url).spawn();
+    {
+        if let Err(err) = Command::new("open").arg(url).spawn() {
+            eprintln!("warning: failed to open URL in browser: {err:#}");
+        }
+    }
     #[cfg(all(unix, not(target_os = "macos")))]
-    let result = Command::new("xdg-open").arg(url).spawn();
-    if let Err(err) = result {
-        eprintln!("warning: failed to open URL in browser: {err:#}");
+    {
+        if let Err(err) = Command::new("xdg-open").arg(url).spawn() {
+            eprintln!("warning: failed to open URL in browser: {err:#}");
+        }
     }
 }
 

--- a/codescope-rs/src/win32_titlebar.rs
+++ b/codescope-rs/src/win32_titlebar.rs
@@ -24,10 +24,12 @@ use gpui::Window;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
 use windows::Win32::UI::Input::KeyboardAndMouse::ReleaseCapture;
+use windows::Win32::UI::Shell::ShellExecuteW;
 use windows::Win32::UI::WindowsAndMessaging::{
-    HTCAPTION, IsZoomed, SC_CLOSE, SC_MAXIMIZE, SC_MINIMIZE, SC_RESTORE, SendMessageW,
-    WM_NCLBUTTONDOWN, WM_SYSCOMMAND,
+    HTCAPTION, IsZoomed, SC_CLOSE, SC_MAXIMIZE, SC_MINIMIZE, SC_RESTORE, SW_SHOWNORMAL,
+    SendMessageW, WM_NCLBUTTONDOWN, WM_SYSCOMMAND,
 };
+use windows::core::HSTRING;
 
 /// Best-effort HWND extraction. Returns `None` when the window is
 /// in a state where the platform handle isn't available — caller
@@ -105,6 +107,28 @@ pub fn close(window: &Window) {
             WM_SYSCOMMAND,
             Some(WPARAM(SC_CLOSE as usize)),
             Some(LPARAM(0)),
+        );
+    }
+}
+
+/// Open a URL via `ShellExecuteW` ("open" verb). This is the
+/// shell-injection-safe path: `cmd /C start <url>` would let
+/// metacharacters in the URL (`&`, `|`, …) be interpreted as
+/// command separators by `cmd.exe`. ShellExecuteW takes the URL
+/// as an opaque wide string and routes it through the registered
+/// protocol handler without going through a shell — same model
+/// `start` would use under the hood, minus the cmd.exe parsing.
+pub fn shell_open_url(url: &str) {
+    let url_wide = HSTRING::from(url);
+    let verb_wide = HSTRING::from("open");
+    unsafe {
+        let _ = ShellExecuteW(
+            None,
+            &verb_wide,
+            &url_wide,
+            None,
+            None,
+            SW_SHOWNORMAL,
         );
     }
 }


### PR DESCRIPTION
Address 5 Copilot review threads on the now-merged PR #82.

1. **Security**: `open_url_in_browser` on Windows used `cmd /C start <url>`, which is command-injection-prone for a URL pulled from git config. Switch to `ShellExecuteW` via a new `win32_titlebar::shell_open_url` helper — opaque wide string, no shell parsing.
2. **Doc accuracy**: `open_worktree_remote_in_browser` doc claimed the row was hidden when no origin exists; it actually no-ops at click. Updated doc + rationale.
3. **Error handling**: `remote_origin_url` now distinguishes exit code 1 (key missing → `Ok(None)`) from anything else (`Err` with stderr).
4. **Tests**: 2 new integration tests (none-when-unset, configured-value). Skipped the non-repo error test — `git config --get` outside a repo can still succeed via global config, so the test is host-dependent; comment in source explains.
5. **Doc accuracy**: `copy_worktree_branch` doc reworded to match the actual gate (tracked branch, not "non-primary").