### PR TITLE
feat(rs): sidebar footer — Overview + New Project buttons (parity)

### DIFF
--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -595,6 +595,19 @@ impl AppShell {
                     };
                     this.push_toast(kind, title.clone(), detail.clone(), cx);
                 }
+                SidebarEvent::OpenOverview => {
+                    // Placeholder until the C# `OverviewView` is
+                    // ported to gpui. Until then, surface a subtle
+                    // info toast so the click is acknowledged. The
+                    // sidebar footer button stays useful as a
+                    // discoverability hook for the upcoming feature.
+                    this.push_toast(
+                        ToastKind::Info,
+                        SharedString::new_static("Overview"),
+                        Some(SharedString::new_static("Coming soon — full Overview view not ported yet.")),
+                        cx,
+                    );
+                }
             }
         })
         .detach();

--- a/codescope-rs/src/new_project_dialog.rs
+++ b/codescope-rs/src/new_project_dialog.rs
@@ -275,11 +275,20 @@ impl Sidebar {
     /// Replaces the previous bare-picker flow — clicking "+" now opens
     /// the in-app modal, and the dialog itself drives the platform
     /// folder picker as part of its Browse button.
+    ///
+    /// Gated: returns silently if a "New project" or "New worktree"
+    /// dialog is already open. All call sites — the heading `+`
+    /// glyph and the sidebar footer's "New Project" button — share
+    /// this single gate so neither path can stack a second modal on
+    /// top of an existing one.
     pub fn open_new_project_dialog(
         &mut self,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.new_project_dialog().is_some() || self.dialog().is_some() {
+            return;
+        }
         let existing_paths: Vec<&str> = self
             .projects()
             .projects

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -34,7 +34,7 @@ use codescope_core::git::GitStatus;
 use gpui::{
     AppContext, ClipboardItem, Context, Corner, EventEmitter, InteractiveElement, IntoElement,
     MouseButton, MouseDownEvent, ParentElement, Pixels, Point, Render,
-    SharedString, Styled, Window, anchored, deferred, div, point, px,
+    SharedString, StatefulInteractiveElement, Styled, Window, anchored, deferred, div, point, px,
 };
 
 use crate::new_project_dialog::NewProjectDialogState;
@@ -1748,12 +1748,22 @@ impl Render for Sidebar {
             }
         }
 
+        // `flex_grow` + `min_h(0)` + `overflow_y_scroll` so the
+        // project/worktree tree absorbs remaining height in the
+        // sidebar's flex column and clips + scrolls instead of
+        // pushing the footer off the bottom edge with a long
+        // project list. Same pattern AppShell's notifications panel
+        // uses; without `min_h(0)` flex children default to their
+        // content's intrinsic size and the column overflows.
         let mut body = div()
+            .id("sidebar-body")
             .flex()
             .flex_col()
             .flex_grow()
+            .overflow_y_scroll()
             .py_1()
             .children(project_and_worktree_rows);
+        body.style().min_size.height = Some(gpui::Length::Definite(px(0.0).into()));
         if let Some(es) = empty_state {
             body = body.child(es);
         }
@@ -1780,9 +1790,10 @@ impl Render for Sidebar {
         //    correct for the future port.
         //    New Project: routes to `open_new_project_dialog`, the
         //    same entry point the `+` glyph in the heading uses (PR
-        //    #124). Mutually exclusive with the "+" via the same
+        //    #124). The function itself enforces the
         //    `new_project_dialog().is_none() && dialog().is_none()`
-        //    gate the heading glyph relies on.
+        //    gate so both call sites share one source of truth and
+        //    neither can stack a second modal on top of an open one.
         let footer = {
             let frost_hover = theme::frost_10(&theme);
             let ink_hover = theme::ink(&theme);
@@ -1859,12 +1870,6 @@ impl Render for Sidebar {
                 .on_mouse_down(
                     MouseButton::Left,
                     cx.listener(|this, _, window, cx| {
-                        // Same gate as the "+" glyph in the heading —
-                        // skip when another modal is already showing
-                        // so we never stack two on top of each other.
-                        if this.new_project_dialog().is_some() || this.dialog().is_some() {
-                            return;
-                        }
                         this.open_new_project_dialog(window, cx);
                     }),
                 )

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -153,6 +153,13 @@ pub enum SidebarEvent {
     /// user can't see them. Severity drives the toast colour stripe
     /// and lifetime.
     Toast { kind: ToastSeverity, title: SharedString, detail: Option<SharedString> },
+    /// User clicked the sidebar's "Overview" footer button. The C#
+    /// build maps Ctrl+Shift+O / this button to a full-window
+    /// `OverviewView` that replaces the workspace layer. The Rust
+    /// port doesn't have that view yet — AppShell currently surfaces
+    /// a "coming soon" toast — so this event is a placeholder hook
+    /// the host can wire up to the real Overview once it lands.
+    OpenOverview,
 }
 
 /// Toast severity emitted by the sidebar. AppShell maps these to its
@@ -1744,11 +1751,145 @@ impl Render for Sidebar {
         let mut body = div()
             .flex()
             .flex_col()
+            .flex_grow()
             .py_1()
             .children(project_and_worktree_rows);
         if let Some(es) = empty_state {
             body = body.child(es);
         }
+
+        // ── Footer: Overview + New Project, stacked, separated from
+        //    the tree by a 1 px divider. Mirrors the bottom block in
+        //    `src/CodeScope.Ui/Views/SidebarView.xaml`:
+        //
+        //    <Border BorderThickness="0,1,0,0" Padding="8">
+        //      <StackPanel>
+        //        <Button (Sidebar.OverviewButton, h=36)>
+        //          <Grid> Overview | ⌃⇧O keycap </Grid>
+        //        </Button>
+        //        <Button (Sidebar.NewProjectButton, h=40, mt=6)
+        //                BorderThickness="2,0,0,0" /* accent rail */>
+        //          <StackPanel> + | New Project </StackPanel>
+        //        </Button>
+        //      </StackPanel>
+        //    </Border>
+        //
+        //    Overview: emits `SidebarEvent::OpenOverview`. The C#
+        //    Overview view isn't ported yet, so AppShell catches the
+        //    event and surfaces a "coming soon" toast — wiring stays
+        //    correct for the future port.
+        //    New Project: routes to `open_new_project_dialog`, the
+        //    same entry point the `+` glyph in the heading uses (PR
+        //    #124). Mutually exclusive with the "+" via the same
+        //    `new_project_dialog().is_none() && dialog().is_none()`
+        //    gate the heading glyph relies on.
+        let footer = {
+            let frost_hover = theme::frost_10(&theme);
+            let ink_hover = theme::ink(&theme);
+            let elev = theme::elevated(&theme);
+            let divider = theme::divider(&theme);
+            let ink_dim = theme::ink_dim(&theme);
+            let ink_ghost = theme::ink_ghost(&theme);
+            let accent = theme::accent(&theme);
+
+            // Overview button — 36 px tall, dim text, mono ⌃⇧O keycap
+            // on the right inside a 1 px outlined pill. Mirrors
+            // `Sidebar.OverviewButton` in `SidebarView.xaml`. The
+            // active state (Overview view visible) isn't represented
+            // here yet because the Rust port has no Overview view to
+            // be active in — once the view lands, swap the bg/text/
+            // rail to the same active palette the C# DataTrigger uses
+            // (`Surface.AccentRowBg` + `Accent.Primary` foreground +
+            // 2 px accent rail on the left edge).
+            let overview_btn = div()
+                .id("sidebar-footer-overview")
+                .h(px(36.0))
+                .px_3()
+                .flex()
+                .flex_row()
+                .items_center()
+                .rounded(px(6.0))
+                .bg(elev)
+                .text_color(ink_dim)
+                .text_size(px(12.0))
+                .cursor_pointer()
+                .hover(move |s| s.bg(frost_hover).text_color(ink_hover))
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|_, _, _, cx| {
+                        cx.emit(SidebarEvent::OpenOverview);
+                    }),
+                )
+                .child(div().flex_grow().child("Overview"))
+                .child(
+                    div()
+                        .px(px(5.0))
+                        .py(px(1.0))
+                        .border_1()
+                        .border_color(divider)
+                        .rounded(px(3.0))
+                        .text_size(px(10.0))
+                        .text_color(ink_ghost)
+                        .font(theme::font_mono())
+                        .child("⌃⇧ O"),
+                );
+
+            // New Project — 40 px tall signature CTA. Flush-left 2 px
+            // accent rail, accent-coloured `+` glyph, sans-serif label.
+            // Mirrors `Sidebar.NewProjectButton` in `SidebarView.xaml`.
+            // `mt(px(6.0))` reproduces the StackPanel's `Margin="0,6,0,0"`
+            // gap between the two buttons.
+            let new_project_btn = div()
+                .id("sidebar-footer-newproject")
+                .mt(px(6.0))
+                .h(px(40.0))
+                .pl(px(12.0))
+                .pr(px(12.0))
+                .flex()
+                .flex_row()
+                .items_center()
+                .border_l_2()
+                .border_color(accent)
+                .rounded(px(6.0))
+                .bg(elev)
+                .text_color(ink_dim)
+                .text_size(px(13.0))
+                .cursor_pointer()
+                .hover(move |s| s.bg(frost_hover).text_color(ink_hover))
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|this, _, window, cx| {
+                        // Same gate as the "+" glyph in the heading —
+                        // skip when another modal is already showing
+                        // so we never stack two on top of each other.
+                        if this.new_project_dialog().is_some() || this.dialog().is_some() {
+                            return;
+                        }
+                        this.open_new_project_dialog(window, cx);
+                    }),
+                )
+                .child(
+                    div()
+                        .text_size(px(14.0))
+                        .text_color(accent)
+                        .font(theme::font_mono())
+                        .child("+"),
+                )
+                .child(
+                    div()
+                        .ml(px(8.0))
+                        .child("New Project"),
+                );
+
+            div()
+                .flex()
+                .flex_col()
+                .border_t_1()
+                .border_color(divider)
+                .p_2()
+                .child(overview_btn)
+                .child(new_project_btn)
+        };
 
         // Width is set by the parent wrapper in `AppShell` so the
         // sidebar can be drag-resized + collapsed at the shell level.
@@ -1769,7 +1910,8 @@ impl Render for Sidebar {
             .font(theme::font_sans())
             .child(heading)
             .child(div().h_px().bg(theme::divider(&theme)))
-            .child(body);
+            .child(body)
+            .child(footer);
 
         // Build whichever context menu is open (project / worktree /
         // none). Snapshot indices + position up-front so the closure-


### PR DESCRIPTION
## Summary

Adds the sidebar bottom-row footer the C# build has — Overview + New Project buttons stacked under the project tree, separated by a 1 px divider. Mirrors `src/CodeScope.Ui/Views/SidebarView.xaml` lines 612–668 (the `<Border BorderThickness=\"0,1,0,0\" Padding=\"8\">` block).

## Layout mapping (C# → Rust)

| C# (`SidebarView.xaml`)                  | Rust (`sidebar.rs`)                                |
| ---------------------------------------- | -------------------------------------------------- |
| `<Border BorderThickness=\"0,1,0,0\" Padding=\"8\">` | `div().border_t_1().border_color(divider).p_2()` |
| `Sidebar.OverviewButton` (36 px tall, mono ⌃⇧O keycap right) | `div().h(px(36.0))`, label + 1 px outlined keycap |
| `Sidebar.NewProjectButton` (40 px, 2 px accent rail, mt 6) | `div().h(px(40.0)).border_l_2().border_color(accent).mt(px(6.0))` |
| `+` glyph (Accent.Primary, mono 14 sp, SemiBold) | `div().text_color(accent).font(font_mono()).child(\"+\")` |
| `Margin=\"0,6,0,0\"` between buttons     | `mt(px(6.0))`                                      |

Colours pulled from `theme::*` helpers — no hardcoded hex.

## Behaviour

- **New Project**: calls `open_new_project_dialog` (the same entry point the heading `+` glyph from #124 uses). Mutually exclusive with the `+` via the same `new_project_dialog().is_none() && dialog().is_none()` gate.
- **Overview**: emits a new `SidebarEvent::OpenOverview` variant. AppShell catches it and surfaces an info toast: *\"Coming soon — full Overview view not ported yet.\"* The C# `OverviewView` is a separate full-window view that replaces the workspace layer; that's a substantial port and is intentionally out of scope here. The button + event wiring lands now so the button reads correctly and the hookup point exists when the Overview view follows.

## Limitations

- No active-state styling for Overview yet (the C# build flips to accent text + accent rail when `IsOverviewVisible == true`). With no Overview view present, there's nothing to be active in. Will be added together with the Overview view port.
- No tests added — sidebar visual layout isn't unit-tested in this codebase (consistent with how `render` is treated everywhere else in `sidebar.rs`).

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo test --workspace` passes (62 tests)
- [ ] Manual: launch dev build, verify the two buttons render at the bottom of the sidebar, pinned to the bottom edge
- [ ] Click Overview → see \"Coming soon\" info toast
- [ ] Click New Project → New Project dialog opens (same as clicking `+` in the header)
- [ ] Click New Project while dialog already open → no-op (gate prevents double-stacking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)