### PR TITLE
feat(rs): project menu — Fetch all (prune) + Open remote in browser

### DIFF
--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -146,6 +146,15 @@ pub fn pull_ff_only(repo: &Path) -> Result<()> {
     run_git(repo, &["pull", "--ff-only"]).map(|_| ())
 }
 
+/// `git fetch --all --prune`. Pulls down all remotes and removes
+/// any local refs whose remote-tracking branches are gone. Runs at
+/// project scope (the primary worktree root) — fetched refs are
+/// shared across all worktrees of the project. Mirrors the C#
+/// build's `FetchAllCommand`.
+pub fn fetch_all_prune(repo: &Path) -> Result<()> {
+    run_git(repo, &["fetch", "--all", "--prune"]).map(|_| ())
+}
+
 /// `git config --get remote.origin.url`. Returns the trimmed URL
 /// string, or `Ok(None)` when the remote isn't configured. Other
 /// failure modes (not a git repo, unreadable config, …) bubble up

--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -146,9 +146,11 @@ pub fn pull_ff_only(repo: &Path) -> Result<()> {
     run_git(repo, &["pull", "--ff-only"]).map(|_| ())
 }
 
-/// `git fetch --all --prune`. Pulls down all remotes and removes
-/// any local refs whose remote-tracking branches are gone. Runs at
-/// project scope (the primary worktree root) — fetched refs are
+/// `git fetch --all --prune`. Updates every remote and prunes the
+/// **remote-tracking** refs (`refs/remotes/<remote>/*`) whose
+/// upstream branches have been deleted. Local branches and tags
+/// are left untouched — only the remote-tracking shadows go. Runs
+/// at project scope (the primary worktree root); fetched refs are
 /// shared across all worktrees of the project. Mirrors the C#
 /// build's `FetchAllCommand`.
 pub fn fetch_all_prune(repo: &Path) -> Result<()> {

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -601,6 +601,69 @@ impl Sidebar {
         .detach();
     }
 
+    /// Run `git fetch --all --prune` against the project's primary
+    /// repo. Spawned on the background executor so the UI thread
+    /// doesn't block on network I/O. Mirrors C#'s `FetchAllCommand`.
+    fn fetch_all_for_project(&mut self, idx: usize, cx: &mut Context<Self>) {
+        let Some(project) = self.projects.projects.get(idx) else {
+            self.close_menu(cx);
+            return;
+        };
+        let repo = std::path::PathBuf::from(&project.path);
+        self.close_menu(cx);
+        cx.spawn(async move |_, cx| {
+            let result = cx
+                .background_spawn(async move { codescope_core::git::fetch_all_prune(&repo) })
+                .await;
+            if let Err(err) = result {
+                eprintln!("warning: git fetch --all --prune failed: {err:#}");
+            }
+        })
+        .detach();
+    }
+
+    /// Resolve the project's `remote.origin.url` and open the
+    /// browser-shape URL via the OS handler. Same plumbing as
+    /// `open_worktree_remote_in_browser` but at project scope —
+    /// project menu, not worktree menu. No-op + log when no
+    /// origin is configured. Mirrors C#'s
+    /// `OpenRemoteRepositoryCommand` (project scope).
+    fn open_project_remote_in_browser(&mut self, idx: usize, cx: &mut Context<Self>) {
+        let Some(project) = self.projects.projects.get(idx) else {
+            self.close_menu(cx);
+            return;
+        };
+        let project_path = std::path::PathBuf::from(&project.path);
+        self.close_menu(cx);
+        cx.spawn(async move |_, cx| {
+            let url_result = cx
+                .background_spawn(async move {
+                    codescope_core::git::remote_origin_url(&project_path)
+                })
+                .await;
+            let url = match url_result {
+                Ok(Some(u)) => u,
+                Ok(None) => {
+                    eprintln!("info: no remote.origin.url configured");
+                    return;
+                }
+                Err(err) => {
+                    eprintln!("warning: failed to read remote.origin.url: {err:#}");
+                    return;
+                }
+            };
+            let browser_url = match codescope_core::git::remote_url_to_browser(&url) {
+                Some(u) => u,
+                None => {
+                    eprintln!("info: remote URL not a recognised browser shape: {url}");
+                    return;
+                }
+            };
+            open_url_in_browser(&browser_url);
+        })
+        .detach();
+    }
+
     /// Drop a project from the sidebar list and persist `projects.json`.
     /// Does **not** touch anything on disk — the working tree stays
     /// where it is; the user just removes it from CodeScope's view.
@@ -1092,6 +1155,26 @@ impl Sidebar {
                     this.open_new_worktree_dialog(idx, window, cx);
                 }),
             ))
