### PR TITLE
feat(rs): title bar brand wordmark + version slug (left)

### DIFF
--- a/codescope-rs/build.rs
+++ b/codescope-rs/build.rs
@@ -9,9 +9,20 @@
 //! `Directory.Build.targets`. We do the same here: at build time
 //! we shell out to git, drop the leading `v`, and expose the
 //! result as the `CODESCOPE_VERSION_DISPLAY` env var so the
-//! caption row can read it via `env!`. Falls back to
-//! `CARGO_PKG_VERSION` if git is unavailable (sandboxed
-//! tarball builds, etc.).
+//! caption row can read it via `env!`.
+//!
+//! Override order:
+//!
+//! 1. `CODESCOPE_VERSION` env var — packaging pipelines set this
+//!    explicitly when they don't want git-derived strings (or
+//!    when git isn't available).
+//! 2. `git describe --tags --always --dirty` — normal dev /
+//!    release builds. Leading `v` / `V` is stripped so the chrome
+//!    can prefix its own `V` consistently.
+//! 3. `0.0-unknown` — last-resort fallback so the slug is
+//!    obviously a placeholder rather than masquerading as a real
+//!    version (`CARGO_PKG_VERSION` would print `0.0.1`, which
+//!    would look like a product release).
 //!
 //! ## Icon
 //!
@@ -21,14 +32,11 @@
 //! resource ID `1`, which is what Windows looks up when it needs
 //! "the" icon for an executable. No-op on non-Windows hosts.
 
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
     bake_version_slug();
-    // Re-run when the git HEAD or refs change so the slug stays in
-    // sync with the latest commit / tag without requiring a clean.
-    println!("cargo:rerun-if-changed=../.git/HEAD");
-    println!("cargo:rerun-if-changed=../.git/refs/tags");
 
     #[cfg(windows)]
     embed_resource::compile("assets/codescope.rc", embed_resource::NONE)
