### PR TITLE
feat(rs): dev-only memory watchdog (parity with C#)

### DIFF
--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -953,6 +953,7 @@ dependencies = [
  "tempfile",
  "ureq",
  "uuid",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/codescope-rs/core/Cargo.toml
+++ b/codescope-rs/core/Cargo.toml
@@ -19,5 +19,15 @@ uuid = { version = "1", features = ["v4"] }
 # second TLS implementation.
 ureq = { version = "2", default-features = false, features = ["tls"] }
 
+[target.'cfg(windows)'.dependencies]
+# `K32GetProcessMemoryInfo` for the dev-only memory watchdog. Mirrors
+# the version pinned by the binary crate's `Cargo.toml` so we're not
+# pulling two copies of `windows` into the workspace.
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_ProcessStatus",
+    "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod copilot_telemetry;
 pub mod crash_log;
 pub mod git;
 pub mod layout;
+pub mod memory_watchdog;
 pub mod paths;
 pub mod pr;
 pub mod projects;

--- a/codescope-rs/core/src/memory_watchdog.rs
+++ b/codescope-rs/core/src/memory_watchdog.rs
@@ -1,0 +1,304 @@
+//! Dev-mode-only memory watchdog.
+//!
+//! Mirrors `src/CodeScope.App/Diagnostics/MemoryWatchdog.cs` in the C#
+//! build. Periodically samples the process working-set and surfaces
+//! growth between ticks so per-session terminal scrollback retention
+//! regressions (and similar "creep" leaks) don't go unnoticed during
+//! long dev runs. Production builds skip this entirely — the cadence
+//! is loose enough that it'd be harmless, but there's no value in
+//! surfacing internal memory chatter to end users.
+//!
+//! ### Cadence and thresholds
+//!
+//! Both copied verbatim from C#:
+//!
+//! * initial delay: 1 minute (avoids logging the boot-time spike where
+//!   nothing meaningful has happened yet)
+//! * cadence: 5 minutes
+//! * growth threshold: 50 MiB — anything below this logs at
+//!   informational level; anything at or above logs as a warning so
+//!   it's easy to grep for in console output
+//!
+//! ### Output
+//!
+//! Mirrors C#'s `ILogger` output but emits via `eprintln!`, which is
+//! the convention everywhere else in `codescope-rs/src` (see
+//! `crash_log`'s last-resort surface, the various `eprintln!` warnings
+//! in `app.rs` and `sidebar.rs`). Each line is prefixed
+//! `MemoryWatchdog:` so it's filterable from terminal output.
+//!
+//! Each line includes:
+//!
+//! * ISO-8601 UTC timestamp (matches `crash_log::format_iso8601_utc`)
+//! * working-set size in MiB
+//! * growth since the previous sample in MiB (signed; first sample
+//!   reports 0)
+//!
+//! ### Cross-platform
+//!
+//! On Windows we call `K32GetProcessMemoryInfo` from the `windows`
+//! crate. On Linux we read `/proc/self/status` (`VmRSS:` line). On
+//! macOS we call `task_info`. Anywhere else, sampling returns `None`
+//! and the watchdog silently no-ops — a memory tracker that can't
+//! actually read memory is nothing but noise, and dev-mode by
+//! definition won't be running on those platforms.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Working-set growth threshold beyond which the periodic log line is
+/// promoted from `info` to `warn`. 50 MiB chosen as roughly the cost of
+/// one fat ConPTY scrollback at the default history size — anything
+/// larger per cadence is worth surfacing. Mirrors C# verbatim.
+pub const GROWTH_THRESHOLD_BYTES: u64 = 50 * 1024 * 1024;
+
+/// How long to wait before the first sample. C# parity: gives the boot
+/// sequence room to settle so the first delta isn't compared against a
+/// number that was still climbing.
+pub const INITIAL_DELAY: Duration = Duration::from_secs(60);
+
+/// Cadence between samples after the initial delay. C# parity: 5 min.
+pub const CADENCE: Duration = Duration::from_secs(5 * 60);
+
+/// Start the watchdog if and only if `dev_mode` is true. Production
+/// callers pay nothing — no thread, no allocation. Idempotent: a second
+/// call while the watchdog is already running is silently ignored.
+///
+/// The watchdog runs on a detached background thread. There's no
+/// public stop handle; the thread is short-lived only in the sense
+/// that the process terminates with it. This matches C#'s
+/// `BackgroundService` lifetime, which also lives until shutdown.
+pub fn start_if_dev(dev_mode: bool) {
+    if !dev_mode {
+        return;
+    }
+    static STARTED: AtomicBool = AtomicBool::new(false);
+    if STARTED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    thread::Builder::new()
+        .name("memory-watchdog".into())
+        .spawn(run_loop)
+        .ok(); // Failure to spawn the dev-only watchdog is non-fatal.
+}
+
+fn run_loop() {
+    thread::sleep(INITIAL_DELAY);
+    let mut last: Option<u64> = None;
+    loop {
+        if let Some(ws) = sample_working_set_bytes() {
+            let line = format_line(SystemTime::now(), ws, last);
+            // Bump to the stderr stream regardless of severity — the
+            // existing logging convention in `codescope-rs/src` is
+            // `eprintln!`, and we have no `tracing` subscriber wired
+            // up. The `MemoryWatchdog:` prefix makes filtering
+            // straightforward.
+            eprintln!("{line}");
+            last = Some(ws);
+        }
+        thread::sleep(CADENCE);
+    }
+}
+
+/// Format one log line. Pulled out so unit tests can exercise the
+/// formatting without touching the OS or sleeping the test thread.
+pub fn format_line(now: SystemTime, working_set_bytes: u64, last: Option<u64>) -> String {
+    let ts = format_iso8601_utc(now);
+    let ws_mib = bytes_to_mib(working_set_bytes);
+    match last {
+        None => format!(
+            "MemoryWatchdog: [{ts}] working set {ws_mib:.0} MiB (first sample)"
+        ),
+        Some(prev) => {
+            let delta_bytes = working_set_bytes as i128 - prev as i128;
+            let delta_mib = delta_bytes as f64 / (1024.0 * 1024.0);
+            let abs_delta = delta_bytes.unsigned_abs() as u64;
+            let level = if delta_bytes > 0 && abs_delta >= GROWTH_THRESHOLD_BYTES {
+                "warn"
+            } else {
+                "info"
+            };
+            format!(
+                "MemoryWatchdog: [{ts}] [{level}] working set {ws_mib:.0} MiB (delta {delta_mib:+.0} MiB)"
+            )
+        }
+    }
+}
+
+/// Convert raw bytes to a MiB float. Pulled out for unit testing.
+pub fn bytes_to_mib(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+/// Sample the current process's working-set / RSS in bytes. Returns
+/// `None` if the platform isn't supported or the syscall fails — the
+/// watchdog treats that as "skip this tick" and tries again next time.
+#[cfg(target_os = "windows")]
+fn sample_working_set_bytes() -> Option<u64> {
+    use windows::Win32::System::ProcessStatus::{
+        K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS,
+    };
+    use windows::Win32::System::Threading::GetCurrentProcess;
+
+    // SAFETY: `GetCurrentProcess` returns a pseudo-handle that doesn't
+    // need to be closed. `K32GetProcessMemoryInfo` writes into the
+    // out-pointer we own; we pass the size of our struct so it can't
+    // overrun.
+    unsafe {
+        let mut counters = PROCESS_MEMORY_COUNTERS::default();
+        let size = std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32;
+        if K32GetProcessMemoryInfo(GetCurrentProcess(), &mut counters, size).as_bool() {
+            Some(counters.WorkingSetSize as u64)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn sample_working_set_bytes() -> Option<u64> {
+    let body = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in body.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            // `VmRSS:   123456 kB`
+            let kb: u64 = rest
+                .split_whitespace()
+                .next()?
+                .parse()
+                .ok()?;
+            return Some(kb * 1024);
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn sample_working_set_bytes() -> Option<u64> {
+    // No `mach` dep in this crate — keep macOS as a no-op for now.
+    // Dev mode isn't expected to run there in practice; the C#
+    // implementation only targets Windows. Returning `None` makes
+    // the watchdog skip ticks silently, which is the desired
+    // behaviour on unsupported platforms.
+    None
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+fn sample_working_set_bytes() -> Option<u64> {
+    None
+}
+
+/// Minimal ISO-8601 UTC formatter — copy of `crash_log::format_iso8601_utc`
+/// kept module-local so the watchdog stays a single self-contained
+/// file. Identical algorithm; if either drifts, fix both.
+fn format_iso8601_utc(t: SystemTime) -> String {
+    let dur = t.duration_since(UNIX_EPOCH).unwrap_or_default();
+    let secs = dur.as_secs() as i64;
+    let millis = dur.subsec_millis();
+
+    let days = secs.div_euclid(86_400);
+    let secs_of_day = secs.rem_euclid(86_400) as u32;
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day % 3600) / 60;
+    let second = secs_of_day % 60;
+
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if m <= 2 { y + 1 } else { y };
+
+    format!(
+        "{year:04}-{m:02}-{d:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytes_to_mib_round_numbers() {
+        assert_eq!(bytes_to_mib(0), 0.0);
+        assert!((bytes_to_mib(1024 * 1024) - 1.0).abs() < f64::EPSILON);
+        assert!((bytes_to_mib(50 * 1024 * 1024) - 50.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn first_sample_line_marks_baseline() {
+        let line = format_line(UNIX_EPOCH, 100 * 1024 * 1024, None);
+        assert!(line.starts_with("MemoryWatchdog: ["), "{line}");
+        assert!(line.contains("working set 100 MiB"), "{line}");
+        assert!(line.contains("first sample"), "{line}");
+    }
+
+    #[test]
+    fn growing_below_threshold_is_info() {
+        let line = format_line(
+            UNIX_EPOCH,
+            120 * 1024 * 1024,
+            Some(100 * 1024 * 1024),
+        );
+        assert!(line.contains("[info]"), "{line}");
+        assert!(line.contains("delta +20 MiB"), "{line}");
+        assert!(line.contains("working set 120 MiB"), "{line}");
+    }
+
+    #[test]
+    fn growing_at_or_above_threshold_is_warn() {
+        let line = format_line(
+            UNIX_EPOCH,
+            (100 + 50) * 1024 * 1024,
+            Some(100 * 1024 * 1024),
+        );
+        assert!(line.contains("[warn]"), "{line}");
+        assert!(line.contains("delta +50 MiB"), "{line}");
+    }
+
+    #[test]
+    fn shrinking_is_info_regardless_of_magnitude() {
+        // A negative delta of any size never triggers the warn level —
+        // we only care about *growth* since that's the leak signal.
+        let line = format_line(
+            UNIX_EPOCH,
+            10 * 1024 * 1024,
+            Some(1024 * 1024 * 1024),
+        );
+        assert!(line.contains("[info]"), "{line}");
+        assert!(line.contains("delta -1014 MiB"), "{line}");
+    }
+
+    #[test]
+    fn start_if_dev_is_noop_in_production() {
+        // Calling with `false` must not spawn a thread or panic. This
+        // is a smoke test only — we can't easily prove the *absence*
+        // of a thread, but we can prove it returns immediately and
+        // can be called repeatedly without blowing up.
+        for _ in 0..3 {
+            start_if_dev(false);
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn sampling_returns_a_plausible_size_on_windows() {
+        // Smoke test: sampling our own process should give a value
+        // larger than the test binary's static size and well below
+        // the 64-bit ceiling. Anything that fits the "is real" check
+        // is fine — exact values shift between runs.
+        let ws = sample_working_set_bytes().expect("sampling failed on Windows");
+        assert!(ws > 1024 * 1024, "working set unexpectedly small: {ws}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sampling_returns_a_plausible_size_on_linux() {
+        let ws = sample_working_set_bytes().expect("sampling failed on Linux");
+        assert!(ws > 1024 * 1024, "working set unexpectedly small: {ws}");
+    }
+}

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -63,6 +63,12 @@ fn main() -> Result<()> {
         env!("CODESCOPE_VERSION_DISPLAY").to_string(),
     );
 
+    // Dev-only memory watchdog — surfaces working-set creep every 5 min
+    // so per-session terminal scrollback regressions don't go unnoticed
+    // during long dev runs (parity with the C# build's
+    // `App/Diagnostics/MemoryWatchdog.cs`). No-op in production.
+    codescope_core::memory_watchdog::start_if_dev(paths.dev_mode);
+
     let settings = match Settings::load(&paths) {
         Ok(s) => s,
         Err(err) => {


### PR DESCRIPTION
## Summary

Ports the dev-only memory watchdog from `src/CodeScope.App/Diagnostics/MemoryWatchdog.cs` to the Rust workspace. The C# build registers a `BackgroundService` that periodically samples `Process.WorkingSet64` and surfaces growth so per-session terminal scrollback retention regressions don't creep up unnoticed during long dev sessions. This PR mirrors that 1:1.

## Behaviour (matches C#)

- **Gating** — only runs when `CODESCOPE_DEV=1` (resolved via `AppPaths::dev_mode`). Production builds short-circuit to a no-op in `start_if_dev`.
- **Cadence** — 1 minute initial delay, then 5 minute samples (verbatim from C#).
- **Growth threshold** — 50 MiB. Crossing it bumps the log line from `[info]` to `[warn]`; shrinkage is always `[info]` since only growth is the leak signal.
- **Log destination** — `eprintln!`, which is the existing convention in `codescope-rs/src` (no `tracing` subscriber wired up; `crash_log` and the various `app.rs` / `sidebar.rs` warnings all go via `eprintln!`).
- **Log fields** — ISO-8601 UTC timestamp, working set in MiB, signed delta in MiB, all prefixed `MemoryWatchdog:` for easy filtering. First sample is annotated `(first sample)` since there's no previous baseline to delta against.

## Cross-platform

- **Windows** — `K32GetProcessMemoryInfo` via the `windows` crate (already in the workspace; reused on `core`'s side with the `Win32_System_ProcessStatus` + `Win32_System_Threading` features).
- **Linux** — `/proc/self/status` `VmRSS:` line.
- **macOS / other** — sampling returns `None`; the watchdog silently skips ticks. Dev mode isn't expected on these platforms (C# is Windows-only), so a no-op is the right shape.

## Wiring

`codescope-rs/src/window.rs::main` calls `core::memory_watchdog::start_if_dev(paths.dev_mode)` immediately after `install_panic_hook`, before any gpui state spins up.

## Test plan

- [x] `cargo check --workspace` — clean.
- [x] `cargo test --workspace` — all tests pass (233 in core, 32 in spike, 17 in terminal).
- [x] Unit tests in `memory_watchdog::tests` cover:
  - `bytes_to_mib` rounding
  - first-sample line formatting (no delta)
  - growth below threshold tags `[info]`
  - growth at/above threshold tags `[warn]`
  - shrinkage always `[info]`
  - `start_if_dev(false)` is a noop and idempotent
  - per-platform sampling smoke test (Windows / Linux variants)