### PR TITLE
feat(rs): live + closed session-state UI (Big-Step-3)

### DIFF
--- a/codescope-rs/core/src/session.rs
+++ b/codescope-rs/core/src/session.rs
@@ -76,11 +76,11 @@ impl RetentionPolicy {
 /// `Services/SessionDescriptor.cs` 1:1: pure data, no terminal-control
 /// dependency, so `core` stays UI-free.
 ///
-/// Producers (the future Rust analogue of C# `SessionManager.Create*`)
-/// build one of these, the UI layer consumes it to wire up the pty.
-/// Not consumed yet on the Rust side — kept here so the agent-launch
-/// port can land in a separate PR without re-litigating the shape.
-#[allow(dead_code)] // Consumed by a follow-up PR (agent-launch port).
+/// Producers (the agent-launch path and the closed-session reopen
+/// flow) build one of these; the UI layer consumes it to wire up the
+/// pty. The reopen path constructs one via [`SessionDescriptor::for_session`]
+/// so the persisted `Session` row drives the next live tab's working
+/// directory + title without UI code reaching into the row directly.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionDescriptor {
     pub id: String,
@@ -88,6 +88,65 @@ pub struct SessionDescriptor {
     pub shell: String,
     pub shell_args: Vec<String>,
     pub title: String,
+}
+
+impl SessionDescriptor {
+    /// Build a descriptor that re-opens `session` in `shell`. Used by
+    /// the sidebar's "click a closed-session row" reopen flow: the
+    /// caller hands us the system shell + the persisted row, we hand
+    /// back the data the pty layer needs. Matches C#
+    /// `SessionManager.BuildDescriptorForSession`.
+    pub fn for_session(session: &Session, shell: String, shell_args: Vec<String>) -> Self {
+        let title = session
+            .display_name
+            .clone()
+            .unwrap_or_else(|| session.branch.clone().unwrap_or_else(|| session.id.clone()));
+        Self {
+            id: session.id.clone(),
+            working_directory: session.worktree_path.clone(),
+            shell,
+            shell_args,
+            title,
+        }
+    }
+}
+
+/// Format a closed-session timestamp as a short relative string —
+/// `just now` / `Nm ago` / `Nh ago` / `yesterday` / `Nd ago` / `MMM d`
+/// (older). Mirrors C# `SessionTabViewModel.ClosedAtRelative`.
+///
+/// Returns an empty string when `closed_at_iso` is `None` or fails to
+/// parse, mirroring the WPF binding's empty-string fallback for live
+/// rows.
+pub fn format_closed_at_relative(closed_at_iso: Option<&str>, now_iso: &str) -> String {
+    let Some(closed_at_iso) = closed_at_iso else { return String::new() };
+    let Some(closed_secs) = parse_iso8601_secs(closed_at_iso) else { return String::new() };
+    let Some(now_secs) = parse_iso8601_secs(now_iso) else { return String::new() };
+    let delta = (now_secs - closed_secs).max(0.0);
+    if delta < 60.0 {
+        return "just now".to_string();
+    }
+    if delta < 3_600.0 {
+        return format!("{}m ago", (delta / 60.0) as i64);
+    }
+    if delta < 86_400.0 {
+        return format!("{}h ago", (delta / 3_600.0) as i64);
+    }
+    if delta < 2.0 * 86_400.0 {
+        return "yesterday".to_string();
+    }
+    if delta < 7.0 * 86_400.0 {
+        return format!("{}d ago", (delta / 86_400.0) as i64);
+    }
+    // Older than a week — fall back to "MMM d" of the closed_at date.
+    let (_y, m, d, _hh, _mm, _ss) = crate::time::unix_secs_to_civil(closed_secs as i64);
+    let month = match m {
+        1 => "Jan", 2 => "Feb", 3 => "Mar", 4 => "Apr",
+        5 => "May", 6 => "Jun", 7 => "Jul", 8 => "Aug",
+        9 => "Sep", 10 => "Oct", 11 => "Nov", 12 => "Dec",
+        _ => "",
+    };
+    format!("{month} {d}")
 }
 
 /// In-memory orchestration over the persisted `Session` rows in a
@@ -555,6 +614,131 @@ mod tests {
         cfg.projects.push(make_project("p1"));
         let err = SessionManager::soft_close(&mut cfg, "ghost", fixed_now()).unwrap_err();
         assert!(err.to_string().contains("ghost"));
+    }
+
+    #[test]
+    fn reopen_round_trip_live_to_closed_to_live() {
+        // Open → soft_close → reopen → soft_close → reopen, asserting
+        // the row goes back and forth between the live and closed
+        // partitions exactly. This is the contract the sidebar's
+        // history-disclosure → AppShell::reopen flow relies on.
+        let mut cfg = ProjectsConfig::default();
+        cfg.projects.push(make_project("p1"));
+
+        // 1. Open: lands in `live`, missing from `closed`.
+        let opened = SessionManager::open(
+            &mut cfg,
+            "p1",
+            make_session("s1", Some("primary")),
+            "2026-05-10T10:00:00Z",
+        )
+        .unwrap();
+        assert!(opened.closed_at.is_none());
+        assert_eq!(SessionManager::live(&cfg).len(), 1);
+        assert!(SessionManager::closed(&cfg).is_empty());
+
+        // 2. Soft-close: moves to `closed`, drops from `live`.
+        SessionManager::soft_close(&mut cfg, "s1", "2026-05-10T11:00:00Z").unwrap();
+        assert!(SessionManager::live(&cfg).is_empty());
+        assert_eq!(SessionManager::closed(&cfg).len(), 1);
+        assert_eq!(
+            cfg.projects[0].sessions[0].closed_at.as_deref(),
+            Some("2026-05-10T11:00:00Z")
+        );
+
+        // 3. Reopen: clears closed_at, bumps last_opened, moves back
+        //    to `live`.
+        let restored = SessionManager::reopen(&mut cfg, "s1", "2026-05-10T12:00:00Z").unwrap();
+        assert!(restored.closed_at.is_none());
+        assert_eq!(restored.last_opened.as_deref(), Some("2026-05-10T12:00:00Z"));
+        assert_eq!(SessionManager::live(&cfg).len(), 1);
+        assert!(SessionManager::closed(&cfg).is_empty());
+
+        // 4. Soft-close again: a second cycle is symmetric — re-closing
+        //    after a reopen produces a fresh `closed_at`, not the old
+        //    one.
+        SessionManager::soft_close(&mut cfg, "s1", "2026-05-10T13:00:00Z").unwrap();
+        assert_eq!(
+            cfg.projects[0].sessions[0].closed_at.as_deref(),
+            Some("2026-05-10T13:00:00Z")
+        );
+        // 5. And one more reopen flips back cleanly. Same row id —
+        //    the reopen must not append a duplicate.
+        SessionManager::reopen(&mut cfg, "s1", "2026-05-10T14:00:00Z").unwrap();
+        assert_eq!(cfg.projects[0].sessions.len(), 1);
+        assert_eq!(SessionManager::live(&cfg).len(), 1);
+    }
+
+    #[test]
+    fn reopen_unknown_session_errors() {
+        let mut cfg = ProjectsConfig::default();
+        cfg.projects.push(make_project("p1"));
+        let err = SessionManager::reopen(&mut cfg, "ghost", fixed_now()).unwrap_err();
+        assert!(err.to_string().contains("ghost"));
+    }
+
+    #[test]
+    fn descriptor_for_session_uses_display_name_then_branch_then_id() {
+        let mut s = make_session("s1", Some("primary"));
+        s.worktree_path = "C:\\repo\\feat-x".into();
+
+        // 1. With display_name set, that wins.
+        s.display_name = Some("Pretty name".into());
+        s.branch = Some("feat-x".into());
+        let d = SessionDescriptor::for_session(&s, "pwsh.exe".into(), Vec::new());
+        assert_eq!(d.id, "s1");
+        assert_eq!(d.working_directory, "C:\\repo\\feat-x");
+        assert_eq!(d.shell, "pwsh.exe");
+        assert_eq!(d.title, "Pretty name");
+
+        // 2. No display_name, branch wins.
+        s.display_name = None;
+        let d = SessionDescriptor::for_session(&s, "pwsh.exe".into(), Vec::new());
+        assert_eq!(d.title, "feat-x");
+
+        // 3. No display_name, no branch, falls back to id.
+        s.branch = None;
+        let d = SessionDescriptor::for_session(&s, "pwsh.exe".into(), Vec::new());
+        assert_eq!(d.title, "s1");
+    }
+
+    #[test]
+    fn closed_at_relative_buckets() {
+        let now = "2026-05-10T12:00:00Z";
+        // Live rows (no closed_at) → empty string.
+        assert_eq!(format_closed_at_relative(None, now), "");
+        // Unparseable timestamps → empty string (fail closed).
+        assert_eq!(format_closed_at_relative(Some("nope"), now), "");
+        // < 1 minute.
+        assert_eq!(
+            format_closed_at_relative(Some("2026-05-10T11:59:30Z"), now),
+            "just now"
+        );
+        // Minutes.
+        assert_eq!(
+            format_closed_at_relative(Some("2026-05-10T11:55:00Z"), now),
+            "5m ago"
+        );
+        // Hours.
+        assert_eq!(
+            format_closed_at_relative(Some("2026-05-10T09:00:00Z"), now),
+            "3h ago"
+        );
+        // Yesterday (between 24h and 48h).
+        assert_eq!(
+            format_closed_at_relative(Some("2026-05-09T08:00:00Z"), now),
+            "yesterday"
+        );
+        // Within the past week.
+        assert_eq!(
+            format_closed_at_relative(Some("2026-05-07T12:00:00Z"), now),
+            "3d ago"
+        );
+        // Older than a week — short month + day.
+        assert_eq!(
+            format_closed_at_relative(Some("2026-04-15T12:00:00Z"), now),
+            "Apr 15"
+        );
     }
 
     #[test]

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -608,6 +608,9 @@ impl AppShell {
                         cx,
                     );
                 }
