### PR TITLE
feat(rs): worktree dirty-state polling + sidebar status dot

### DIFF
--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -146,6 +146,16 @@ pub fn pull_ff_only(repo: &Path) -> Result<()> {
     run_git(repo, &["pull", "--ff-only"]).map(|_| ())
 }
 
+/// `git status --porcelain` — empty stdout means a clean worktree
+/// (no staged, unstaged, or untracked changes), anything else
+/// means dirty. Cheap enough to poll a couple of times per second
+/// per worktree without blowing the I/O budget. Mirrors C#'s
+/// `WorktreePoller.IsDirtyAsync`.
+pub fn is_dirty(repo: &Path) -> Result<bool> {
+    let output = run_git(repo, &["status", "--porcelain"])?;
+    Ok(!output.stdout.is_empty())
+}
+
 /// `git fetch --all --prune`. Updates every remote and prunes the
 /// **remote-tracking** refs (`refs/remotes/<remote>/*`) whose
 /// upstream branches have been deleted. Local branches and tags

--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -611,6 +611,31 @@ some-future-field foo bar\n";
     // than a flaky integration test would.
 
     #[test]
+    fn is_dirty_false_on_freshly_initialised_repo() {
+        let Some((_guard, repo, _wts)) = init_repo() else { return };
+        assert!(!is_dirty(&repo).expect("call ok"));
+    }
+
+    #[test]
+    fn is_dirty_true_after_creating_an_untracked_file() {
+        let Some((_guard, repo, _wts)) = init_repo() else { return };
+        std::fs::write(repo.join("dirty.txt"), b"hello").expect("write");
+        assert!(is_dirty(&repo).expect("call ok"));
+    }
+
+    #[test]
+    fn is_dirty_true_after_modifying_tracked_file() {
+        let Some((_guard, repo, _wts)) = init_repo() else { return };
+        // Commit a file first so it's tracked, then modify it.
+        std::fs::write(repo.join("README"), b"v1").expect("write");
+        run(&repo, &["add", "README"]);
+        run(&repo, &["commit", "-m", "add README", "-q"]);
+        assert!(!is_dirty(&repo).expect("clean after commit"));
+        std::fs::write(repo.join("README"), b"v2").expect("write");
+        assert!(is_dirty(&repo).expect("dirty after modify"));
+    }
+
+    #[test]
     fn add_worktree_existing_branch_returns_stderr_error() {
         let Some((_guard, repo, wts_root)) = init_repo() else { return };
         let wt1 = wts_root.join("dup-1");

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -314,8 +314,15 @@ impl AppShell {
         // sidebar writes (and vice versa). Two writers to the same
         // file is acceptable — both go through the same atomic write
         // wrapper, last-writer-wins on order.
-        let sidebar = cx.new(|_| {
-            Sidebar::new(projects, layout.clone(), theme.clone(), paths.clone())
+        let sidebar = cx.new(|cx| {
+            let sidebar =
+                Sidebar::new(projects, layout.clone(), theme.clone(), paths.clone());
+            // Kick off the per-worktree dirty-state poll. Has to be
+            // called from inside the `cx.new` callback because that's
+            // where we have a `Context<Sidebar>` to register the
+            // background task against.
+            sidebar.start_dirty_poll(cx);
+            sidebar
         });
 
         // Spawn a tab whenever the sidebar asks us to — fired by a

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -23,9 +23,11 @@
 //! └───────────────┘
 //! ```
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
+use std::time::Duration;
 
 use codescope_core::{AppPaths, LayoutState, Project, ProjectsConfig, Theme};
 use gpui::{
@@ -36,6 +38,14 @@ use gpui::{
 
 use crate::new_worktree_dialog::NewWorktreeDialogState;
 use crate::theme;
+
+/// How often the dirty-state poller wakes up. 5 s is well under
+/// the user's reaction-to-edit window (most workflows save +
+/// glance at the sidebar within 1-2 seconds), and well over the
+/// per-call I/O budget of `git status --porcelain` even on
+/// thousand-file repos. Mirrors the C# build's
+/// `WorktreePoller.Interval`.
+const DIRTY_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Default sidebar width when none is persisted in `layout.json`.
 /// Mirrors the C# build's initial 240 px. The actual rendered width
@@ -130,6 +140,13 @@ pub struct Sidebar {
     /// At most one dialog at a time — opening another would race
     /// against an in-flight `git worktree add` call from the first.
     dialog: Option<NewWorktreeDialogState>,
+    /// Per-worktree clean/dirty state, keyed by absolute path.
+    /// Updated by the background poller spawned in `Sidebar::new`;
+    /// `None` = unknown (still loading), `Some(true)` = dirty,
+    /// `Some(false)` = clean. The render loop maps that to a tiny
+    /// status dot next to each worktree row. Mirrors C# build's
+    /// `WorktreePoller` cache.
+    dirty_state: HashMap<String, bool>,
 }
 
 impl Sidebar {
@@ -147,7 +164,91 @@ impl Sidebar {
             None => None,
         }
         .or_else(|| (!projects.projects.is_empty()).then_some(0));
-        Self { projects, selected, theme, paths, layout, menu: None, dialog: None }
+        Self {
+            projects,
+            selected,
+            theme,
+            paths,
+            layout,
+            menu: None,
+            dialog: None,
+            dirty_state: HashMap::new(),
+        }
+    }
+
+    /// Spawn the dirty-state polling loop. Runs every
+    /// `DIRTY_POLL_INTERVAL` and walks every known worktree path,
+    /// running `git status --porcelain`. Per-call latency is in the
+    /// 10–50 ms range on small repos, low single-digit seconds on
+    /// large ones — both well below the poll interval. The loop
+    /// dies when the entity drops (`update` returns Err). Mirrors
+    /// the C# build's `WorktreePoller`.
+    ///
+    /// Called from `AppShell::new` after the entity is constructed;
+    /// can't run inside `Sidebar::new` itself because we don't have
+    /// `cx.spawn` access until we're past the constructor.
+    pub fn start_dirty_poll(&self, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor().timer(DIRTY_POLL_INTERVAL).await;
+                if this.upgrade().is_none() {
+                    break;
+                }
+                // Snapshot every worktree path under each project so
+                // the background `git status` calls don't pin an
+                // entity borrow.
+                let paths: Vec<String> = match this.update(cx, |this, _| {
+                    this.projects
+                        .projects
+                        .iter()
+                        .flat_map(|p| {
+                            // Primary path counts too — the Sidebar
+                            // only renders non-primary worktrees, but
+                            // we still want the dirty-state cache
+                            // populated for the project row's
+                            // worktree.
+                            std::iter::once(p.path.clone()).chain(
+                                p.worktrees.iter().map(|wt| wt.path.clone()),
+                            )
+                        })
+                        .collect()
+                }) {
+                    Ok(p) => p,
+                    Err(_) => break,
+                };
+                let updates: Vec<(String, bool)> = cx
+                    .background_spawn(async move {
+                        paths
+                            .into_iter()
+                            .filter_map(|p| {
+                                let path = std::path::PathBuf::from(&p);
+                                codescope_core::git::is_dirty(&path)
+                                    .ok()
+                                    .map(|dirty| (p, dirty))
+                            })
+                            .collect()
+                    })
+                    .await;
+                if this
+                    .update(cx, |this, cx| {
+                        let mut changed = false;
+                        for (path, dirty) in updates {
+                            let prev = this.dirty_state.insert(path, dirty);
+                            if prev != Some(dirty) {
+                                changed = true;
+                            }
+                        }
+                        if changed {
+                            cx.notify();
+                        }
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        })
+        .detach();
     }
 
     /// Read-only handle to the in-memory project list. Exposed so the
@@ -876,6 +977,15 @@ impl Render for Sidebar {
                 ));
                 let frost_hover = theme::frost_10(&theme);
                 let ink_hover = theme::ink(&theme);
+                // Resolve dirty-state for this worktree. `None` (still
+                // loading) gets a dim ghost dot; `Some(false)` (clean)
+                // a small accent-coloured dot; `Some(true)` (dirty) a
+                // warning-coloured dot.
+                let dirty_dot_color = match self.dirty_state.get(&wt.path) {
+                    Some(true) => theme::status_dirty(&theme),
+                    Some(false) => theme::status_clean(&theme),
+                    None => theme::ink_ghost(&theme),
+                };
                 let wt_row = div()
                     .id(("worktree", id_hash(&wt.id)))
                     .h(px(28.0))
@@ -884,6 +994,7 @@ impl Render for Sidebar {
                     .items_center()
                     .pl(px(34.0)) // align under the project text past the rail + indent
                     .pr_3()
+                    .gap_2()
                     .text_color(theme::ink_ghost(&theme))
                     .text_size(px(12.0))
                     .cursor_pointer()
@@ -911,6 +1022,13 @@ impl Render for Sidebar {
                                 );
                             }
                         }),
+                    )
+                    .child(
+                        div()
+                            .w(px(6.0))
+                            .h(px(6.0))
+                            .rounded_full()
+                            .bg(dirty_dot_color),
                     )
                     .child(div().flex_grow().truncate().child(wt_label));
                 project_and_worktree_rows.push(wt_row.into_any_element());

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -141,10 +141,14 @@ pub struct Sidebar {
     /// against an in-flight `git worktree add` call from the first.
     dialog: Option<NewWorktreeDialogState>,
     /// Per-worktree clean/dirty state, keyed by absolute path.
-    /// Updated by the background poller spawned in `Sidebar::new`;
-    /// `None` = unknown (still loading), `Some(true)` = dirty,
-    /// `Some(false)` = clean. The render loop maps that to a tiny
-    /// status dot next to each worktree row. Mirrors C# build's
+    /// Updated by the background poller spawned via
+    /// `start_dirty_poll`, which `AppShell::new` calls from inside
+    /// the `cx.new(|cx| { … })` closure that builds the Sidebar
+    /// entity (we can't call it from `Sidebar::new` itself because
+    /// that signature has no `Context<Sidebar>`). `None` = unknown
+    /// (still loading), `Some(true)` = dirty, `Some(false)` =
+    /// clean. The render loop maps that to a tiny status dot next
+    /// to each worktree row. Mirrors the C# build's
     /// `WorktreePoller` cache.
     dirty_state: HashMap<String, bool>,
 }
@@ -194,10 +198,11 @@ impl Sidebar {
                 if this.upgrade().is_none() {
                     break;
                 }
-                // Snapshot every worktree path under each project so
-                // the background `git status` calls don't pin an
-                // entity borrow.
-                let paths: Vec<String> = match this.update(cx, |this, _| {
+                // Snapshot every worktree path under each project
+                // into a `HashSet` so duplicates (primary worktree
+                // also listed under `worktrees`, two projects sharing
+                // a path, …) only run `git status` once per tick.
+                let paths: std::collections::HashSet<String> = match this.update(cx, |this, _| {
                     this.projects
                         .projects
                         .iter()
@@ -216,6 +221,7 @@ impl Sidebar {
                     Ok(p) => p,
                     Err(_) => break,
                 };
+                let known: std::collections::HashSet<String> = paths.clone();
                 let updates: Vec<(String, bool)> = cx
                     .background_spawn(async move {
                         paths
@@ -232,6 +238,15 @@ impl Sidebar {
                 if this
                     .update(cx, |this, cx| {
                         let mut changed = false;
+                        // Prune cache entries for paths that no longer
+                        // exist in the current project list — projects
+                        // / worktrees can be removed between ticks and
+                        // the map would otherwise grow stale.
+                        let prev_len = this.dirty_state.len();
+                        this.dirty_state.retain(|path, _| known.contains(path));
+                        if this.dirty_state.len() != prev_len {
+                            changed = true;
+                        }
                         for (path, dirty) in updates {
                             let prev = this.dirty_state.insert(path, dirty);
                             if prev != Some(dirty) {

--- a/codescope-rs/src/theme.rs
+++ b/codescope-rs/src/theme.rs
@@ -77,6 +77,16 @@ pub fn ink_ghost(theme: &Theme) -> Hsla { with_alpha(theme.chrome.ink, 0.40) }
 /// reads as "running" in every dark theme we ship. Themable later.
 pub fn status_running() -> Hsla { rgb_to_hsla(Rgb::from_hex(0x22c55e)) }
 
+/// Worktree dirty indicator. Amber, distinct enough from
+/// `status_running` (green) and `danger` (red) that the user can
+/// tell at a glance.
+pub fn status_dirty(_theme: &Theme) -> Hsla { rgb_to_hsla(Rgb::from_hex(0xf5a623)) }
+
+/// Worktree clean indicator. Reuses the accent colour so a fully-
+/// clean worktree visually rhymes with the focus / accent rail
+/// elsewhere in the chrome.
+pub fn status_clean(theme: &Theme) -> Hsla { accent(theme) }
+
 /// Foreground for destructive context-menu entries ("Remove project",
 /// "Discard changes…"). Mirrors `Ctx.Color.Danger` from the C# build's
 /// `ContextMenuStyles.xaml`. Hard-coded — a danger red that reads


### PR DESCRIPTION
5s background poll runs git status --porcelain on every known worktree, feeds a HashMap<String,bool> on Sidebar, drives a 6×6 dot per worktree row (ink_ghost loading / accent clean / amber dirty). Mirrors C# WorktreePoller. Self-terminates when entity drops; only notifies on actual state change. core/git.rs gains is_dirty(repo). Conflicts / ahead-behind / per-status colours land later.