### PR TITLE
feat(rs): persistent notifications + popover

### DIFF
--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -47,6 +47,7 @@ windows = { version = "0.61", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",
+    "Win32_System_SystemInformation",
 ] }
 
 [target.'cfg(windows)'.build-dependencies]

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -387,6 +387,12 @@ pub struct AppShell {
     /// double-clicks are 100 ms+ apart. Anything under 10 ms is
     /// treated as the synthetic echo and ignored.
     last_titlebar_press_at: Option<std::time::Instant>,
+    /// Persistent notification ring buffer + popover visibility state.
+    /// Mirrors `INotificationService` / `NotificationService` from the
+    /// C# build.  The bell button (landing in the integrating PR) calls
+    /// `notifications.toggle()` and the render calls
+    /// `render_notifications_popover` alongside `render_toasts`.
+    pub(crate) notifications: crate::notifications::Notifications,
 }
 
 impl AppShell {
@@ -648,6 +654,7 @@ impl AppShell {
             theme,
             sidebar,
             last_titlebar_press_at: None,
+            notifications: crate::notifications::Notifications::new(),
         };
         shell.rehydrate_or_cold_start(window, cx);
         shell
@@ -1327,6 +1334,258 @@ impl AppShell {
         )
     }
 
+    /// Build the floating notifications popover.  Anchored bottom-right
+    /// (same corner as the toast stack), deferred so it paints over all
+    /// chrome.  Returns `None` when the popover is closed so the root
+    /// render's `.children(...)` stays an empty iterator.
+    ///
+    /// Geometry mirrors `BellPopup` in `StatusBarView.xaml` exactly:
+    /// - 360 px wide, max-height 420 px
+    /// - Header: 14 l / 12 t / 10 r / 10 b — title + conditional "Clear"
+    /// - Entry rows: 14 l/r, 10 t/b, 1 px top divider between consecutive rows
+    /// - Kind dot: 6×6, `margin-top: 5`, `margin-right: 10`, top-aligned
+    /// - Footer: 14 l/r, 8 t/b, 1 px top border, dim hint text
+    fn render_notifications_popover(
+        &self,
+        theme: &Arc<Theme>,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        if !self.notifications.is_open() {
+            return None;
+        }
+
+        let elevated = theme::elevated(theme);
+        let divider = theme::divider(theme);
+        let ink = theme::ink(theme);
+        let ink_dim = theme::ink_dim(theme);
+        let ink_muted = theme::ink_muted(theme);
+        let frost = theme::frost_10(theme);
+        let accent = theme::accent(theme);
+        // Signal.Warn from DesignTokens.xaml: Signal.Color.Warn = #FFFF5A5A.
+        // HSL: hue=0 (red), sat=1.0, lum=0.671.
+        let signal_warn = gpui::Hsla {
+            h: 0.0,
+            s: 1.0,
+            l: 0.671,
+            a: 1.0,
+        };
+
+        let has_any = self.notifications.has_any();
+
+        // Header: "Notifications" label + conditional "Clear" button.
+        let clear_btn = if has_any {
+            Some(
+                div()
+                    .id("notif-clear-btn")
+                    .px(px(6.0))
+                    .py(px(3.0))
+                    .rounded_md()
+                    .text_size(px(11.0))
+                    .text_color(ink_dim)
+                    .cursor_pointer()
+                    .hover(move |s| s.bg(frost))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, _, _, cx| {
+                            this.notifications.clear_all();
+                            cx.notify();
+                        }),
+                    )
+                    .child("Clear"),
+            )
+        } else {
+            None
+        };
+
+        let header = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .justify_between()
+            .pl(px(14.0))
+            .pt(px(12.0))
+            .pr(px(10.0))
+            .pb(px(10.0))
+            .child(
+                div()
+                    .text_size(px(12.0))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_color(ink)
+                    .child("Notifications"),
+            )
+            .children(clear_btn);
+
+        // Body — either the "No notifications yet." empty state or the
+        // scrollable entry list.
+        let body: gpui::AnyElement = if !has_any {
+            div()
+                .flex()
+                .items_center()
+                .justify_center()
+                .mt(px(28.0))
+                .mb(px(36.0))
+                .text_size(px(11.5))
+                .text_color(ink_dim)
+                .child("No notifications yet.")
+                .into_any_element()
+        } else {
+            let entries: Vec<gpui::AnyElement> = self
+                .notifications
+                .entries()
+                .iter()
+                .enumerate()
+                .map(|(i, entry)| {
+                    let id = entry.id;
+                    let dot_color = match entry.kind {
+                        crate::notifications::NotificationKind::Generic => ink_dim,
+                        crate::notifications::NotificationKind::SessionWaiting => signal_warn,
+                        crate::notifications::NotificationKind::SessionReady => accent,
+                    };
+                    let title = entry.title.clone();
+                    let detail = entry.detail.clone();
+                    let session_title = entry.session_title.clone();
+                    let timestamp =
+                        crate::notifications::format_hhmm(entry.timestamp);
+                    let has_divider = i > 0;
+
+                    // Hover tint: #0EFFFFFF = ink at ~5.5 % alpha.
+                    let hover_tint = gpui::Hsla {
+                        h: 1.0,
+                        s: 1.0,
+                        l: 1.0,
+                        a: 0.055,
+                    };
+
+                    let mut row = div()
+                        .id(("notif-entry", id))
+                        .flex()
+                        .flex_row()
+                        .items_start()
+                        .pl(px(14.0))
+                        .pr(px(14.0))
+                        .pt(px(10.0))
+                        .pb(px(10.0))
+                        .cursor_pointer()
+                        .hover(move |s| s.bg(hover_tint));
+
+                    if has_divider {
+                        row = row.border_t_1().border_color(divider);
+                    }
+
+                    row = row
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| {
+                                this.notifications.activate(id);
+                                this.notifications.set_open(false);
+                                cx.notify();
+                            }),
+                        )
+                        // Kind dot — 6×6, top-aligned, 10 px right margin.
+                        .child(
+                            div()
+                                .w(px(6.0))
+                                .h(px(6.0))
+                                .mt(px(5.0))
+                                .mr(px(10.0))
+                                .flex_shrink_0()
+                                .rounded_full()
+                                .bg(dot_color),
+                        )
+                        // Text column: title / detail / session_title (mono).
+                        .child(
+                            div()
+                                .flex()
+                                .flex_col()
+                                .flex_grow()
+                                .child(
+                                    div()
+                                        .text_size(px(12.0))
+                                        .font_weight(gpui::FontWeight::MEDIUM)
+                                        .text_color(ink)
+                                        .child(title),
+                                )
+                                .child(
+                                    div()
+                                        .mt(px(2.0))
+                                        .text_size(px(11.0))
+                                        .text_color(ink_muted)
+                                        .child(detail),
+                                )
+                                .children(session_title.map(|st| {
+                                    div()
+                                        .mt(px(3.0))
+                                        .text_size(px(10.5))
+                                        .text_color(ink_dim)
+                                        .child(st)
+                                })),
+                        )
+                        // Timestamp — top-aligned dim mono label.
+                        .child(
+                            div()
+                                .ml(px(10.0))
+                                .mt(px(1.0))
+                                .flex_shrink_0()
+                                .text_size(px(10.5))
+                                .text_color(ink_dim)
+                                .child(timestamp),
+                        );
+
+                    row.into_any_element()
+                })
+                .collect();
+
+            div()
+                .id("notif-entry-list")
+                .flex()
+                .flex_col()
+                .overflow_y_scroll()
+                .children(entries)
+                .into_any_element()
+        };
+
+        // Footer: 1 px top border, dim hint text.
+        let footer = div()
+            .border_t_1()
+            .border_color(divider)
+            .pl(px(14.0))
+            .pr(px(14.0))
+            .pt(px(8.0))
+            .pb(px(8.0))
+            .text_size(px(10.5))
+            .text_color(ink_dim)
+            .child("Click an entry to jump to its session.");
+
+        // Outer panel — 360 px wide, max-height 420 px, anchored
+        // bottom-right above the status bar (mirroring the Popup
+        // `Placement="Top"` in the XAML, offset from the bell button).
+        let panel = div()
+            .id("notif-popover")
+            .w(px(360.0))
+            .max_h(px(420.0))
+            .flex()
+            .flex_col()
+            .bg(elevated)
+            .border_1()
+            .border_color(divider)
+            .rounded_md()
+            .shadow_lg()
+            .child(header)
+            .child(body)
+            .child(footer);
+
+        Some(
+            gpui::deferred(
+                gpui::anchored()
+                    .position(gpui::point(px(0.0), px(0.0)))
+                    .anchor(gpui::Corner::BottomRight)
+                    .snap_to_window_with_margin(px(8.0))
+                    .child(panel),
+            )
+            .into_any_element(),
+        )
+    }
+
     /// Build the tab right-click menu when one is open. Returns
     /// `None` when no menu is showing — caller uses `.children(...)`
     /// so 0 / 1 children both work without splitting the chain.