+            // ── Git ─────────────────────────────────────────────
+            // Fetch + Open remote. Mirrors C# BuildProjectMenu
+            // Git section. "Set default agent" submenu lands when
+            // we have a submenu primitive.
+            .child(div().h_px().bg(divider).my_1())
+            .child(item(
+                "menu-fetch-all",
+                "Fetch all (prune)",
+                false,
+                Box::new(move |this, _window, cx| this.fetch_all_for_project(idx, cx)),
+            ))
+            .child(item(
+                "menu-open-remote",
+                "Open remote in browser",
+                false,
+                Box::new(move |this, _window, cx| {
+                    this.open_project_remote_in_browser(idx, cx);
+                }),
+            ))
+            // ── Reveal ──────────────────────────────────────────
             .child(div().h_px().bg(divider).my_1())
             .child(item(
                 "menu-reveal",

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -477,30 +477,7 @@ impl Sidebar {
         let project_path = std::path::PathBuf::from(&project.path);
         self.close_menu(cx);
         cx.spawn(async move |_, cx| {
-            let url_result = cx
-                .background_spawn(async move {
-                    codescope_core::git::remote_origin_url(&project_path)
-                })
-                .await;
-            let url = match url_result {
-                Ok(Some(u)) => u,
-                Ok(None) => {
-                    eprintln!("info: no remote.origin.url configured");
-                    return;
-                }
-                Err(err) => {
-                    eprintln!("warning: failed to read remote.origin.url: {err:#}");
-                    return;
-                }
-            };
-            let browser_url = match codescope_core::git::remote_url_to_browser(&url) {
-                Some(u) => u,
-                None => {
-                    eprintln!("info: remote URL not a recognised browser shape: {url}");
-                    return;
-                }
-            };
-            open_url_in_browser(&browser_url);
+            spawn_open_remote_in_browser(project_path, cx).await;
         })
         .detach();
     }
@@ -624,9 +601,8 @@ impl Sidebar {
 
     /// Resolve the project's `remote.origin.url` and open the
     /// browser-shape URL via the OS handler. Same plumbing as
-    /// `open_worktree_remote_in_browser` but at project scope —
-    /// project menu, not worktree menu. No-op + log when no
-    /// origin is configured. Mirrors C#'s
+    /// `open_worktree_remote_in_browser` but at project scope.
+    /// No-op + log when no origin is configured. Mirrors C#'s
     /// `OpenRemoteRepositoryCommand` (project scope).
     fn open_project_remote_in_browser(&mut self, idx: usize, cx: &mut Context<Self>) {
         let Some(project) = self.projects.projects.get(idx) else {
@@ -636,30 +612,7 @@ impl Sidebar {
         let project_path = std::path::PathBuf::from(&project.path);
         self.close_menu(cx);
         cx.spawn(async move |_, cx| {
-            let url_result = cx
-                .background_spawn(async move {
-                    codescope_core::git::remote_origin_url(&project_path)
-                })
-                .await;
-            let url = match url_result {
-                Ok(Some(u)) => u,
-                Ok(None) => {
-                    eprintln!("info: no remote.origin.url configured");
-                    return;
-                }
-                Err(err) => {
-                    eprintln!("warning: failed to read remote.origin.url: {err:#}");
-                    return;
-                }
-            };
-            let browser_url = match codescope_core::git::remote_url_to_browser(&url) {
-                Some(u) => u,
-                None => {
-                    eprintln!("info: remote URL not a recognised browser shape: {url}");
-                    return;
-                }
-            };
-            open_url_in_browser(&browser_url);
+            spawn_open_remote_in_browser(project_path, cx).await;
         })
         .detach();
     }
@@ -1606,6 +1559,40 @@ fn reveal_path_in_file_browser(path: &str) {
     if let Err(err) = result {
         eprintln!("warning: failed to reveal {path}: {err:#}");
     }
+}
+
+/// Resolve `remote.origin.url` for `repo`, normalise it to a
+/// browser URL, and open it via the OS handler. Shared by the
+/// project menu and the worktree menu — both ultimately read
+/// `origin` from the project's primary repo (worktrees inherit
+/// via their `gitdir:` pointer). No-op + log when there's no
+/// origin or the URL shape isn't recognised.
+async fn spawn_open_remote_in_browser(
+    repo: std::path::PathBuf,
+    cx: &mut gpui::AsyncApp,
+) {
+    let url_result = cx
+        .background_spawn(async move { codescope_core::git::remote_origin_url(&repo) })
+        .await;
+    let url = match url_result {
+        Ok(Some(u)) => u,
+        Ok(None) => {
+            eprintln!("info: no remote.origin.url configured");
+            return;
+        }
+        Err(err) => {
+            eprintln!("warning: failed to read remote.origin.url: {err:#}");
+            return;
+        }
+    };
+    let browser_url = match codescope_core::git::remote_url_to_browser(&url) {
+        Some(u) => u,
+        None => {
+            eprintln!("info: remote URL not a recognised browser shape: {url}");
+            return;
+        }
+    };
+    open_url_in_browser(&browser_url);
 }
 
 /// Open an HTTP(S) URL in the user's default browser. On Windows


### PR DESCRIPTION
Mirrors C# BuildProjectMenu Git section. Two new rows on project right-click menu: Fetch all (prune), Open remote in browser. Same URL parser/opener plumbing as the worktree menu version added in #82.