### PR TITLE
feat(rs): persist sidebar collapsed_projects to layout.json

### DIFF
--- a/codescope-rs/core/src/layout.rs
+++ b/codescope-rs/core/src/layout.rs
@@ -182,8 +182,9 @@ mod tests {
     fn legacy_layout_without_collapsed_projects_loads() {
         // layout.json files written before sidebar collapse persistence
         // landed don't carry `collapsed_projects`. They must still load
-        // and produce an empty list — `#[serde(default)]` on the field
-        // backfills.
+        // and produce an empty list — the struct-level
+        // `#[serde(default)]` on `LayoutState` backfills the missing
+        // field with `Vec::new()` from `Default`.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("layout.json");
         std::fs::write(

--- a/codescope-rs/core/src/layout.rs
+++ b/codescope-rs/core/src/layout.rs
@@ -48,6 +48,15 @@ pub struct LayoutState {
     /// install / migration from older layout.json), AppShell falls
     /// back to a single cold-start tab.
     pub open_tabs: Vec<RestoreTab>,
+    /// Project ids the user has collapsed in the sidebar tree.
+    /// Restored on launch so chevron state survives a restart;
+    /// project ids not in this list render expanded (the default).
+    /// Stored as a `Vec<String>` rather than the in-memory
+    /// `HashSet` so the on-disk JSON is a stable, ordered array —
+    /// nicer to diff and hand-edit. Sidebar prunes ids that no
+    /// longer match a known project before saving so the file
+    /// can't grow stale entries across many sessions.
+    pub collapsed_projects: Vec<String>,
 }
 
 /// One tab worth of restore metadata. Light enough to round-trip
@@ -86,6 +95,7 @@ impl Default for LayoutState {
             group_weights: Vec::new(),
             focused_group_index: 0,
             open_tabs: Vec::new(),
+            collapsed_projects: Vec::new(),
         }
     }
 }
@@ -154,6 +164,7 @@ mod tests {
                 group_index: 0,
                 active_in_group: true,
             }],
+            collapsed_projects: vec!["proj-2".into(), "proj-3".into()],
         };
         state.save_to(&path).unwrap();
         let loaded = LayoutState::load_from(&path).unwrap();
