### PR TITLE
feat(rs): worktree menu — Discard changes (dirty-aware, prompt-confirmed)

### DIFF
--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -146,6 +146,16 @@ pub fn pull_ff_only(repo: &Path) -> Result<()> {
     run_git(repo, &["pull", "--ff-only"]).map(|_| ())
 }
 
+/// Drop every uncommitted change in the worktree: `git reset --hard
+/// HEAD` resets tracked files, then `git clean -fd` removes untracked
+/// files and directories. Destructive — callers must confirm with
+/// the user first. Mirrors the C# build's `DiscardChangesCommand`.
+pub fn discard_all_changes(repo: &Path) -> Result<()> {
+    run_git(repo, &["reset", "--hard", "HEAD"])?;
+    run_git(repo, &["clean", "-fd"])?;
+    Ok(())
+}
+
 /// `git status --porcelain` — empty stdout means a clean worktree
 /// (no staged, unstaged, or untracked changes), anything else
 /// means dirty. Cheap enough to poll a couple of times per second
@@ -633,6 +643,27 @@ some-future-field foo bar\n";
         assert!(!is_dirty(&repo).expect("clean after commit"));
         std::fs::write(repo.join("README"), b"v2").expect("write");
         assert!(is_dirty(&repo).expect("dirty after modify"));
+    }
+
+    #[test]
+    fn discard_all_changes_resets_tracked_and_drops_untracked() {
+        let Some((_guard, repo, _wts)) = init_repo() else { return };
+        // Track a file then modify it; create an untracked file too.
+        std::fs::write(repo.join("tracked.txt"), b"v1").expect("write");
+        run(&repo, &["add", "tracked.txt"]);
+        run(&repo, &["commit", "-m", "add tracked", "-q"]);
+        std::fs::write(repo.join("tracked.txt"), b"v2").expect("write");
+        std::fs::write(repo.join("untracked.txt"), b"junk").expect("write");
+        assert!(is_dirty(&repo).expect("dirty before discard"));
+
+        discard_all_changes(&repo).expect("discard");
+
+        assert!(!is_dirty(&repo).expect("clean after discard"));
+        // tracked.txt back to v1
+        let body = std::fs::read_to_string(repo.join("tracked.txt")).expect("read");
+        assert_eq!(body, "v1");
+        // untracked.txt gone
+        assert!(!repo.join("untracked.txt").exists());
     }
 
     #[test]

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -618,6 +618,27 @@ impl Sidebar {
     /// up-front means we don't have to re-borrow `self.projects` after
     /// the await point — the worktree may have moved or vanished by
     /// then.
+    /// Friendly user-facing label for a worktree — branch name when
+    /// tracked, otherwise the folder leaf. Used by every prompt /
+    /// confirm dialog that names a worktree (Remove, Discard, …)
+    /// so the strings stay consistent across actions.
+    fn worktree_display_label(&self, project_idx: usize, worktree_id: &str) -> Option<String> {
+        let wt = self
+            .projects
+            .projects
+            .get(project_idx)?
+            .worktrees
+            .iter()
+            .find(|wt| wt.id == worktree_id)?;
+        Some(wt.branch.clone().unwrap_or_else(|| {
+            std::path::Path::new(&wt.path)
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| wt.path.clone())
+        }))
+    }
+
     fn worktree_remove_context(
         &self,
         project_idx: usize,
@@ -628,22 +649,15 @@ impl Sidebar {
         if wt.is_primary {
             return None;
         }
-        let label = wt
-            .branch
-            .clone()
-            .unwrap_or_else(|| {
-                std::path::Path::new(&wt.path)
-                    .file_name()
-                    .and_then(|s| s.to_str())
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| wt.path.clone())
-            });
+        let display_label = self
+            .worktree_display_label(project_idx, worktree_id)
+            .unwrap_or_else(|| wt.path.clone());
         Some(WorktreeRemoveContext {
             project_id: project.id.clone(),
             worktree_id: wt.id.clone(),
             project_path: project.path.clone(),
             worktree_path: wt.path.clone(),
-            display_label: label,
+            display_label,
         })
     }
 
@@ -662,21 +676,12 @@ impl Sidebar {
             self.close_menu(cx);
             return;
         };
-        // Build a friendly label for the prompt — branch name when
-        // we have one, folder leaf otherwise.
+        // Friendly label for the prompt — shared with the rest of
+        // the worktree-action surface so wording stays consistent
+        // (`Remove worktree '<label>'?` and `Discard all changes
+        // in '<label>'?` line up).
         let label = self
