### PR TITLE
feat(rs): core::update_check — GitHub release poll (Velopack parity)

### DIFF
--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "ureq",
  "uuid",
 ]
 
@@ -4612,6 +4613,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5958,6 +5960,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6388,6 +6405,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/codescope-rs/core/Cargo.toml
+++ b/codescope-rs/core/Cargo.toml
@@ -10,6 +10,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
 uuid = { version = "1", features = ["v4"] }
+# `ureq` powers the GitHub release poll in `update_check`. Picked over
+# `reqwest` because it's blocking (so it composes cleanly with
+# `cx.background_spawn` from app.rs), has no tokio runtime requirement,
+# and rolls up to ~1/4 the compile-time of `reqwest`. `rustls-tls`
+# selects the rustls backend already in our dep tree (pulled by gpui),
+# avoiding a second TLS implementation.
+ureq = { version = "2", default-features = false, features = ["tls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/codescope-rs/core/Cargo.toml
+++ b/codescope-rs/core/Cargo.toml
@@ -13,9 +13,10 @@ uuid = { version = "1", features = ["v4"] }
 # `ureq` powers the GitHub release poll in `update_check`. Picked over
 # `reqwest` because it's blocking (so it composes cleanly with
 # `cx.background_spawn` from app.rs), has no tokio runtime requirement,
-# and rolls up to ~1/4 the compile-time of `reqwest`. `rustls-tls`
-# selects the rustls backend already in our dep tree (pulled by gpui),
-# avoiding a second TLS implementation.
+# and rolls up to ~1/4 the compile-time of `reqwest`. The `tls` feature
+# (ureq 2.x's name for the rustls backend, see `ureq/src/tls.rs`) reuses
+# the rustls already in our dep tree (pulled by gpui), avoiding a
+# second TLS implementation.
 ureq = { version = "2", default-features = false, features = ["tls"] }
 
 [dev-dependencies]

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod session;
 pub mod settings;
 pub mod theme;
 pub mod time;
+pub mod update_check;
 pub mod window_state;
 
 pub use claude_discovery::{AdoptionCandidate, POLL_INTERVAL_MS as CLAUDE_DISCOVERY_POLL_MS};

--- a/codescope-rs/core/src/update_check.rs
+++ b/codescope-rs/core/src/update_check.rs
@@ -37,8 +37,8 @@
 //! # Notification surface
 //!
 //! `app.rs` reads `UpdateStatus::Available` and pushes a `Generic`
-//! notification with a fixed title (`"Update available"`) and a detail
-//! line containing the new version + release URL. The C# build uses a
+//! notification titled `CodeScope <version> available` with a detail
+//! line containing the release URL. The C# build uses a
 //! `ToastSeverity.Ok` snackbar plus a confirmation dialog; we use the
 //! existing Notification ring buffer because (a) the Rust port has no
 //! restart-and-apply path, so the dialog wouldn't have anything
@@ -56,8 +56,9 @@
 //!
 //! # Network-failure semantics
 //!
-//! Every error path collapses to `UpdateStatus::Unknown` — the caller
-//! logs a single line and tries again on the next interval. We never
+//! Every error path collapses to `UpdateStatus::Unknown`. We log one
+//! `eprintln!` line at the failure site (fetch error, JSON parse
+//! error) and the caller just retries on the next interval. We never
 //! panic, never propagate a `Result`, and never re-toast the same
 //! version twice in a single process lifetime (the caller dedupes by
 //! holding the last-announced version in `AppShell` state).
@@ -212,15 +213,24 @@ pub fn evaluate(json_body: &str, current_version: &str) -> UpdateStatus {
     }
 }
 
+/// Maximum response body we'll buffer from the release endpoint.
+/// Real GitHub `/releases/latest` payloads are ~10 KiB; anything
+/// larger almost certainly means we got an HTML error page or a
+/// MITM is feeding us garbage. Refuse to read beyond this so a
+/// hostile (or just broken) endpoint can't OOM the process.
+const MAX_RESPONSE_BYTES: u64 = 1 << 20;
+
 /// HTTP GET against GitHub's API. Returns the response body on 2xx,
 /// `Err(message)` for any failure — including non-2xx, network error,
-/// timeout, or oversized response. Caller treats every error as
-/// "skip this tick".
+/// timeout, or response larger than `MAX_RESPONSE_BYTES`. Caller
+/// treats every error as "skip this tick".
 ///
-/// `pub(crate)` rather than `pub` because the only legitimate caller
-/// is `check_once`; tests that need to exercise parse + version
-/// logic go through `evaluate` with a fixture JSON string.
+/// Private (not `pub(crate)`) because the only legitimate caller is
+/// `check_once`; tests that need to exercise parse + version logic
+/// go through `evaluate` with a fixture JSON string.
 fn fetch_latest_release_json(url: &str, current_version: &str) -> Result<String, String> {
+    use std::io::Read;
+
     let response = ureq::get(url)
         .set("User-Agent", &user_agent(current_version))
         .set("Accept", "application/vnd.github+json")
@@ -230,12 +240,20 @@ fn fetch_latest_release_json(url: &str, current_version: &str) -> Result<String,
     if response.status() < 200 || response.status() >= 300 {
         return Err(format!("HTTP {}", response.status()));
     }
-    // Cap the body at 1 MiB. Real responses are ~10 KiB; anything
-    // larger almost certainly means GitHub returned an HTML error
-    // page or our endpoint is being MITMed.
-    response
-        .into_string()
-        .map_err(|e| format!("read body failed: {e}"))
+    // Read at most MAX_RESPONSE_BYTES + 1 so we can tell the
+    // difference between "exactly the cap" and "exceeded the cap".
+    // The `+ 1` byte read is the canary: if the limited reader
+    // delivered anything past the cap, we know the source had more
+    // and we refuse to deserialise a truncated JSON document.
+    let mut buf = Vec::with_capacity(16 * 1024);
+    let mut limited = response.into_reader().take(MAX_RESPONSE_BYTES + 1);
+    limited
+        .read_to_end(&mut buf)
+        .map_err(|e| format!("read body failed: {e}"))?;
+    if buf.len() as u64 > MAX_RESPONSE_BYTES {
+        return Err(format!("response exceeded {} bytes", MAX_RESPONSE_BYTES));
+    }
+    String::from_utf8(buf).map_err(|e| format!("response not utf-8: {e}"))
 }
 
 /// Strip a leading `v` or `V` from a version string. Mirrors
@@ -362,9 +380,12 @@ mod tests {
 
     #[test]
     fn normalise_current_unknown_passes_through() {
-        // The "0.0-unknown" build.rs fallback. Comparison against any
-        // semver tag will fail (no patch number) and `evaluate`
-        // returns UpToDate.
+        // The "0.0-unknown" build.rs fallback reduces to "0.0" here.
+        // That string would parse as the triple (0, 0, 0) and
+        // compare false-newer against every published tag, which is
+        // why `evaluate` short-circuits via `is_unknown_fallback`
+        // before this normalisation result is fed to
+        // `compare_versions`.
         assert_eq!(normalise_current("0.0-unknown"), "0.0");
     }
 
@@ -469,8 +490,11 @@ mod tests {
 
     #[test]
     fn evaluate_uptodate_when_current_is_unknown_fallback() {
-        // The build.rs `0.0-unknown` fallback — no patch number, parse
-        // fails, comparison ambiguous → UpToDate (don't spam).
+        // The build.rs `0.0-unknown` fallback. `normalise_current`
+        // would otherwise reduce this to `0.0` (parsing as the triple
+        // `(0, 0, 0)`) and compare false-newer against every published
+        // tag — `is_unknown_fallback` short-circuits before that and
+        // returns UpToDate so we don't spam notifications.
         let json = release_json("v0.2.5", "https://example.invalid", None);
         assert_eq!(evaluate(&json, "0.0-unknown"), UpdateStatus::UpToDate);
     }

--- a/codescope-rs/core/src/update_check.rs
+++ b/codescope-rs/core/src/update_check.rs
@@ -1,0 +1,527 @@
+//! GitHub release polling — Velopack parity for the Rust port.
+//!
+//! The C# build (`src/CodeScope.App/Updates/UpdateService.cs`) wires
+//! Velopack against `https://github.com/maui1911/CodeScope`'s `win`
+//! channel. It checks once at startup and every 3 hours thereafter,
+//! downloads any newer release in the background, and surfaces a toast
+//! + restart-confirmation dialog when the staged update is ready.
+//!
+//! The Rust port doesn't bundle Velopack (no automatic downloader, no
+//! restart-and-apply hook). What we *can* mirror is the visible signal:
+//! poll the same release endpoint on the same cadence, compare against
+//! the version baked in by `build.rs`, and push a notification entry
+//! when a newer release exists. The user then upgrades manually — same
+//! end-to-end shape as Velopack's "Later" path, where the staged
+//! update applies on the next clean exit.
+//!
+//! # Endpoint
+//!
+//! `https://api.github.com/repos/maui1911/CodeScope/releases/latest`.
+//! GitHub's REST API returns the most recent **non-prerelease** release
+//! published with `vpk upload github` (which is what `release.yml` uses
+//! per the C# build). Unauthenticated requests get 60/h per source IP
+//! — far above our once-every-3-hours cadence even with multiple
+//! processes on the same network.
+//!
+//! # Comparison rule
+//!
+//! Strict semver-major.minor.patch. A leading `v`/`V` is stripped from
+//! both sides. A `-dirty` (or any other) suffix on the *current*
+//! version is stripped before comparison so a developer build that
+//! describes as `0.2.5-dirty` is treated as `0.2.5` for "is the
+//! published release newer?" purposes. Prerelease suffixes on the
+//! published tag (e.g. `0.3.0-rc1`) are likewise dropped — we use the
+//! GitHub `latest` endpoint precisely so we never see them in
+//! practice, but the parser handles them defensively.
+//!
+//! # Notification surface
+//!
+//! `app.rs` reads `UpdateStatus::Available` and pushes a `Generic`
+//! notification with a fixed title (`"Update available"`) and a detail
+//! line containing the new version + release URL. The C# build uses a
+//! `ToastSeverity.Ok` snackbar plus a confirmation dialog; we use the
+//! existing Notification ring buffer because (a) the Rust port has no
+//! restart-and-apply path, so the dialog wouldn't have anything
+//! actionable to do, and (b) the bell button already collects "passive
+//! event" entries, which is exactly what an "update available" hint
+//! is.
+//!
+//! # Dev-mode behaviour
+//!
+//! `should_poll(paths)` returns `false` under `CODESCOPE_DEV=1` —
+//! mirrors the C# `IsDevMode` early return in `UpdateService.CheckAsync`.
+//! A dev build runs from `cargo run`, has no installer to upgrade, and
+//! the `0.0-unknown` git-describe slug compares falsely-newer against
+//! every published tag.
+//!
+//! # Network-failure semantics
+//!
+//! Every error path collapses to `UpdateStatus::Unknown` — the caller
+//! logs a single line and tries again on the next interval. We never
+//! panic, never propagate a `Result`, and never re-toast the same
+//! version twice in a single process lifetime (the caller dedupes by
+//! holding the last-announced version in `AppShell` state).
+
+use std::cmp::Ordering;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::AppPaths;
+
+/// Public GitHub release endpoint we poll. Mirrors the `RepoUrl`
+/// constant in C# `UpdateService` (the `/releases/latest` path is
+/// what Velopack hits internally).
+pub const RELEASES_LATEST_URL: &str =
+    "https://api.github.com/repos/maui1911/CodeScope/releases/latest";
+
+/// Initial delay before the first poll fires — keeps the network call
+/// off the startup-critical path. Mirrors the 10 s delay in
+/// `App.xaml.cs`.
+pub const INITIAL_DELAY: Duration = Duration::from_secs(10);
+
+/// Cadence between polls. Mirrors the 3 h interval in `App.xaml.cs`.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(3 * 60 * 60);
+
+/// HTTP timeout for a single poll. We're hitting `api.github.com`,
+/// which is normally <1 s round-trip — anything longer than 30 s
+/// almost always means a captive portal or DNS hijack we can't recover
+/// from anyway, so we bail and try again on the next interval.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// User-agent header sent with the poll. GitHub's API rejects requests
+/// without one (returns 403). Format follows common conventions —
+/// `<product>/<version>` — using the slug the caller passes in (the
+/// top-level binary bakes `CODESCOPE_VERSION_DISPLAY` via `build.rs`;
+/// the `core` crate doesn't see that env var directly).
+fn user_agent(current_version: &str) -> String {
+    format!("CodeScope/{current_version}")
+}
+
+/// One published release as returned by GitHub's `/releases/latest`
+/// endpoint. We deserialise only the three fields we surface; GitHub
+/// adds new fields regularly and we don't want a future addition to
+/// break the parse.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReleaseInfo {
+    /// Git tag of the published release, e.g. `v0.2.5` or `0.2.5`.
+    pub tag_name: String,
+    /// HTML URL the user clicks to view the release notes / download.
+    pub html_url: String,
+    /// Release notes body (Markdown). Optional because some early
+    /// releases have an empty body and GitHub returns `null` rather
+    /// than `""` in that case.
+    #[serde(default)]
+    pub body: Option<String>,
+}
+
+/// Result of one poll cycle.
+///
+/// `UpToDate` and `Unknown` look the same to the user (no
+/// notification), but the caller may use them differently — e.g.
+/// `Unknown` could trigger a faster retry. We currently treat them
+/// identically and just keep the next-tick cadence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateStatus {
+    /// A newer release is published. Caller should surface a
+    /// notification with the supplied fields.
+    Available {
+        /// Version string with any `v`/`V` prefix stripped.
+        version: String,
+        /// HTML URL of the GitHub release page.
+        url: String,
+        /// Release notes (Markdown, possibly empty).
+        body: String,
+    },
+    /// The latest published release is the same as or older than the
+    /// running build.
+    UpToDate,
+    /// We couldn't determine the answer (network failure, parse
+    /// failure, version comparison ambiguous). Caller logs and retries
+    /// on the next tick.
+    Unknown,
+}
+
+/// Should the background poll run for this process?
+///
+/// Skips dev builds (`CODESCOPE_DEV=1`) — mirrors the
+/// `AppPaths.IsDevMode` early return in C# `UpdateService.CheckAsync`.
+/// A dev build has no installer to upgrade, and the `0.0-unknown`
+/// git-describe fallback would compare falsely-newer against every
+/// published tag.
+pub fn should_poll(paths: &AppPaths) -> bool {
+    !paths.dev_mode
+}
+
+/// Run one poll cycle synchronously: fetch the GitHub `latest`
+/// release, parse the tag, compare against `current_version`. Returns
+/// `UpdateStatus::Unknown` for any failure path.
+///
+/// Designed to be called from `cx.background_spawn` — blocking work
+/// that must not run on the UI thread.
+pub fn check_once(current_version: &str) -> UpdateStatus {
+    let body = match fetch_latest_release_json(RELEASES_LATEST_URL, current_version) {
+        Ok(body) => body,
+        Err(err) => {
+            eprintln!("[update_check] fetch failed: {err}");
+            return UpdateStatus::Unknown;
+        }
+    };
+    evaluate(&body, current_version)
+}
+
+/// Pure logic: given the JSON body of a `/releases/latest` response
+/// and the currently-running version slug, decide what to surface.
+///
+/// Split out from `check_once` so unit tests can exercise the full
+/// version-comparison + JSON-shape logic without touching the
+/// network. Mirrors the way `pr::parse_pr_url_json` is split from
+/// `pr::detect_pr_url`.
+pub fn evaluate(json_body: &str, current_version: &str) -> UpdateStatus {
+    let release: ReleaseInfo = match serde_json::from_str(json_body) {
+        Ok(r) => r,
+        Err(err) => {
+            eprintln!("[update_check] release parse failed: {err}");
+            return UpdateStatus::Unknown;
+        }
+    };
+    let latest = strip_v_prefix(release.tag_name.trim());
+    // Reject the build.rs `0.0-unknown` fallback explicitly: a dev
+    // build that couldn't resolve git would otherwise normalise to
+    // `0.0`, compare false-newer against every published tag, and
+    // get spammed with notifications on every poll.
+    if is_unknown_fallback(current_version) {
+        return UpdateStatus::UpToDate;
+    }
+    let current = normalise_current(current_version);
+    match compare_versions(latest, &current) {
+        Some(Ordering::Greater) => UpdateStatus::Available {
+            version: latest.to_owned(),
+            url: release.html_url,
+            body: release.body.unwrap_or_default(),
+        },
+        Some(Ordering::Equal | Ordering::Less) => UpdateStatus::UpToDate,
+        None => {
+            // Version comparison is ambiguous — e.g. the running
+            // build is `0.0-unknown` (no tag yet) or the published
+            // tag isn't semver-shaped. Pretend up-to-date so we
+            // don't spam notifications about an "unknown" version
+            // delta.
+            UpdateStatus::UpToDate
+        }
+    }
+}
+
+/// HTTP GET against GitHub's API. Returns the response body on 2xx,
+/// `Err(message)` for any failure — including non-2xx, network error,
+/// timeout, or oversized response. Caller treats every error as
+/// "skip this tick".
+///
+/// `pub(crate)` rather than `pub` because the only legitimate caller
+/// is `check_once`; tests that need to exercise parse + version
+/// logic go through `evaluate` with a fixture JSON string.
+fn fetch_latest_release_json(url: &str, current_version: &str) -> Result<String, String> {
+    let response = ureq::get(url)
+        .set("User-Agent", &user_agent(current_version))
+        .set("Accept", "application/vnd.github+json")
+        .timeout(REQUEST_TIMEOUT)
+        .call()
+        .map_err(|e| format!("request failed: {e}"))?;
+    if response.status() < 200 || response.status() >= 300 {
+        return Err(format!("HTTP {}", response.status()));
+    }
+    // Cap the body at 1 MiB. Real responses are ~10 KiB; anything
+    // larger almost certainly means GitHub returned an HTML error
+    // page or our endpoint is being MITMed.
+    response
+        .into_string()
+        .map_err(|e| format!("read body failed: {e}"))
+}
+
+/// Strip a leading `v` or `V` from a version string. Mirrors
+/// `build.rs::strip_v_prefix` so the same rule applies on both sides
+/// of the comparison.
+fn strip_v_prefix(s: &str) -> &str {
+    s.strip_prefix('v')
+        .or_else(|| s.strip_prefix('V'))
+        .unwrap_or(s)
+}
+
+/// Reduce the current build slug to a semver-shaped string for
+/// comparison against a published tag.
+///
+/// `CODESCOPE_VERSION_DISPLAY` comes from `git describe --tags
+/// --always --dirty`, which produces shapes like:
+///
+/// * `0.2.5` — exact tag
+/// * `0.2.5-dirty` — exact tag with uncommitted changes
+/// * `0.2.5-3-g1a2b3c4` — 3 commits past the tag
+/// * `0.2.5-3-g1a2b3c4-dirty` — same plus dirty
+/// * `0.0-unknown` — no git info available (build.rs fallback)
+///
+/// We strip the `v` prefix and drop everything from the first `-`
+/// onward, treating "past the tag with uncommitted changes" as the
+/// tagged version itself. Conservative on purpose: a dev who's three
+/// commits ahead of `0.2.5` shouldn't get a "0.2.5 is available"
+/// notification.
+/// Recognise the `build.rs` last-resort fallback (`0.0-unknown`).
+/// A dev build that can't resolve git gets stamped with this slug;
+/// treating it as a real version would compare false-newer against
+/// every published tag.
+fn is_unknown_fallback(s: &str) -> bool {
+    let s = strip_v_prefix(s.trim());
+    s == "0.0-unknown" || s.ends_with("-unknown")
+}
+
+fn normalise_current(s: &str) -> String {
+    let s = strip_v_prefix(s.trim());
+    match s.find('-') {
+        Some(idx) => s[..idx].to_owned(),
+        None => s.to_owned(),
+    }
+}
+
+/// Lexicographic comparison over `(major, minor, patch)` triples.
+/// Both inputs must already have their `v` prefix stripped and
+/// suffixes normalised away. Returns `None` when either side fails
+/// to parse as a semver triple — caller treats this as "ambiguous,
+/// don't notify".
+///
+/// We accept 1-, 2-, or 3-segment versions; missing segments default
+/// to 0 (`1.2` becomes `(1, 2, 0)`). This matches Velopack's
+/// `SemanticVersion.Parse` behaviour for short tags like the early
+/// `0.1` releases.
+fn compare_versions(latest: &str, current: &str) -> Option<Ordering> {
+    let l = parse_triple(latest)?;
+    let c = parse_triple(current)?;
+    Some(l.cmp(&c))
+}
+
+fn parse_triple(s: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = s.split('.');
+    let major: u64 = parts.next()?.parse().ok()?;
+    let minor: u64 = parts.next().unwrap_or("0").parse().ok()?;
+    let patch_raw = parts.next().unwrap_or("0");
+    // A 4th segment (`a.b.c.d`) is rejected — we don't ship 4-part
+    // versions and accepting them would mask malformed tags.
+    if parts.next().is_some() {
+        return None;
+    }
+    // Drop any prerelease tail on the patch segment (`0.3.0-rc1` →
+    // `0`) so the published `latest` endpoint's defensive parse
+    // matches `normalise_current` on the dev side.
+    let patch_clean = patch_raw.split('-').next().unwrap_or("0");
+    let patch: u64 = patch_clean.parse().ok()?;
+    Some((major, minor, patch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── strip_v_prefix ──────────────────────────────────────────────────
+
+    #[test]
+    fn strip_v_prefix_removes_lower_v() {
+        assert_eq!(strip_v_prefix("v0.2.5"), "0.2.5");
+    }
+
+    #[test]
+    fn strip_v_prefix_removes_upper_v() {
+        assert_eq!(strip_v_prefix("V0.2.5"), "0.2.5");
+    }
+
+    #[test]
+    fn strip_v_prefix_no_prefix_unchanged() {
+        assert_eq!(strip_v_prefix("0.2.5"), "0.2.5");
+    }
+
+    #[test]
+    fn strip_v_prefix_preserves_internal_v() {
+        assert_eq!(strip_v_prefix("0.2.5-rc1"), "0.2.5-rc1");
+    }
+
+    // ── normalise_current ───────────────────────────────────────────────
+
+    #[test]
+    fn normalise_current_strips_dirty_suffix() {
+        assert_eq!(normalise_current("0.2.5-dirty"), "0.2.5");
+    }
+
+    #[test]
+    fn normalise_current_strips_describe_distance() {
+        assert_eq!(normalise_current("0.2.5-3-g1a2b3c4"), "0.2.5");
+        assert_eq!(normalise_current("0.2.5-3-g1a2b3c4-dirty"), "0.2.5");
+    }
+
+    #[test]
+    fn normalise_current_strips_v_prefix() {
+        assert_eq!(normalise_current("v0.2.5"), "0.2.5");
+        assert_eq!(normalise_current("V0.2.5-dirty"), "0.2.5");
+    }
+
+    #[test]
+    fn normalise_current_unknown_passes_through() {
+        // The "0.0-unknown" build.rs fallback. Comparison against any
+        // semver tag will fail (no patch number) and `evaluate`
+        // returns UpToDate.
+        assert_eq!(normalise_current("0.0-unknown"), "0.0");
+    }
+
+    // ── compare_versions ────────────────────────────────────────────────
+
+    #[test]
+    fn compare_patch_increment() {
+        assert_eq!(compare_versions("0.2.6", "0.2.5"), Some(Ordering::Greater));
+        assert_eq!(compare_versions("0.2.5", "0.2.6"), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn compare_minor_increment() {
+        assert_eq!(compare_versions("0.3.0", "0.2.99"), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn compare_major_increment() {
+        assert_eq!(compare_versions("1.0.0", "0.99.99"), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn compare_equal() {
+        assert_eq!(compare_versions("0.2.5", "0.2.5"), Some(Ordering::Equal));
+    }
+
+    #[test]
+    fn compare_short_form_treats_missing_as_zero() {
+        // `0.2` and `0.2.0` are equivalent.
+        assert_eq!(compare_versions("0.2", "0.2.0"), Some(Ordering::Equal));
+        assert_eq!(compare_versions("1", "1.0.0"), Some(Ordering::Equal));
+    }
+
+    #[test]
+    fn compare_rejects_too_many_segments() {
+        // Four-part versions are not a shape we ship; treat as
+        // ambiguous so the caller doesn't notify on garbage input.
+        assert_eq!(compare_versions("1.0.0.0", "1.0.0"), None);
+    }
+
+    #[test]
+    fn compare_rejects_non_numeric() {
+        assert_eq!(compare_versions("abc.def.ghi", "0.0.0"), None);
+        // Empty component
+        assert_eq!(compare_versions("..", "0.0.0"), None);
+    }
+
+    #[test]
+    fn compare_strips_prerelease_tail_from_patch() {
+        // The `latest` endpoint normally returns non-prereleases, but
+        // the parser still handles them defensively.
+        assert_eq!(compare_versions("0.3.0-rc1", "0.3.0"), Some(Ordering::Equal));
+    }
+
+    // ── evaluate (full pipeline, JSON → UpdateStatus) ───────────────────
+
+    fn release_json(tag: &str, url: &str, body: Option<&str>) -> String {
+        let body_field = match body {
+            Some(b) => format!("\"{}\"", b.replace('\"', "\\\"")),
+            None => "null".to_string(),
+        };
+        format!(
+            "{{\"tag_name\":\"{tag}\",\"html_url\":\"{url}\",\"body\":{body_field}}}"
+        )
+    }
+
+    #[test]
+    fn evaluate_available_when_published_newer() {
+        let json = release_json(
+            "v0.2.6",
+            "https://github.com/maui1911/CodeScope/releases/tag/v0.2.6",
+            Some("Bug fixes"),
+        );
+        let status = evaluate(&json, "0.2.5");
+        match status {
+            UpdateStatus::Available { version, url, body } => {
+                assert_eq!(version, "0.2.6");
+                assert_eq!(
+                    url,
+                    "https://github.com/maui1911/CodeScope/releases/tag/v0.2.6"
+                );
+                assert_eq!(body, "Bug fixes");
+            }
+            other => panic!("expected Available, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evaluate_uptodate_when_running_dirty_at_same_tag() {
+        let json = release_json("v0.2.5", "https://example.invalid", None);
+        // `-dirty` on the local build still maps to 0.2.5.
+        assert_eq!(evaluate(&json, "0.2.5-dirty"), UpdateStatus::UpToDate);
+    }
+
+    #[test]
+    fn evaluate_uptodate_when_running_ahead_of_release() {
+        // Developer building from a future commit shouldn't see a
+        // notification for a release they're already past.
+        let json = release_json("v0.2.5", "https://example.invalid", None);
+        assert_eq!(evaluate(&json, "0.2.6"), UpdateStatus::UpToDate);
+    }
+
+    #[test]
+    fn evaluate_uptodate_when_current_is_unknown_fallback() {
+        // The build.rs `0.0-unknown` fallback — no patch number, parse
+        // fails, comparison ambiguous → UpToDate (don't spam).
+        let json = release_json("v0.2.5", "https://example.invalid", None);
+        assert_eq!(evaluate(&json, "0.0-unknown"), UpdateStatus::UpToDate);
+    }
+
+    #[test]
+    fn evaluate_unknown_on_malformed_json() {
+        assert_eq!(evaluate("not json", "0.2.5"), UpdateStatus::Unknown);
+        assert_eq!(evaluate("", "0.2.5"), UpdateStatus::Unknown);
+    }
+
+    #[test]
+    fn evaluate_unknown_on_missing_required_fields() {
+        // Missing `tag_name` — serde_json fails the field, returns
+        // Unknown. `body` is optional; everything else isn't.
+        assert_eq!(
+            evaluate("{\"html_url\":\"x\"}", "0.2.5"),
+            UpdateStatus::Unknown
+        );
+    }
+
+    #[test]
+    fn evaluate_handles_null_body() {
+        let json = release_json("v0.2.6", "https://example.invalid", None);
+        match evaluate(&json, "0.2.5") {
+            UpdateStatus::Available { body, .. } => assert_eq!(body, ""),
+            other => panic!("expected Available, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evaluate_handles_unprefixed_tag() {
+        let json = release_json("0.2.6", "https://example.invalid", Some("notes"));
+        match evaluate(&json, "0.2.5") {
+            UpdateStatus::Available { version, .. } => assert_eq!(version, "0.2.6"),
+            other => panic!("expected Available, got {other:?}"),
+        }
+    }
+
+    // ── should_poll (dev-mode gate) ─────────────────────────────────────
+
+    #[test]
+    fn should_poll_skips_dev_mode() {
+        let mut paths = AppPaths::detect();
+        paths.dev_mode = true;
+        assert!(!should_poll(&paths));
+    }
+
+    #[test]
+    fn should_poll_allows_production() {
+        let mut paths = AppPaths::detect();
+        paths.dev_mode = false;
+        assert!(should_poll(&paths));
+    }
+}

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -441,6 +441,12 @@ pub struct AppShell {
     /// (0, 0). Refreshed every frame, so window resizes / status-bar
     /// reflows track the popover automatically.
     bell_bounds: Option<gpui::Bounds<gpui::Pixels>>,
+    /// The last release version we've already announced to the user
+    /// this process lifetime. Mirrors `_stagedVersion` in C#
+    /// `UpdateService` — keeps the 3-hourly re-poll from re-pushing the
+    /// same notification entry on every tick. `None` until the first
+    /// poll surfaces an `Available` result.
+    last_announced_update: Option<String>,
 }
 
 impl AppShell {
@@ -741,9 +747,11 @@ impl AppShell {
             notifications: crate::notifications::Notifications::new(),
             telemetry_tails: HashMap::new(),
             bell_bounds: None,
+            last_announced_update: None,
         };
         shell.start_telemetry_poll(cx);
         shell.start_claude_discovery_poll(cx);
+        shell.start_update_check_poll(cx);
         shell.rehydrate_or_cold_start(window, cx);
         shell
     }
@@ -1029,6 +1037,86 @@ impl AppShell {
                     Ok(next) => interval = next,
                     Err(_) => break,
                 }
+            }
+        })
+        .detach();
+    }
+
+    /// Spawn the GitHub release polling loop — Velopack parity for the
+    /// Rust port.
+    ///
+    /// Runs once after `update_check::INITIAL_DELAY` (10 s) and every
+    /// `update_check::POLL_INTERVAL` (3 h) thereafter — the same
+    /// cadence the C# `App.xaml.cs` uses for `UpdateService.CheckAsync`.
+    /// Network work is dispatched through `cx.background_executor()`
+    /// so the UI thread never sees a blocking `ureq::call`. On
+    /// `UpdateStatus::Available` we push a single `Generic`
+    /// notification per unique version per process lifetime; the C#
+    /// build's `_stagedVersion` field plays the same role.
+    ///
+    /// Skipped entirely under `CODESCOPE_DEV=1` — mirrors C#
+    /// `UpdateService.CheckAsync`'s `IsDevMode` early return.
+    fn start_update_check_poll(&self, cx: &mut Context<Self>) {
+        let paths = self.paths.clone();
+        if !codescope_core::update_check::should_poll(&paths) {
+            return;
+        }
+        cx.spawn(async move |this, cx| {
+            // Initial 10 s delay — keeps the first network call off
+            // the startup-critical path.
+            cx.background_executor()
+                .timer(codescope_core::update_check::INITIAL_DELAY)
+                .await;
+            loop {
+                if this.upgrade().is_none() {
+                    break;
+                }
+                let status = cx
+                    .background_executor()
+                    .spawn(async move {
+                        codescope_core::update_check::check_once(env!(
+                            "CODESCOPE_VERSION_DISPLAY"
+                        ))
+                    })
+                    .await;
+                if this.upgrade().is_none() {
+                    break;
+                }
+                if let codescope_core::update_check::UpdateStatus::Available {
+                    version,
+                    url,
+                    body: _,
+                } = status
+                {
+                    let _ = this.update(cx, |this, cx| {
+                        // Suppress duplicate announcements for the
+                        // same version this process lifetime, the
+                        // way C# `_stagedVersion` does.
+                        if this
+                            .last_announced_update
+                            .as_deref()
+                            .map(|v| v == version)
+                            .unwrap_or(false)
+                        {
+                            return;
+                        }
+                        this.last_announced_update = Some(version.clone());
+                        let title: SharedString =
+                            format!("CodeScope {version} available").into();
+                        let detail: SharedString =
+                            format!("A newer release is published. {url}").into();
+                        this.push_notification(
+                            crate::notifications::NotificationKind::Generic,
+                            title,
+                            detail,
+                            None,
+                            cx,
+                        );
+                    });
+                }
+                cx.background_executor()
+                    .timer(codescope_core::update_check::POLL_INTERVAL)
+                    .await;
             }
         })
         .detach();


### PR DESCRIPTION
## Summary

The C# build (`src/CodeScope.App/Updates/UpdateService.cs`) wires Velopack against `maui1911/CodeScope`'s `win` channel — checks once at startup, again every 3 hours, downloads any newer release in the background, and surfaces a toast plus restart-confirmation dialog. The Rust port doesn't bundle Velopack (no auto-downloader, no apply-and-restart hook), so this PR ports the **visible signal**: poll the same release endpoint on the same cadence, compare against the version baked in by `build.rs`, and push a Generic notification when a newer release is published. The user upgrades manually.

## Endpoint and cadence

- **Endpoint:** `https://api.github.com/repos/maui1911/CodeScope/releases/latest` (the same channel `release.yml` publishes to via `vpk upload github`).
- **Cadence:** 10 s initial delay, then every 3 h. Mirrors the constants in `App.xaml.cs`.
- **Dispatch:** `cx.background_executor().spawn(...)` so the blocking `ureq` call never touches the UI thread.
- **Failure mode:** every error path collapses to `UpdateStatus::Unknown`, logs one line via `eprintln!`, and tries again on the next interval. No panics, no `Result` propagation.

## Comparison rule

`compare_versions` parses `(major, minor, patch)` u64 triples after stripping a leading `v`/`V`. A `-dirty`, `-3-g1a2b3c4`, or `-rc1` suffix is dropped from the patch segment. Short forms (`0.2`, `1`) are widened to 3 segments with trailing zeros. Four-segment versions and non-numeric input return `None` (treated as "ambiguous, don't notify"). The `0.0-unknown` `build.rs` fallback is detected explicitly and short-circuits to `UpToDate` so a dev build that couldn't resolve git doesn't get spammed about every release.

## Notification

`UpdateStatus::Available` pushes a `NotificationKind::Generic` entry titled `CodeScope <version> available` with the release URL in the detail line. C# uses a toast plus a restart dialog — we use the existing notification ring buffer because (a) the Rust port has no apply-and-restart hook for the dialog to trigger, and (b) the bell button already collects passive system events. `last_announced_update` on `AppShell` dedupes by version so the 3-hourly re-poll doesn't re-push the same entry.

## Dev mode

`should_poll(&AppPaths)` returns `false` under `CODESCOPE_DEV=1` — mirrors `IsDevMode` early-return in C# `UpdateService.CheckAsync`. A dev build runs from `cargo run`, has no installer to upgrade, and the `0.0-unknown` git-describe fallback would be a noisy false-positive. The poll spawn is skipped entirely in `start_update_check_poll` rather than gated inside the loop, so dev runs don't hold the background task.

## Dependency

Adds `ureq = { version = "2", default-features = false, features = ["tls"] }` to `core`. Picked over `reqwest` because it's blocking (no tokio runtime), composes cleanly with `cx.background_spawn`, and rolls up to ~1/4 the compile time. The `tls` feature selects the rustls backend already in our dep tree (pulled by gpui), avoiding a second TLS implementation.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace` — 255 tests pass (26 new in `update_check::tests`)
- [x] Version comparison: patch / minor / major increments, equal, short-form widening, 4-segment rejection, non-numeric rejection, prerelease-tail strip
- [x] `normalise_current`: `0.2.5-dirty`, `0.2.5-3-g1a2b3c4`, `0.2.5-3-g1a2b3c4-dirty`, `v0.2.5`, `0.0-unknown` fallback
- [x] `evaluate`: Available on newer published, UpToDate on equal-with-dirty, UpToDate when running ahead, UpToDate on `0.0-unknown` (dev fallback no-spam), Unknown on malformed JSON / missing fields, null-body handling, unprefixed tag
- [x] `should_poll` skips dev mode, allows production
- [ ] Manual: launch a non-dev build, wait 10 s, confirm no notification when on latest tag (no easy way to mock the endpoint in-process — verifying through unit fixtures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)