### PR TITLE
fix(rs): SessionManager follow-ups from PR #123 review

### DIFF
--- a/codescope-rs/core/src/session.rs
+++ b/codescope-rs/core/src/session.rs
@@ -123,10 +123,39 @@ impl SessionManager {
     /// Missing files surface as an empty config, matching
     /// [`ProjectsConfig::load_from`] semantics — the legacy upgrade
     /// path the C# `LoadAsync` walks for first-launch users.
+    ///
+    /// **In-memory only.** Production launch paths should call
+    /// [`Self::load_with_sweep_persisting`] so a sweep that prunes
+    /// rows actually persists, mirroring the C# `LoadAsync`'s
+    /// `if (prunedSessionIds.Count > 0) { await SaveSnapshotAsync(); }`
+    /// finally-block.
     pub fn load_with_sweep(paths: &AppPaths, now_iso: &str) -> Result<ProjectsConfig> {
         let mut cfg = ProjectsConfig::load(paths)?;
         Self::apply_retention(&mut cfg, now_iso, None);
         Ok(cfg)
+    }
+
+    /// Load + sweep + persist when the sweep actually pruned anything.
+    /// Mirrors the C# `SessionStore.LoadAsync` finally-block — without
+    /// the persisting save, expired closed-session rows would linger
+    /// on disk forever even after the in-memory state had dropped them.
+    ///
+    /// Persistence failure is non-fatal: the in-memory state is
+    /// already pruned and is returned as-is so the runtime can
+    /// proceed; the next mutation will retry the save. The error is
+    /// surfaced via the second tuple element so the caller can log
+    /// without aborting startup.
+    pub fn load_with_sweep_persisting(
+        paths: &AppPaths,
+        now_iso: &str,
+    ) -> Result<(ProjectsConfig, Option<anyhow::Error>)> {
+        let mut cfg = ProjectsConfig::load(paths)?;
+        let pruned = Self::apply_retention(&mut cfg, now_iso, None);
+        if pruned.is_empty() {
+            return Ok((cfg, None));
+        }
+        let save_err = save(&cfg, paths).err();
+        Ok((cfg, save_err))
     }
 
     /// Same as [`Self::load_with_sweep`] but reads from an explicit
@@ -951,6 +980,87 @@ mod tests {
         // sweep would early-return on every call.
         let now = now_iso8601();
         assert!(parse_iso8601_secs(&now).is_some(), "produced: {now}");
+    }
+
+    // ---- load + sweep + persist --------------------------------
+
+    #[test]
+    fn load_with_sweep_persisting_writes_back_when_pruning_happens() {
+        // The whole point of the persisting variant: a TTL-expired
+        // closed row that gets pruned in-memory must also disappear
+        // from `projects.json`, otherwise the next launch sees the
+        // same stale row and re-prunes it forever (effectively a
+        // no-op on disk). Mirrors C# `SessionStore.LoadAsync`'s
+        // post-prune `SaveSnapshotAsync`.
+        let root = tempfile::tempdir().unwrap();
+        let paths = crate::paths::rooted_for_tests(false, root.path());
+        paths.ensure_dirs().unwrap();
+
+        let mut cfg = ProjectsConfig::default();
+        let mut p = make_project("p1");
+        let mut old = make_session("old", Some("primary"));
+        old.closed_at = Some(iso_days_ago(180));
+        p.sessions.push(old);
+        p.sessions.push(make_session("live", Some("primary")));
+        cfg.projects.push(p);
+        cfg.save(&paths).unwrap();
+
+        let (loaded, save_err) =
+            SessionManager::load_with_sweep_persisting(&paths, fixed_now()).unwrap();
+        assert!(save_err.is_none(), "the save should succeed");
+        let ids: Vec<_> = loaded.projects[0]
+            .sessions
+            .iter()
+            .map(|s| s.id.clone())
+            .collect();
+        assert!(!ids.iter().any(|id| id == "old"));
+        assert!(ids.iter().any(|id| id == "live"));
+
+        // And the on-disk file reflects the prune.
+        let on_disk = ProjectsConfig::load(&paths).unwrap();
+        let disk_ids: Vec<_> = on_disk.projects[0]
+            .sessions
+            .iter()
+            .map(|s| s.id.clone())
+            .collect();
+        assert!(
+            !disk_ids.iter().any(|id| id == "old"),
+            "pruned row must not survive on disk"
+        );
+    }
+
+    #[test]
+    fn load_with_sweep_persisting_skips_save_when_nothing_pruned() {
+        // No-op write when nothing was pruned keeps the file mtime
+        // stable across launches. Useful both for predictable file
+        // timestamps and for skipping a write entirely on the
+        // happy-path startup.
+        let root = tempfile::tempdir().unwrap();
+        let paths = crate::paths::rooted_for_tests(false, root.path());
+        paths.ensure_dirs().unwrap();
+
+        let mut cfg = ProjectsConfig::default();
+        cfg.projects.push(make_project("p1"));
+        cfg.save(&paths).unwrap();
+        let mtime_before = std::fs::metadata(paths.projects_file())
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        // Sleep a tiny amount so a write would *visibly* bump mtime.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let (_loaded, save_err) =
+            SessionManager::load_with_sweep_persisting(&paths, fixed_now()).unwrap();
+        assert!(save_err.is_none());
+
+        let mtime_after = std::fs::metadata(paths.projects_file())
+            .unwrap()
+            .modified()
+            .unwrap();
+        assert_eq!(
+            mtime_before, mtime_after,
+            "no prune ⇒ no rewrite ⇒ file mtime must be unchanged"
+        );
     }
 
     // ---- AppShell ↔ SessionManager persistence wiring ----------

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -174,18 +174,27 @@ struct SplitterDrag {
     px_per_unit: f32,
 }
 
-/// Case-insensitive equality for filesystem paths after stripping
-/// any trailing separator. Windows paths persisted under different
-/// casings ("C:\\Repo" vs "c:\\repo") still need to compare equal so
-/// `locate_project_for_path` lands on the right project on every
-/// platform our build targets.
+/// Filesystem path equality after stripping any trailing separator.
+/// Case-insensitive on Windows (NTFS / ReFS are case-preserving but
+/// case-insensitive by default, so "C:\\Repo" and "c:\\repo" must
+/// compare equal); case-sensitive everywhere else (Linux ext4 / APFS
+/// in its default case-sensitive mode treat them as distinct paths,
+/// and a case-insensitive compare here would mis-route a tab to the
+/// wrong project / worktree).
 fn path_eq_ci(a: &str, b: &str) -> bool {
     fn norm(s: &str) -> &str {
         s.trim_end_matches(|c| c == '\\' || c == '/')
     }
     let a = norm(a);
     let b = norm(b);
-    a.len() == b.len() && a.chars().zip(b.chars()).all(|(x, y)| x.eq_ignore_ascii_case(&y))
+    if cfg!(windows) {
+        a.len() == b.len()
+            && a.chars()
+                .zip(b.chars())
+                .all(|(x, y)| x.eq_ignore_ascii_case(&y))
+    } else {
+        a == b
+    }
 }
 
 /// `mtime` for the watcher loop's "did the file change?" check.
@@ -1228,14 +1237,16 @@ impl AppShell {
             let title = SharedString::from(tab.title);
             let auto = tab.auto_type.map(SharedString::from);
             // Rehydrate path lets `spawn_tab_in` mint a fresh session
-            // id rather than try to map back to a stored row — the
-            // launch-time `restore_live_sessions` pass handles the
-            // session-restore flow separately, mirroring C# where the
-            // tab list and the session list are adopted via two
-            // distinct entry points (`SessionStore.LoadAsync` for the
-            // store; `MainViewModel.RestoreClosedWorktreeSessionsAsync`
-            // for the tab side, but here unified into
-            // `restore_live_sessions`).
+            // id and append a new row through `SessionManager::open`,
+            // even though the tab is logically "the same" tab the
+            // user closed in the previous launch. This is a known
+            // limitation: `LayoutState::open_tabs` does not yet carry
+            // the persisted `Session.id`, so we can't map back to the
+            // stored row. The follow-up that unifies the rehydrate
+            // path with `SessionManager::live` will tighten this up;
+            // until then, accept the duplicate row as the cost of
+            // landing the lifecycle plumbing without a coordinated
+            // schema change.
             self.spawn_tab_in(Some(path), Some(title), auto, None, window, cx);
             spawned_any = true;
             if tab.active_in_group {
@@ -1338,14 +1349,14 @@ impl AppShell {
         let Some(wd) = working_directory else {
             return new_id;
         };
-        let Some((project_id, worktree_id)) = self.locate_project_for_path(wd) else {
-            return new_id;
-        };
-        // Reload from disk before mutating — the sidebar may have
-        // persisted a project / worktree change since our last
-        // snapshot. Mirrors C# `SessionStore`'s read-then-write
-        // pattern (it owns the in-memory list under a lock; we don't,
-        // so re-reading is the cheapest equivalent).
+        // Reload from disk *before* the project lookup — the sidebar
+        // may have added or removed a project / worktree since our
+        // last snapshot. Looking up against a stale in-memory copy
+        // would miss a freshly-added worktree (no persistence) or
+        // stamp the session with a stale `worktree_id` that the
+        // sidebar has since deleted. Mirrors C# `SessionStore`'s
+        // read-then-mutate pattern (it owns the in-memory list under
+        // a lock; we don't, so re-reading is the cheapest equivalent).
         match ProjectsConfig::load(&self.paths) {
             Ok(cfg) => {
                 self.projects = cfg;
@@ -1354,6 +1365,9 @@ impl AppShell {
                 eprintln!("warning: failed to reload projects.json before SessionManager::open: {err:#}");
             }
         }
+        let Some((project_id, worktree_id)) = self.locate_project_for_path(wd) else {
+            return new_id;
+        };
         let session = Session {
             id: new_id.clone(),
             worktree_path: wd.to_string_lossy().into_owned(),
@@ -4345,11 +4359,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn path_eq_ci_handles_case_and_trailing_slash() {
-        assert!(path_eq_ci("C:\\Repos\\Foo", "c:\\repos\\foo"));
-        assert!(path_eq_ci("C:\\Repos\\Foo\\", "C:\\Repos\\Foo"));
+    fn path_eq_ci_handles_trailing_slash_on_every_platform() {
+        // Trailing-separator stripping is platform-independent — both
+        // POSIX `/` and Windows `\` get trimmed regardless of host.
         assert!(path_eq_ci("/usr/local/bin/", "/usr/local/bin"));
-        assert!(!path_eq_ci("C:\\Repos\\Foo", "C:\\Repos\\Bar"));
+        assert!(path_eq_ci("C:\\Repos\\Foo\\", "C:\\Repos\\Foo"));
         assert!(!path_eq_ci("foo", "foobar"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn path_eq_ci_on_windows_is_case_insensitive() {
+        assert!(path_eq_ci("C:\\Repos\\Foo", "c:\\repos\\foo"));
+        assert!(!path_eq_ci("C:\\Repos\\Foo", "C:\\Repos\\Bar"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn path_eq_ci_off_windows_is_case_sensitive() {
+        // Linux ext4 / case-sensitive APFS treat "/Repo" and "/repo"
+        // as distinct paths — comparing case-insensitively here would
+        // route a tab to the wrong project.
+        assert!(!path_eq_ci("/repos/Foo", "/repos/foo"));
+        assert!(path_eq_ci("/repos/foo", "/repos/foo"));
     }
 }

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -97,13 +97,22 @@ fn main() -> Result<()> {
     let theme = Arc::new(builtin::by_name(&settings.theme));
     let settings = Arc::new(settings);
 
-    // Load projects via `SessionManager::load_with_sweep` so the
-    // closed-session retention policy runs once per launch, mirroring
-    // C# `SessionStore.LoadAsync` which fires a one-shot migration
-    // sweep on every load. Pre-PR this called `ProjectsConfig::load`
-    // directly, which left expired closed-history rows around forever.
-    let projects = match SessionManager::load_with_sweep(&paths, &now_iso8601()) {
-        Ok(p) => p,
+    // Load projects via `SessionManager::load_with_sweep_persisting`
+    // so the closed-session retention policy runs once per launch and
+    // any pruned rows are written back to disk in the same step,
+    // mirroring C# `SessionStore.LoadAsync`'s finally-block. Without
+    // the persisting save, expired closed-history rows would linger
+    // on disk forever even after the in-memory state had dropped them.
+    let projects = match SessionManager::load_with_sweep_persisting(&paths, &now_iso8601()) {
+        Ok((p, save_err)) => {
+            if let Some(err) = save_err {
+                eprintln!(
+                    "warning: post-load retention sweep persisted state \
+                     but failed to save: {err:#}"
+                );
+            }
+            p
+        }
         Err(err) => {
             eprintln!(
                 "warning: failed to load {} ({}); starting with no projects",


### PR DESCRIPTION
Follow-up to #123 — addresses 4 Copilot review threads that landed after that PR was merged.

## Fixes
- Sweep now persists pruned rows (was in-memory only)
- `path_eq_ci` gated to Windows (case-insensitive there only, byte-equal elsewhere)
- Reload-before-locate so concurrent edits to projects.json aren't lost
- Removed stale comment

## Test plan
- [ ] cargo test --workspace
- [ ] new tab + close still flows through SessionManager.soft_close
- [ ] launch-time retention sweep persists changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)