### PR TITLE
fix(rs): worktree click focuses an existing tab instead of spawning

### DIFF
--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -466,7 +466,39 @@ impl AppShell {
         // focus inline.
         cx.subscribe_in(&sidebar, window, |this, _sidebar, event, window, cx| {
             match event {
-                SidebarEvent::OpenSession { working_directory, title, auto_type } => {
+                SidebarEvent::OpenSession {
+                    working_directory,
+                    title,
+                    auto_type,
+                    force_new,
+                } => {
+                    // Focus-or-open by default: walk every group's
+                    // tabs for one whose `working_directory` matches
+                    // and activate it. Only fall through to a fresh
+                    // spawn when nothing matches *or* the caller
+                    // explicitly asked for `force_new` (the
+                    // "New session" / "New Claude session" menu
+                    // rows). This is what the user means by
+                    // "clicking a worktree shouldn't pile up new
+                    // sessions every time".
+                    if !*force_new {
+                        let mut focus_target: Option<(usize, usize)> = None;
+                        for (g_idx, group) in this.groups.iter().enumerate() {
+                            for (t_idx, tab) in group.tabs.iter().enumerate() {
+                                if tab.working_directory.as_deref() == Some(working_directory.as_path()) {
+                                    focus_target = Some((g_idx, t_idx));
+                                    break;
+                                }
+                            }
+                            if focus_target.is_some() {
+                                break;
+                            }
+                        }
+                        if let Some((g_idx, t_idx)) = focus_target {
+                            this.activate_tab(g_idx, t_idx, window, cx);
+                            return;
+                        }
+                    }
                     this.spawn_tab_in(
                         Some(working_directory.clone()),
                         Some(title.clone()),

--- a/codescope-rs/src/new_worktree_dialog.rs
+++ b/codescope-rs/src/new_worktree_dialog.rs
@@ -505,10 +505,15 @@ impl Sidebar {
                 // `$"{project.Name} · {branch}"` convention in
                 // `MainViewModel.RefreshTabTitlesForWorktree`.
                 if spawn_session {
+                    // Just-created worktree → there's no existing
+                    // tab for it; force a fresh spawn rather than
+                    // letting the focus-or-open path no-op against
+                    // an unrelated tab in the same path.
                     cx.emit(crate::sidebar::SidebarEvent::OpenSession {
                         working_directory: std::path::PathBuf::from(&folder),
                         title: format!("{project_name} · {branch}").into(),
                         auto_type: None,
+                        force_new: true,
                     });
                 }
             }

--- a/codescope-rs/src/new_worktree_dialog.rs
+++ b/codescope-rs/src/new_worktree_dialog.rs
@@ -505,10 +505,15 @@ impl Sidebar {
                 // `$"{project.Name} · {branch}"` convention in
                 // `MainViewModel.RefreshTabTitlesForWorktree`.
                 if spawn_session {
-                    // Just-created worktree → there's no existing
-                    // tab for it; force a fresh spawn rather than
-                    // letting the focus-or-open path no-op against
-                    // an unrelated tab in the same path.
+                    // Just-created worktree, just-created folder —
+                    // the user explicitly asked for a session here,
+                    // so always spawn one. `force_new: true` skips
+                    // the focus-or-open path entirely (matters in
+                    // the unlikely-but-possible case where another
+                    // tab already happens to point at the new
+                    // worktree's folder, e.g. because the user
+                    // rebuilt over a path a previous session was
+                    // sitting in).
                     cx.emit(crate::sidebar::SidebarEvent::OpenSession {
                         working_directory: std::path::PathBuf::from(&folder),
                         title: format!("{project_name} · {branch}").into(),

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -96,25 +96,35 @@ type MenuItemAction = Box<dyn Fn(&mut Sidebar, &mut Window, &mut Context<Sidebar
 /// the trait wiring.
 #[derive(Debug, Clone)]
 pub enum SidebarEvent {
-    /// Spawn a new tab whose terminal is pinned to `working_directory`,
-    /// using `title` for the tab strip. Title is just a label — the
-    /// host decides what to actually show (in practice the worktree
-    /// branch name suffixed with the project name).
+    /// Open a session for `working_directory`, using `title` for the
+    /// tab strip. Title is just a label — the host decides what to
+    /// actually show (in practice the worktree branch name suffixed
+    /// with the project name).
+    ///
+    /// Default semantics are *focus-or-open*: the host activates an
+    /// existing tab whose working directory matches and only spawns a
+    /// new one when nothing matches. Set `force_new: true` to always
+    /// spawn (used by the explicit "New session" / "New Claude
+    /// session" rows in the project context menu and the worktree
+    /// menu's "New Claude session" row).
     OpenSession {
         working_directory: PathBuf,
         title: SharedString,
         /// Optional command to auto-type at the shell prompt once the
-        /// pty has come up. Used by "New Claude session" / "New
-        /// Codex session" rows to launch the agent inline; `None`
-        /// just opens a plain shell. The host adds the trailing CR.
+        /// pty has come up. Used by the agent-launch rows ("New
+        /// Claude session", and any future agent variants) to fire
+        /// the agent inline; `None` just opens a plain shell. The
+        /// host adds the trailing CR.
         auto_type: Option<SharedString>,
-        /// When `true`, the host should always spawn a fresh tab
-        /// (used by the worktree menu's explicit "New session" /
-        /// "New Claude session" rows). When `false`, the host
-        /// activates an existing tab whose working directory matches
-        /// `working_directory` and only spawns a new one if no match
-        /// is found — the desired behaviour for a plain row click,
-        /// which would otherwise pile up a new tab on every click.
+        /// When `true`, the host always spawns a fresh tab — used by
+        /// the project menu's "New session" / "New Claude session"
+        /// rows, the worktree menu's "New Claude session" row, and
+        /// the new-worktree dialog's auto-spawn. When `false`, the
+        /// host activates an existing tab whose `working_directory`
+        /// matches and only spawns a new one if no match is found —
+        /// the desired behaviour for a plain worktree row click and
+        /// the worktree menu's "Open session" row, both of which
+        /// would otherwise pile up a duplicate tab on every click.
         force_new: bool,
     },
     /// Surface a status notification to the user. The sidebar emits
@@ -1447,10 +1457,12 @@ impl Render for Sidebar {
                         cx.listener(move |_, _, _, cx| {
                             // Plain row click — focus an existing
                             // tab for this worktree if one is open,
-                            // otherwise spawn one. The "New session"
-                            // / "New Claude session" rows in the
-                            // worktree context menu still pass
-                            // `force_new: true` to always spawn.
+                            // otherwise spawn one. The worktree
+                            // context menu's "New Claude session"
+                            // row (and the project menu's "New
+                            // session" / "New Claude session" rows)
+                            // still pass `force_new: true` to always
+                            // spawn a fresh tab.
                             cx.emit(SidebarEvent::OpenSession {
                                 working_directory: PathBuf::from(&wt_path_for_event),
                                 title: title_label.clone(),

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -108,6 +108,14 @@ pub enum SidebarEvent {
         /// Codex session" rows to launch the agent inline; `None`
         /// just opens a plain shell. The host adds the trailing CR.
         auto_type: Option<SharedString>,
+        /// When `true`, the host should always spawn a fresh tab
+        /// (used by the worktree menu's explicit "New session" /
+        /// "New Claude session" rows). When `false`, the host
+        /// activates an existing tab whose working directory matches
+        /// `working_directory` and only spawns a new one if no match
+        /// is found — the desired behaviour for a plain row click,
+        /// which would otherwise pile up a new tab on every click.
+        force_new: bool,
     },
     /// Surface a status notification to the user. The sidebar emits
     /// these from menu actions (pull / fetch / open remote / discard)
@@ -1437,10 +1445,17 @@ impl Render for Sidebar {
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(move |_, _, _, cx| {
+                            // Plain row click — focus an existing
+                            // tab for this worktree if one is open,
+                            // otherwise spawn one. The "New session"
+                            // / "New Claude session" rows in the
+                            // worktree context menu still pass
+                            // `force_new: true` to always spawn.
                             cx.emit(SidebarEvent::OpenSession {
                                 working_directory: PathBuf::from(&wt_path_for_event),
                                 title: title_label.clone(),
                                 auto_type: None,
+                                force_new: false,
                             });
                         }),
                     )
@@ -1662,6 +1677,7 @@ impl Sidebar {
                             working_directory: PathBuf::from(&project_path),
                             title: project_title.clone(),
                             auto_type: None,
+                            force_new: true,
                         });
                         this.close_menu(cx);
                     }),
@@ -1679,6 +1695,7 @@ impl Sidebar {
                             working_directory: PathBuf::from(&project_path),
                             title: project_title.clone(),
                             auto_type: Some(claude_command().into()),
+                            force_new: true,
                         });
                         this.close_menu(cx);
                     }),
@@ -1872,10 +1889,17 @@ impl Sidebar {
                     "Open session",
                     false,
                     Box::new(move |this, _window, cx| {
+                        // The worktree menu's "Open session" row is a
+                        // synonym for clicking the row itself —
+                        // focus-or-open rather than always-spawn —
+                        // so a user already running a session for
+                        // this worktree gets routed to it instead of
+                        // accidentally piling up duplicates.
                         cx.emit(SidebarEvent::OpenSession {
                             working_directory: path_for_open.clone(),
                             title: title_for_open.clone(),
                             auto_type: None,
+                            force_new: false,
                         });
                         this.close_menu(cx);
                     }),
@@ -1905,6 +1929,7 @@ impl Sidebar {
                             working_directory: path.clone(),
                             title: title.clone(),
                             auto_type: Some(claude_command().into()),
+                            force_new: true,
                         });
                         this.close_menu(cx);
                     }),


### PR DESCRIPTION
## What was wrong

Single-clicking a worktree row in the sidebar always emitted \`OpenSession\` which always called \`spawn_tab_in\`. Net effect: every click on the same worktree piled up another duplicate tab.

## Fix

- \`SidebarEvent::OpenSession\` gains a \`force_new: bool\` field.
- \`AppShell\` honours it: when \`force_new == false\`, walk every group's tabs for one whose \`working_directory\` matches and \`activate_tab\` it; only if nothing matches does it fall through to \`spawn_tab_in\`.
- Plain row clicks and the worktree menu's "Open session" row pass \`false\` (focus-or-open).
- Explicit "New session" / "New Claude session" menu rows and the new-worktree dialog's auto-spawn pass \`true\` (always create a fresh tab).

Mirrors the focus-or-open semantics C# \`MainViewModel.OpenSessionAsync\` uses by default.

## Test plan

- [x] \`cargo test --workspace\` — 166 passing.
- [x] \`cargo build --bin window\` clean.