@@ -37,32 +45,73 @@ fn main() {
 }
 
 fn bake_version_slug() {
-    let display = git_describe()
-        .unwrap_or_else(|| std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0".into()));
+    // Always honour the env-var override first so packaging
+    // pipelines can pin the slug regardless of what's checked out.
+    println!("cargo:rerun-if-env-changed=CODESCOPE_VERSION");
+    if let Ok(explicit) = std::env::var("CODESCOPE_VERSION") {
+        let v = strip_v_prefix(explicit.trim());
+        println!("cargo:rustc-env=CODESCOPE_VERSION_DISPLAY={v}");
+        return;
+    }
+
+    let display = git_describe().unwrap_or_else(|| "0.0-unknown".into());
     println!("cargo:rustc-env=CODESCOPE_VERSION_DISPLAY={display}");
+
+    // `rerun-if-changed` for the *real* git refs so a fresh commit
+    // or tag updates the slug without a `cargo clean`. The naive
+    // `../.git/HEAD` form misses two important shapes:
+    //
+    //   * `.git` is a **file** inside a linked worktree (`git
+    //     worktree add` writes a `gitdir:` pointer to the canonical
+    //     workdir under `<repo>/.git/worktrees/<name>`).
+    //   * Branch-tracked HEAD updates `refs/heads/<branch>` (and
+    //     `packed-refs` after a gc), not `HEAD` itself.
+    //
+    // Resolving via `git rev-parse --git-path` handles both.
+    // Failures (no git, not a repo, …) just skip the trigger — the
+    // env-var / fallback path above still produces a usable slug.
+    for relative in ["HEAD", "packed-refs", "index", "refs/tags"] {
+        if let Some(p) = git_path(relative) {
+            if p.exists() {
+                println!("cargo:rerun-if-changed={}", p.display());
+            }
+        }
+    }
+    // The current branch's actual ref file. Resolves even when
+    // packed (in which case the file may not exist; we already
+    // watch `packed-refs` above).
+    if let Some(symref) = run_git(&["symbolic-ref", "--quiet", "HEAD"]) {
+        if let Some(p) = git_path(&symref) {
+            if p.exists() {
+                println!("cargo:rerun-if-changed={}", p.display());
+            }
+        }
+    }
 }
 
-/// Run `git describe --tags --always --dirty` from the workspace
-/// root and return the trimmed result with a leading `v` / `V`
-/// stripped (so `v0.2.6-52-g…` becomes `0.2.6-52-g…`). Returns
-/// `None` if git isn't on PATH or exits non-zero.
-fn git_describe() -> Option<String> {
+fn strip_v_prefix(s: &str) -> String {
+    s.strip_prefix('v').or_else(|| s.strip_prefix('V')).unwrap_or(s).to_owned()
+}
+
+fn run_git(args: &[&str]) -> Option<String> {
     let output = Command::new("git")
-        .args(["describe", "--tags", "--always", "--dirty"])
-        // The build runs from `codescope-rs/` but the git repo root
-        // is one level up. Keeping the manifest dir as the working
-        // directory still works because git walks parents — but be
-        // explicit to avoid surprises if the layout shifts later.
+        .args(args)
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .output()
         .ok()?;
     if !output.status.success() {
         return None;
     }
-    let raw = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    if raw.is_empty() {
-        return None;
-    }
-    let stripped = raw.strip_prefix('v').or_else(|| raw.strip_prefix('V')).unwrap_or(&raw);
-    Some(stripped.to_owned())
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+fn git_path(relative: &str) -> Option<PathBuf> {
+    let raw = run_git(&["rev-parse", "--git-path", relative])?;
+    Some(PathBuf::from(raw))
+}
+
+fn git_describe() -> Option<String> {
+    let raw = run_git(&["describe", "--tags", "--always", "--dirty"])?;
+    Some(strip_v_prefix(&raw))
 }

--- a/codescope-rs/build.rs
+++ b/codescope-rs/build.rs
@@ -1,15 +1,68 @@
-//! Build script — embeds the Windows application icon into the
-//! `window` binary. On non-Windows hosts this is a no-op.
+//! Build script — bakes the product version slug + (on Windows)
+//! embeds the application icon into the `window` binary.
+//!
+//! ## Version slug
+//!
+//! Mirrors C# `VersionInfo.Display`, which reads
+//! `AssemblyInformationalVersionAttribute` filled in from
+//! `git describe --tags --always --dirty` via
+//! `Directory.Build.targets`. We do the same here: at build time
+//! we shell out to git, drop the leading `v`, and expose the
+//! result as the `CODESCOPE_VERSION_DISPLAY` env var so the
+//! caption row can read it via `env!`. Falls back to
+//! `CARGO_PKG_VERSION` if git is unavailable (sandboxed
+//! tarball builds, etc.).
+//!
+//! ## Icon
 //!
 //! Mirrors `<ApplicationIcon>assets\codescope.ico</ApplicationIcon>`
 //! from the C# build's `CodeScope.App.csproj`. The resource script
-//! at `assets/codescope.rc` references `codescope.ico` (in the same
-//! folder) under resource ID `1`, which is what Windows looks up
-//! when it needs "the" icon for an executable.
+//! at `assets/codescope.rc` references `codescope.ico` under
+//! resource ID `1`, which is what Windows looks up when it needs
+//! "the" icon for an executable. No-op on non-Windows hosts.
+
+use std::process::Command;
 
 fn main() {
+    bake_version_slug();
+    // Re-run when the git HEAD or refs change so the slug stays in
+    // sync with the latest commit / tag without requiring a clean.
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs/tags");
+
     #[cfg(windows)]
     embed_resource::compile("assets/codescope.rc", embed_resource::NONE)
         .manifest_optional()
         .expect("compile codescope.rc");
+}
+
+fn bake_version_slug() {
+    let display = git_describe()
+        .unwrap_or_else(|| std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0".into()));
+    println!("cargo:rustc-env=CODESCOPE_VERSION_DISPLAY={display}");
+}
+
+/// Run `git describe --tags --always --dirty` from the workspace
+/// root and return the trimmed result with a leading `v` / `V`
+/// stripped (so `v0.2.6-52-g…` becomes `0.2.6-52-g…`). Returns
+/// `None` if git isn't on PATH or exits non-zero.
+fn git_describe() -> Option<String> {
+    let output = Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        // The build runs from `codescope-rs/` but the git repo root
+        // is one level up. Keeping the manifest dir as the working
+        // directory still works because git walks parents — but be
+        // explicit to avoid surprises if the layout shifts later.
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if raw.is_empty() {
+        return None;
+    }
+    let stripped = raw.strip_prefix('v').or_else(|| raw.strip_prefix('V')).unwrap_or(&raw);
+    Some(stripped.to_owned())
 }

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -3302,7 +3302,8 @@ impl Render for AppShell {
         // The padding is itself a drag region so the user can grab
         // the empty bit between the toggle and the first tab to
         // drag the window — same behaviour as the brand-mark.
-        let chrome_left_w = 40.0 + 32.0; // brand + sidebar_toggle
+        // brand mark + brand wordmark/version label + sidebar toggle.
+        let chrome_left_w = 40.0 + BRAND_LABEL_W + 32.0;
         let strip_left_pad_w = if self.sidebar_visible {
             (self.sidebar_width + DIVIDER_VISUAL_WIDTH - chrome_left_w).max(0.0)
         } else {
@@ -3327,6 +3328,56 @@ impl Render for AppShell {
                 this.handle_titlebar_press(event, window, cx);
             }),
         );
+
+        // Brand label + version slug — mirrors the C# title bar's
+        // "CodeScope" wordmark + `V0.2.6` slug pair (MainWindow.xaml
+        // lines 166–184). Sans 16/SemiBold for the wordmark, mono-
+        // ish 10 dim for the slug; the slug is baked at build time
+        // from `git describe --tags --always --dirty` (see build.rs)
+        // so tagging a release flips every consumer automatically.
+        // Both elements participate in the window-drag region so the
+        // user can grab the chrome anywhere along the brand cluster.
+        let version_display: SharedString =
+            format!("V{}", env!("CODESCOPE_VERSION_DISPLAY")).into();
+        // Fixed width keeps the `chrome_left_w` calculation below
+        // predictable so the per-group tab strip dividers can still
+        // line up with the splitters between panes. Long dev-build
+        // slugs (`V0.2.6-52-g…-dirty`) get clipped via
+        // `overflow_hidden` rather than pushing the tabs around.
+        const BRAND_LABEL_W: f32 = 150.0;
+        let brand_label = div()
+            .id("titlebar-brand-label")
+            .w(px(BRAND_LABEL_W))
+            .h(px(40.0))
+            .pl(px(2.0))
+            .pr(px(10.0))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(8.0))
+            .overflow_hidden()
+            .window_control_area(WindowControlArea::Drag)
+            .child(
+                div()
+                    .text_size(px(16.0))
+                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                    .text_color(theme::ink(&theme))
+                    .child("CodeScope"),
+            )
+            .child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(theme::ink_ghost(&theme))
+                    .truncate()
+                    .child(version_display),
+            )
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, event: &gpui::MouseDownEvent, window, cx| {
+                    this.handle_titlebar_press(event, window, cx);
+                }),
+            );
+
         let tab_strip_inline = div()
             .flex()
             .flex_row()
