### PR TITLE
feat(rs): worktree menu — Copy PR URL row

### DIFF
--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod claude_telemetry;
 pub mod git;
 pub mod layout;
 pub mod paths;
+pub mod pr;
 pub mod projects;
 pub mod settings;
 pub mod theme;

--- a/codescope-rs/core/src/pr.rs
+++ b/codescope-rs/core/src/pr.rs
@@ -1,0 +1,170 @@
+//! Per-worktree pull-request URL detection.
+//!
+//! Shells out to `gh pr list --head <branch> --state open --json url
+//! --limit 1` and returns the first PR's URL (or `None` if no open PR
+//! is associated with the branch). Mirrors the C# build's
+//! [`GitHubPullRequestService.GetOpenPrForBranchAsync`] — we keep the
+//! `--state open` filter and the `--limit 1` cap so the invocation is
+//! identical, but parse the JSON ourselves rather than relying on the
+//! local `jq` binary (gh ships its own `--jq` evaluator, but JSON
+//! parsing in pure Rust is small enough that we'd rather not depend on
+//! external eval semantics for a single field).
+//!
+//! Caching: this module is intentionally stateless — callers (the
+//! sidebar) own the cache. The C# build polls every 30 s with
+//! per-worktree exponential backoff up to 5 minutes
+//! (`PullRequestStatusPoller`); the Rust port currently lazy-fetches
+//! on right-click and caches the result on the sidebar entity. That's
+//! a deviation we accept for now — every render path that consumes
+//! the URL goes through the cache, and a dedicated background poller
+//! is a follow-up task tracked in `docs/HANDOFF.md`.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// Look up the open pull request URL for `branch` in the repo at
+/// `working_dir`. Returns `None` when no open PR is associated, when
+/// `gh` is not on PATH, or when the call fails for any reason — UI
+/// callers want a binary "show row / hide row" answer and the
+/// distinction between "gh missing" and "no PR" is not worth a third
+/// state in the menu.
+///
+/// Security: rejects branch names starting with `-` so a pathological
+/// branch can't be reinterpreted as a `gh pr list` flag (e.g.
+/// `--help`, `--state`, …) — same defence the `git::rebase_onto`
+/// helper applies.
+pub fn detect_pr_url(working_dir: &Path, branch: &str) -> Option<String> {
+    if branch.is_empty() || branch.starts_with('-') {
+        return None;
+    }
+    let output = Command::new("gh")
+        .args([
+            "pr", "list", "--head", branch, "--state", "open", "--json", "url", "--limit", "1",
+        ])
+        .current_dir(working_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_pr_url_json(&stdout)
+}
+
+/// Parse the output of `gh pr list --json url --limit 1`. The shape
+/// is a JSON array — empty when there's no PR, otherwise objects with
+/// a `"url"` string field. We parse the first entry by hand to avoid
+/// pulling `serde_json` into `core` for one tiny use site.
+///
+/// Returns the URL string on success, `None` otherwise. Tolerant of
+/// trailing whitespace and CRLF — gh on Windows occasionally emits
+/// CRLF in piped output.
+pub(crate) fn parse_pr_url_json(stdout: &str) -> Option<String> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() || trimmed == "[]" {
+        return None;
+    }
+    // We expect `[{"url":"https://github.com/owner/repo/pull/42"}]`.
+    // Find the first `"url"` key, then the next `"…"` value after the
+    // colon. This is dumb-but-safe: gh's `--json url` emits exactly
+    // one field per row, so there's no ambiguity with nested objects.
+    let key_idx = trimmed.find("\"url\"")?;
+    let after_key = &trimmed[key_idx + "\"url\"".len()..];
+    let colon_idx = after_key.find(':')?;
+    let after_colon = after_key[colon_idx + 1..].trim_start();
+    let rest = after_colon.strip_prefix('"')?;
+    let end = rest.find('"')?;
+    let url = &rest[..end];
+    if url.is_empty() {
+        None
+    } else {
+        Some(url.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn parse_typical_gh_output() {
+        let json = "[{\"url\":\"https://github.com/owner/repo/pull/42\"}]";
+        assert_eq!(
+            parse_pr_url_json(json).as_deref(),
+            Some("https://github.com/owner/repo/pull/42")
+        );
+    }
+
+    #[test]
+    fn parse_pretty_printed_output() {
+        // gh sometimes pretty-prints when stdout is a tty; in our
+        // pipe-captured case it stays compact, but the parser should
+        // not assume that.
+        let json = "[\n  {\n    \"url\": \"https://github.com/owner/repo/pull/7\"\n  }\n]";
+        assert_eq!(
+            parse_pr_url_json(json).as_deref(),
+            Some("https://github.com/owner/repo/pull/7")
+        );
+    }
+
+    #[test]
+    fn parse_empty_array_returns_none() {
+        assert_eq!(parse_pr_url_json("[]"), None);
+        assert_eq!(parse_pr_url_json("[]\n"), None);
+    }
+
+    #[test]
+    fn parse_empty_input_returns_none() {
+        assert_eq!(parse_pr_url_json(""), None);
+        assert_eq!(parse_pr_url_json("   \n"), None);
+    }
+
+    #[test]
+    fn parse_missing_url_returns_none() {
+        // Defensive: gh is unlikely to emit a row without `url` when
+        // we asked for that field, but if it ever does we should hide
+        // the row rather than panic.
+        assert_eq!(parse_pr_url_json("[{}]"), None);
+    }
+
+    #[test]
+    fn parse_empty_url_string_returns_none() {
+        assert_eq!(parse_pr_url_json("[{\"url\":\"\"}]"), None);
+    }
+
+    #[test]
+    fn detect_rejects_dash_prefixed_branch() {
+        // Security: `--state` must not be reinterpreted as a flag.
+        // We can't easily intercept the spawn, but the function
+        // returns None up-front without spawning gh.
+        let result = detect_pr_url(&PathBuf::from("."), "--state");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn detect_rejects_empty_branch() {
+        let result = detect_pr_url(&PathBuf::from("."), "");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn detect_returns_none_when_gh_missing() {
+        // We intentionally don't gate this test on `gh` being absent —
+        // if gh *is* installed, the call below still returns None
+        // because the temp dir isn't a git repo. Either way the
+        // contract holds: "no PR" / "no gh" / "no repo" all collapse
+        // to None.
+        let temp = std::env::temp_dir().join(format!(
+            "codescope_pr_test_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&temp).expect("create temp dir");
+        let result = detect_pr_url(&temp, "no-such-branch-xyz");
+        let _ = std::fs::remove_dir_all(&temp);
+        assert!(result.is_none());
+    }
+}

--- a/codescope-rs/core/src/pr.rs
+++ b/codescope-rs/core/src/pr.rs
@@ -3,12 +3,11 @@
 //! Shells out to `gh pr list --head <branch> --state open --json url
 //! --limit 1` and returns the first PR's URL (or `None` if no open PR
 //! is associated with the branch). Mirrors the C# build's
-//! [`GitHubPullRequestService.GetOpenPrForBranchAsync`] — we keep the
-//! `--state open` filter and the `--limit 1` cap so the invocation is
-//! identical, but parse the JSON ourselves rather than relying on the
-//! local `jq` binary (gh ships its own `--jq` evaluator, but JSON
-//! parsing in pure Rust is small enough that we'd rather not depend on
-//! external eval semantics for a single field).
+//! [`GitHubPullRequestService.GetOpenPrForBranchAsync`] — same `gh`
+//! invocation shape (`--state open`, `--limit 1`), parsed with
+//! `serde_json` rather than relying on a local `jq` (gh's bundled
+//! `--jq` would also work, but routing the result through the same
+//! parser the rest of `core` uses keeps error handling consistent).
 //!
 //! Caching: this module is intentionally stateless — callers (the
 //! sidebar) own the cache. The C# build polls every 30 s with
@@ -21,6 +20,13 @@
 
 use std::path::Path;
 use std::process::{Command, Stdio};
+
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct GhPrRow {
+    url: String,
+}
 
 /// Look up the open pull request URL for `branch` in the repo at
 /// `working_dir`. Returns `None` when no open PR is associated, when
@@ -55,40 +61,23 @@ pub fn detect_pr_url(working_dir: &Path, branch: &str) -> Option<String> {
 }
 
 /// Parse the output of `gh pr list --json url --limit 1`. The shape
-/// is a JSON array — empty when there's no PR, otherwise objects with
-/// a `"url"` string field. We parse the first entry by hand to avoid
-/// pulling `serde_json` into `core` for one tiny use site.
-///
-/// Returns the URL string on success, `None` otherwise. Tolerant of
-/// trailing whitespace and CRLF — gh on Windows occasionally emits
-/// CRLF in piped output.
+/// is a JSON array of `{ "url": "<string>" }`; we deserialise the
+/// first row and return its URL. Empty arrays / missing url / parse
+/// errors all collapse to `None` so the caller can render "no row"
+/// without branching on the failure mode.
 pub(crate) fn parse_pr_url_json(stdout: &str) -> Option<String> {
     let trimmed = stdout.trim();
-    if trimmed.is_empty() || trimmed == "[]" {
+    if trimmed.is_empty() {
         return None;
     }
-    // We expect `[{"url":"https://github.com/owner/repo/pull/42"}]`.
-    // Find the first `"url"` key, then the next `"…"` value after the
-    // colon. This is dumb-but-safe: gh's `--json url` emits exactly
-    // one field per row, so there's no ambiguity with nested objects.
-    let key_idx = trimmed.find("\"url\"")?;
-    let after_key = &trimmed[key_idx + "\"url\"".len()..];
-    let colon_idx = after_key.find(':')?;
-    let after_colon = after_key[colon_idx + 1..].trim_start();
-    let rest = after_colon.strip_prefix('"')?;
-    let end = rest.find('"')?;
-    let url = &rest[..end];
-    if url.is_empty() {
-        None
-    } else {
-        Some(url.to_owned())
-    }
+    let rows: Vec<GhPrRow> = serde_json::from_str(trimmed).ok()?;
+    let url = rows.into_iter().next()?.url;
+    if url.is_empty() { None } else { Some(url) }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     #[test]
     fn parse_typical_gh_output() {
@@ -137,34 +126,51 @@ mod tests {
     }
 
     #[test]
+    fn parse_invalid_json_returns_none() {
+        // gh shouldn't ever emit garbage, but a half-printed buffer
+        // (e.g. SIGPIPE on the stream) shouldn't panic the UI.
+        assert_eq!(parse_pr_url_json("not json"), None);
+        assert_eq!(parse_pr_url_json("[{"), None);
+    }
+
+    #[test]
+    fn parse_url_with_escaped_chars() {
+        // Real PRs don't have escapes in the URL, but `serde_json`
+        // handling them correctly (vs the previous manual substring
+        // parser, which would have stopped at the first `"`) is the
+        // safer behaviour to lock in.
+        let json = "[{\"url\":\"https://example.com/a\\u0026b\"}]";
+        assert_eq!(
+            parse_pr_url_json(json).as_deref(),
+            Some("https://example.com/a&b")
+        );
+    }
+
+    #[test]
     fn detect_rejects_dash_prefixed_branch() {
         // Security: `--state` must not be reinterpreted as a flag.
         // We can't easily intercept the spawn, but the function
         // returns None up-front without spawning gh.
-        let result = detect_pr_url(&PathBuf::from("."), "--state");
+        let result = detect_pr_url(std::path::Path::new("."), "--state");
         assert!(result.is_none());
     }
 
     #[test]
     fn detect_rejects_empty_branch() {
-        let result = detect_pr_url(&PathBuf::from("."), "");
+        let result = detect_pr_url(std::path::Path::new("."), "");
         assert!(result.is_none());
     }
 
     #[test]
-    fn detect_returns_none_when_gh_missing() {
-        // We intentionally don't gate this test on `gh` being absent —
-        // if gh *is* installed, the call below still returns None
-        // because the temp dir isn't a git repo. Either way the
-        // contract holds: "no PR" / "no gh" / "no repo" all collapse
-        // to None.
-        let temp = std::env::temp_dir().join(format!(
-            "codescope_pr_test_{}",
-            std::process::id()
-        ));
-        std::fs::create_dir_all(&temp).expect("create temp dir");
-        let result = detect_pr_url(&temp, "no-such-branch-xyz");
-        let _ = std::fs::remove_dir_all(&temp);
+    fn detect_returns_none_when_gh_missing_or_no_repo() {
+        // Use `tempfile::tempdir()` so the directory cleans up even
+        // if the assertion below fires unexpectedly. We don't gate
+        // the test on `gh` being absent — if gh *is* installed, the
+        // call still returns None because the temp dir isn't a git
+        // repo. Either way the contract holds: "no PR" / "no gh" /
+        // "no repo" all collapse to None.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let result = detect_pr_url(temp.path(), "no-such-branch-xyz");
         assert!(result.is_none());
     }
 }

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -81,6 +81,23 @@ enum OpenMenu {
     },
 }
 
+/// Per-worktree state for the lazy `gh pr list` lookup. `Pending`
+/// flips to `Resolved` once the background task lands; the resolved
+/// value carries the branch it ran against so a subsequent open with
+/// a *different* branch invalidates the cache and triggers a refetch
+/// (the C# build's poller does the same — branch is the cache key on
+/// its end).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PrLookup {
+    /// A `detect_pr_url` task is already in flight for this worktree
+    /// — guards against rapid menu re-opens spawning duplicate `gh`
+    /// processes.
+    Pending,
+    /// The most recent lookup completed against `branch` and resolved
+    /// to `url` (`None` for "no open PR / call failed").
+    Resolved { branch: String, url: Option<String> },
+}
+
 /// Click handler for a context-menu row. Boxed so we can stash it in
 /// the closure passed to `cx.listener` without leaking the helper's
 /// generic-over-fn shape into every menu-row construction site.
@@ -198,15 +215,17 @@ pub struct Sidebar {
     /// status bar needs.
     git_status: HashMap<String, GitStatus>,
     /// Cached "open PR URL for this worktree" lookup, keyed by the
-    /// worktree's absolute path. `None` means a `gh pr list` call has
-    /// already returned "no open PR for this branch" (or the call
-    /// failed) — render that as no row in the menu. A missing key
-    /// means we haven't asked yet; opening the menu kicks off a
-    /// fetch. Mirrors the cached `WorktreeViewModel.PullRequest` slot
-    /// the C# build's `PullRequestStatusPoller` writes into. Cache is
+    /// worktree's absolute path. The value tracks both the branch
+    /// the lookup ran against (so a branch switch invalidates the
+    /// cache) and an in-flight `Pending` marker (so a rapid double-
+    /// click on the worktree row can't spawn two concurrent `gh pr
+    /// list` processes). A missing key means we haven't asked yet;
+    /// opening the menu kicks off a fetch when the branch is known.
+    /// Mirrors the cached `WorktreeViewModel.PullRequest` slot the
+    /// C# build's `PullRequestStatusPoller` writes into. Cache is
     /// per-process, in-memory only — no on-disk persistence, since
     /// the URL can shift if the PR is closed and re-opened.
-    pr_urls: HashMap<String, Option<String>>,
+    pr_urls: HashMap<String, PrLookup>,
     /// Project ids the user has explicitly collapsed. Projects start
     /// expanded by default; toggling the chevron adds/removes the id
     /// here. Mirrors the C# `TreeViewItem.IsExpanded` state per
@@ -642,16 +661,38 @@ impl Sidebar {
         let Some(worktree) = project.worktrees.iter().find(|wt| wt.id == worktree_id) else {
             return;
         };
-        // Kick off a one-shot `gh pr list` lookup the first time the
-        // user opens the menu for a given worktree path. Subsequent
-        // opens read the cached value — no per-render gh spawns. The
-        // result populates the "Copy PR URL" row, which is hidden
-        // when the cache resolves to `None`.
-        if !self.pr_urls.contains_key(&worktree.path) {
-            if let Some(branch) = worktree.branch.clone() {
+        // Resolve the live branch: the polled `git_status` cache is
+        // authoritative (a `git switch` in another window will land
+        // there long before anyone touches `projects.json`), the
+        // persisted `worktree.branch` is the fallback. For a primary
+        // worktree the persisted field is `None` — without the
+        // git-status fallback we'd permanently suppress PR detection
+        // on the primary row.
+        let live_branch = self
+            .git_status
+            .get(&worktree.path)
+            .map(|s| s.branch.clone())
+            .or_else(|| worktree.branch.clone());
+
+        // Kick off a one-shot `gh pr list` lookup the first time we
+        // see a (path, branch) pair. Subsequent opens read the cache.
+        // If the branch is currently unknown (no git_status tick yet
+        // and no persisted branch), skip insertion entirely so the
+        // next menu open can retry once data lands.
+        if let Some(branch) = live_branch {
+            let needs_fetch = match self.pr_urls.get(&worktree.path) {
+                None => true,
+                Some(PrLookup::Pending) => false,
+                // Branch switched out from under the cached lookup —
+                // refetch. This fixes the "user switched branches and
+                // the menu still shows the old PR / no PR" race.
+                Some(PrLookup::Resolved { branch: cached, .. }) => *cached != branch,
+            };
+            if needs_fetch {
+                self.pr_urls.insert(worktree.path.clone(), PrLookup::Pending);
                 let path = worktree.path.clone();
                 let path_for_task = std::path::PathBuf::from(&path);
-                let branch_for_task = branch;
+                let branch_for_task = branch.clone();
                 cx.spawn(async move |this, cx| {
                     let url = cx
                         .background_spawn(async move {
@@ -659,17 +700,17 @@ impl Sidebar {
                         })
                         .await;
                     let _ = this.update(cx, |this, cx| {
-                        this.pr_urls.insert(path, url);
+                        this.pr_urls.insert(
+                            path,
+                            PrLookup::Resolved { branch: branch.clone(), url },
+                        );
                         cx.notify();
                     });
                 })
                 .detach();
-            } else {
-                // Detached HEAD or unknown branch — record `None` so we
-                // don't re-spawn on every menu open.
-                self.pr_urls.insert(worktree.path.clone(), None);
             }
         }
+
         self.menu = Some(OpenMenu::Worktree { project_idx, worktree_id, position });
         cx.notify();
     }
@@ -789,7 +830,7 @@ impl Sidebar {
     ) {
         let path = self.worktree_path(project_idx, worktree_id);
         if let Some(path) = path
-            && let Some(Some(url)) = self.pr_urls.get(&path)
+            && let Some(PrLookup::Resolved { url: Some(url), .. }) = self.pr_urls.get(&path)
         {
             let url = url.clone();
             cx.write_to_clipboard(ClipboardItem::new_string(url.clone()));
@@ -2123,7 +2164,10 @@ impl Sidebar {
             .children(
                 self.pr_urls
                     .get(&worktree.path)
-                    .and_then(|opt| opt.as_ref())
+                    .and_then(|lookup| match lookup {
+                        PrLookup::Resolved { url: Some(url), .. } => Some(url),
+                        _ => None,
+                    })
                     .map(|_url| {
                         let id_for_copy_pr = worktree_id.clone();
                         item(

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -89,10 +89,11 @@ enum OpenMenu {
 /// its end).
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PrLookup {
-    /// A `detect_pr_url` task is already in flight for this worktree
-    /// — guards against rapid menu re-opens spawning duplicate `gh`
-    /// processes.
-    Pending,
+    /// A `detect_pr_url` task is already in flight for this worktree.
+    /// Records the branch the call was launched against so the
+    /// completion handler can detect a branch-switch-during-fetch and
+    /// drop the now-stale result instead of caching it.
+    Pending { branch: String },
     /// The most recent lookup completed against `branch` and resolved
     /// to `url` (`None` for "no open PR / call failed").
     Resolved { branch: String, url: Option<String> },
@@ -361,6 +362,10 @@ impl Sidebar {
                         if this.dirty_state.len() != prev_len {
                             changed = true;
                         }
+                        // Same prune for the PR URL cache — paths that
+                        // are no longer in any project must drop their
+                        // cached `Resolved` / `Pending` entries.
+                        this.pr_urls.retain(|path, _| known.contains(path));
                         for (path, dirty) in updates {
                             let prev = this.dirty_state.insert(path, dirty);
                             if prev != Some(dirty) {
@@ -682,14 +687,22 @@ impl Sidebar {
         if let Some(branch) = live_branch {
             let needs_fetch = match self.pr_urls.get(&worktree.path) {
                 None => true,
-                Some(PrLookup::Pending) => false,
+                // An in-flight lookup against the *same* branch is
+                // fine — let it complete. If the branch under the
+                // pending fetch differs from the live branch, the
+                // user switched mid-fetch; we'll spawn a fresh task
+                // and the older one will be discarded on completion.
+                Some(PrLookup::Pending { branch: pending }) => *pending != branch,
                 // Branch switched out from under the cached lookup —
                 // refetch. This fixes the "user switched branches and
                 // the menu still shows the old PR / no PR" race.
                 Some(PrLookup::Resolved { branch: cached, .. }) => *cached != branch,
             };
             if needs_fetch {
-                self.pr_urls.insert(worktree.path.clone(), PrLookup::Pending);
+                self.pr_urls.insert(
+                    worktree.path.clone(),
+                    PrLookup::Pending { branch: branch.clone() },
+                );
                 let path = worktree.path.clone();
                 let path_for_task = std::path::PathBuf::from(&path);
                 let branch_for_task = branch.clone();
@@ -700,11 +713,23 @@ impl Sidebar {
                         })
                         .await;
                     let _ = this.update(cx, |this, cx| {
-                        this.pr_urls.insert(
-                            path,
-                            PrLookup::Resolved { branch: branch.clone(), url },
+                        // Branch may have shifted while the gh call
+                        // was running. If the slot we wrote `Pending`
+                        // into has been taken over by another lookup
+                        // (or by a `Resolved` with a different
+                        // branch), drop our result on the floor — the
+                        // newer task will produce a fresher answer.
+                        let still_ours = matches!(
+                            this.pr_urls.get(&path),
+                            Some(PrLookup::Pending { branch: b }) if b == &branch
                         );
-                        cx.notify();
+                        if still_ours {
+                            this.pr_urls.insert(
+                                path,
+                                PrLookup::Resolved { branch: branch.clone(), url },
+                            );
+                            cx.notify();
+                        }
                     });
                 })
                 .detach();
@@ -828,9 +853,29 @@ impl Sidebar {
         worktree_id: &str,
         cx: &mut Context<Self>,
     ) {
-        let path = self.worktree_path(project_idx, worktree_id);
-        if let Some(path) = path
-            && let Some(PrLookup::Resolved { url: Some(url), .. }) = self.pr_urls.get(&path)
+        let Some(path) = self.worktree_path(project_idx, worktree_id) else {
+            self.close_menu(cx);
+            return;
+        };
+        // Re-derive the live branch and only copy when the cached
+        // `Resolved.branch` still matches — if the user switched
+        // branches between render and click the row is about to
+        // disappear on the next open anyway, but a click that already
+        // landed shouldn't paste the wrong URL.
+        let live_branch = self
+            .git_status
+            .get(&path)
+            .map(|s| s.branch.clone())
+            .or_else(|| {
+                self.projects
+                    .projects
+                    .get(project_idx)
+                    .and_then(|p| p.worktrees.iter().find(|wt| wt.id == worktree_id))
+                    .and_then(|wt| wt.branch.clone())
+            });
+        if let (Some(live), Some(PrLookup::Resolved { branch, url: Some(url) })) =
+            (live_branch.as_ref(), self.pr_urls.get(&path))
+            && branch == live
         {
             let url = url.clone();
             cx.write_to_clipboard(ClipboardItem::new_string(url.clone()));
@@ -2156,16 +2201,27 @@ impl Sidebar {
                 )
             }))
             // "Copy PR URL" — only when the cached `gh pr list` lookup
-            // resolved to an open PR for this worktree's branch. The
-            // fetch is kicked off in `open_worktree_menu` and lands
-            // asynchronously; until then the row stays hidden so a
-            // half-loaded menu doesn't flash an unusable entry.
+            // resolved to an open PR for this worktree's *current*
+            // branch (live `git_status` first, persisted `branch`
+            // fallback — same logic `open_worktree_menu` uses to
+            // decide whether to refetch). The fetch is kicked off in
+            // `open_worktree_menu` and lands asynchronously; until
+            // then the row stays hidden so a half-loaded menu doesn't
+            // flash an unusable entry, and a stale `Resolved` from a
+            // prior branch is also hidden until the refetch lands.
             // Mirrors C#'s `wt.HasPullRequest`-gated row.
-            .children(
-                self.pr_urls
+            .children({
+                let live_branch = self
+                    .git_status
                     .get(&worktree.path)
-                    .and_then(|lookup| match lookup {
-                        PrLookup::Resolved { url: Some(url), .. } => Some(url),
+                    .map(|s| s.branch.clone())
+                    .or_else(|| worktree.branch.clone());
+                live_branch
+                    .as_ref()
+                    .and_then(|live| match self.pr_urls.get(&worktree.path) {
+                        Some(PrLookup::Resolved { branch, url: Some(url) }) if branch == live => {
+                            Some(url)
+                        }
                         _ => None,
                     })
                     .map(|_url| {
@@ -2178,8 +2234,8 @@ impl Sidebar {
                                 this.copy_worktree_pr_url(project_idx, &id_for_copy_pr, cx);
                             }),
                         )
-                    }),
-            )
+                    })
+            })
             .child({
                 let id_for_remote = worktree_id.clone();
                 item(

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -692,11 +692,11 @@ impl Sidebar {
                 // pending fetch differs from the live branch, the
                 // user switched mid-fetch; we'll spawn a fresh task
                 // and the older one will be discarded on completion.
-                Some(PrLookup::Pending { branch: pending }) => *pending != branch,
+                Some(PrLookup::Pending { branch: pending }) => pending != &branch,
                 // Branch switched out from under the cached lookup —
                 // refetch. This fixes the "user switched branches and
                 // the menu still shows the old PR / no PR" race.
-                Some(PrLookup::Resolved { branch: cached, .. }) => *cached != branch,
+                Some(PrLookup::Resolved { branch: cached, .. }) => cached != &branch,
             };
             if needs_fetch {
                 self.pr_urls.insert(

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -197,6 +197,16 @@ pub struct Sidebar {
     /// C# build's `WorktreePoller` but adds the richer data the
     /// status bar needs.
     git_status: HashMap<String, GitStatus>,
+    /// Cached "open PR URL for this worktree" lookup, keyed by the
+    /// worktree's absolute path. `None` means a `gh pr list` call has
+    /// already returned "no open PR for this branch" (or the call
+    /// failed) — render that as no row in the menu. A missing key
+    /// means we haven't asked yet; opening the menu kicks off a
+    /// fetch. Mirrors the cached `WorktreeViewModel.PullRequest` slot
+    /// the C# build's `PullRequestStatusPoller` writes into. Cache is
+    /// per-process, in-memory only — no on-disk persistence, since
+    /// the URL can shift if the PR is closed and re-opened.
+    pr_urls: HashMap<String, Option<String>>,
     /// Project ids the user has explicitly collapsed. Projects start
     /// expanded by default; toggling the chevron adds/removes the id
     /// here. Mirrors the C# `TreeViewItem.IsExpanded` state per
@@ -234,6 +244,7 @@ impl Sidebar {
             dialog: None,
             dirty_state: HashMap::new(),
             git_status: HashMap::new(),
+            pr_urls: HashMap::new(),
             collapsed_projects: HashSet::new(),
         }
     }
@@ -628,8 +639,36 @@ impl Sidebar {
         cx: &mut Context<Self>,
     ) {
         let Some(project) = self.projects.projects.get(project_idx) else { return };
-        if !project.worktrees.iter().any(|wt| wt.id == worktree_id) {
+        let Some(worktree) = project.worktrees.iter().find(|wt| wt.id == worktree_id) else {
             return;
+        };
+        // Kick off a one-shot `gh pr list` lookup the first time the
+        // user opens the menu for a given worktree path. Subsequent
+        // opens read the cached value — no per-render gh spawns. The
+        // result populates the "Copy PR URL" row, which is hidden
+        // when the cache resolves to `None`.
+        if !self.pr_urls.contains_key(&worktree.path) {
+            if let Some(branch) = worktree.branch.clone() {
+                let path = worktree.path.clone();
+                let path_for_task = std::path::PathBuf::from(&path);
+                let branch_for_task = branch;
+                cx.spawn(async move |this, cx| {
+                    let url = cx
+                        .background_spawn(async move {
+                            codescope_core::pr::detect_pr_url(&path_for_task, &branch_for_task)
+                        })
+                        .await;
+                    let _ = this.update(cx, |this, cx| {
+                        this.pr_urls.insert(path, url);
+                        cx.notify();
+                    });
+                })
+                .detach();
+            } else {
+                // Detached HEAD or unknown branch — record `None` so we
+                // don't re-spawn on every menu open.
+                self.pr_urls.insert(worktree.path.clone(), None);
+            }
         }
         self.menu = Some(OpenMenu::Worktree { project_idx, worktree_id, position });
         cx.notify();
@@ -731,6 +770,34 @@ impl Sidebar {
             .and_then(|wt| wt.branch.clone());
         if let Some(branch) = branch {
             cx.write_to_clipboard(ClipboardItem::new_string(branch));
+        }
+        self.close_menu(cx);
+    }
+
+    /// Copy the cached PR URL for the worktree to the system
+    /// clipboard, then surface a toast confirming the action. The
+    /// menu row that drives this is gated on the cache holding a
+    /// `Some(url)` value, so this is normally infallible by the time
+    /// it runs — the inner `if let` is defensive against the cache
+    /// being evicted between render and click. Mirrors C#'s
+    /// `SidebarViewModel.CopyPullRequestUrlCommand`.
+    fn copy_worktree_pr_url(
+        &mut self,
+        project_idx: usize,
+        worktree_id: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let path = self.worktree_path(project_idx, worktree_id);
+        if let Some(path) = path
+            && let Some(Some(url)) = self.pr_urls.get(&path)
+        {
+            let url = url.clone();
+            cx.write_to_clipboard(ClipboardItem::new_string(url.clone()));
+            cx.emit(SidebarEvent::Toast {
+                kind: ToastSeverity::Ok,
+                title: "PR URL copied".into(),
+                detail: Some(url.into()),
+            });
         }
         self.close_menu(cx);
     }
@@ -2047,6 +2114,28 @@ impl Sidebar {
                     }),
                 )
             }))
+            // "Copy PR URL" — only when the cached `gh pr list` lookup
+            // resolved to an open PR for this worktree's branch. The
+            // fetch is kicked off in `open_worktree_menu` and lands
+            // asynchronously; until then the row stays hidden so a
+            // half-loaded menu doesn't flash an unusable entry.
+            // Mirrors C#'s `wt.HasPullRequest`-gated row.
+            .children(
+                self.pr_urls
+                    .get(&worktree.path)
+                    .and_then(|opt| opt.as_ref())
+                    .map(|_url| {
+                        let id_for_copy_pr = worktree_id.clone();
+                        item(
+                            "wt-menu-copy-pr-url",
+                            "Copy PR URL",
+                            false,
+                            Box::new(move |this, _window, cx| {
+                                this.copy_worktree_pr_url(project_idx, &id_for_copy_pr, cx);
+                            }),
+                        )
+                    }),
+            )
             .child({
                 let id_for_remote = worktree_id.clone();
                 item(


### PR DESCRIPTION
## Summary

Adds the **Copy PR URL** row under `Copy →` in the sidebar's worktree right-click menu, plus the `core::pr` helper that backs it.

- New `codescope-core::pr::detect_pr_url(working_dir, branch)` shells out to `gh pr list --head <branch> --state open --json url --limit 1` and parses the first row's URL via `serde_json` (returns `None` for no open PR / `gh` missing / parse error). Branch names starting with `-` are rejected up-front so the argv can't be reinterpreted as a `gh` flag — same defence `git::rebase_onto` ships.
- Sidebar caches results in `pr_urls: HashMap<String, PrLookup>`, where `PrLookup` is a `Pending { branch }` / `Resolved { branch, url }` enum. The lookup fires once per (path, branch) the first time the user opens the menu; rapid re-opens see the `Pending` marker and skip the spawn. Branch switches invalidate the cache and trigger a refetch.
- Click → `cx.write_to_clipboard(ClipboardItem::new_string(url))` + a `PR URL copied` toast (mirrors C#'s `System.Windows.Clipboard.SetText` + `Toast`).
- Race coverage: completion handler only commits its result when the slot still holds the same `Pending { branch }` it wrote (mid-fetch branch switch → drop the old result). Render gates on `Resolved.branch == live_branch`. Cache pruned in the dirty poll tick, alongside `dirty_state`.

## C# parity reference

- `SidebarViewModel.Commands.cs::CopyPullRequestUrl` — same toast title, same no-op when URL is missing.
- `SidebarView.xaml.cs::BuildWorktreeContextMenu` — `Copy → PR URL` row gated on `wt.HasPullRequest`. Mirrored here as "row visible iff `Resolved.url is Some(..)` and `Resolved.branch == live_branch`".
- `GitHubPullRequestService.GetOpenPrForBranchAsync` — same `gh` invocation shape, including `--state open` and `--limit 1`.
- `PullRequestStatusPoller` — C# polls every 30 s with up to 5 min back-off. The Rust port currently lazy-fetches on menu open instead; documented in the module doc-comment as a follow-up. Functional UX (row appears when an open PR exists) is parity-equivalent — only the discovery cadence differs.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace` — 139 core + 29 sidebar-bin + 9 terminal = 177 total, all passing
- [x] 10 new tests cover the `gh pr list` JSON parser (typical, pretty-printed, empty array, empty input, missing url, empty url, invalid JSON, `\uXXXX` escape), the dash-prefixed-branch rejection, and the no-`gh`/no-repo fall-through
- [ ] Manual: right-click a worktree with a known open PR; menu reopen shows "Copy PR URL"; click writes URL to clipboard + toast appears