@@ -164,6 +175,25 @@ mod tests {
         assert_eq!(loaded.open_tabs.len(), 1);
         assert_eq!(loaded.open_tabs[0].auto_type.as_deref(), Some("claude"));
         assert!(loaded.open_tabs[0].active_in_group);
+        assert_eq!(loaded.collapsed_projects, vec!["proj-2", "proj-3"]);
+    }
+
+    #[test]
+    fn legacy_layout_without_collapsed_projects_loads() {
+        // layout.json files written before sidebar collapse persistence
+        // landed don't carry `collapsed_projects`. They must still load
+        // and produce an empty list — `#[serde(default)]` on the field
+        // backfills.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("layout.json");
+        std::fs::write(
+            &path,
+            r#"{"sidebar_visible":true,"sidebar_width":240,"selected_project_id":"proj-x","group_weights":[],"focused_group_index":0,"open_tabs":[]}"#,
+        )
+        .unwrap();
+        let loaded = LayoutState::load_from(&path).unwrap();
+        assert_eq!(loaded.selected_project_id.as_deref(), Some("proj-x"));
+        assert!(loaded.collapsed_projects.is_empty());
     }
 
     #[test]

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -227,6 +227,10 @@ impl Sidebar {
         // Restore collapsed-project ids from disk, dropping any ids
         // that no longer match a known project so a removed-then-
         // re-added project doesn't inherit a stale collapsed flag.
+        // Mirror the filtered set back into `layout.collapsed_projects`
+        // (sorted) so any later `save_layout()` (selection change,
+        // add/remove project) doesn't resurrect the stale ids we
+        // dropped here.
         let live: HashSet<&str> =
             projects.projects.iter().map(|p| p.id.as_str()).collect();
         let collapsed_projects: HashSet<String> = layout
@@ -235,6 +239,10 @@ impl Sidebar {
             .filter(|id| live.contains(id.as_str()))
             .cloned()
             .collect();
+        let mut layout = layout;
+        let mut filtered: Vec<String> = collapsed_projects.iter().cloned().collect();
+        filtered.sort();
+        layout.collapsed_projects = filtered;
         Self {
             projects,
             selected,

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -203,9 +203,9 @@ pub struct Sidebar {
     /// project — except the C# build hangs that off WPF's tree
     /// control, while we keep an explicit `HashSet<String>` so the
     /// render loop can decide visibility without per-row state.
-    /// In-memory only for now; persisting to `layout.json` is a
-    /// follow-up (matches what the C# build does — TreeView state
-    /// is also session-scoped over there).
+    /// Hydrated from `layout.collapsed_projects` on construction and
+    /// flushed back via `save_layout` whenever the user toggles a
+    /// chevron, so the disclosure state survives a restart.
     collapsed_projects: HashSet<String>,
 }
 
@@ -224,6 +224,17 @@ impl Sidebar {
             None => None,
         }
         .or_else(|| (!projects.projects.is_empty()).then_some(0));
+        // Restore collapsed-project ids from disk, dropping any ids
+        // that no longer match a known project so a removed-then-
+        // re-added project doesn't inherit a stale collapsed flag.
+        let live: HashSet<&str> =
+            projects.projects.iter().map(|p| p.id.as_str()).collect();
+        let collapsed_projects: HashSet<String> = layout
+            .collapsed_projects
+            .iter()
+            .filter(|id| live.contains(id.as_str()))
+            .cloned()
+            .collect();
         Self {
             projects,
             selected,
@@ -234,7 +245,7 @@ impl Sidebar {
             dialog: None,
             dirty_state: HashMap::new(),
             git_status: HashMap::new(),
-            collapsed_projects: HashSet::new(),
+            collapsed_projects,
         }
     }
 
@@ -247,7 +258,19 @@ impl Sidebar {
         } else {
             self.collapsed_projects.insert(id.to_owned());
         }
+        self.sync_layout_collapsed_projects();
+        self.save_layout();
         cx.notify();
+    }
+
+    /// Mirror the in-memory `collapsed_projects` set onto the in-memory
+    /// `LayoutState` copy so the next `save_layout` writes the current
+    /// disclosure state. Sorted for stable on-disk ordering — handy
+    /// for diffs and hand-edits.
+    fn sync_layout_collapsed_projects(&mut self) {
+        let mut ids: Vec<String> = self.collapsed_projects.iter().cloned().collect();
+        ids.sort();
+        self.layout.collapsed_projects = ids;
     }
 
     /// Drop any `collapsed_projects` entries that no longer exist in
@@ -261,7 +284,18 @@ impl Sidebar {
             return;
         }
         let live: HashSet<&str> = self.projects.projects.iter().map(|p| p.id.as_str()).collect();
+        let before = self.collapsed_projects.len();
         self.collapsed_projects.retain(|id| live.contains(id.as_str()));
+        if self.collapsed_projects.len() != before {
+            // Pruning ran before persistence existed, so callers got
+            // away with leaving the on-disk copy alone. Now that we
+            // persist, mirror the cleaned set back into `layout` so
+            // the next save reflects reality. Caller decides whether
+            // to flush — keeping it lockstep with the existing
+            // `replace_projects` / `remove_project` write order is
+            // their job.
+            self.sync_layout_collapsed_projects();
+        }
     }
 
     /// Spawn the dirty-state polling loop. Runs every
@@ -484,7 +518,11 @@ impl Sidebar {
     /// ordering matches `add_project` / `remove_project`.
     pub(crate) fn replace_projects(&mut self, next: ProjectsConfig) {
         self.projects = next;
+        let prev_collapsed = self.layout.collapsed_projects.clone();
         self.prune_collapsed_projects();
+        if self.layout.collapsed_projects != prev_collapsed {
+            self.save_layout();
+        }
     }
 
     /// Dialog accessors used by the dialog module's helpers. Kept
@@ -543,6 +581,7 @@ impl Sidebar {
             }
         };
         on_disk.selected_project_id = self.layout.selected_project_id.clone();
+        on_disk.collapsed_projects = self.layout.collapsed_projects.clone();
         if let Err(err) = on_disk.save(&self.paths) {
             eprintln!("warning: failed to save layout.json: {err:#}");
         }
@@ -1109,6 +1148,7 @@ impl Sidebar {
             return;
         }
         let prev_selected_id = self.layout.selected_project_id.clone();
+        let prev_collapsed = self.layout.collapsed_projects.clone();
         let mut next = self.projects.clone();
         next.projects.remove(idx);
         if let Err(err) = next.save(&self.paths) {
@@ -1131,10 +1171,14 @@ impl Sidebar {
         };
         self.layout.selected_project_id =
             self.selected.and_then(|i| self.projects.projects.get(i).map(|p| p.id.clone()));
-        // Only persist layout when the persisted id actually changed —
-        // i.e. when the removed project was the active one. Removing
-        // a row before/after the active one leaves the id intact.
-        if self.layout.selected_project_id != prev_selected_id {
+        // Persist layout when either the persisted id or the
+        // collapsed-projects list actually changed — removing the
+        // active row rewrites the id, and removing a collapsed row
+        // prunes its entry. Removing an unrelated, expanded row
+        // leaves both intact and skips the write.
+        if self.layout.selected_project_id != prev_selected_id
+            || self.layout.collapsed_projects != prev_collapsed
+        {
             self.save_layout();
         }
         self.close_menu(cx);


### PR DESCRIPTION
## Summary

- Sidebar chevron state per project survives an app restart, instead of resetting to fully-expanded on every launch.
- New `collapsed_projects: Vec<String>` field on `LayoutState`, gated by `#[serde(default)]` so older `layout.json` files load cleanly.
- Hydrated into the in-memory `HashSet<String>` on `Sidebar::new` with stale ids (projects that no longer exist) filtered out; flushed back through `save_layout` from `toggle_project_collapsed` and after `prune_collapsed_projects` when a project removal drops a collapsed id.

## Parity reference

The C# build keeps `ProjectViewModel.IsExpanded` as a `[ObservableProperty]` and re-derives it on each launch (always starts expanded — see `src/CodeScope.Ui/ViewModels/ProjectViewModel.cs`). The Rust port deliberately deviates here: persisting the disclosure state is a small UX win that costs nothing on disk (sorted list of stable project ids), and the `serde(default)` migration keeps cross-version reads safe in both directions.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace` — 129 core tests (+1 new layout legacy test, +1 collapsed_projects round-trip assertion), all green
- [ ] Manual smoke: collapse a project, restart, project still collapsed; remove a collapsed project, confirm its id is dropped from `layout.json` on next save