-            .projects
-            .projects
-            .get(project_idx)
-            .and_then(|p| p.worktrees.iter().find(|wt| wt.id == worktree_id))
-            .and_then(|wt| {
-                wt.branch.clone().or_else(|| {
-                    std::path::Path::new(&wt.path)
-                        .file_name()
-                        .and_then(|s| s.to_str())
-                        .map(|s| s.to_string())
-                })
-            })
+            .worktree_display_label(project_idx, worktree_id)
             .unwrap_or_else(|| "this worktree".into());
         self.close_menu(cx);
         let prompt_msg = format!("Discard all changes in '{label}'?");

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -647,6 +647,70 @@ impl Sidebar {
         })
     }
 
+    /// Confirm-then-run `git reset --hard HEAD` + `git clean -fd`
+    /// for a worktree. Destructive — uses a `Critical`-level prompt
+    /// so the user has to actively confirm. Mirrors C#'s
+    /// `DiscardChangesCommand`.
+    fn discard_worktree_changes(
+        &mut self,
+        project_idx: usize,
+        worktree_id: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(path) = self.worktree_path(project_idx, worktree_id) else {
+            self.close_menu(cx);
+            return;
+        };
+        // Build a friendly label for the prompt — branch name when
+        // we have one, folder leaf otherwise.
+        let label = self
+            .projects
+            .projects
+            .get(project_idx)
+            .and_then(|p| p.worktrees.iter().find(|wt| wt.id == worktree_id))
+            .and_then(|wt| {
+                wt.branch.clone().or_else(|| {
+                    std::path::Path::new(&wt.path)
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s.to_string())
+                })
+            })
+            .unwrap_or_else(|| "this worktree".into());
+        self.close_menu(cx);
+        let prompt_msg = format!("Discard all changes in '{label}'?");
+        let detail = format!(
+            "Path: {path}\n\nThis runs `git reset --hard HEAD` followed \
+             by `git clean -fd`. Untracked files and modifications to \
+             tracked files will be lost — there's no undo."
+        );
+        let rx = window.prompt(
+            gpui::PromptLevel::Critical,
+            &prompt_msg,
+            Some(&detail),
+            &["Discard", "Cancel"],
+            cx,
+        );
+        let path = std::path::PathBuf::from(path);
+        cx.spawn(async move |_, cx| {
+            // 0 = first button ("Discard"). Anything else = cancel.
+            match rx.await {
+                Ok(0) => {}
+                _ => return,
+            }
+            let result = cx
+                .background_spawn(
+                    async move { codescope_core::git::discard_all_changes(&path) },
+                )
+                .await;
+            if let Err(err) = result {
+                eprintln!("warning: discard_all_changes failed: {err:#}");
+            }
+        })
+        .detach();
+    }
+
     /// Drop a non-primary worktree from this project. Calls
     /// `git worktree remove` (force=false first; on failure prompts
     /// the user before retrying with `--force`), then rewrites
@@ -1497,6 +1561,32 @@ impl Sidebar {
                     }),
                 )
             })
+            // "Discard changes…" — only surface when the dirty
+            // poller has flagged this worktree as having changes;
+            // for clean / unknown worktrees the action would be a
+            // no-op + scary prompt, so hide the row entirely.
+            .children(
+                self.dirty_state
+                    .get(&worktree.path)
+                    .copied()
+                    .unwrap_or(false)
+                    .then(|| {
+                        let id_for_discard = worktree_id.clone();
+                        item(
+                            "wt-menu-discard",
+                            "Discard changes…",
+                            true,
+                            Box::new(move |this, window, cx| {
+                                this.discard_worktree_changes(
+                                    project_idx,
+                                    &id_for_discard,
+                                    window,
+                                    cx,
+                                );
+                            }),
+                        )
+                    }),
+            )
             // ── Reveal ──────────────────────────────────────────
             .child(div().h_px().bg(divider).my_1())
             .child({


### PR DESCRIPTION
Adds 'Discard changes…' to the worktree right-click menu. Hidden on clean worktrees (no-op + scary prompt mismatch); on dirty surfaces with a Critical-level confirm prompt before running git reset --hard HEAD + git clean -fd. Dirty poller picks up the cleared state on next tick. core/git.rs gains discard_all_changes() with full integration test.