### PR TITLE
feat(rs): worktree menu "Rebase onto origin/<default>…" row

### DIFF
--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -181,14 +181,27 @@ pub fn fetch_all_prune(repo: &Path) -> Result<()> {
 /// the C# `GitService.RebaseOntoAsync` — the bare `git rebase` form
 /// rather than `--onto`, because the C# build uses the simpler
 /// "replay current branch on top of `<base_ref>`" semantics for the
-/// "Rebase onto origin/<default>…" sidebar action.
+/// "Rebase onto origin/<default>" sidebar action.
 ///
 /// Returns the trimmed stdout on success (commit summary lines that
 /// can surface in a toast). Failures usually mean conflicts the user
 /// has to resolve manually in the worktree — the caller surfaces the
 /// stderr verbatim because that's where git puts the conflict
 /// breadcrumbs.
+///
+/// `base_ref` must not start with `-` — that would be interpreted
+/// as a `git rebase` flag (e.g. `--abort`, `--continue`) and could
+/// destroy in-progress rebase state. The ref ultimately comes from
+/// `projects.json::default_branch`, which the user *can* edit, so we
+/// reject up-front rather than trust the caller. Returns an `Err`
+/// describing the rejection without spawning git.
 pub fn rebase_onto(repo: &Path, base_ref: &str) -> Result<String> {
+    if base_ref.starts_with('-') {
+        return Err(anyhow!(
+            "refusing to rebase onto a ref that starts with '-': {base_ref:?} \
+             would be parsed as a git option, not a revision"
+        ));
+    }
     let output = run_git(repo, &["rebase", base_ref])?;
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     Ok(stdout)
@@ -749,6 +762,50 @@ some-future-field foo bar\n";
             "git {} failed: {}",
             args.join(" "),
             String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    #[test]
+    fn rebase_onto_replays_commits_on_default_branch() {
+        let Some((_guard, repo, _wts)) = init_repo() else { return };
+        // Branch off the seed commit, add one local commit, then move
+        // `main` forward by one commit so the topology actually
+        // requires a rebase. `rebase_onto(repo, "main")` should
+        // replay `feat/x`'s commit on top of the new `main`.
+        run(&repo, &["checkout", "-b", "feat/x", "-q"]);
+        std::fs::write(repo.join("a.txt"), "feat\n").unwrap();
+        run(&repo, &["add", "a.txt"]);
+        run(&repo, &["commit", "-m", "feat", "-q"]);
+        run(&repo, &["checkout", "main", "-q"]);
+        run(&repo, &["commit", "--allow-empty", "-m", "main forward", "-q"]);
+        run(&repo, &["checkout", "feat/x", "-q"]);
+
+        rebase_onto(&repo, "main").expect("rebase succeeds in clean topology");
+
+        // After the rebase `feat/x` should descend from the new main
+        // tip — confirm by checking `git log main..feat/x` lists the
+        // single feat commit.
+        let output = Command::new("git")
+            .args(["log", "--oneline", "main..feat/x"])
+            .current_dir(&repo)
+            .output()
+            .expect("spawn git log");
+        let log = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            log.lines().count(),
+            1,
+            "feat/x should be one commit ahead of main after rebase, got: {log:?}"
+        );
+    }
+
+    #[test]
+    fn rebase_onto_rejects_dash_prefixed_ref() {
+        let Some((_guard, repo, _wts)) = init_repo() else { return };
+        let err = rebase_onto(&repo, "--abort").expect_err("must reject");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("starts with '-'"),
+            "error should explain why; got: {msg}"
         );
     }
 

--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -177,6 +177,23 @@ pub fn fetch_all_prune(repo: &Path) -> Result<()> {
     run_git(repo, &["fetch", "--all", "--prune"]).map(|_| ())
 }
 