+                SidebarEvent::ReopenSession { session_id } => {
+                    this.reopen_session(session_id.clone(), window, cx);
+                }
             }
         })
         .detach();
@@ -1435,6 +1438,94 @@ impl AppShell {
                 // is null.
             }
         }
+    }
+
+    /// Reopen the soft-closed session `session_id`: clear `closed_at`,
+    /// stamp `last_opened`, persist, mirror the updated config to the
+    /// sidebar so the row leaves the history list, then spawn a tab
+    /// pinned to the persisted `worktree_path` and (where applicable)
+    /// the persisted `agent_id`'s auto-type command. Mirrors C#
+    /// `MainViewModel.ReopenClosedSessionAsync`.
+    ///
+    /// Best-effort: a `session_id` not found on disk (race with a
+    /// retention sweep, or stale event from a closed sidebar that has
+    /// since rebuilt) is logged and swallowed — there's nothing useful
+    /// to spawn at that point.
+    fn reopen_session(
+        &mut self,
+        session_id: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // Reload-then-mutate-then-save mirrors the pattern around
+        // `allocate_session_id` / `soft_close_session`: a sidebar
+        // write between two of ours can otherwise clobber the
+        // sessions array.
+        match ProjectsConfig::load(&self.paths) {
+            Ok(cfg) => {
+                self.projects = cfg;
+            }
+            Err(err) => {
+                eprintln!("warning: failed to reload projects.json before reopen: {err:#}");
+            }
+        }
+        let restored = match SessionManager::reopen(
+            &mut self.projects,
+            &session_id,
+            &now_iso8601(),
+        ) {
+            Ok(s) => s,
+            Err(err) => {
+                eprintln!("warning: SessionManager::reopen failed: {err:#}");
+                return;
+            }
+        };
+        if let Err(err) = codescope_core::session::save(&self.projects, &self.paths) {
+            eprintln!("warning: failed to persist session reopen: {err:#}");
+        }
+        // Mirror the updated config into the sidebar so the closed
+        // row disappears from the history disclosure on the same
+        // frame as the new tab opens. Without this push the sidebar
+        // would still see the row in its `closed_at = Some(_)` state
+        // until the next sidebar-side mutation (add/remove project)
+        // refreshes the snapshot.
+        let projects_for_sidebar = self.projects.clone();
+        self.sidebar.update(cx, |sidebar, _| {
+            sidebar.replace_projects(projects_for_sidebar);
+        });
+
+        // Build a working SessionDescriptor for the spawn. The shell
+        // value is informational here — `spawn_tab_in` resolves the
+        // shell from `CODESCOPE_SHELL` / pwsh — but constructing the
+        // descriptor ties the reopen flow to the same data shape the
+        // agent-launch path already uses, matching C#
+        // `SessionManager.BuildDescriptorForSession`.
+        let descriptor = codescope_core::session::SessionDescriptor::for_session(
+            &restored,
+            std::env::var("CODESCOPE_SHELL").unwrap_or_else(|_| "pwsh.exe".into()),
+            Vec::new(),
+        );
+        let working_directory = std::path::PathBuf::from(&descriptor.working_directory);
+        let title: SharedString = descriptor.title.clone().into();
+
+        // `agent_id` → auto-type command. Only the `claude*` family
+        // round-trips today; future agent profiles can extend this
+        // map as their auto-launch verbs are added. Plain shell
+        // sessions (no agent_id) come back as plain shells.
+        let auto_type: Option<SharedString> = restored
+            .agent_id
+            .as_deref()
+            .filter(|id| id.starts_with("claude"))
+            .map(|_| "claude".into());
+
+        self.spawn_tab_in(
+            Some(working_directory),
+            Some(title),
+            auto_type,
+            Some(restored.id),
+            window,
+            cx,
+        );
     }
 
     fn focused_group(&self) -> &Group {
@@ -3405,10 +3496,29 @@ impl Render for AppShell {
                     .tabs
                     .iter()
                     .enumerate()
-                    .map(|(t_idx, tab)| TabRenderData {
-                        tab_idx: t_idx,
-                        tab_id: tab.id,
-                        title: tab.title.clone(),
+                    .map(|(t_idx, tab)| {
+                        // Resolve the tab's telemetry-derived busy
+                        // state. Tabs without an adopted Claude
+                        // session id have no telemetry to read and
+                        // sit calm (`busy: false`), matching C#
+                        // `SessionTabViewModel.Status`'s default of
+                        // `TabStatus.Idle` for plain shell tabs.
+                        let busy = tab
+                            .adopted_session_id
+                            .as_deref()
+                            .and_then(|sid| self.telemetry_for(sid))
+                            .map(|s| matches!(
+                                s.state,
+                                codescope_core::SessionState::Busy
+                                    | codescope_core::SessionState::PendingToolUse
+                            ))
+                            .unwrap_or(false);
+                        TabRenderData {
+                            tab_idx: t_idx,
+                            tab_id: tab.id,
+                            title: tab.title.clone(),
+                            busy,
+                        }
                     })
                     .collect(),
                 active_terminal: group
@@ -3930,6 +4040,14 @@ struct TabRenderData {
     tab_idx: usize,
     tab_id: u64,
     title: SharedString,
+    /// Tab activity state derived from the latest telemetry snapshot,
+    /// mirroring C# `SessionTabViewModel.Status` (`TabStatus.Idle` /
+    /// `TabStatus.Busy`). Drives the colour of the 6 px dot on the
+    /// tab strip — green for idle / no-telemetry, red for the agent
+    /// composing or paused on a tool call. Snapshotted up front so
+    /// the per-tab render closure doesn't have to re-borrow
+    /// `self.telemetry_tails`.
+    busy: bool,
 }
 
 /// Frame-local snapshot for one group. We snapshot `Entity<TerminalView>`
@@ -4037,6 +4155,14 @@ impl AppShell {
         let divider = theme::divider(theme);
 
         let theme_for_drag = theme.clone();
+        // Tab-strip status dot colours — 6 px dot per tab, mirrors
+        // C# `GroupStripView`'s `TabStatusToBrushConverter`. Busy
+        // ⇒ Signal.Warn (red, agent composing / paused on tool),
+        // idle ⇒ Signal.Ok (green, awaiting your input). Sourced via
+        // `theme::signal_*` so the values stay in sync with
+        // DesignTokens.xaml without hard-coded hex.
+        let signal_ok = theme::signal_ok();
+        let signal_warn = theme::signal_warn();
         let tabs = gmeta.tabs.iter().map(|tmeta| {
             let tab_idx = tmeta.tab_idx;
             let tab_id = tmeta.tab_id;
@@ -4046,11 +4172,13 @@ impl AppShell {
             let bg = if card { canvas } else { gpui::transparent_black() };
             let text_color = if active { ink } else { ink_dim };
             let top_border = if active { accent } else { gpui::transparent_black() };
-            let status_dot = if active {
-                theme::status_running()
-            } else {
-                ink_ghost
-            };
+            // Status dot: green when idle / no telemetry, red when
+            // the agent is busy (Composing / PendingToolUse). Selection
+            // chrome lives elsewhere (text colour, top accent rail) so
+            // the dot is reserved for agent state, exactly the way C#
+            // `GroupStripView` keeps the dot tied to `Status` rather
+            // than `IsSelected`.
+            let status_dot = if tmeta.busy { signal_warn } else { signal_ok };
             // Drag payload — stable ids + the title so the drag
             // preview can render without holding a borrow on
             // `self.groups`.

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -160,6 +160,11 @@ pub enum SidebarEvent {
     /// a "coming soon" toast — so this event is a placeholder hook
     /// the host can wire up to the real Overview once it lands.
     OpenOverview,
+    /// Reopen a soft-closed session by id. AppShell looks up the row,
+    /// calls `SessionManager::reopen`, then spawns a tab pinned to
+    /// the persisted `worktree_path` + `agent_id`. Mirrors C#
+    /// `MainViewModel.ReopenClosedSessionAsync`.
+    ReopenSession { session_id: String },
 }
 
 /// Toast severity emitted by the sidebar. AppShell maps these to its
@@ -181,6 +186,24 @@ struct WorktreeRowData {
     id: String,
     path: String,
     branch: Option<String>,
+    /// Closed sessions belonging to this worktree, newest-first
+    /// (matches `SessionManager::closed`'s sort). Already capped by
+    /// the retention sweep, so we render every row here without a
+    /// per-render slice. Used to drive the per-worktree history
+    /// disclosure in the sidebar — mirrors C#
+    /// `WorktreeViewModel.History`.
+    closed_sessions: Vec<ClosedSessionRow>,
+}
+
+/// Display data for a single closed-session row inside a worktree's
+/// history disclosure. Snapshotted at render time so the per-row
+/// listener closure can hold an owned `session_id` without keeping
+/// a borrow on `self.projects`.
+#[derive(Clone)]
+struct ClosedSessionRow {
+    session_id: String,
+    label: SharedString,
+    closed_at: Option<String>,
 }
 
 pub struct Sidebar {
@@ -249,6 +272,13 @@ pub struct Sidebar {
     /// flushed back via `save_layout` whenever the user toggles a
     /// chevron, so the disclosure state survives a restart.
     collapsed_projects: HashSet<String>,
+    /// Worktree rows whose closed-session history disclosure is
+    /// expanded. Keyed by `"{project_id}/{worktree_id}"` so primary
+    /// rows from different projects don't collide. Defaults to
+    /// collapsed; toggling the chevron flips the entry. Process-local
+    /// only — mirrors `WorktreeViewModel.IsExpanded` in the C# build,
+    /// which is also a per-process flag (WPF tree-view state).
+    expanded_worktrees: HashSet<String>,
 }
 
 impl Sidebar {
@@ -298,7 +328,19 @@ impl Sidebar {
             git_status: HashMap::new(),
             pr_urls: HashMap::new(),
             collapsed_projects,
+            expanded_worktrees: HashSet::new(),
         }
+    }
+
+    /// Flip the expand / collapse state for a worktree's history
+    /// disclosure. Default is collapsed. Re-renders via `cx.notify`.
+    fn toggle_worktree_expanded(&mut self, key: &str, cx: &mut Context<Self>) {
+        if self.expanded_worktrees.contains(key) {
+            self.expanded_worktrees.remove(key);
+        } else {
+            self.expanded_worktrees.insert(key.to_owned());
+        }
+        cx.notify();
     }
 
     /// Flip the collapse / expand state for the project at `id`.
@@ -1403,13 +1445,61 @@ impl Render for Sidebar {
                 // perfectly normal "single repo on main" project
                 // render with the misleading "(no worktrees)"
                 // placeholder from #101.
+                // Pre-bucket the project's closed sessions by
+                // worktree id so each `WorktreeRowData` carries its
+                // own already-sorted history slice. The bucket key
+                // matches the retention sweep's
+                // `s.worktree_id.unwrap_or_default()` so primary
+                // rows whose worktree id was never written collapse
+                // cleanly into the orphan bucket.
+                let mut closed_by_wt: HashMap<String, Vec<ClosedSessionRow>> = HashMap::new();
+                for s in &p.sessions {
+                    if s.closed_at.is_none() {
+                        continue;
+                    }
+                    let key = s.worktree_id.clone().unwrap_or_default();
+                    let label: SharedString = s
+                        .display_name
+                        .clone()
+                        .or_else(|| s.branch.clone())
+                        .unwrap_or_else(|| s.id.clone())
+                        .into();
+                    closed_by_wt
+                        .entry(key)
+                        .or_default()
+                        .push(ClosedSessionRow {
+                            session_id: s.id.clone(),
+                            label,
+                            closed_at: s.closed_at.clone(),
+                        });
+                }
+                // Newest-first by `closed_at` — mirrors
+                // `SessionManager::closed` so the sidebar disclosure
+                // shows the most recently closed row at the top.
+                for bucket in closed_by_wt.values_mut() {
+                    bucket.sort_by(|a, b| {
+                        let ka = a
+                            .closed_at
+                            .as_deref()
+                            .and_then(codescope_core::time::parse_iso8601_secs);
+                        let kb = b
+                            .closed_at
+                            .as_deref()
+                            .and_then(codescope_core::time::parse_iso8601_secs);
+                        kb.partial_cmp(&ka).unwrap_or(std::cmp::Ordering::Equal)
+                    });
+                }
                 let worktrees = p
                     .worktrees
                     .iter()
-                    .map(|wt| WorktreeRowData {
-                        id: wt.id.clone(),
-                        path: wt.path.clone(),
-                        branch: wt.branch.clone(),
+                    .map(|wt| {
+                        let closed_sessions = closed_by_wt.remove(&wt.id).unwrap_or_default();
+                        WorktreeRowData {
+                            id: wt.id.clone(),
+                            path: wt.path.clone(),
+                            branch: wt.branch.clone(),
+                            closed_sessions,
+                        }
                     })
                     .collect();
                 (
@@ -1744,7 +1834,123 @@ impl Render for Sidebar {
                             .child(status_slug),
                     )
                 };
+                // History disclosure chevron — only when the worktree
+                // has any closed-session rows. Mirrors C# `SidebarView`'s
+                // chevron Border which is gated on `HasHistory`.
+                // ▸ collapsed, ▾ expanded; click flips
+                // `expanded_worktrees`. Hit-target is a 14×14 box so the
+                // glyph is comfortable to click without the user having
+                // to land on the 8 px arrow itself.
+                let wt_key = wt_row_id.clone();
+                let has_history = !wt.closed_sessions.is_empty();
+                let history_expanded = self.expanded_worktrees.contains(&wt_key);
+                let wt_row = if has_history {
+                    let glyph = if history_expanded { "\u{25BE}" } else { "\u{25B8}" };
+                    let key_for_toggle = wt_key.clone();
+                    wt_row.child(
+                        div()
+                            .id(("worktree-history-chevron", id_hash(&wt_key)))
+                            .w(px(14.0))
+                            .h(px(14.0))
+                            .ml(px(4.0))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .text_size(px(10.0))
+                            .text_color(theme::ink_ghost(&theme))
+                            .cursor_pointer()
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |this, _, _, cx| {
+                                    cx.stop_propagation();
+                                    this.toggle_worktree_expanded(&key_for_toggle, cx);
+                                }),
+                            )
+                            .child(glyph),
+                    )
+                } else {
+                    wt_row
+                };
                 project_and_worktree_rows.push(wt_row.into_any_element());
+
+                // Closed-session history rows. Hidden unless the user
+                // has expanded this worktree's chevron. Each row is dim
+                // (mirrors C#'s `Opacity=0.55` data template) with a
+                // hollow outline dot, the session label in mono, and a
+                // right-aligned relative-time stamp. Click emits
+                // `ReopenSession` so AppShell can run
+                // `SessionManager::reopen` and spawn a fresh tab.
+                if has_history && history_expanded {
+                    let now_iso = codescope_core::session::now_iso8601();
+                    let outline_color = theme::ink_ghost(&theme);
+                    let label_color = theme::ink_dim(&theme);
+                    let ts_color = theme::ink_ghost(&theme);
+                    let frost_hover = theme::frost_10(&theme);
+                    let ink_hover = theme::ink(&theme);
+                    for row in wt.closed_sessions.into_iter() {
+                        let session_id = row.session_id.clone();
+                        let id_for_click = session_id.clone();
+                        let relative = codescope_core::session::format_closed_at_relative(
+                            row.closed_at.as_deref(),
+                            &now_iso,
+                        );
+                        let history_id = format!("{}/{}", wt_key, session_id);
+                        let history_row = div()
+                            .id(("history", id_hash(&history_id)))
+                            .h(px(24.0))
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .pl(px(46.0)) // indent under the parent worktree's branch label
+                            .pr_3()
+                            .gap_2()
+                            .text_size(px(11.0))
+                            .cursor_pointer()
+                            .hover(move |s| s.bg(frost_hover).text_color(ink_hover))
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |_, _, _, cx| {
+                                    cx.emit(SidebarEvent::ReopenSession {
+                                        session_id: id_for_click.clone(),
+                                    });
+                                }),
+                            )
+                            // Hollow outline dot — `border_1` + transparent
+                            // bg matches the WPF `Stroke=Text.Faint`
+                            // ellipse on the closed-row template, marking
+                            // the row as inactive at a glance.
+                            .child(
+                                div()
+                                    .w(px(6.0))
+                                    .h(px(6.0))
+                                    .rounded_full()
+                                    .border_1()
+                                    .border_color(outline_color),
+                            )
+                            // Strikethrough on the session label — soft
+                            // close visual cue mirroring the dimmer
+                            // history palette in the C# build's history
+                            // data template.
+                            .child(
+                                div()
+                                    .flex_grow()
+                                    .truncate()
+                                    .font(theme::font_mono())
+                                    .text_color(label_color)
+                                    .line_through()
+                                    .child(row.label.clone()),
+                            )
+                            .child(
+                                div()
+                                    .ml(px(8.0))
+                                    .text_size(px(10.0))
+                                    .text_color(ts_color)
+                                    .font(theme::font_mono())
+                                    .child(relative),
+                            );
+                        project_and_worktree_rows.push(history_row.into_any_element());
+                    }
+                }
             }
         }
 

--- a/codescope-rs/src/theme.rs
+++ b/codescope-rs/src/theme.rs
@@ -77,6 +77,11 @@ pub fn ink_ghost(theme: &Theme) -> Hsla { with_alpha(theme.chrome.ink, 0.40) }
 
 /// Status-dot colour. Hard-coded across themes for now — a green dot
 /// reads as "running" in every dark theme we ship. Themable later.
+/// Superseded for the tab-strip dot by [`signal_ok`] / [`signal_warn`]
+/// (see `app.rs::render_group`); kept for any future non-tab caller
+/// that wants a generic "running" green without going through the
+/// signal pair's busy/idle semantics.
+#[allow(dead_code)]
 pub fn status_running() -> Hsla { rgb_to_hsla(Rgb::from_hex(0x22c55e)) }
 
 /// Worktree dirty indicator. Amber, distinct enough from


### PR DESCRIPTION
## Summary

Adds the visible UI for session-state tracking on top of the data
layer shipped in PRs #114 / #123 / #125. Tab-strip dots now reflect
per-tab telemetry state, the sidebar gets per-worktree closed-session
history disclosures, and clicking a closed-session row reopens it as
a fresh tab pinned to the persisted `worktree_path` + `agent_id`.

## Mapping table — C# control → Rust render path

| C# (WPF / VM) | Rust (gpui) |
|---|---|
| `GroupStripView.xaml` — 6 px Ellipse + `TabStatusToBrushConverter` | `app.rs::render_group` — `tmeta.busy ? signal_warn : signal_ok` |
| `SessionTabViewModel.Status` (`TabStatus.Idle/Busy`) | `TabRenderData.busy` (telemetry-derived) |
| `WorktreeViewModel.IsExpanded` | `Sidebar.expanded_worktrees: HashSet<String>` |
| `WorktreeViewModel.History` | `WorktreeRowData.closed_sessions` (sorted newest-first by `closed_at`) |
| Closed-row data template (`Opacity=0.55`, hollow ellipse, `ClosedAtRelative`) | `sidebar.rs` history row — `ink_dim` label + `line_through()` + outline dot + relative-time slug |
| `SessionTabViewModel.ClosedAtRelative` | `core::session::format_closed_at_relative` |
| `MainViewModel.ReopenClosedSessionAsync` | `AppShell::reopen_session` |
| `SessionManager.BuildDescriptorForSession` | `SessionDescriptor::for_session` |

## Reopen flow

1. User clicks a closed-session row in an expanded worktree's history.
2. Sidebar emits `SidebarEvent::ReopenSession { session_id }`.
3. `AppShell::reopen_session` reloads `projects.json`, calls
   `SessionManager::reopen` (clears `closed_at`, bumps `last_opened`),
   persists, and pushes the updated config into the sidebar via
   `replace_projects` so the closed row leaves the disclosure on the
   same frame.
4. Builds a `SessionDescriptor::for_session` and calls
   `spawn_tab_in(working_directory, title, auto_type, restore_session_id)`
   — `auto_type` becomes `"claude"` when `agent_id` starts with
   `claude*`, `None` otherwise.

## Tests

- `core::session::SessionManager::reopen` round-trip across multiple
  live ↔ closed cycles (exercise the contract the sidebar relies on).
- `descriptor_for_session_uses_display_name_then_branch_then_id`.
- `closed_at_relative_buckets` (every bucket in the C# parity set).

## Follow-ups (not in this PR)

- Busy-state pulsing halo on the tab dot (C# uses a 1.4 s `Storyboard`;
  gpui needs a different animation primitive).
- Per-tab close button visibility tied to selection / hover (the
  C# template hides `×` until `IsActive || IsMouseOver` — gpui
  currently shows it at all times).
- "Remove session row" / right-click menu on a closed-session
  history row to hard-remove without waiting for retention.

## Test plan

- [ ] Open a Claude session and watch the tab dot flip red while the
      agent composes, green while waiting for input.
- [ ] Close a tab, observe the row appears under the worktree's
      history disclosure (after expanding the chevron).
- [ ] Click a closed-session row, confirm a new live tab opens at the
      same worktree path with the right auto-type.
- [ ] Confirm the row leaves the history list immediately after
      reopen (no stale view).
- [ ] Restart the app — closed rows persist; live rows from the
      previous session still rehydrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)