### PR TITLE
fix(rs): sidebar — render primary worktrees so the branch shows

### DIFF
--- a/codescope-rs/core/src/projects.rs
+++ b/codescope-rs/core/src/projects.rs
@@ -47,7 +47,11 @@ pub struct Project {
     /// Sessions persisted across restarts.
     #[serde(default)]
     pub sessions: Vec<Session>,
-    /// Tracked worktrees. The primary worktree at `path` is implicit.
+    /// Tracked worktrees. Includes the primary worktree at `path`
+    /// (the one with `is_primary: true`) as an explicit row;
+    /// `Project::new` seeds it on creation, and
+    /// [`ProjectsConfig::migrate`] back-fills it for legacy configs
+    /// that don't have one yet.
     #[serde(default)]
     pub worktrees: Vec<Worktree>,
 }
@@ -102,9 +106,12 @@ impl Project {
     }
 }
 
-/// One git worktree under a [`Project`]. Every project has an
-/// implicit primary worktree at `Project::path`; additional ones live
-/// here and get `is_primary = false`.
+/// One git worktree under a [`Project`]. Every project carries an
+/// explicit primary row (`is_primary: true`) pointing at
+/// `Project::path` plus zero or more additional worktrees with
+/// `is_primary: false`. The primary row is seeded by `Project::new`
+/// and back-filled by [`ProjectsConfig::migrate`] for legacy
+/// configs that predate that rule.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Worktree {
@@ -190,22 +197,35 @@ impl ProjectsConfig {
     /// C# `ProjectStore.Migrate`.
     ///
     /// **Rule 1 — primary worktree synthesis.** Every project with a
-    /// non-empty `path` and an empty `worktrees` list gets a synthetic
-    /// `Worktree { id: "primary", path, is_primary: true, branch: None }`.
-    /// Without this, the sidebar's worktree row loop skips the primary
-    /// checkout and a project added via `Project::new` (which seeds
-    /// `worktrees: Vec::new()`) renders as if it had no checkouts at
-    /// all, hiding the branch the user is actually on. The
-    /// `WorktreeStatusPoller` fills in the branch on its first tick.
+    /// non-empty `path` and *no* worktree marked `is_primary: true`
+    /// gets a synthetic `Worktree { id: "primary", path,
+    /// is_primary: true, branch: None }`. Without this, the sidebar
+    /// can't render a row for the project's own checkout and the
+    /// branch the user is currently on stays invisible.
+    ///
+    /// We key on the `is_primary` flag rather than "list is empty"
+    /// because legacy `projects.json` files written by the Rust UI
+    /// before this rule landed could have one or more *non-primary*
+    /// rows added later but still no primary entry — hitting only
+    /// the empty-list case would leave those projects in the broken
+    /// state. The `WorktreeStatusPoller` fills in the branch on its
+    /// first tick.
     pub fn migrate(&mut self) {
         for p in &mut self.projects {
-            if p.worktrees.is_empty() && !p.path.is_empty() {
-                p.worktrees.push(Worktree {
-                    id: "primary".to_owned(),
-                    path: p.path.clone(),
-                    branch: None,
-                    is_primary: true,
-                });
+            if p.path.is_empty() {
+                continue;
+            }
+            let has_primary = p.worktrees.iter().any(|wt| wt.is_primary);
+            if !has_primary {
+                p.worktrees.insert(
+                    0,
+                    Worktree {
+                        id: "primary".to_owned(),
+                        path: p.path.clone(),
+                        branch: None,
+                        is_primary: true,
+                    },
+                );
             }
         }
     }
@@ -329,6 +349,44 @@ mod tests {
         assert!(p.worktrees[0].is_primary);
         assert_eq!(p.worktrees[0].path, "C:\\repos\\repo");
         assert_eq!(p.worktrees[0].id, "primary");
+    }
+
+    #[test]
+    fn migrate_back_fills_primary_when_only_secondary_worktrees_exist() {
+        // Legacy projects.json from a Rust UI that had no
+        // primary-seeding rule but did support adding secondary
+        // worktrees via "New worktree from branch…". The user could
+        // end up with a project that has secondaries but no primary,
+        // which the original empty-list-only migration would skip.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("projects.json");
+        std::fs::write(
+            &path,
+            r#"{
+              "version": 1,
+              "projects": [
+                {
+                  "id": "p1",
+                  "name": "Repo",
+                  "path": "C:\\repos\\repo",
+                  "defaultBranch": "main",
+                  "worktrees": [
+                    { "id": "feat-x", "path": "C:\\repos\\repo.worktrees\\feat-x", "branch": "feat/x", "isPrimary": false }
+                  ]
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        let cfg = ProjectsConfig::load_from(&path).unwrap();
+        let p = &cfg.projects[0];
+        assert_eq!(p.worktrees.len(), 2, "primary back-filled in addition to existing secondary");
+        assert!(p.worktrees[0].is_primary, "primary inserted at index 0");
+        assert_eq!(p.worktrees[0].id, "primary");
+        assert_eq!(p.worktrees[0].path, "C:\\repos\\repo");
+        assert!(!p.worktrees[1].is_primary, "secondary preserved");
+        assert_eq!(p.worktrees[1].id, "feat-x");
     }
 
     #[test]

--- a/codescope-rs/core/src/projects.rs
+++ b/codescope-rs/core/src/projects.rs
@@ -68,6 +68,18 @@ impl Project {
             .and_then(|s| s.to_str())
             .map(|s| s.to_string())
             .unwrap_or_else(|| "project".to_string());
+        // Seed a primary worktree row so the sidebar has a child row
+        // to bind to immediately. Mirrors C# `SessionStore.AddProjectAsync`,
+        // which synthesises the same primary entry — without it the
+        // newly-added project renders as an empty shell. Branch is
+        // left None; the dirty / git-status pollers fill it in on the
+        // first tick.
+        let primary = Worktree {
+            id: "primary".to_owned(),
+            path: path.clone(),
+            branch: None,
+            is_primary: true,
+        };
         Self {
             id: uuid::Uuid::new_v4().to_string(),
             name,
@@ -76,7 +88,7 @@ impl Project {
             worktree_root: None,
             default_agent_id: None,
             sessions: Vec::new(),
-            worktrees: Vec::new(),
+            worktrees: vec![primary],
         }
     }
 
@@ -162,12 +174,39 @@ impl ProjectsConfig {
     }
 
     pub fn load_from(path: &Path) -> Result<Self> {
-        match std::fs::read(path) {
-            Ok(bytes) if bytes.is_empty() => Ok(Self::default()),
+        let mut config: Self = match std::fs::read(path) {
+            Ok(bytes) if bytes.is_empty() => Self::default(),
             Ok(bytes) => serde_json::from_slice(&bytes)
-                .with_context(|| format!("parse {}", path.display())),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
-            Err(err) => Err(err).with_context(|| format!("read {}", path.display())),
+                .with_context(|| format!("parse {}", path.display()))?,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Self::default(),
+            Err(err) => return Err(err).with_context(|| format!("read {}", path.display())),
+        };
+        config.migrate();
+        Ok(config)
+    }
+
+    /// Apply schema migrations to an in-memory config. Idempotent —
+    /// rerunning is a no-op once every rule has converged. Mirrors
+    /// C# `ProjectStore.Migrate`.
+    ///
+    /// **Rule 1 — primary worktree synthesis.** Every project with a
+    /// non-empty `path` and an empty `worktrees` list gets a synthetic
+    /// `Worktree { id: "primary", path, is_primary: true, branch: None }`.
+    /// Without this, the sidebar's worktree row loop skips the primary
+    /// checkout and a project added via `Project::new` (which seeds
+    /// `worktrees: Vec::new()`) renders as if it had no checkouts at
+    /// all, hiding the branch the user is actually on. The
+    /// `WorktreeStatusPoller` fills in the branch on its first tick.
+    pub fn migrate(&mut self) {
+        for p in &mut self.projects {
+            if p.worktrees.is_empty() && !p.path.is_empty() {
+                p.worktrees.push(Worktree {
+                    id: "primary".to_owned(),
+                    path: p.path.clone(),
+                    branch: None,
+                    is_primary: true,
+                });
+            }
         }
     }
 
@@ -258,6 +297,76 @@ mod tests {
         assert_eq!(p.default_branch, "main");
         // UUIDv4 is 36 chars including the dashes.
         assert_eq!(p.id.len(), 36);
+    }
+
+    #[test]
+    fn new_project_seeds_a_primary_worktree() {
+        let p = Project::new("/home/me/codescope".into());
+        assert_eq!(p.worktrees.len(), 1);
+        let wt = &p.worktrees[0];
+        assert_eq!(wt.id, "primary");
+        assert_eq!(wt.path, "/home/me/codescope");
+        assert!(wt.is_primary);
+        assert!(wt.branch.is_none());
+    }
+
+    #[test]
+    fn migrate_synthesises_primary_for_legacy_projects_without_worktrees() {
+        // Old projects.json from before the seed-on-create rule:
+        // a project entry with no `worktrees` field. The migration
+        // should add a primary so the sidebar isn't blank for it.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("projects.json");
+        std::fs::write(
+            &path,
+            r#"{"version":1,"projects":[{"id":"p1","name":"Repo","path":"C:\\repos\\repo","defaultBranch":"main"}]}"#,
+        )
+        .unwrap();
+
+        let cfg = ProjectsConfig::load_from(&path).unwrap();
+        let p = &cfg.projects[0];
+        assert_eq!(p.worktrees.len(), 1, "primary should be synthesised");
+        assert!(p.worktrees[0].is_primary);
+        assert_eq!(p.worktrees[0].path, "C:\\repos\\repo");
+        assert_eq!(p.worktrees[0].id, "primary");
+    }
+
+    #[test]
+    fn migrate_is_idempotent_on_already_migrated_config() {
+        // Project that already has a primary should *not* get a
+        // second one. Migration is idempotent.
+        let mut cfg = ProjectsConfig {
+            version: CURRENT_VERSION,
+            agents: Vec::new(),
+            projects: vec![Project::new("/home/me/repo".into())],
+        };
+        let before_len = cfg.projects[0].worktrees.len();
+        cfg.migrate();
+        cfg.migrate();
+        assert_eq!(cfg.projects[0].worktrees.len(), before_len);
+    }
+
+    #[test]
+    fn migrate_skips_projects_with_empty_path() {
+        // No path = no checkout to bind the primary to. Don't
+        // synthesise a worktree pointing at "" — that would render
+        // a broken row in the sidebar.
+        let mut cfg = ProjectsConfig {
+            version: CURRENT_VERSION,
+            agents: Vec::new(),
+            projects: vec![Project {
+                id: "p1".into(),
+                name: "Empty".into(),
+                path: String::new(),
+                default_branch: "main".into(),
+                worktree_root: None,
+                default_agent_id: None,
+                sessions: Vec::new(),
+                worktrees: Vec::new(),
+            }],
+        };
+        cfg.migrate();
+        assert!(cfg.projects[0].worktrees.is_empty());
     }
 
     #[test]

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -1150,12 +1150,12 @@ impl Render for Sidebar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = self.theme.clone();
         let selected = self.selected;
-        // Snapshot project + non-primary worktree metadata up front so
-        // each row's `cx.listener` closure can hold owned values
-        // without overlapping the immutable borrow `iter()` would
-        // otherwise extend across the rest of `render`. Primary
-        // worktrees are implicit at `Project::path`; we only emit
-        // child rows for the extras.
+        // Snapshot project + worktree metadata (every worktree,
+        // primary included — see the per-project comment below for
+        // why) up front so each row's `cx.listener` closure can hold
+        // owned values without overlapping the immutable borrow
+        // `iter()` would otherwise extend across the rest of
+        // `render`.
         let rows: Vec<(usize, String, SharedString, String, Vec<WorktreeRowData>)> = self
             .projects
             .projects
@@ -1416,8 +1416,13 @@ impl Render for Sidebar {
                     Some(false) => theme::status_clean(&theme),
                     None => theme::ink_ghost(&theme),
                 };
+                // Element id is keyed off `(project.id, worktree.id)`
+                // so primary rows from different projects (which all
+                // share `wt.id == "primary"`) don't collide in gpui's
+                // id-based element reuse table.
+                let wt_row_id = format!("{}/{}", id, wt.id);
                 let wt_row = div()
-                    .id(("worktree", id_hash(&wt.id)))
+                    .id(("worktree", id_hash(&wt_row_id)))
                     .h(px(28.0))
                     .flex()
                     .flex_row()

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -1162,10 +1162,18 @@ impl Render for Sidebar {
             .iter()
             .enumerate()
             .map(|(idx, p)| {
+                // Render every worktree, primary included. The C#
+                // sidebar template is keyed off the same flat
+                // `Worktrees` list and shows the primary row too so
+                // the user sees the branch they're currently on. The
+                // earlier `!wt.is_primary` filter was a porting
+                // mistake — it hid the primary checkout and made a
+                // perfectly normal "single repo on main" project
+                // render with the misleading "(no worktrees)"
+                // placeholder from #101.
                 let worktrees = p
                     .worktrees
                     .iter()
-                    .filter(|wt| !wt.is_primary)
                     .map(|wt| WorktreeRowData {
                         id: wt.id.clone(),
                         path: wt.path.clone(),
@@ -1359,14 +1367,20 @@ impl Render for Sidebar {
             // worktree's path. Right-click opens the worktree context
             // menu (Reveal / Open in WT / Copy path / Remove…).
             for wt in worktrees.into_iter() {
-                let wt_label: SharedString = wt
-                    .branch
-                    .clone()
+                // Prefer the live branch from `git_status` over the
+                // persisted `worktree.branch` — primary worktrees in
+                // `projects.json` carry `branch: None` (the migration
+                // synthesises them without a branch label) and the
+                // git poller fills in the real value within a few
+                // seconds of launch. Falling back to the persisted
+                // branch then to the folder leaf keeps the row
+                // useful while the first poll is still in flight.
+                let wt_label: SharedString = self
+                    .git_status
+                    .get(&wt.path)
+                    .map(|g| g.branch.clone())
+                    .or_else(|| wt.branch.clone())
                     .unwrap_or_else(|| {
-                        // Fallback when the worktree row in
-                        // `projects.json` predates branch tracking:
-                        // surface the folder leaf so the user still
-                        // sees something useful.
                         std::path::Path::new(&wt.path)
                             .file_name()
                             .and_then(|s| s.to_str())


### PR DESCRIPTION
## What was wrong

Two bugs combined to make a perfectly normal "single-repo on main" project render with the misleading "(no worktrees)" placeholder from PR #101:

1. **Worktree row loop filtered out primary checkouts** — `!wt.is_primary` filter hid the project's own checkout. C# sidebar template binds to the same flat list and shows the primary too.
2. **`Project::new` seeded `worktrees: Vec::new()`** — the C# `SessionStore.AddProjectAsync` synthesises a `primary` worktree at creation time. Rust port skipped that step, so projects added via the Rust UI (and every legacy `projects.json` from before this fix) had no worktrees to render at all.

## Fix

- `Project::new` seeds the `primary` worktree row with `branch: None`; the git status poller fills the branch in within a few seconds.
- New `ProjectsConfig::migrate()` runs on every `load_from` and synthesises a primary for any project that has empty `worktrees`. Idempotent. Mirrors C# `ProjectStore.Migrate` Rule 2.
- Sidebar renders every worktree (primary included). Label prefers the live `git_status.branch` over the persisted `worktree.branch` so primary rows show the right branch even while the first poll is in flight.

## Test plan

- [x] `cargo test --workspace` — 165 passing (4 new migration / seeding tests).
- [x] `cargo build --bin window` clean.
- [ ] User reports that single-repo projects now show the branch name in the sidebar.