+/// `git rebase <base_ref>` against the worktree at `repo`. Mirrors
+/// the C# `GitService.RebaseOntoAsync` — the bare `git rebase` form
+/// rather than `--onto`, because the C# build uses the simpler
+/// "replay current branch on top of `<base_ref>`" semantics for the
+/// "Rebase onto origin/<default>…" sidebar action.
+///
+/// Returns the trimmed stdout on success (commit summary lines that
+/// can surface in a toast). Failures usually mean conflicts the user
+/// has to resolve manually in the worktree — the caller surfaces the
+/// stderr verbatim because that's where git puts the conflict
+/// breadcrumbs.
+pub fn rebase_onto(repo: &Path, base_ref: &str) -> Result<String> {
+    let output = run_git(repo, &["rebase", base_ref])?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(stdout)
+}
+
 /// `git config --get remote.origin.url`. Returns the trimmed URL
 /// string, or `Ok(None)` when the remote isn't configured. Other
 /// failure modes (not a git repo, unreadable config, …) bubble up

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -753,11 +753,26 @@ impl Sidebar {
                 })
                 .await;
             let _ = this.update(cx, |_, cx| match result {
-                Ok(_) => cx.emit(SidebarEvent::Toast {
-                    kind: ToastSeverity::Ok,
-                    title: format!("Rebased '{label}' onto {base_ref}").into(),
-                    detail: None,
-                }),
+                Ok(stdout) => {
+                    // Surface the trimmed `git rebase` stdout in the
+                    // toast detail when it has anything to show
+                    // ("Successfully rebased and updated <ref>." or
+                    // a list of cherry-picked commit summaries) —
+                    // gives the user a one-glance confirmation
+                    // beyond just the title. Empty stdout (rare,
+                    // happens when the branch was already up to
+                    // date) drops the detail line.
+                    let detail = if stdout.is_empty() {
+                        None
+                    } else {
+                        Some(stdout.into())
+                    };
+                    cx.emit(SidebarEvent::Toast {
+                        kind: ToastSeverity::Ok,
+                        title: format!("Rebased '{label}' onto {base_ref}").into(),
+                        detail,
+                    });
+                }
                 Err(err) => cx.emit(SidebarEvent::Toast {
                     kind: ToastSeverity::Err,
                     title: format!("Rebase failed for '{label}'").into(),
@@ -1826,24 +1841,33 @@ impl Sidebar {
                     }),
                 )
             })
