### PR TITLE
feat(rs): drop sidebar project chevron collapse / expand

### DIFF
--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -197,16 +197,6 @@ pub struct Sidebar {
     /// C# build's `WorktreePoller` but adds the richer data the
     /// status bar needs.
     git_status: HashMap<String, GitStatus>,
-    /// Project ids the user has explicitly collapsed. Projects start
-    /// expanded by default; toggling the chevron adds/removes the id
-    /// here. Mirrors the C# `TreeViewItem.IsExpanded` state per
-    /// project — except the C# build hangs that off WPF's tree
-    /// control, while we keep an explicit `HashSet<String>` so the
-    /// render loop can decide visibility without per-row state.
-    /// In-memory only for now; persisting to `layout.json` is a
-    /// follow-up (matches what the C# build does — TreeView state
-    /// is also session-scoped over there).
-    collapsed_projects: HashSet<String>,
 }
 
 impl Sidebar {
@@ -234,20 +224,7 @@ impl Sidebar {
             dialog: None,
             dirty_state: HashMap::new(),
             git_status: HashMap::new(),
-            collapsed_projects: HashSet::new(),
         }
-    }
-
-    /// Flip the collapse / expand state for the project at `id`.
-    /// Default is expanded; toggling for the first time collapses,
-    /// next toggle expands. Re-renders via `cx.notify`.
-    fn toggle_project_collapsed(&mut self, id: &str, cx: &mut Context<Self>) {
-        if self.collapsed_projects.contains(id) {
-            self.collapsed_projects.remove(id);
-        } else {
-            self.collapsed_projects.insert(id.to_owned());
-        }
-        cx.notify();
     }
 
     /// Spawn the dirty-state polling loop. Runs every
@@ -1281,34 +1258,6 @@ impl Render for Sidebar {
             let frost_hover = theme::frost_10(&theme);
             let ink_hover = theme::ink(&theme);
 
-            let collapsed = self.collapsed_projects.contains(&id);
-            // Chevron — points right when the project is collapsed,
-            // down when expanded. Mirrors the C# `TreeViewItem`
-            // chevron template (RotateTransform 0°/90° driven by
-            // `IsExpanded`). Click toggles; the click handler stops
-            // propagation so the chevron doesn't double-fire `select`.
-            let chevron_glyph = if collapsed { "\u{25B8}" } else { "\u{25BE}" };
-            let id_for_toggle = id.clone();
-            let chevron = div()
-                .id(("project-chevron", id_hash(&id)))
-                .w(px(14.0))
-                .h(px(14.0))
-                .mr(px(6.0))
-                .flex()
-                .items_center()
-                .justify_center()
-                .text_size(px(10.0))
-                .text_color(theme::ink_ghost(&theme))
-                .cursor_pointer()
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |this, _, _, cx| {
-                        cx.stop_propagation();
-                        this.toggle_project_collapsed(&id_for_toggle, cx);
-                    }),
-                )
-                .child(chevron_glyph);
-
             let project_row = div()
                 .id(("project", id_hash(&id)))
                 .h(px(32.0))
@@ -1318,14 +1267,7 @@ impl Render for Sidebar {
                 .pr_3()
                 .border_l_2()
                 .border_color(rail)
-                // 4 px row inset; the chevron (14 px wide + 6 px right
-                // margin) sits between the rail and the project name.
-                // This is a small rightward shift versus the pre-chevron
-                // 10 px inset (project name now starts ~14 px further
-                // right), matching the C# TreeViewItem template's
-                // disclosure indent rather than trying to claw the name
-                // back to its old origin.
-                .pl(px(4.0))
+                .pl(px(10.0)) // 12px - 2px border = 10
                 .bg(bg)
                 .text_color(text_color)
                 .text_size(px(13.0))
@@ -1343,17 +1285,8 @@ impl Render for Sidebar {
                         this.open_project_menu(idx, event.position, cx);
                     }),
                 )
-                .child(chevron)
                 .child(div().flex_grow().truncate().child(name));
             project_and_worktree_rows.push(project_row.into_any_element());
-
-            // Skip rendering the worktree children + placeholder
-            // entirely when the user has collapsed the project.
-            // The chevron icon flipping right is the only visible
-            // change in that case.
-            if collapsed {
-                continue;
-            }
 
             // Empty-state placeholder when a project has no non-primary
             // worktrees. Mirrors the `(no worktrees)` row C# renders


### PR DESCRIPTION
## Summary

Reverts PR #103 — user feedback that the chevron affordance wasn't carrying its weight. Removes:

- `Sidebar::collapsed_projects` field + `toggle_project_collapsed` method.
- Chevron element from the project row + the `continue` skip that hid worktree children when collapsed.
- Restores the row's pre-chevron 10 px left padding.

If we want collapse back later, better to do it as part of a wider `TreeView` refactor than ad-hoc per-row state.

## Test plan

- [x] `cargo test --workspace` — 166 passing.
- [x] `cargo build --bin window` clean.
