### PR TITLE
feat(rs): Claude session adoption + telemetry register/unregister wire-up

### DIFF
--- a/codescope-rs/core/src/claude_discovery.rs
+++ b/codescope-rs/core/src/claude_discovery.rs
@@ -1,0 +1,304 @@
+//! Claude Code session adoption — find the JSONL transcript a freshly
+//! launched `claude` pwsh session writes inside
+//! `~/.claude/projects/<encoded-cwd>/`.
+//!
+//! Mirrors `ClaudeSessionDiscovery` from the C# build but uses polling
+//! only (no `notify` crate dep). The caller drives the cadence — the
+//! C# build polls every 350 ms next to its FSWatcher; we keep the same
+//! interval as a single source of truth.
+//!
+//! # Semantics
+//!
+//! Adoption fires once per unique `.jsonl` path discovered with
+//! `created_at >= since` *or* `last_modified >= since`. Tracking
+//! already-fired paths is the caller's responsibility (the C# build
+//! does this inside `WatchHandle._fired`); we return *every* eligible
+//! file each call so the caller can dedupe by id and keep the watch
+//! alive across `/clear` rotations.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use crate::claude_telemetry::encode_cwd;
+
+/// Suggested poll interval for adoption watches — 350 ms matches the
+/// C# `ClaudeSessionDiscovery.PollInterval`.
+pub const POLL_INTERVAL_MS: u64 = 350;
+
+/// One adoption candidate found in a projects-root scan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdoptionCandidate {
+    /// UUID parsed from the `.jsonl` filename (without extension).
+    pub session_id: String,
+    /// Absolute path to the `.jsonl` file.
+    pub path: PathBuf,
+}
+
+/// Scan `~/.claude/projects/<encoded_cwd(working_directory)>/` for
+/// `.jsonl` files whose `created_at` or `last_modified` timestamps are
+/// at or after `since`. Returns every match — the caller dedupes by
+/// path.
+///
+/// Returns an empty vec when the directory doesn't exist, can't be
+/// read, or contains no eligible candidates. Callers should treat
+/// "empty" as "keep polling".
+///
+/// Filenames must parse as UUIDs (Claude Code v2.x uses 8-4-4-4-12 hex
+/// digits) — anything else is silently skipped. Mirrors C#
+/// `WatchHandle.IsValidSessionId`.
+pub fn scan(
+    projects_root: &Path,
+    working_directory: &str,
+    since: SystemTime,
+) -> Vec<AdoptionCandidate> {
+    let dir = projects_root.join(encode_cwd(working_directory));
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(it) => it,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if !is_session_id(stem) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let created = meta.created().ok();
+        let modified = meta.modified().ok();
+        let eligible = matches!(created, Some(t) if t >= since)
+            || matches!(modified, Some(t) if t >= since);
+        if !eligible {
+            continue;
+        }
+        out.push(AdoptionCandidate {
+            session_id: stem.to_owned(),
+            path,
+        });
+    }
+    out
+}
+
+/// Does an auto-typed command launch a Claude Code session?
+///
+/// Mirrors the `agentId == "claude"` branch in C#
+/// `MainViewModel.RegisterAgentTelemetry`. We don't carry an
+/// `agentId` field on tabs — instead we match the literal command
+/// `claude` modulo leading whitespace and trailing args / flags.
+/// `claude --resume <id>` and `claude --new` both qualify; plain
+/// `pwsh` (`None`) and other agents (`pi`, `opencode`, `copilot`,
+/// `gemini`, …) do not.
+pub fn is_claude_auto_type(auto_type: Option<&str>) -> bool {
+    let Some(s) = auto_type else { return false };
+    let s = s.trim_start();
+    let first = s.split(|c: char| c.is_whitespace()).next().unwrap_or("");
+    first.eq_ignore_ascii_case("claude")
+}
+
+/// Recognise a Claude Code session id — the `.jsonl` filename without
+/// extension. The C# build uses `Guid.TryParseExact(id, "D")` which
+/// accepts the `8-4-4-4-12` lowercase-hex form. We mirror that exactly:
+/// 36 chars, ASCII hex digits with hyphens at 8/13/18/23.
+pub fn is_session_id(s: &str) -> bool {
+    if s.len() != 36 {
+        return false;
+    }
+    let bytes = s.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        let is_hyphen = matches!(i, 8 | 13 | 18 | 23);
+        if is_hyphen {
+            if b != b'-' {
+                return false;
+            }
+        } else if !b.is_ascii_hexdigit() {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    const SID_A: &str = "11111111-2222-3333-4444-555555555555";
+    const SID_B: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+    // --- is_claude_auto_type ---
+
+    #[test]
+    fn auto_type_none_is_not_claude() {
+        assert!(!is_claude_auto_type(None));
+    }
+
+    #[test]
+    fn auto_type_plain_claude_is_claude() {
+        assert!(is_claude_auto_type(Some("claude")));
+    }
+
+    #[test]
+    fn auto_type_claude_with_args_is_claude() {
+        assert!(is_claude_auto_type(Some("claude --resume abc-123")));
+        assert!(is_claude_auto_type(Some("claude --new")));
+    }
+
+    #[test]
+    fn auto_type_leading_whitespace_is_claude() {
+        assert!(is_claude_auto_type(Some("   claude")));
+        assert!(is_claude_auto_type(Some("\tclaude --new")));
+    }
+
+    #[test]
+    fn auto_type_case_insensitive() {
+        assert!(is_claude_auto_type(Some("Claude")));
+        assert!(is_claude_auto_type(Some("CLAUDE")));
+    }
+
+    #[test]
+    fn auto_type_other_agents_are_not_claude() {
+        assert!(!is_claude_auto_type(Some("pi")));
+        assert!(!is_claude_auto_type(Some("opencode")));
+        assert!(!is_claude_auto_type(Some("copilot")));
+        assert!(!is_claude_auto_type(Some("gemini")));
+        assert!(!is_claude_auto_type(Some("pwsh")));
+    }
+
+    #[test]
+    fn auto_type_empty_string_is_not_claude() {
+        assert!(!is_claude_auto_type(Some("")));
+        assert!(!is_claude_auto_type(Some("   ")));
+    }
+
+    #[test]
+    fn auto_type_substring_is_not_match() {
+        // "claudeflare" is not the agent — only `claude` itself.
+        assert!(!is_claude_auto_type(Some("claudeflare")));
+        assert!(!is_claude_auto_type(Some("notclaude")));
+    }
+
+    // --- is_session_id ---
+
+    #[test]
+    fn is_session_id_accepts_lowercase_uuid() {
+        assert!(is_session_id(SID_A));
+        assert!(is_session_id(SID_B));
+    }
+
+    #[test]
+    fn is_session_id_accepts_uppercase_hex() {
+        assert!(is_session_id("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"));
+    }
+
+    #[test]
+    fn is_session_id_rejects_wrong_length() {
+        assert!(!is_session_id("11111111-2222-3333-4444-55555555555")); // 35
+        assert!(!is_session_id("11111111-2222-3333-4444-5555555555555")); // 37
+    }
+
+    #[test]
+    fn is_session_id_rejects_misplaced_hyphens() {
+        assert!(!is_session_id("111111112-2223-3334-4445-55555555555"));
+    }
+
+    #[test]
+    fn is_session_id_rejects_non_hex() {
+        assert!(!is_session_id("zzzzzzzz-2222-3333-4444-555555555555"));
+    }
+
+    #[test]
+    fn is_session_id_rejects_empty_and_arbitrary() {
+        assert!(!is_session_id(""));
+        assert!(!is_session_id("not-a-uuid"));
+        assert!(!is_session_id("backup"));
+    }
+
+    // --- scan ---
+
+    fn working_dir_layout(tmp: &TempDir, working_directory: &str) -> PathBuf {
+        let dir = tmp.path().join(encode_cwd(working_directory));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_jsonl(dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(format!("{name}.jsonl"));
+        std::fs::write(&path, b"{\"type\":\"user\"}\n").unwrap();
+        path
+    }
+
+    #[test]
+    fn scan_returns_empty_when_root_missing() {
+        let tmp = TempDir::new().unwrap();
+        let res = scan(tmp.path(), "/no/such/dir", SystemTime::UNIX_EPOCH);
+        assert!(res.is_empty());
+    }
+
+    #[test]
+    fn scan_finds_jsonl_after_since() {
+        let tmp = TempDir::new().unwrap();
+        let wd = "/some/project";
+        let dir = working_dir_layout(&tmp, wd);
+        let _path = write_jsonl(&dir, SID_A);
+
+        // since = a long time ago, file definitely qualifies.
+        let res = scan(tmp.path(), wd, SystemTime::UNIX_EPOCH);
+        assert_eq!(res.len(), 1, "expected one candidate, got {res:?}");
+        assert_eq!(res[0].session_id, SID_A);
+    }
+
+    #[test]
+    fn scan_skips_non_jsonl_files() {
+        let tmp = TempDir::new().unwrap();
+        let wd = "/some/project";
+        let dir = working_dir_layout(&tmp, wd);
+        std::fs::write(dir.join("not-a-transcript.txt"), b"hi").unwrap();
+        std::fs::write(dir.join(format!("{SID_A}.json")), b"hi").unwrap();
+        let res = scan(tmp.path(), wd, SystemTime::UNIX_EPOCH);
+        assert!(res.is_empty(), "got {res:?}");
+    }
+
+    #[test]
+    fn scan_skips_filenames_that_arent_uuids() {
+        let tmp = TempDir::new().unwrap();
+        let wd = "/some/project";
+        let dir = working_dir_layout(&tmp, wd);
+        write_jsonl(&dir, "backup");
+        write_jsonl(&dir, "not-a-real-id");
+        let res = scan(tmp.path(), wd, SystemTime::UNIX_EPOCH);
+        assert!(res.is_empty(), "got {res:?}");
+    }
+
+    #[test]
+    fn scan_returns_all_eligible_files() {
+        let tmp = TempDir::new().unwrap();
+        let wd = "/some/project";
+        let dir = working_dir_layout(&tmp, wd);
+        write_jsonl(&dir, SID_A);
+        write_jsonl(&dir, SID_B);
+
+        let res = scan(tmp.path(), wd, SystemTime::UNIX_EPOCH);
+        let mut ids: Vec<_> = res.iter().map(|c| c.session_id.clone()).collect();
+        ids.sort();
+        assert_eq!(ids, vec![SID_A.to_owned(), SID_B.to_owned()]);
+    }
+
+    #[test]
+    fn scan_filters_files_modified_before_since() {
+        let tmp = TempDir::new().unwrap();
+        let wd = "/some/project";
+        let dir = working_dir_layout(&tmp, wd);
+        write_jsonl(&dir, SID_A);
+
+        // since = far in the future — nothing qualifies.
+        let future = SystemTime::now() + Duration::from_secs(60 * 60 * 24 * 365 * 50);
+        let res = scan(tmp.path(), wd, future);
+        assert!(res.is_empty(), "got {res:?}");
+    }
+}

--- a/codescope-rs/core/src/claude_discovery.rs
+++ b/codescope-rs/core/src/claude_discovery.rs
@@ -102,8 +102,12 @@ pub fn is_claude_auto_type(auto_type: Option<&str>) -> bool {
 
 /// Recognise a Claude Code session id — the `.jsonl` filename without
 /// extension. The C# build uses `Guid.TryParseExact(id, "D")` which
-/// accepts the `8-4-4-4-12` lowercase-hex form. We mirror that exactly:
-/// 36 chars, ASCII hex digits with hyphens at 8/13/18/23.
+/// accepts the `8-4-4-4-12` UUID form *case-insensitively* (`D`
+/// allows either case for the hex digits). We mirror that: 36 chars,
+/// ASCII hex digits with hyphens at indices 8 / 13 / 18 / 23.
+/// Practical Claude Code transcripts always emit lowercase, but the
+/// validator stays permissive so a manually-renamed file or future
+/// CLI revision keeps working.
 pub fn is_session_id(s: &str) -> bool {
     if s.len() != 36 {
         return false;

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -13,6 +13,7 @@
 //! lives in the `app` crate. Anything terminal-protocol-bound lives in
 //! `codescope-terminal`.
 
+pub mod claude_discovery;
 pub mod claude_telemetry;
 pub mod git;
 pub mod layout;
@@ -22,6 +23,7 @@ pub mod settings;
 pub mod theme;
 pub mod window_state;
 
+pub use claude_discovery::{AdoptionCandidate, POLL_INTERVAL_MS as CLAUDE_DISCOVERY_POLL_MS};
 pub use claude_telemetry::{
     SessionState, TelemetrySnapshot, TranscriptTail, context_window_for_model, encode_cwd,
 };

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -39,7 +39,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use codescope_core::{AppPaths, LayoutState, ProjectsConfig, Settings, Theme, WindowState};
 use codescope_terminal::{
@@ -93,6 +93,18 @@ struct Tab {
     /// agent-launch tabs). Persisted so "New Claude session" comes
     /// back as claude on restore.
     auto_type: Option<SharedString>,
+    /// Wall-clock spawn time, captured at `spawn_tab_in`. Used as the
+    /// `since` filter for Claude session adoption — only `.jsonl`
+    /// transcripts created/modified at or after this point qualify
+    /// as "this tab's session". Mirrors the `since` arg of
+    /// `ClaudeSessionDiscovery.Watch`.
+    spawned_at: SystemTime,
+    /// Adopted Claude session id, set once `claude_discovery::scan`
+    /// returns a fresh transcript for this tab. `None` until the agent
+    /// has written its first jsonl line — and stays `None` for plain
+    /// pwsh tabs (no `claude` auto-type). On adoption we register the
+    /// telemetry tail; on close we unregister.
+    adopted_session_id: Option<String>,
 }
 
 /// One column in the work area: a tab strip + the currently-selected
@@ -668,6 +680,7 @@ impl AppShell {
             telemetry_tails: HashMap::new(),
         };
         shell.start_telemetry_poll(cx);
+        shell.start_claude_discovery_poll(cx);
         shell.rehydrate_or_cold_start(window, cx);
         shell
     }
@@ -815,6 +828,107 @@ impl AppShell {
                         Duration::from_millis(250)
                     } else {
                         Duration::from_secs(2)
+                    }
+                });
+                match result {
+                    Ok(next) => interval = next,
+                    Err(_) => break,
+                }
+            }
+        })
+        .detach();
+    }
+
+    /// Resolve `~/.claude/projects/`. Returns `None` when neither
+    /// USERPROFILE nor HOME is set — same gate `register_telemetry`
+    /// uses, kept here so the discovery poll skips silently instead
+    /// of repeatedly logging.
+    fn claude_projects_root() -> Option<std::path::PathBuf> {
+        let home = std::env::var_os("USERPROFILE").or_else(|| std::env::var_os("HOME"))?;
+        Some(std::path::PathBuf::from(home).join(".claude").join("projects"))
+    }
+
+    /// Spawn the background per-tab Claude session adoption loop.
+    ///
+    /// Mirrors `ClaudeSessionDiscovery.Watch` from the C# build: every
+    /// 350 ms while at least one tab is awaiting adoption, scan
+    /// `~/.claude/projects/<encoded-cwd>/` for `.jsonl` files written
+    /// at or after the tab's `spawned_at`. On a hit, register the
+    /// telemetry tail and stamp `adopted_session_id` on the tab so
+    /// subsequent ticks skip it. Idle (no Claude tabs awaiting
+    /// adoption) bumps the cadence to 5 s.
+    ///
+    /// Called from `AppShell::new` after the struct is constructed.
+    fn start_claude_discovery_poll(&self, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx| {
+            let mut interval =
+                Duration::from_millis(codescope_core::CLAUDE_DISCOVERY_POLL_MS);
+            let idle = Duration::from_secs(5);
+            loop {
+                cx.background_executor().timer(interval).await;
+                if this.upgrade().is_none() {
+                    break;
+                }
+                let result = this.update(cx, |this, _cx| {
+                    let Some(root) = Self::claude_projects_root() else {
+                        return idle;
+                    };
+                    // Walk every tab, adopt fresh transcripts in place.
+                    // Two-pass (collect candidates, then mutate) keeps
+                    // the borrow rules happy: `register_telemetry`
+                    // takes `&mut self`, so we can't hold a `&mut Tab`
+                    // across the call.
+                    struct Found {
+                        group_idx: usize,
+                        tab_idx: usize,
+                        session_id: String,
+                        working_directory: String,
+                    }
+                    let mut found = Vec::new();
+                    let mut any_pending = false;
+                    for (g_idx, group) in this.groups.iter().enumerate() {
+                        for (t_idx, tab) in group.tabs.iter().enumerate() {
+                            if tab.adopted_session_id.is_some() {
+                                continue;
+                            }
+                            if !codescope_core::claude_discovery::is_claude_auto_type(
+                                tab.auto_type.as_ref().map(|s| s.as_ref()),
+                            ) {
+                                continue;
+                            }
+                            let Some(ref wd) = tab.working_directory else { continue };
+                            any_pending = true;
+                            let wd_str = wd.to_string_lossy().into_owned();
+                            let mut hits = codescope_core::claude_discovery::scan(
+                                &root, &wd_str, tab.spawned_at,
+                            );
+                            // Multiple hits: keep the lowest-id (any
+                            // deterministic pick will do — we'll
+                            // re-fire on subsequent rotations as the
+                            // file modtimes update).
+                            hits.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+                            if let Some(c) = hits.into_iter().next() {
+                                found.push(Found {
+                                    group_idx: g_idx,
+                                    tab_idx: t_idx,
+                                    session_id: c.session_id,
+                                    working_directory: wd_str,
+                                });
+                            }
+                        }
+                    }
+                    for f in found {
+                        this.register_telemetry(f.session_id.clone(), &f.working_directory);
+                        if let Some(group) = this.groups.get_mut(f.group_idx) {
+                            if let Some(tab) = group.tabs.get_mut(f.tab_idx) {
+                                tab.adopted_session_id = Some(f.session_id);
+                            }
+                        }
+                    }
+                    if any_pending {
+                        Duration::from_millis(codescope_core::CLAUDE_DISCOVERY_POLL_MS)
+                    } else {
+                        idle
                     }
                 });
                 match result {
@@ -1045,6 +1159,8 @@ impl AppShell {
             terminal,
             working_directory: working_directory_for_tab,
             auto_type: auto_type.clone(),
+            spawned_at: SystemTime::now(),
+            adopted_session_id: None,
         });
         let new_idx = group.tabs.len() - 1;
         self.activate_tab(group_idx, new_idx, window, cx);
@@ -1082,6 +1198,17 @@ impl AppShell {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Look up the closing tab's adopted Claude session id (if any)
+        // *before* mutating, so we can drop the telemetry tail without
+        // holding `&mut group` across the call.
+        let adopted = self
+            .groups
+            .get(group_idx)
+            .and_then(|g| g.tabs.get(tab_idx))
+            .and_then(|t| t.adopted_session_id.clone());
+        if let Some(sid) = adopted {
+            self.unregister_telemetry(&sid);
+        }
         let Some(group) = self.groups.get_mut(group_idx) else { return };
         if tab_idx >= group.tabs.len() {
             return;

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -104,7 +104,19 @@ struct Tab {
     /// has written its first jsonl line — and stays `None` for plain
     /// pwsh tabs (no `claude` auto-type). On adoption we register the
     /// telemetry tail; on close we unregister.
+    ///
+    /// Updates again on `/clear` rotations (Claude Code mints a new
+    /// `.jsonl` and a new id under the same encoded-cwd directory).
+    /// In that case the discovery loop unregisters the previous tail
+    /// before swapping in the new id, mirroring C# `WatchHandle._fired`
+    /// + `ApplyAdoption`.
     adopted_session_id: Option<String>,
+    /// Every Claude session id we've already registered telemetry for
+    /// on this tab — i.e. the historical adoption set.  Kept so the
+    /// discovery loop can dedupe when re-scanning after `/clear`
+    /// rotations and avoid registering the same tail twice.  Mirrors
+    /// the C# `WatchHandle._fired` HashSet.
+    fired_session_ids: std::collections::HashSet<String>,
 }
 
 /// One column in the work area: a tab strip + the currently-selected
@@ -851,12 +863,16 @@ impl AppShell {
     /// Spawn the background per-tab Claude session adoption loop.
     ///
     /// Mirrors `ClaudeSessionDiscovery.Watch` from the C# build: every
-    /// 350 ms while at least one tab is awaiting adoption, scan
-    /// `~/.claude/projects/<encoded-cwd>/` for `.jsonl` files written
-    /// at or after the tab's `spawned_at`. On a hit, register the
-    /// telemetry tail and stamp `adopted_session_id` on the tab so
-    /// subsequent ticks skip it. Idle (no Claude tabs awaiting
-    /// adoption) bumps the cadence to 5 s.
+    /// 350 ms while at least one Claude tab is alive, scan
+    /// `~/.claude/projects/<encoded-cwd>/` for `.jsonl` transcripts
+    /// written at or after `spawned_at`. The watch stays armed for
+    /// the tab's full lifetime (`/clear` rotates the session id and
+    /// writes a fresh `.jsonl`; the C# `WatchHandle._fired` HashSet
+    /// remembers paths already fired so each new id triggers exactly
+    /// one re-adoption). On rotation we unregister the previous
+    /// tail before registering the new one so `telemetry_tails`
+    /// doesn't accumulate stale entries. With no Claude tabs the
+    /// cadence drops to 5 s.
     ///
     /// Called from `AppShell::new` after the struct is constructed.
     fn start_claude_discovery_poll(&self, cx: &mut Context<Self>) {
@@ -873,59 +889,86 @@ impl AppShell {
                     let Some(root) = Self::claude_projects_root() else {
                         return idle;
                     };
-                    // Walk every tab, adopt fresh transcripts in place.
-                    // Two-pass (collect candidates, then mutate) keeps
-                    // the borrow rules happy: `register_telemetry`
-                    // takes `&mut self`, so we can't hold a `&mut Tab`
-                    // across the call.
+                    // Two-pass scan/mutate so we can't deadlock on
+                    // `register_telemetry`'s `&mut self` borrow:
+                    // collect candidates first (ids the tab hasn't
+                    // fired yet), then perform the register / un-
+                    // register dance. Keeps the watch alive for the
+                    // tab's full lifetime so `/clear` rotations are
+                    // adopted as new id-paths appear.
                     struct Found {
                         group_idx: usize,
                         tab_idx: usize,
-                        session_id: String,
+                        previous_session_id: Option<String>,
+                        new_session_id: String,
                         working_directory: String,
                     }
                     let mut found = Vec::new();
-                    let mut any_pending = false;
+                    let mut any_active = false;
                     for (g_idx, group) in this.groups.iter().enumerate() {
                         for (t_idx, tab) in group.tabs.iter().enumerate() {
-                            if tab.adopted_session_id.is_some() {
-                                continue;
-                            }
                             if !codescope_core::claude_discovery::is_claude_auto_type(
                                 tab.auto_type.as_ref().map(|s| s.as_ref()),
                             ) {
                                 continue;
                             }
                             let Some(ref wd) = tab.working_directory else { continue };
-                            any_pending = true;
+                            any_active = true;
                             let wd_str = wd.to_string_lossy().into_owned();
-                            let mut hits = codescope_core::claude_discovery::scan(
+                            let hits = codescope_core::claude_discovery::scan(
                                 &root, &wd_str, tab.spawned_at,
                             );
-                            // Multiple hits: keep the lowest-id (any
-                            // deterministic pick will do — we'll
-                            // re-fire on subsequent rotations as the
-                            // file modtimes update).
-                            hits.sort_by(|a, b| a.session_id.cmp(&b.session_id));
-                            if let Some(c) = hits.into_iter().next() {
+                            // Pick the newest unseen candidate by
+                            // last-modified mtime so a `/clear`
+                            // rotation supplants the previous id
+                            // rather than the loop oscillating
+                            // between concurrent transcripts.
+                            let mut newest: Option<(SystemTime, codescope_core::AdoptionCandidate)> = None;
+                            for c in hits {
+                                if tab.fired_session_ids.contains(&c.session_id) {
+                                    continue;
+                                }
+                                let mtime = std::fs::metadata(&c.path)
+                                    .ok()
+                                    .and_then(|m| m.modified().ok())
+                                    .unwrap_or(SystemTime::UNIX_EPOCH);
+                                let take = newest
+                                    .as_ref()
+                                    .map(|(prev, _)| mtime >= *prev)
+                                    .unwrap_or(true);
+                                if take {
+                                    newest = Some((mtime, c));
+                                }
+                            }
+                            if let Some((_, c)) = newest {
                                 found.push(Found {
                                     group_idx: g_idx,
                                     tab_idx: t_idx,
-                                    session_id: c.session_id,
+                                    previous_session_id: tab.adopted_session_id.clone(),
+                                    new_session_id: c.session_id,
                                     working_directory: wd_str,
                                 });
                             }
                         }
                     }
                     for f in found {
-                        this.register_telemetry(f.session_id.clone(), &f.working_directory);
+                        if let Some(prev) = f.previous_session_id.as_deref() {
+                            if prev != f.new_session_id {
+                                this.unregister_telemetry(prev);
+                            }
+                        }
+                        this.register_telemetry(
+                            f.new_session_id.clone(),
+                            &f.working_directory,
+                        );
                         if let Some(group) = this.groups.get_mut(f.group_idx) {
                             if let Some(tab) = group.tabs.get_mut(f.tab_idx) {
-                                tab.adopted_session_id = Some(f.session_id);
+                                tab.adopted_session_id = Some(f.new_session_id.clone());
+                                tab.fired_session_ids.insert(f.new_session_id);
                             }
                         }
                     }
-                    if any_pending {
+                    if any_active {
                         Duration::from_millis(codescope_core::CLAUDE_DISCOVERY_POLL_MS)
                     } else {
                         idle
@@ -1161,6 +1204,7 @@ impl AppShell {
             auto_type: auto_type.clone(),
             spawned_at: SystemTime::now(),
             adopted_session_id: None,
+            fired_session_ids: std::collections::HashSet::new(),
         });
         let new_idx = group.tabs.len() - 1;
         self.activate_tab(group_idx, new_idx, window, cx);


### PR DESCRIPTION
## Summary

- New `core/src/claude_discovery.rs` mirrors C# `ClaudeSessionDiscovery` (poll-only, no FSWatcher). Scans `~/.claude/projects/<encoded-cwd>/` for `.jsonl` transcripts written at/after a tab's `spawned_at`. UUID validation matches C# `Guid.TryParseExact(id, \"D\")`.
- `Tab` gains `spawned_at: SystemTime` + `adopted_session_id: Option<String>`. New background `start_claude_discovery_poll` (350 ms while pending, 5 s idle) registers the telemetry tail on adoption. `close_tab` unregisters before mutating the group.
- Helper `is_claude_auto_type` ported into core so the agent-id heuristic is unit-tested (matches `claude` modulo leading whitespace + trailing flags, rejects `claudeflare`-style substrings).

This is the prerequisite step from the session-36 HANDOFF cursor: \"Plumbing through `spawn_tab` / `close_tab` is the prerequisite for the right-cluster slots showing real data.\" The integrating PR (status-bar UI consuming `telemetry_for` / `git_status_for` / `notifications`) will follow.

## Test plan

- [x] `cargo test --workspace` — 141 passing (19 new: 12 scan + UUID + 7 auto-type).
- [x] `cargo build --bin window` clean (one deliberate \"telemetry_for never used\" warning until the integrating PR consumes it).
- [ ] Manual: launch a \"New Claude session\" tab, watch HANDOFF-mentioned `\$env:CODESCOPE_DEV=1` build, confirm a `.jsonl` lands in `~/.claude/projects/<encoded-cwd>/` and the discovery poll picks it up. (User can't live-test this run; verifies on next session.)