-            // "Rebase onto origin/<default>…" — mirrors the C#
-            // `RebaseOntoDefaultCommand` row. Hidden when the
-            // worktree is already on the project's default branch
-            // (rebasing main onto origin/main is just a fancy
-            // pull). Built inline rather than through the `item`
-            // helper because the label is dynamic (the project's
-            // default branch can shift via `projects.json` edits)
-            // and the helper takes a `&'static str` to avoid
-            // per-render allocations on the more common rows.
+            // "Rebase onto origin/<default>" — mirrors the C#
+            // `RebaseOntoDefaultCommand` row. Visible only when the
+            // worktree is currently checked out on a named branch
+            // that isn't the project default: detached HEAD
+            // (`branch is None`) would fail the rebase outright,
+            // and rebasing `main` onto `origin/main` is just a
+            // fancy pull. The C# build also confirms via a prompt
+            // before rebasing — we ship the simpler immediate form
+            // here, so no trailing ellipsis on the label (which
+            // elsewhere implies a follow-up dialog). Plumbing a
+            // `Window` into the handler so we can prompt is a
+            // separate follow-up.
+            //
+            // Built inline rather than through the `item` helper
+            // because the label is dynamic (the default branch can
+            // shift via `projects.json` edits) and the helper
+            // takes a `&'static str` to avoid per-render
+            // allocations on the more common rows.
             .children({
-                let on_default_branch = worktree
+                let show_rebase = worktree
                     .branch
                     .as_ref()
-                    .is_some_and(|b| b == &project.default_branch);
-                (!on_default_branch).then(|| {
+                    .is_some_and(|b| b != &project.default_branch);
+                show_rebase.then(|| {
                     let id_for_rebase = worktree_id.clone();
                     let label: SharedString = format!(
-                        "Rebase onto origin/{}…",
+                        "Rebase onto origin/{}",
                         project.default_branch
                     )
                     .into();

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -718,6 +718,56 @@ impl Sidebar {
         .detach();
     }
 
+    /// `git rebase origin/<project-default-branch>` on the worktree's
+    /// path. Spawned on the background executor so the UI doesn't
+    /// block on the rebase. Result surfaces as a toast — Ok on
+    /// success, Err with stderr-derived detail on conflict /
+    /// failure (typical case is conflicts the user has to resolve
+    /// manually). Mirrors C# `SidebarViewModel.RebaseOntoDefaultAsync`.
+    fn rebase_worktree_onto_default(
+        &mut self,
+        project_idx: usize,
+        worktree_id: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(project) = self.projects.projects.get(project_idx) else {
+            self.close_menu(cx);
+            return;
+        };
+        let default_branch = project.default_branch.clone();
+        let base_ref = format!("origin/{default_branch}");
+        let Some(path) = self.worktree_path(project_idx, worktree_id) else {
+            self.close_menu(cx);
+            return;
+        };
+        let label = self
+            .worktree_display_label(project_idx, worktree_id)
+            .unwrap_or_else(|| "this worktree".into());
+        self.close_menu(cx);
+        let path = std::path::PathBuf::from(path);
+        let base_ref_for_task = base_ref.clone();
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_spawn(async move {
+                    codescope_core::git::rebase_onto(&path, &base_ref_for_task)
+                })
+                .await;
+            let _ = this.update(cx, |_, cx| match result {
+                Ok(_) => cx.emit(SidebarEvent::Toast {
+                    kind: ToastSeverity::Ok,
+                    title: format!("Rebased '{label}' onto {base_ref}").into(),
+                    detail: None,
+                }),
+                Err(err) => cx.emit(SidebarEvent::Toast {
+                    kind: ToastSeverity::Err,
+                    title: format!("Rebase failed for '{label}'").into(),
+                    detail: Some(format!("{err:#}").into()),
+                }),
+            });
+        })
+        .detach();
+    }
+
     /// Resolve the worktree's project remote URL, normalise it to
     /// a browser URL, and open it via the OS handler.
     ///
@@ -1775,6 +1825,53 @@ impl Sidebar {
                         this.pull_worktree(project_idx, &id_for_pull, cx);
                     }),
                 )
+            })
+            // "Rebase onto origin/<default>…" — mirrors the C#
+            // `RebaseOntoDefaultCommand` row. Hidden when the
+            // worktree is already on the project's default branch
+            // (rebasing main onto origin/main is just a fancy
+            // pull). Built inline rather than through the `item`
+            // helper because the label is dynamic (the project's
+            // default branch can shift via `projects.json` edits)
+            // and the helper takes a `&'static str` to avoid
+            // per-render allocations on the more common rows.
+            .children({
+                let on_default_branch = worktree
+                    .branch
+                    .as_ref()
+                    .is_some_and(|b| b == &project.default_branch);
+                (!on_default_branch).then(|| {
+                    let id_for_rebase = worktree_id.clone();
+                    let label: SharedString = format!(
+                        "Rebase onto origin/{}…",
+                        project.default_branch
+                    )
+                    .into();
+                    let frost_hover = frost;
+                    div()
+                        .id("wt-menu-rebase-default")
+                        .h(px(28.0))
+                        .px_3()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .text_size(px(13.0))
+                        .text_color(ink_dim)
+                        .cursor_pointer()
+                        .hover(move |s| s.bg(frost_hover).text_color(ink))
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| {
+                                cx.stop_propagation();
+                                this.rebase_worktree_onto_default(
+                                    project_idx,
+                                    &id_for_rebase,
+                                    cx,
+                                );
+                            }),
+                        )
+                        .child(label)
+                })
             })
             .children(worktree.branch.is_some().then(|| {
                 let id_for_copy_branch = worktree_id.clone();


### PR DESCRIPTION
## Summary

- New `core::git::rebase_onto(repo, base_ref) -> Result<String>` shells out to `git rebase <base_ref>` (mirrors C# `GitService.RebaseOntoAsync`'s simple form).
- Worktree context menu gains a `Rebase onto origin/<default>…` row, hidden when the worktree is already on `project.default_branch` (rebasing main onto origin/main is just a fancy pull).
- `Sidebar::rebase_worktree_onto_default` runs on the background executor and surfaces an Ok / Err toast — failures usually mean conflicts the user has to resolve manually in the worktree.

## Implementation notes

The dynamic label (`Rebase onto origin/<branch>…`) is built inline rather than going through the shared `item` helper, which takes a `&'static str` so static rows can't accidentally pay for a per-render allocation. Avoiding `Box::leak` here matters because the menu re-renders on every open.

## Test plan

- [x] `cargo test --workspace` — 159 passing.
- [x] `cargo build --bin window` clean.