@@ -1638,6 +1897,26 @@ impl AppShell {
             self.toasts.pop_back();
         }
         cx.notify();
+    }
+
+    /// Push a persistent notification entry.  Unlike toasts these
+    /// accumulate in the ring buffer until the user clears them or the
+    /// ring reaches its cap (50).  Returns the id of the new entry.
+    ///
+    /// The bell button (integrating PR) wires this up for session events;
+    /// callers can also call it directly for generic system events.
+    #[allow(dead_code)]
+    pub(crate) fn push_notification(
+        &mut self,
+        kind: crate::notifications::NotificationKind,
+        title: impl Into<SharedString>,
+        detail: impl Into<SharedString>,
+        session_title: Option<SharedString>,
+        cx: &mut Context<Self>,
+    ) -> u64 {
+        let id = self.notifications.push(kind, title, detail, session_title);
+        cx.notify();
+        id
     }
 
     /// Dismiss a toast immediately by id. Wired to a small `×` on
@@ -2493,6 +2772,7 @@ impl Render for AppShell {
             .child(self.render_status_bar(&theme, cx))
             .children(self.render_tab_menu(&theme, cx))
             .children(self.render_toasts(&theme, cx))
+            .children(self.render_notifications_popover(&theme, cx))
     }
 }
 

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1480,7 +1480,11 @@ impl AppShell {
     /// tabs. Mirrors the C# build's `StatusBarView` minus the live
     /// git-status / agent-state badges (those land when the polling
     /// infra does).
-    fn render_status_bar(&self, theme: &Arc<Theme>) -> impl IntoElement {
+    fn render_status_bar(
+        &self,
+        theme: &Arc<Theme>,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
         let group_count = self.groups.len();
         let focused_group_idx = self.focused_group;
         let focused_group = self.focused_group();
@@ -1491,40 +1495,108 @@ impl AppShell {
             .get(active_tab)
             .map(|t| t.title.clone());
 
-        let group_label = format!("group {}/{}", focused_group_idx + 1, group_count);
+        // ─── Right cluster pieces ────────────────────────────────
+        // Mirrors the C# `StatusBarView` right cluster, *minus* the
+        // telemetry-driven slots (model, tokens, turns, agent
+        // rollup) and the notifications bell — those land when the
+        // Claude transcript tail and the notifications subsystem
+        // come online. For now we ship the bits whose data already
+        // exists in `AppShell` / `Sidebar`:
+        //   - group count (only when there's more than one group,
+        //     same conditional as C#'s `StatusGroupCountVisible`)
+        //   - workspace summary: `N worktrees · M dirty`, fed by
+        //     `Sidebar::worktree_counts`. Dirty-segment hides when
+        //     no worktree is currently dirty (matches C#'s
+        //     `StatusDirtyVisible`).
+        // The active-tab title takes the left cluster as a
+        // truncating flex-grow span until session/branch/git-state
+        // pollers exist to populate the proper left cluster.
+        let (worktree_total, worktree_dirty) =
+            self.sidebar.read(cx).worktree_counts();
+        let group_label = if group_count > 1 {
+            Some(format!("{} groups", group_count))
+        } else {
+            None
+        };
         let tab_label = if tab_count == 0 {
             "no tabs".to_string()
         } else {
             format!("tab {}/{}", active_tab + 1, tab_count)
         };
+        let _ = focused_group_idx;
         let title_text: SharedString = active_title
             .unwrap_or_else(|| SharedString::from("(empty group)"));
 
-        div()
-            .h(px(24.0))
+        let ink = theme::ink(theme);
+        let ink_dim = theme::ink_dim(theme);
+        let divider_clr = theme::divider(theme);
+
+        // 1×14 vertical separator between right-cluster items.
+        // Same colour and proportions as the C# `SbSep` style.
+        let sep = move || {
+            div()
+                .w_px()
+                .h(px(14.0))
+                .bg(divider_clr)
+        };
+
+        // Workspace summary — `N worktrees · M dirty`. The middle
+        // dot only appears when the dirty segment is visible.
+        let worktree_text = format!(
+            "{} {}",
+            worktree_total,
+            if worktree_total == 1 { "worktree" } else { "worktrees" }
+        );
+        let mut workspace_summary = div()
             .flex()
             .flex_row()
             .items_center()
-            .px_3()
-            .gap_3()
+            .gap(px(6.0))
+            .text_color(ink_dim)
+            .child(div().child(worktree_text));
+        if worktree_dirty > 0 {
+            workspace_summary = workspace_summary
+                .child(div().child("·"))
+                .child(div().child(format!("{} dirty", worktree_dirty)));
+        }
+
+        // ─── Bar ─────────────────────────────────────────────────
+        // 32 px tall (matches C# `<Border Height="32">`), 12 px
+        // horizontal padding, 1 px top divider, elevated bg.
+        let mut bar = div()
+            .h(px(32.0))
+            .flex()
+            .flex_row()
+            .items_center()
+            .px(px(12.0))
+            .gap(px(14.0))
             .border_t_1()
-            .border_color(theme::divider(theme))
+            .border_color(divider_clr)
             .bg(theme::elevated(theme))
-            .text_size(px(11.0))
-            .text_color(theme::ink_dim(theme))
-            // Active title is the most prominent piece — gets `flex_grow`
-            // so it eats the rest of the row before the per-group counts
-            // on the right.
-            .child(
-                div()
-                    .flex_grow()
-                    .truncate()
-                    .text_color(theme::ink(theme))
-                    .child(title_text),
-            )
-            .child(div().child(tab_label))
-            .child(div().w_px().h(px(12.0)).bg(theme::divider(theme)))
-            .child(div().child(group_label))
+            .text_size(px(11.5))
+            .text_color(ink_dim);
+
+        // Left cluster — active tab title (placeholder for the
+        // session-context cluster the C# build shows once we have
+        // branch / git-state data).
+        bar = bar.child(
+            div()
+                .flex_grow()
+                .truncate()
+                .text_color(ink)
+                .child(title_text),
+        );
+
+        // Right cluster — workspace summary, optional group count,
+        // tab counter. Each pair is separated by a 1×14 vertical
+        // rule; the rules collapse together with their items
+        // (group-count rule only renders when there's >1 group).
+        bar = bar.child(workspace_summary).child(sep());
+        if let Some(gl) = group_label {
+            bar = bar.child(div().child(gl)).child(sep());
+        }
+        bar = bar.child(div().child(tab_label));
+        bar
     }
 
     /// Push a toast onto the top of the floating stack. Each kind
@@ -2418,7 +2490,7 @@ impl Render for AppShell {
             .text_color(theme::ink(&theme))
             .child(caption_row)
             .child(main_row)
-            .child(self.render_status_bar(&theme))
+            .child(self.render_status_bar(&theme, cx))
             .children(self.render_tab_menu(&theme, cx))
             .children(self.render_toasts(&theme, cx))
     }

--- a/codescope-rs/src/notifications.rs
+++ b/codescope-rs/src/notifications.rs
@@ -1,0 +1,462 @@
+//! Persistent notification state.
+//!
+//! This is the Rust port of the C# `INotificationService` /
+//! `NotificationService` pair (`src/CodeScope.Core/Services/`).
+//! The popover render lives in `app.rs` as `AppShell::render_notifications_popover`,
+//! mirroring how `render_toasts` and `render_tab_menu` are structured there.
+//!
+//! # Lifecycle
+//!
+//! `Notifications` lives as a plain struct field inside `AppShell` — no
+//! `Entity<T>` wrapper needed because all mutations are driven from
+//! `AppShell` methods that already hold `&mut self`.
+//! `AppShell::push_notification` is the only external writer path; the
+//! future bell button calls `toggle_open` via `AppShell`.
+//!
+//! # Ring buffer
+//!
+//! Newest entry sits at index 0 (most-recent-first), mirroring
+//! `LinkedList.AddFirst` in the C# build.  When the buffer is full
+//! (`MAX_ENTRIES = 50`) the oldest tail entry falls off.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use gpui::SharedString;
+
+// ─── Id generator ──────────────────────────────────────────────────────────
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_id() -> u64 {
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+// ─── Domain types ──────────────────────────────────────────────────────────
+
+/// Semantic class of a notification — drives the colour of the kind dot
+/// in the popover.  Mirrors the C# `NotificationKind` enum.
+///
+/// Variants that appear unused at compile-time are intentional:
+/// the bell button (integrating PR) is the primary call site.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotificationKind {
+    /// Agent finished a turn after being in Wait/Composing — user can reply.
+    SessionReady,
+    /// Agent paused for a permission prompt (manual-mode tool_use).
+    SessionWaiting,
+    /// Catch-all for future event sources.
+    Generic,
+}
+
+/// One entry in the ring buffer.  Mutable only for the `read` flag
+/// (mark_read / mark_all_read).
+#[derive(Clone, Debug)]
+pub struct NotificationEntry {
+    pub id: u64,
+    pub kind: NotificationKind,
+    pub title: SharedString,
+    pub detail: SharedString,
+    /// `None` when the notification is not tied to a specific session.
+    pub session_title: Option<SharedString>,
+    /// UTC seconds since the Unix epoch — formatted as "HH:mm" by
+    /// `format_hhmm`.  Matches the `Timestamp` column in the BellPopup XAML.
+    pub timestamp: u64,
+    pub read: bool,
+}
+
+impl NotificationEntry {
+    /// Create a new unread entry, stamping it with the current wall clock.
+    pub fn new(
+        kind: NotificationKind,
+        title: impl Into<SharedString>,
+        detail: impl Into<SharedString>,
+        session_title: Option<SharedString>,
+    ) -> Self {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        Self {
+            id: next_id(),
+            kind,
+            title: title.into(),
+            detail: detail.into(),
+            session_title,
+            timestamp,
+            read: false,
+        }
+    }
+}
+
+// ─── Timestamp formatting ──────────────────────────────────────────────────
+
+/// Format a Unix-epoch second value as "HH:mm" in local time.
+///
+/// We avoid the `chrono` crate (not in the dependency tree).  The UTC
+/// offset is probed via `GetLocalTime` / `GetSystemTime` on Windows.
+/// Accuracy to the minute is all the popover timestamp column needs.
+pub fn format_hhmm(epoch_secs: u64) -> SharedString {
+    let utc_offset_secs = local_utc_offset_secs();
+    // Wrapping add is safe: even at epoch 0 with a +14 h offset the
+    // result is positive, and u64 wrapping at year ~584 billion is fine.
+    let local_secs = (epoch_secs as i64).wrapping_add(utc_offset_secs) as u64;
+    let secs_of_day = local_secs % 86400;
+    let hours = secs_of_day / 3600;
+    let minutes = (secs_of_day % 3600) / 60;
+    format!("{:02}:{:02}", hours, minutes).into()
+}
+
+/// Attempt to determine the local UTC offset in whole seconds.
+/// Returns 0 (UTC) when the platform gives us nothing useful.
+fn local_utc_offset_secs() -> i64 {
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::System::SystemInformation::{GetLocalTime, GetSystemTime};
+        // SAFETY: GetLocalTime / GetSystemTime have no preconditions —
+        // they simply return the current time as a SYSTEMTIME struct.
+        // The `windows-0.61` bindings expose them as zero-arg functions
+        // that return the value directly (no out-pointer).
+        unsafe {
+            let local = GetLocalTime();
+            let utc = GetSystemTime();
+            let local_secs = (local.wHour as i64 * 3600)
+                + (local.wMinute as i64 * 60)
+                + local.wSecond as i64;
+            let utc_secs = (utc.wHour as i64 * 3600)
+                + (utc.wMinute as i64 * 60)
+                + utc.wSecond as i64;
+            // Guard against midnight rollover (offset can be at most ±14 h).
+            let mut diff = local_secs - utc_secs;
+            if diff > 14 * 3600 {
+                diff -= 86400;
+            }
+            if diff < -14 * 3600 {
+                diff += 86400;
+            }
+            diff
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        // The Rust port only targets Windows; return UTC for any other host.
+        0
+    }
+}
+
+// ─── Ring buffer state ─────────────────────────────────────────────────────
+
+/// Maximum number of entries kept in the ring buffer.
+/// Mirrors `NotificationService.MaxEntries` default (50) in the C# build.
+pub const MAX_ENTRIES: usize = 50;
+
+/// In-memory ring buffer of recent agent events.
+///
+/// Lives as a plain struct field inside `AppShell` — no separate `Entity<T>`
+/// needed.  The popover render is `AppShell::render_notifications_popover`
+/// in `app.rs` (same pattern as `render_toasts` / `render_tab_menu`).
+pub struct Notifications {
+    /// Most-recent-first.  Cap: `MAX_ENTRIES`.
+    entries: Vec<NotificationEntry>,
+    /// Whether the popover is currently visible.  The bell button (integrating
+    /// PR) toggles this; the render method checks it before producing an element.
+    is_open: bool,
+}
+
+impl Notifications {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            is_open: false,
+        }
+    }
+
+    // ── Accessors ──────────────────────────────────────────────────────
+
+    /// Snapshot of entries, most-recent-first.
+    pub fn entries(&self) -> &[NotificationEntry] {
+        &self.entries
+    }
+
+    pub fn has_any(&self) -> bool {
+        !self.entries.is_empty()
+    }
+
+    /// Returns `true` when at least one entry has not been read.
+    /// Used by the bell button (integrating PR) to show the unread dot.
+    #[allow(dead_code)]
+    pub fn has_unread(&self) -> bool {
+        self.entries.iter().any(|e| !e.read)
+    }
+
+    /// Number of unread entries.
+    #[allow(dead_code)]
+    pub fn unread_count(&self) -> usize {
+        self.entries.iter().filter(|e| !e.read).count()
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.is_open
+    }
+
+    // ── Popover visibility ─────────────────────────────────────────────
+
+    pub fn set_open(&mut self, open: bool) {
+        self.is_open = open;
+    }
+
+    /// Toggle popover open/closed.  Called by the bell button (integrating PR).
+    #[allow(dead_code)]
+    pub fn toggle(&mut self) {
+        self.is_open = !self.is_open;
+    }
+
+    // ── Mutations ──────────────────────────────────────────────────────
+
+    /// Push a new unread entry, evicting the oldest when the ring is full.
+    /// Returns the id of the new entry.
+    pub fn push(
+        &mut self,
+        kind: NotificationKind,
+        title: impl Into<SharedString>,
+        detail: impl Into<SharedString>,
+        session_title: Option<SharedString>,
+    ) -> u64 {
+        let entry = NotificationEntry::new(kind, title, detail, session_title);
+        let id = entry.id;
+        self.entries.insert(0, entry);
+        if self.entries.len() > MAX_ENTRIES {
+            self.entries.pop();
+        }
+        id
+    }
+
+    /// Mark a single entry read by id.
+    #[allow(dead_code)]
+    pub fn mark_read(&mut self, id: u64) {
+        if let Some(e) = self.entries.iter_mut().find(|e| e.id == id) {
+            e.read = true;
+        }
+    }
+
+    /// Mark all entries for a given session read (e.g. when the user
+    /// focuses that tab).  Mirrors `MarkSessionRead` from the C# build.
+    #[allow(dead_code)]
+    pub fn mark_session_read(&mut self, session_title: &str) {
+        for e in self.entries.iter_mut() {
+            if e.session_title
+                .as_ref()
+                .map(|s| s.as_ref() == session_title)
+                .unwrap_or(false)
+            {
+                e.read = true;
+            }
+        }
+    }
+
+    /// Mark every entry read.
+    #[allow(dead_code)]
+    pub fn mark_all_read(&mut self) {
+        for e in self.entries.iter_mut() {
+            e.read = true;
+        }
+    }
+
+    /// Remove all entries and close the popover.
+    pub fn clear_all(&mut self) {
+        self.entries.clear();
+        self.is_open = false;
+    }
+
+    /// Mark the entry read and return its `session_title` so the caller
+    /// (`AppShell`) can jump to that tab.
+    pub fn activate(&mut self, id: u64) -> Option<SharedString> {
+        let entry = self.entries.iter_mut().find(|e| e.id == id)?;
+        entry.read = true;
+        entry.session_title.clone()
+    }
+}
+
+impl Default for Notifications {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── Unit tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn push_one(kind: NotificationKind, title: &'static str) -> (u64, Notifications) {
+        let mut n = Notifications::new();
+        let id = n.push(kind, title, "detail", None);
+        (id, n)
+    }
+
+    #[test]
+    fn push_adds_entry_most_recent_first() {
+        let mut n = Notifications::new();
+        n.push(NotificationKind::Generic, "first", "d", None);
+        n.push(NotificationKind::Generic, "second", "d", None);
+        assert_eq!(n.entries().len(), 2);
+        assert_eq!(n.entries()[0].title, SharedString::from("second"));
+        assert_eq!(n.entries()[1].title, SharedString::from("first"));
+    }
+
+    #[test]
+    fn push_evicts_oldest_when_at_cap() {
+        let mut n = Notifications::new();
+        for i in 0..MAX_ENTRIES + 5 {
+            n.push(NotificationKind::Generic, format!("entry {i}"), "d", None);
+        }
+        assert_eq!(n.entries().len(), MAX_ENTRIES);
+        // Newest entry is at index 0.
+        assert_eq!(
+            n.entries()[0].title,
+            SharedString::from(format!("entry {}", MAX_ENTRIES + 4))
+        );
+    }
+
+    #[test]
+    fn new_entries_are_unread() {
+        let (_, n) = push_one(NotificationKind::Generic, "t");
+        assert!(n.has_unread());
+        assert!(!n.entries()[0].read);
+    }
+
+    #[test]
+    fn mark_read_by_id() {
+        let (id, mut n) = push_one(NotificationKind::Generic, "t");
+        n.mark_read(id);
+        assert!(!n.has_unread());
+        assert!(n.entries()[0].read);
+    }
+
+    #[test]
+    fn mark_read_unknown_id_is_noop() {
+        let (_, mut n) = push_one(NotificationKind::Generic, "t");
+        n.mark_read(9999);
+        assert!(n.has_unread());
+    }
+
+    #[test]
+    fn mark_all_read_clears_unread_flag() {
+        let mut n = Notifications::new();
+        n.push(NotificationKind::Generic, "a", "d", None);
+        n.push(NotificationKind::SessionReady, "b", "d", None);
+        assert!(n.has_unread());
+        n.mark_all_read();
+        assert!(!n.has_unread());
+        assert!(n.entries().iter().all(|e| e.read));
+    }
+
+    #[test]
+    fn clear_all_empties_and_closes() {
+        let mut n = Notifications::new();
+        n.push(NotificationKind::Generic, "a", "d", None);
+        n.set_open(true);
+        n.clear_all();
+        assert!(!n.has_any());
+        assert!(!n.is_open());
+    }
+
+    #[test]
+    fn has_any_and_has_unread_invariants() {
+        let mut n = Notifications::new();
+        assert!(!n.has_any());
+        assert!(!n.has_unread());
+
+        let id = n.push(NotificationKind::Generic, "t", "d", None);
+        assert!(n.has_any());
+        assert!(n.has_unread());
+
+        n.mark_read(id);
+        assert!(n.has_any()); // entry still present
+        assert!(!n.has_unread()); // but now read
+    }
+
+    #[test]
+    fn toggle_open_flips_state() {
+        let mut n = Notifications::new();
+        assert!(!n.is_open());
+        n.toggle();
+        assert!(n.is_open());
+        n.toggle();
+        assert!(!n.is_open());
+    }
+
+    #[test]
+    fn mark_session_read_targets_correct_entries() {
+        let mut n = Notifications::new();
+        n.push(
+            NotificationKind::SessionReady,
+            "a",
+            "d",
+            Some("session-A".into()),
+        );
+        n.push(
+            NotificationKind::SessionReady,
+            "b",
+            "d",
+            Some("session-B".into()),
+        );
+        n.mark_session_read("session-A");
+        let entries = n.entries();
+        let a = entries
+            .iter()
+            .find(|e| e.title == SharedString::from("a"))
+            .unwrap();
+        let b = entries
+            .iter()
+            .find(|e| e.title == SharedString::from("b"))
+            .unwrap();
+        assert!(a.read);
+        assert!(!b.read);
+    }
+
+    #[test]
+    fn activate_marks_read_and_returns_session_title() {
+        let mut n = Notifications::new();
+        let id = n.push(
+            NotificationKind::SessionReady,
+            "t",
+            "d",
+            Some("my-session".into()),
+        );
+        let title = n.activate(id);
+        assert_eq!(title, Some(SharedString::from("my-session")));
+        assert!(n.entries()[0].read);
+    }
+
+    #[test]
+    fn activate_unknown_id_returns_none() {
+        let mut n = Notifications::new();
+        assert!(n.activate(9999).is_none());
+    }
+
+    #[test]
+    fn format_hhmm_produces_padded_string() {
+        // We can't guarantee the local offset in CI, so we just check
+        // the format: exactly 5 chars, colon at index 2, digits elsewhere.
+        let s: String = format_hhmm(0).to_string();
+        assert_eq!(s.len(), 5);
+        assert_eq!(&s[2..3], ":");
+        assert!(s[0..2].chars().all(|c| c.is_ascii_digit()));
+        assert!(s[3..5].chars().all(|c| c.is_ascii_digit()));
+    }
+
+    #[test]
+    fn unread_count_reflects_mixed_state() {
+        let mut n = Notifications::new();
+        let id1 = n.push(NotificationKind::Generic, "a", "d", None);
+        n.push(NotificationKind::Generic, "b", "d", None);
+        assert_eq!(n.unread_count(), 2);
+        n.mark_read(id1);
+        assert_eq!(n.unread_count(), 1);
+        n.mark_all_read();
+        assert_eq!(n.unread_count(), 0);
+    }
+}

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -297,6 +297,32 @@ impl Sidebar {
         &self.paths
     }
 
+    /// Workspace-wide worktree counts for the status bar's right
+    /// cluster. Returns `(total, dirty)`:
+    /// - `total` — every distinct worktree path across every project
+    ///   (primary trees included), de-duplicated so a path that
+    ///   appears in two projects (or as both primary and an explicit
+    ///   `worktrees[]` entry) is only counted once.
+    /// - `dirty` — number of those paths whose `dirty_state` lookup
+    ///   is `Some(true)`. Paths with no recorded state yet (still
+    ///   loading) and `Some(false)` (clean) don't count.
+    pub(crate) fn worktree_counts(&self) -> (usize, usize) {
+        let mut paths: std::collections::HashSet<&str> =
+            std::collections::HashSet::new();
+        for project in &self.projects.projects {
+            paths.insert(project.path.as_str());
+            for wt in &project.worktrees {
+                paths.insert(wt.path.as_str());
+            }
+        }
+        let total = paths.len();
+        let dirty = paths
+            .iter()
+            .filter(|p| self.dirty_state.get(**p).copied().unwrap_or(false))
+            .count();
+        (total, dirty)
+    }
+
     /// Commit a freshly-built `ProjectsConfig` into in-memory state
     /// after the dialog has already saved it to disk. Save-then-commit
     /// ordering matches `add_project` / `remove_project`.

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -13,6 +13,7 @@
 
 mod app;
 mod new_worktree_dialog;
+mod notifications;
 mod sidebar;
 mod theme;
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary

- **New module `codescope-rs/src/notifications.rs`** — pure state layer, 1:1 port of C# `INotificationService` / `NotificationService`:
  - `NotificationKind { SessionReady, SessionWaiting, Generic }`
  - `NotificationEntry { id, kind, title, detail, session_title, timestamp, read }`
  - `Notifications` ring buffer: `push`, `mark_read`, `mark_session_read`, `mark_all_read`, `clear_all`, `activate`, `is_open`, `set_open`, `toggle`, `entries`, `has_any`, `has_unread`, `unread_count`
  - `format_hhmm(epoch_secs) -> SharedString` — local "HH:mm" via Win32 `GetLocalTime` / `GetSystemTime` (no new crates)
  - 14 unit tests covering all invariants

- **`app.rs`** — `AppShell.notifications: Notifications` field + `push_notification` helper + `render_notifications_popover` wired into the root render alongside `render_toasts`

- **`window.rs`** — `mod notifications` declaration

- **`Cargo.toml`** — `Win32_System_SystemInformation` feature added to `windows` crate for the UTC-offset probe

## Popover geometry (mirrors BellPopup XAML exactly)

- Width 360 px, max-height 420 px, `bg(elevated)`, 1 px border, `rounded_md`, `shadow_lg`
- Header: 14 l / 12 t / 10 r / 10 b — "Notifications" label + conditional "Clear" button
- Entry rows: 14 l/r, 10 t/b, 1 px top border from row 2 onward; kind dot 6x6 mt=5 mr=10
  - `Generic` dot: `ink_dim` / `SessionWaiting`: `#FF5A5A` (Signal.Warn) / `SessionReady`: `accent`
  - Title 12 px Medium, Detail 11 px ink_muted, SessionTitle 10.5 px ink_dim, Timestamp 10.5 px ink_dim
- Footer: 1 px top border, 14 l/r, 8 t/b, "Click an entry to jump to its session."
- Anchored bottom-right, deferred (same pattern as `render_toasts`)

## Bell button hook (integrating PR)

```rust
// Toggle the popover:
this.notifications.toggle(); cx.notify();

// Unread dot visibility:
self.notifications.has_unread()

// Push from session events:
this.push_notification(NotificationKind::SessionReady, title, detail, Some(session_title), cx);
```

## Test plan

- [x] `cargo build --bin window` clean (0 errors, 0 new warnings from our code)
- [x] `cargo test` — 29 tests pass (14 new `notifications::tests` + 15 pre-existing)
- [x] `cargo clippy --bin window` — no new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)