@@ -3368,6 +3419,7 @@ impl Render for AppShell {
             .border_color(theme::divider(&theme))
             .bg(theme::elevated(&theme))
             .child(brand_mark)
+            .child(brand_label)
             .child(sidebar_toggle)
             .child(strip_left_pad)
             .child(tab_strip_inline)

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -3337,8 +3337,10 @@ impl Render for AppShell {
         // so tagging a release flips every consumer automatically.
         // Both elements participate in the window-drag region so the
         // user can grab the chrome anywhere along the brand cluster.
-        let version_display: SharedString =
-            format!("V{}", env!("CODESCOPE_VERSION_DISPLAY")).into();
+        // `concat!` keeps the slug as a `&'static str` so the
+        // caption-row hot path doesn't pay for a `format!` on
+        // every render.
+        const VERSION_DISPLAY: &str = concat!("V", env!("CODESCOPE_VERSION_DISPLAY"));
         // Fixed width keeps the `chrome_left_w` calculation below
         // predictable so the per-group tab strip dividers can still
         // line up with the splitters between panes. Long dev-build
@@ -3369,7 +3371,7 @@ impl Render for AppShell {
                     .text_size(px(10.0))
                     .text_color(theme::ink_ghost(&theme))
                     .truncate()
-                    .child(version_display),
+                    .child(VERSION_DISPLAY),
             )
             .on_mouse_down(
                 MouseButton::Left,


### PR DESCRIPTION
## Summary

- Adds a \`CodeScope\` wordmark (sans 16/SemiBold) + version slug (mono 10, dim) to the left of the title bar, mirroring C# \`MainWindow.xaml\` lines 166–184.
- New \`build.rs\` step shells out to \`git describe --tags --always --dirty\` and bakes the trimmed result into \`CODESCOPE_VERSION_DISPLAY\` for the chrome to read via \`env!\`. Falls back to \`CARGO_PKG_VERSION\`.
- Fixed-width 150 px label with \`overflow_hidden\` + \`truncate\` so a long dev-build slug doesn't shove the tab strip out of splitter alignment. \`chrome_left_w\` updated.

## Test plan

- [x] \`cargo check --bin window\` clean, \`cargo test --workspace\` 166 passing.
- [ ] Manual: dev build shows \`CodeScope V0.2.6-…-dirty\` (the live git describe slug); v0.2.6 release build will show plain \`V0.2.6\`.