### PR TITLE
fix(rs): drop title-bar sidebar-toggle, restore per-project chevrons

### DIFF
--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -3279,15 +3279,24 @@ impl Render for AppShell {
         // The padding is itself a drag region so the user can grab
         // the empty bit between the toggle and the first tab to
         // drag the window — same behaviour as the brand-mark.
-        // brand mark + brand wordmark/version label. The sidebar
-        // visibility is now keyboard-only (Ctrl+B); the title-bar
-        // chevron has been removed at user request.
-        let chrome_left_w = 40.0 + BRAND_LABEL_W;
-        let strip_left_pad_w = if self.sidebar_visible {
-            (self.sidebar_width + DIVIDER_VISUAL_WIDTH - chrome_left_w).max(0.0)
+        // The brand cluster (mark + wordmark/version label) spans
+        // the full width above the sidebar so the column header
+        // visually "owns" the sidebar; that means the wordmark
+        // label grows to fill `(sidebar_width + divider) - brand_mark`
+        // when the sidebar is visible. When the sidebar is
+        // collapsed, fall back to a fixed 150 px so the wordmark
+        // still has a readable footprint. With the wordmark
+        // absorbing the space the strip pad goes to zero — tabs sit
+        // flush against the wordmark column.
+        let brand_label_w = if self.sidebar_visible {
+            (self.sidebar_width + DIVIDER_VISUAL_WIDTH - 40.0).max(BRAND_LABEL_FALLBACK_W)
         } else {
-            0.0
+            BRAND_LABEL_FALLBACK_W
         };
+        // The strip pad is no longer needed (the wordmark absorbs
+        // the column width), but kept as a 0 px drag region so the
+        // assembly below stays structurally identical.
+        let strip_left_pad_w: f32 = 0.0;
         // Drag spots route through `handle_titlebar_press` for
         // shared single-vs-double-click discrimination.
         let strip_left_pad = div()
@@ -3320,15 +3329,16 @@ impl Render for AppShell {
         // caption-row hot path doesn't pay for a `format!` on
         // every render.
         const VERSION_DISPLAY: &str = concat!("V", env!("CODESCOPE_VERSION_DISPLAY"));
-        // Fixed width keeps the `chrome_left_w` calculation below
-        // predictable so the per-group tab strip dividers can still
-        // line up with the splitters between panes. Long dev-build
-        // slugs (`V0.2.6-52-g…-dirty`) get clipped via
-        // `overflow_hidden` rather than pushing the tabs around.
-        const BRAND_LABEL_W: f32 = 150.0;
+        // Fallback width when the sidebar is collapsed — the
+        // wordmark + slug fit comfortably; long dev-build slugs
+        // (`V0.2.6-52-g…-dirty`) get clipped via `overflow_hidden`
+        // rather than pushing the tabs around. With the sidebar
+        // visible the label grows to span the column (see
+        // `brand_label_w` above).
+        const BRAND_LABEL_FALLBACK_W: f32 = 150.0;
         let brand_label = div()
             .id("titlebar-brand-label")
-            .w(px(BRAND_LABEL_W))
+            .w(px(brand_label_w))
             .h(px(40.0))
             .pl(px(2.0))
             .pr(px(10.0))

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -3272,22 +3272,15 @@ impl Render for AppShell {
         // tab/"+" content normally lives well to the left of the
         // overlap so it stays clickable.
         //
-        // `strip_left_pad` keeps the *left* side of the tab area
-        // aligned with the *left* side of the work area (panes start
-        // at `sidebar_width + handle`). When the sidebar is collapsed
-        // the padding is zero so tabs sit flush against the toggle.
-        // The padding is itself a drag region so the user can grab
-        // the empty bit between the toggle and the first tab to
-        // drag the window — same behaviour as the brand-mark.
         // The brand cluster (mark + wordmark/version label) spans
         // the full width above the sidebar so the column header
-        // visually "owns" the sidebar; that means the wordmark
-        // label grows to fill `(sidebar_width + divider) - brand_mark`
-        // when the sidebar is visible. When the sidebar is
-        // collapsed, fall back to a fixed 150 px so the wordmark
-        // still has a readable footprint. With the wordmark
-        // absorbing the space the strip pad goes to zero — tabs sit
-        // flush against the wordmark column.
+        // visually "owns" the sidebar — the wordmark label grows
+        // to fill `(sidebar_width + divider) - brand_mark` when the
+        // sidebar is visible. When the sidebar is collapsed it
+        // falls back to a fixed 150 px so the wordmark still has a
+        // readable footprint. With the wordmark absorbing the
+        // space the strip pad below stays a 0 px placeholder; the
+        // brand cluster runs straight into the first tab.
         let brand_label_w = if self.sidebar_visible {
             (self.sidebar_width + DIVIDER_VISUAL_WIDTH - 40.0).max(BRAND_LABEL_FALLBACK_W)
         } else {

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -3251,29 +3251,6 @@ impl Render for AppShell {
             group_panes.push(pane.into_any_element());
         }
 
-        // Sidebar toggle (chevron). 32×32 cell in the caption row,
-        // immediately right of the brand mark. `«` when the sidebar
-        // is visible (click to collapse), `»` when hidden (click to
-        // expand). Pure client-area click — `on_mouse_down` is the
-        // primary path.
-        let toggle_glyph = if self.sidebar_visible { "«" } else { "»" };
-        let sidebar_toggle = div()
-            .id("titlebar-sidebar-toggle")
-            .h(px(40.0))
-            .w(px(32.0))
-            .flex()
-            .items_center()
-            .justify_center()
-            .text_size(px(14.0))
-            .text_color(ink_dim)
-            .cursor_pointer()
-            .hover(move |s| s.bg(frost_hover).text_color(ink))
-            .on_mouse_down(
-                MouseButton::Left,
-                cx.listener(|this, _, _, cx| this.toggle_sidebar(cx)),
-            )
-            .child(toggle_glyph);
-
         // ─── Title bar (40 px) ────────────────────────────────────
         // Single row, Chrome / VS Code / Windows Terminal layout:
         // tabs live in the title bar so we don't waste a second
@@ -3302,8 +3279,10 @@ impl Render for AppShell {
         // The padding is itself a drag region so the user can grab
         // the empty bit between the toggle and the first tab to
         // drag the window — same behaviour as the brand-mark.
-        // brand mark + brand wordmark/version label + sidebar toggle.
-        let chrome_left_w = 40.0 + BRAND_LABEL_W + 32.0;
+        // brand mark + brand wordmark/version label. The sidebar
+        // visibility is now keyboard-only (Ctrl+B); the title-bar
+        // chevron has been removed at user request.
+        let chrome_left_w = 40.0 + BRAND_LABEL_W;
         let strip_left_pad_w = if self.sidebar_visible {
             (self.sidebar_width + DIVIDER_VISUAL_WIDTH - chrome_left_w).max(0.0)
         } else {
@@ -3422,7 +3401,6 @@ impl Render for AppShell {
             .bg(theme::elevated(&theme))
             .child(brand_mark)
             .child(brand_label)
-            .child(sidebar_toggle)
             .child(strip_left_pad)
             .child(tab_strip_inline)
             .child(caption_controls);

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -197,6 +197,16 @@ pub struct Sidebar {
     /// C# build's `WorktreePoller` but adds the richer data the
     /// status bar needs.
     git_status: HashMap<String, GitStatus>,
+    /// Project ids the user has explicitly collapsed. Projects start
+    /// expanded by default; toggling the chevron adds/removes the id
+    /// here. Mirrors the C# `TreeViewItem.IsExpanded` state per
+    /// project — except the C# build hangs that off WPF's tree
+    /// control, while we keep an explicit `HashSet<String>` so the
+    /// render loop can decide visibility without per-row state.
+    /// In-memory only for now; persisting to `layout.json` is a
+    /// follow-up (matches what the C# build does — TreeView state
+    /// is also session-scoped over there).
+    collapsed_projects: HashSet<String>,
 }
 
 impl Sidebar {
@@ -224,7 +234,20 @@ impl Sidebar {
             dialog: None,
             dirty_state: HashMap::new(),
             git_status: HashMap::new(),
+            collapsed_projects: HashSet::new(),
         }
+    }
+
+    /// Flip the collapse / expand state for the project at `id`.
+    /// Default is expanded; toggling for the first time collapses,
+    /// next toggle expands. Re-renders via `cx.notify`.
+    fn toggle_project_collapsed(&mut self, id: &str, cx: &mut Context<Self>) {
+        if self.collapsed_projects.contains(id) {
+            self.collapsed_projects.remove(id);
+        } else {
+            self.collapsed_projects.insert(id.to_owned());
+        }
+        cx.notify();
     }
 
     /// Spawn the dirty-state polling loop. Runs every
@@ -1258,6 +1281,34 @@ impl Render for Sidebar {
             let frost_hover = theme::frost_10(&theme);
             let ink_hover = theme::ink(&theme);
 
+            let collapsed = self.collapsed_projects.contains(&id);
+            // Chevron — points right when the project is collapsed,
+            // down when expanded. Mirrors the C# `TreeViewItem`
+            // chevron template (RotateTransform 0°/90° driven by
+            // `IsExpanded`). Click toggles; the click handler stops
+            // propagation so the chevron doesn't double-fire `select`.
+            let chevron_glyph = if collapsed { "\u{25B8}" } else { "\u{25BE}" };
+            let id_for_toggle = id.clone();
+            let chevron = div()
+                .id(("project-chevron", id_hash(&id)))
+                .w(px(14.0))
+                .h(px(14.0))
+                .mr(px(6.0))
+                .flex()
+                .items_center()
+                .justify_center()
+                .text_size(px(10.0))
+                .text_color(theme::ink_ghost(&theme))
+                .cursor_pointer()
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.toggle_project_collapsed(&id_for_toggle, cx);
+                    }),
+                )
+                .child(chevron_glyph);
+
             let project_row = div()
                 .id(("project", id_hash(&id)))
                 .h(px(32.0))
@@ -1267,7 +1318,14 @@ impl Render for Sidebar {
                 .pr_3()
                 .border_l_2()
                 .border_color(rail)
-                .pl(px(10.0)) // 12px - 2px border = 10
+                // 4 px row inset; the chevron (14 px wide + 6 px right
+                // margin) sits between the rail and the project name.
+                // This is a small rightward shift versus the pre-chevron
+                // 10 px inset (project name now starts ~14 px further
+                // right), matching the C# TreeViewItem template's
+                // disclosure indent rather than trying to claw the name
+                // back to its old origin.
+                .pl(px(4.0))
                 .bg(bg)
                 .text_color(text_color)
                 .text_size(px(13.0))
@@ -1285,8 +1343,17 @@ impl Render for Sidebar {
                         this.open_project_menu(idx, event.position, cx);
                     }),
                 )
+                .child(chevron)
                 .child(div().flex_grow().truncate().child(name));
             project_and_worktree_rows.push(project_row.into_any_element());
+
+            // Skip rendering the worktree children + placeholder
+            // entirely when the user has collapsed the project.
+            // The chevron icon flipping right is the only visible
+            // change in that case.
+            if collapsed {
+                continue;
+            }
 
             // Empty-state placeholder when a project has no non-primary
             // worktrees. Mirrors the `(no worktrees)` row C# renders

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -250,6 +250,20 @@ impl Sidebar {
         cx.notify();
     }
 
+    /// Drop any `collapsed_projects` entries that no longer exist in
+    /// the current `projects.projects` list. Called after every
+    /// mutation that removes or replaces project rows so the set
+    /// can't grow monotonically across a long-running session
+    /// (project removed → its id sat there forever; same id later
+    /// re-added would inherit the stale collapsed flag).
+    fn prune_collapsed_projects(&mut self) {
+        if self.collapsed_projects.is_empty() {
+            return;
+        }
+        let live: HashSet<&str> = self.projects.projects.iter().map(|p| p.id.as_str()).collect();
+        self.collapsed_projects.retain(|id| live.contains(id.as_str()));
+    }
+
     /// Spawn the dirty-state polling loop. Runs every
     /// `DIRTY_POLL_INTERVAL` and walks every known worktree path,
     /// running `git status --porcelain`. Per-call latency is in the
@@ -470,6 +484,7 @@ impl Sidebar {
     /// ordering matches `add_project` / `remove_project`.
     pub(crate) fn replace_projects(&mut self, next: ProjectsConfig) {
         self.projects = next;
+        self.prune_collapsed_projects();
     }
 
     /// Dialog accessors used by the dialog module's helpers. Kept
@@ -1101,6 +1116,7 @@ impl Sidebar {
             return;
         }
         self.projects = next;
+        self.prune_collapsed_projects();
         // Selection housekeeping: if we just removed the selected
         // project, fall back to the previous row (or `None` when the
         // list is empty). Otherwise shift the cursor left when an


### PR DESCRIPTION
## What changed

- **Restore** per-project chevrons (revert PR #108). PR #108 dropped them by mistake — the user actually wanted the *other* chevron gone.
- **Remove** the title-bar `«` / `»` sidebar-visibility toggle that sat between the version slug and the tab strip.

Sidebar visibility is now keyboard-only via Ctrl+B (already wired). `chrome_left_w` shrinks by 32 px so tab-strip / splitter alignment stays correct.

## Test plan

- [x] `cargo test --workspace` — 166 passing.
- [x] `cargo check --bin window` clean (window.exe is locked by the running dev build, but no source-level warnings).
