### PR TITLE
feat(rs): wire Copilot/OpenCode/Pi telemetry into status bar

### DIFF
--- a/codescope-rs/core/src/agent.rs
+++ b/codescope-rs/core/src/agent.rs
@@ -1,0 +1,151 @@
+//! Agent identity for the Rust port.
+//!
+//! Mirrors the `agentId` strings the C# build threads through
+//! `MainViewModel.RegisterAgentTelemetry` / `BeginAgentAdoption`:
+//! `"claude"`, `"copilot"`, `"opencode"`, `"pi"`. The Rust port doesn't
+//! yet have a settings-driven agent picker (the sidebar today only
+//! offers a "New Claude session" menu row), but the dispatch surface
+//! needs an enum so the telemetry / discovery layer can fan out
+//! correctly when other agents land.
+//!
+//! Detection is currently based on the auto-typed launch command
+//! recorded on each [`crate::projects::Session`]'s tab — the same
+//! signal `claude_discovery::is_claude_auto_type` already uses.
+//! Anything else (plain `pwsh`, no auto-type, an unknown agent) maps
+//! to `None`, leaving the tab telemetry-less just like a shell tab.
+
+/// One of the four supported agent backends. Names match the
+/// `agentId` strings the C# `MainViewModel` branches on; keep them
+/// stable so on-disk session records (which carry `AgentId` as a
+/// plain string) round-trip cleanly between builds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AgentId {
+    Claude,
+    Copilot,
+    OpenCode,
+    Pi,
+}
+
+impl AgentId {
+    /// Stable string id — matches the C# `agentId` literals used by
+    /// `RegisterAgentTelemetry` / `BeginAgentAdoption`.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            AgentId::Claude => "claude",
+            AgentId::Copilot => "copilot",
+            AgentId::OpenCode => "opencode",
+            AgentId::Pi => "pi",
+        }
+    }
+
+    /// Parse a stable string id back into the enum (case-insensitive).
+    /// Mirrors `string.Equals(agentId, "...", OrdinalIgnoreCase)` in
+    /// the C# dispatch.
+    pub fn from_str(s: &str) -> Option<Self> {
+        if s.eq_ignore_ascii_case("claude") {
+            Some(AgentId::Claude)
+        } else if s.eq_ignore_ascii_case("copilot") {
+            Some(AgentId::Copilot)
+        } else if s.eq_ignore_ascii_case("opencode") {
+            Some(AgentId::OpenCode)
+        } else if s.eq_ignore_ascii_case("pi") {
+            Some(AgentId::Pi)
+        } else {
+            None
+        }
+    }
+}
+
+/// Detect the agent id from the auto-typed launch command recorded on
+/// a tab. Returns `None` for plain shell tabs, missing commands, or
+/// unrecognised binaries — same gate `is_claude_auto_type` was using
+/// before this PR, just generalised across the four agents we know.
+///
+/// Matching is case-insensitive on the first whitespace-delimited
+/// token, so `claude --resume <id>` and `pi --new` both resolve. The
+/// goal is parity with `MainViewModel.ResolveAgentIdForNewSession`'s
+/// final string id once the new-session menu grows beyond Claude.
+pub fn agent_id_from_auto_type(auto_type: Option<&str>) -> Option<AgentId> {
+    let s = auto_type?.trim_start();
+    let first = s.split(|c: char| c.is_whitespace()).next().unwrap_or("");
+    if first.is_empty() {
+        return None;
+    }
+    AgentId::from_str(first)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_round_trip() {
+        for id in [AgentId::Claude, AgentId::Copilot, AgentId::OpenCode, AgentId::Pi] {
+            assert_eq!(AgentId::from_str(id.as_str()), Some(id));
+        }
+    }
+
+    #[test]
+    fn from_str_is_case_insensitive() {
+        assert_eq!(AgentId::from_str("CLAUDE"), Some(AgentId::Claude));
+        assert_eq!(AgentId::from_str("Copilot"), Some(AgentId::Copilot));
+        assert_eq!(AgentId::from_str("OPENCODE"), Some(AgentId::OpenCode));
+        assert_eq!(AgentId::from_str("Pi"), Some(AgentId::Pi));
+    }
+
+    #[test]
+    fn from_str_rejects_unknown() {
+        assert_eq!(AgentId::from_str(""), None);
+        assert_eq!(AgentId::from_str("gemini"), None);
+        assert_eq!(AgentId::from_str("pwsh"), None);
+        assert_eq!(AgentId::from_str("claudeflare"), None);
+    }
+
+    #[test]
+    fn auto_type_none_or_blank_is_no_agent() {
+        assert_eq!(agent_id_from_auto_type(None), None);
+        assert_eq!(agent_id_from_auto_type(Some("")), None);
+        assert_eq!(agent_id_from_auto_type(Some("   ")), None);
+        assert_eq!(agent_id_from_auto_type(Some("\t")), None);
+    }
+
+    #[test]
+    fn auto_type_resolves_each_agent() {
+        assert_eq!(agent_id_from_auto_type(Some("claude")), Some(AgentId::Claude));
+        assert_eq!(agent_id_from_auto_type(Some("copilot")), Some(AgentId::Copilot));
+        assert_eq!(agent_id_from_auto_type(Some("opencode")), Some(AgentId::OpenCode));
+        assert_eq!(agent_id_from_auto_type(Some("pi")), Some(AgentId::Pi));
+    }
+
+    #[test]
+    fn auto_type_with_args_resolves_first_token() {
+        assert_eq!(
+            agent_id_from_auto_type(Some("claude --resume abc-123")),
+            Some(AgentId::Claude),
+        );
+        assert_eq!(
+            agent_id_from_auto_type(Some("pi --new")),
+            Some(AgentId::Pi),
+        );
+        assert_eq!(
+            agent_id_from_auto_type(Some("\tcopilot --workspace .")),
+            Some(AgentId::Copilot),
+        );
+    }
+
+    #[test]
+    fn auto_type_case_insensitive() {
+        assert_eq!(agent_id_from_auto_type(Some("Claude")), Some(AgentId::Claude));
+        assert_eq!(agent_id_from_auto_type(Some("OPENCODE")), Some(AgentId::OpenCode));
+    }
+
+    #[test]
+    fn auto_type_rejects_unknown_binaries() {
+        assert_eq!(agent_id_from_auto_type(Some("pwsh")), None);
+        assert_eq!(agent_id_from_auto_type(Some("gemini --foo")), None);
+        assert_eq!(agent_id_from_auto_type(Some("notclaude")), None);
+        // `claudeflare` must NOT match Claude — same anti-substring rule
+        // `is_claude_auto_type` enforced.
+        assert_eq!(agent_id_from_auto_type(Some("claudeflare")), None);
+    }
+}

--- a/codescope-rs/core/src/copilot_discovery.rs
+++ b/codescope-rs/core/src/copilot_discovery.rs
@@ -1,0 +1,267 @@
+//! Copilot session adoption — find the session-state directory a
+//! freshly launched `copilot` session writes under
+//! `~/.copilot/session-state/<sid>/`.
+//!
+//! Mirrors `CopilotSessionDiscovery` from the C# build but uses
+//! polling only (no `notify` crate dep). Same `scan_*` shape as
+//! [`crate::claude_discovery`]: pure logic, the caller drives the
+//! cadence.
+//!
+//! # Semantics
+//!
+//! Adoption fires once per unique session id (a UUID directory name)
+//! discovered when:
+//!
+//! 1. The directory's name parses as a UUID.
+//! 2. `created_at` or `last_modified` is at or after `since`.
+//! 3. Either `workspace.yaml` records a matching `cwd:` line, or
+//!    `events.jsonl`'s first `session.start` event records a matching
+//!    `data.context.cwd`.
+//!
+//! Tracking already-fired ids is the caller's responsibility (mirrors
+//! `WatchHandle._fired`). Returns *every* eligible candidate each call
+//! so the caller can dedupe by id.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use crate::path_canon::canonicalize_path;
+
+/// Suggested poll interval — 350 ms matches the C#
+/// `CopilotSessionDiscovery.PollInterval`.
+pub const POLL_INTERVAL_MS: u64 = 350;
+
+/// One adoption candidate found in a session-state-root scan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdoptionCandidate {
+    /// UUID parsed from the directory name.
+    pub session_id: String,
+    /// Absolute path to the session directory.
+    pub session_dir: PathBuf,
+}
+
+/// Scan `session_state_root` for direct-child UUID directories whose
+/// `created_at` or `last_modified` is at or after `since`, and whose
+/// `workspace.yaml` (or `events.jsonl` fallback) records a `cwd` that
+/// canonicalises to the same string as `working_directory`.
+///
+/// Returns an empty vec when the root doesn't exist, can't be read,
+/// or contains no eligible candidates. Callers should treat "empty"
+/// as "keep polling".
+pub fn scan(
+    session_state_root: &Path,
+    working_directory: &str,
+    since: SystemTime,
+) -> Vec<AdoptionCandidate> {
+    if !session_state_root.is_dir() {
+        return Vec::new();
+    }
+    let canon_cwd = canonicalize_path(working_directory);
+    let entries = match std::fs::read_dir(session_state_root) {
+        Ok(it) => it,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        if !ft.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if !is_uuid(name) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let created = meta.created().ok();
+        let modified = meta.modified().ok();
+        let eligible = matches!(created, Some(t) if t >= since)
+            || matches!(modified, Some(t) if t >= since);
+        if !eligible {
+            continue;
+        }
+        if !cwd_matches(&path, &canon_cwd) {
+            continue;
+        }
+        out.push(AdoptionCandidate {
+            session_id: name.to_owned(),
+            session_dir: path,
+        });
+    }
+    out
+}
+
+/// Accepts the canonical `8-4-4-4-12` UUID form (case-insensitive).
+fn is_uuid(s: &str) -> bool {
+    if s.len() != 36 {
+        return false;
+    }
+    let bytes = s.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        let is_dash = matches!(i, 8 | 13 | 18 | 23);
+        if is_dash {
+            if b != b'-' {
+                return false;
+            }
+        } else if !b.is_ascii_hexdigit() {
+            return false;
+        }
+    }
+    true
+}
+
+fn cwd_matches(session_dir: &Path, canon_cwd: &str) -> bool {
+    let yaml = session_dir.join("workspace.yaml");
+    if let Some(cwd) = read_yaml_cwd(&yaml) {
+        return canonicalize_path(&cwd) == canon_cwd;
+    }
+    let events = session_dir.join("events.jsonl");
+    if let Some(cwd) = read_session_start_cwd(&events) {
+        return canonicalize_path(&cwd) == canon_cwd;
+    }
+    false
+}
+
+/// Tiny single-line YAML reader: scan for `cwd: <value>` and return the
+/// trimmed value. We don't pull in a YAML crate — Copilot's
+/// workspace.yaml has a stable two-line layout and a real parser would
+/// be overkill for one field.
+fn read_yaml_cwd(path: &Path) -> Option<String> {
+    use std::io::{BufRead, BufReader};
+    let file = std::fs::File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line = line.ok()?;
+        let trimmed = line.trim();
+        let Some(rest) = trimmed.strip_prefix("cwd:") else {
+            continue;
+        };
+        let value = rest.trim();
+        let value = value
+            .trim_start_matches('"')
+            .trim_end_matches('"')
+            .trim_start_matches('\'')
+            .trim_end_matches('\'');
+        if value.is_empty() {
+            return None;
+        }
+        return Some(value.to_owned());
+    }
+    None
+}
+
+/// Peek `events.jsonl` for the first `session.start` event and return
+/// its `data.context.cwd`. Mirrors C# `CopilotSessionDiscovery.CwdMatchesFromEvents`.
+fn read_session_start_cwd(path: &Path) -> Option<String> {
+    use std::io::{BufRead, BufReader};
+    let file = std::fs::File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let Ok(line) = line else { return None };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(&line).ok()?;
+        let obj = v.as_object()?;
+        if obj.get("type").and_then(serde_json::Value::as_str) != Some("session.start") {
+            continue;
+        }
+        let cwd = obj
+            .get("data")
+            .and_then(|d| d.get("context"))
+            .and_then(|c| c.get("cwd"))
+            .and_then(serde_json::Value::as_str)?;
+        return Some(cwd.to_owned());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const SID_A: &str = "11111111-2222-3333-4444-555555555555";
+
+    fn write_workspace_yaml(dir: &Path, cwd: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join("workspace.yaml"),
+            format!("schemaVersion: 1\ncwd: {cwd}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn scan_returns_empty_when_root_missing() {
+        let tmp = TempDir::new().unwrap();
+        let res = scan(
+            &tmp.path().join("nope"),
+            "/some/dir",
+            SystemTime::UNIX_EPOCH,
+        );
+        assert!(res.is_empty());
+    }
+
+    #[test]
+    fn scan_finds_uuid_dir_with_matching_cwd() {
+        let tmp = TempDir::new().unwrap();
+        let session_dir = tmp.path().join(SID_A);
+        write_workspace_yaml(&session_dir, "C:/dev/x");
+
+        let res = scan(tmp.path(), "C:/dev/x", SystemTime::UNIX_EPOCH);
+        assert_eq!(res.len(), 1, "got {res:?}");
+        assert_eq!(res[0].session_id, SID_A);
+    }
+
+    #[test]
+    fn scan_skips_non_uuid_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let session_dir = tmp.path().join("not-a-uuid");
+        write_workspace_yaml(&session_dir, "C:/dev/x");
+
+        let res = scan(tmp.path(), "C:/dev/x", SystemTime::UNIX_EPOCH);
+        assert!(res.is_empty(), "got {res:?}");
+    }
+
+    #[test]
+    fn scan_skips_mismatched_cwd() {
+        let tmp = TempDir::new().unwrap();
+        let session_dir = tmp.path().join(SID_A);
+        write_workspace_yaml(&session_dir, "C:/dev/y");
+
+        let res = scan(tmp.path(), "C:/dev/x", SystemTime::UNIX_EPOCH);
+        assert!(res.is_empty(), "got {res:?}");
+    }
+
+    #[test]
+    fn scan_falls_back_to_events_jsonl_when_yaml_missing() {
+        let tmp = TempDir::new().unwrap();
+        let session_dir = tmp.path().join(SID_A);
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join("events.jsonl"),
+            br#"{"type":"session.start","timestamp":"2026-04-22T08:00:00Z","data":{"sessionId":"x","selectedModel":"gpt-5","context":{"cwd":"C:/dev/x"}}}
+"#,
+        )
+        .unwrap();
+
+        let res = scan(tmp.path(), "C:/dev/x", SystemTime::UNIX_EPOCH);
+        assert_eq!(res.len(), 1, "got {res:?}");
+    }
+
+    #[test]
+    fn is_uuid_accepts_canonical_form() {
+        assert!(is_uuid(SID_A));
+        assert!(is_uuid("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"));
+    }
+
+    #[test]
+    fn is_uuid_rejects_off_lengths() {
+        assert!(!is_uuid(""));
+        assert!(!is_uuid("not-a-uuid"));
+        assert!(!is_uuid("11111111-2222-3333-4444-55555555555"));
+    }
+}

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -13,15 +13,20 @@
 //! lives in the `app` crate. Anything terminal-protocol-bound lives in
 //! `codescope-terminal`.
 
+pub mod agent;
 pub mod claude_discovery;
 pub mod claude_telemetry;
+pub mod copilot_discovery;
 pub mod copilot_telemetry;
 pub mod crash_log;
 pub mod git;
 pub mod layout;
 pub mod memory_watchdog;
+pub mod opencode_discovery;
 pub mod opencode_telemetry;
+pub mod path_canon;
 pub mod paths;
+pub mod pi_discovery;
 pub mod pi_telemetry;
 pub mod pr;
 pub mod projects;
@@ -32,11 +37,18 @@ pub mod time;
 pub mod update_check;
 pub mod window_state;
 
+pub use agent::{AgentId, agent_id_from_auto_type};
 pub use claude_discovery::{AdoptionCandidate, POLL_INTERVAL_MS as CLAUDE_DISCOVERY_POLL_MS};
 pub use claude_telemetry::{
     SessionState, TelemetrySnapshot, TranscriptTail, context_window_for_model, encode_cwd,
     format_context_pct, format_tokens, model_display_name,
 };
+pub use copilot_discovery::POLL_INTERVAL_MS as COPILOT_DISCOVERY_POLL_MS;
+pub use copilot_telemetry::CopilotTranscriptTail;
+pub use opencode_discovery::POLL_INTERVAL_MS as OPENCODE_DISCOVERY_POLL_MS;
+pub use opencode_telemetry::OpenCodeMessageTail;
+pub use pi_discovery::POLL_INTERVAL_MS as PI_DISCOVERY_POLL_MS;
+pub use pi_telemetry::PiTranscriptTail;
 pub use layout::{LayoutState, RestoreTab};
 pub use paths::AppPaths;
 pub use projects::{Project, ProjectsConfig, Session, Worktree};

--- a/codescope-rs/core/src/opencode_discovery.rs
+++ b/codescope-rs/core/src/opencode_discovery.rs
@@ -1,0 +1,252 @@
+//! OpenCode session adoption — find the message directory a freshly
+//! launched `opencode` session writes under
+//! `~/.local/share/opencode/project/<slug>/storage/message/<sid>/`.
+//!
+//! Mirrors `OpenCodeSessionDiscovery` from the C# build but uses
+//! polling only (no `notify` crate dep). Same `scan_*` shape as
+//! [`crate::claude_discovery`]: pure logic, the caller drives the
+//! cadence.
+//!
+//! # Semantics
+//!
+//! Adoption fires once per unique session id discovered when:
+//!
+//! 1. Some `msg_*.json` file exists under
+//!    `<root>/.../message/<sid>/`.
+//! 2. The file's `created_at` or `last_modified` is at or after
+//!    `since`.
+//! 3. The first parseable message's `cwd` (canonicalised) matches the
+//!    tab's working directory.
+//!
+//! Tracking already-fired ids is the caller's responsibility (mirrors
+//! `WatchHandle._firedSessions`). Returns *every* eligible candidate
+//! each call so the caller can dedupe by id.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use crate::opencode_telemetry::parse_content;
+use crate::path_canon::canonicalize_path;
+
+/// Suggested poll interval — 400 ms matches the C#
+/// `OpenCodeSessionDiscovery.PollInterval`.
+pub const POLL_INTERVAL_MS: u64 = 400;
+
+/// Bound on recursion depth when walking the data root. The OpenCode
+/// layout is `project/<slug>/storage/message/<sid>/<msg>.json`, so 6
+/// is plenty while still terminating on a stray symlink loop.
+const MAX_RECURSION_DEPTH: usize = 6;
+
+/// One adoption candidate found in a data-root scan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdoptionCandidate {
+    /// OpenCode session id — the directory name immediately under
+    /// `message/`. Not necessarily a UUID; OpenCode mints its own
+    /// session ids.
+    pub session_id: String,
+    /// Absolute path to the first matching `msg_*.json` we found.
+    pub message_path: PathBuf,
+}
+
+/// Recursively scan `data_root` for OpenCode message files whose
+/// `created_at` or `last_modified` timestamps are at or after `since`,
+/// and whose first parseable message records a `cwd` that
+/// canonicalises to the same string as `working_directory`.
+///
+/// Returns an empty vec when the root doesn't exist, can't be read,
+/// or contains no eligible candidates. Callers should treat "empty"
+/// as "keep polling".
+pub fn scan(
+    data_root: &Path,
+    working_directory: &str,
+    since: SystemTime,
+) -> Vec<AdoptionCandidate> {
+    if !data_root.is_dir() {
+        return Vec::new();
+    }
+    let canon_cwd = canonicalize_path(working_directory);
+    let mut out = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    walk(data_root, since, &canon_cwd, 0, &mut seen, &mut out);
+    out
+}
+
+fn walk(
+    dir: &Path,
+    since: SystemTime,
+    canon_cwd: &str,
+    depth: usize,
+    seen: &mut std::collections::HashSet<String>,
+    out: &mut Vec<AdoptionCandidate>,
+) {
+    if depth > MAX_RECURSION_DEPTH {
+        return;
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(it) => it,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        let path = entry.path();
+        if ft.is_dir() {
+            walk(&path, since, canon_cwd, depth + 1, seen, out);
+            continue;
+        }
+        if !ft.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if !is_message_file(name) {
+            continue;
+        }
+        // Path layout: <root>/.../message/<sid>/msg_*.json
+        let Some(parent) = path.parent() else { continue };
+        let Some(grandparent) = parent.parent() else { continue };
+        let parent_name = grandparent.file_name().and_then(|s| s.to_str());
+        if parent_name.map(|n| !n.eq_ignore_ascii_case("message")).unwrap_or(true) {
+            continue;
+        }
+        let Some(sid) = parent.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if sid.is_empty() {
+            continue;
+        }
+        if seen.contains(sid) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let created = meta.created().ok();
+        let modified = meta.modified().ok();
+        let eligible = matches!(created, Some(t) if t >= since)
+            || matches!(modified, Some(t) if t >= since);
+        if !eligible {
+            continue;
+        }
+        if !cwd_matches(&path, canon_cwd) {
+            continue;
+        }
+        seen.insert(sid.to_owned());
+        out.push(AdoptionCandidate {
+            session_id: sid.to_owned(),
+            message_path: path,
+        });
+    }
+}
+
+fn is_message_file(name: &str) -> bool {
+    name.starts_with("msg_") && name.to_ascii_lowercase().ends_with(".json")
+}
+
+fn cwd_matches(path: &Path, canon_cwd: &str) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Some(entry) = parse_content(&content) else {
+        return false;
+    };
+    let Some(cwd) = entry.cwd else {
+        return false;
+    };
+    canonicalize_path(&cwd) == canon_cwd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_msg(path: &Path, cwd: &str) {
+        // Mirrors the assistant-message shape `parse_content` reads
+        // `metadata.assistant.path.cwd` from. The discovery scan only
+        // matches messages whose first parseable file records a cwd,
+        // so we always write an assistant message here.
+        let content = format!(
+            r#"{{
+                "id":"msg-1","role":"assistant",
+                "metadata":{{
+                    "sessionID":"x",
+                    "time":{{"created":1700000000000}},
+                    "assistant":{{
+                        "modelID":"m","providerID":"p",
+                        "path":{{"cwd":"{cwd}","root":"{cwd}"}},
+                        "tokens":{{"input":0,"output":0,"reasoning":0,"cache":{{"read":0,"write":0}}}},
+                        "cost":0
+                    }}
+                }},
+                "parts":[{{"type":"text","text":"ok"}}]
+            }}"#
+        );
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn scan_returns_empty_when_root_missing() {
+        let tmp = TempDir::new().unwrap();
+        let res = scan(
+            &tmp.path().join("nonexistent"),
+            "/some/dir",
+            SystemTime::UNIX_EPOCH,
+        );
+        assert!(res.is_empty());
+    }
+
+    #[test]
+    fn scan_finds_candidate_under_message_dir() {
+        let tmp = TempDir::new().unwrap();
+        let msg_path = tmp
+            .path()
+            .join("project/slug/storage/message/sid-123/msg_001.json");
+        write_msg(&msg_path, "C:/dev/x");
+
+        let res = scan(tmp.path(), "C:/dev/x", SystemTime::UNIX_EPOCH);
+        assert_eq!(res.len(), 1, "got {res:?}");
+        assert_eq!(res[0].session_id, "sid-123");
+    }
+
+    #[test]
+    fn scan_skips_files_outside_message_dir() {
+        let tmp = TempDir::new().unwrap();
+        // Wrong grandparent — not "message".
+        let msg_path = tmp
+            .path()
+            .join("project/slug/storage/foo/sid-123/msg_001.json");
+        write_msg(&msg_path, "C:/dev/x");
+
+        let res = scan(tmp.path(), "C:/dev/x", SystemTime::UNIX_EPOCH);
+        assert!(res.is_empty(), "got {res:?}");
+    }
+
+    #[test]
+    fn scan_skips_mismatched_cwd() {
+        let tmp = TempDir::new().unwrap();
+        let msg_path = tmp
+            .path()
+            .join("project/slug/storage/message/sid-123/msg_001.json");
+        write_msg(&msg_path, "C:/dev/y");
+
+        let res = scan(tmp.path(), "C:/dev/x", SystemTime::UNIX_EPOCH);
+        assert!(res.is_empty(), "got {res:?}");
+    }
+
+    #[test]
+    fn scan_dedupes_by_session_id() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp
+            .path()
+            .join("project/slug/storage/message/sid-123");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_msg(&dir.join("msg_001.json"), "C:/dev/x");
+        write_msg(&dir.join("msg_002.json"), "C:/dev/x");
+
+        let res = scan(tmp.path(), "C:/dev/x", SystemTime::UNIX_EPOCH);
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].session_id, "sid-123");
+    }
+}

--- a/codescope-rs/core/src/path_canon.rs
+++ b/codescope-rs/core/src/path_canon.rs
@@ -1,0 +1,59 @@
+//! Cross-platform path canonicalisation for cwd comparison.
+//!
+//! Mirrors C# `PiSessionDiscovery.CanonicalizePath` — used by every
+//! non-Claude session-discovery service to compare a transcript's
+//! recorded `cwd` against the spawned tab's working directory across
+//! slash direction, drive-letter colon, leading/trailing slashes, and
+//! case.
+//!
+//! Examples (all collapse to the same canonical form):
+//!
+//! ```
+//! # use codescope_core::path_canon::canonicalize_path;
+//! assert_eq!(canonicalize_path("C:\\dev\\codescope"), "c/dev/codescope");
+//! assert_eq!(canonicalize_path("/c/dev/codescope"),  "c/dev/codescope");
+//! assert_eq!(canonicalize_path("c:/dev/codescope"),  "c/dev/codescope");
+//! ```
+
+/// Canonicalise a path for cross-platform comparison: lowercase,
+/// forward-slashes, drive-colon stripped, trimmed leading and trailing
+/// slashes. Mirrors C# `PiSessionDiscovery.CanonicalizePath`.
+pub fn canonicalize_path(path: &str) -> String {
+    if path.is_empty() {
+        return String::new();
+    }
+    let mut s: String = path
+        .chars()
+        .map(|c| match c {
+            '\\' => '/',
+            ':' => '\0',
+            other => other,
+        })
+        .collect();
+    s.retain(|c| c != '\0');
+    let trimmed = s.trim_start_matches('/').trim_end_matches('/');
+    trimmed.to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_and_posix_forms_collapse() {
+        assert_eq!(canonicalize_path("C:\\dev\\codescope"), "c/dev/codescope");
+        assert_eq!(canonicalize_path("/c/dev/codescope"), "c/dev/codescope");
+        assert_eq!(canonicalize_path("c:/dev/codescope"), "c/dev/codescope");
+        assert_eq!(canonicalize_path("c:/dev/codescope/"), "c/dev/codescope");
+    }
+
+    #[test]
+    fn empty_input_yields_empty() {
+        assert_eq!(canonicalize_path(""), "");
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert_eq!(canonicalize_path("C:/Dev/CodeScope"), "c/dev/codescope");
+    }
+}

--- a/codescope-rs/core/src/pi_discovery.rs
+++ b/codescope-rs/core/src/pi_discovery.rs
@@ -1,0 +1,215 @@
+//! Pi session adoption — find the JSONL transcript a freshly launched
+//! `pi` session writes under `~/.pi/agent/sessions/--<encoded-cwd>--/`.
+//!
+//! Mirrors `PiSessionDiscovery` from the C# build but uses polling
+//! only (no `notify` crate dep). Same `scan_*` shape as
+//! [`crate::claude_discovery`]: pure logic, the caller drives the
+//! cadence.
+//!
+//! # Semantics
+//!
+//! Adoption fires once per unique `.jsonl` path discovered with
+//! `created_at >= since` *or* `last_modified >= since`, whose first
+//! parseable line is a `session` header whose `cwd` field
+//! (after canonicalisation) matches the tab's working directory.
+//! Tracking already-fired ids is the caller's responsibility (mirrors
+//! `WatchHandle._fired`).
+//!
+//! Returns *every* eligible candidate each call so the caller can dedupe
+//! by id and keep the watch alive across CLI invocations (each `pi`
+//! invocation lands in its own session id).
+//!
+//! Pi stores transcripts inside subdirectories of the sessions root,
+//! so we walk recursively (bounded by [`MAX_RECURSION_DEPTH`] to avoid
+//! pathological symlink loops).
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use crate::path_canon::canonicalize_path;
+use crate::pi_telemetry;
+
+/// Suggested poll interval — 350 ms matches the C#
+/// `PiSessionDiscovery.PollInterval`.
+pub const POLL_INTERVAL_MS: u64 = 350;
+
+/// Bound on recursion depth when walking the sessions root. Pi
+/// typically only nests one level (`<root>/--<cwd>--/<file>.jsonl`)
+/// so 4 is plenty, while still terminating on a stray symlink loop.
+const MAX_RECURSION_DEPTH: usize = 4;
+
+/// One adoption candidate found in a sessions-root scan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdoptionCandidate {
+    /// UUID parsed from the `_<sid>.jsonl` filename suffix.
+    pub session_id: String,
+    /// Absolute path to the `.jsonl` file.
+    pub path: PathBuf,
+}
+
+/// Recursively scan `sessions_root` for `.jsonl` transcripts whose
+/// `created_at` or `last_modified` timestamps are at or after `since`,
+/// and whose `session` header line records a `cwd` that canonicalises
+/// to the same string as `working_directory`.
+///
+/// Returns an empty vec when the root doesn't exist, can't be read,
+/// or contains no eligible candidates. Callers should treat "empty"
+/// as "keep polling".
+pub fn scan(
+    sessions_root: &Path,
+    working_directory: &str,
+    since: SystemTime,
+) -> Vec<AdoptionCandidate> {
+    if !sessions_root.exists() {
+        return Vec::new();
+    }
+    let canon_cwd = canonicalize_path(working_directory);
+    let mut out = Vec::new();
+    walk(sessions_root, since, &canon_cwd, 0, &mut out);
+    out
+}
+
+fn walk(
+    dir: &Path,
+    since: SystemTime,
+    canon_cwd: &str,
+    depth: usize,
+    out: &mut Vec<AdoptionCandidate>,
+) {
+    if depth > MAX_RECURSION_DEPTH {
+        return;
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(it) => it,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        let path = entry.path();
+        if ft.is_dir() {
+            walk(&path, since, canon_cwd, depth + 1, out);
+            continue;
+        }
+        if !ft.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let Some(sid) = pi_telemetry::extract_session_id_from_file_name(name) else {
+            continue;
+        };
+        let Ok(meta) = entry.metadata() else { continue };
+        let created = meta.created().ok();
+        let modified = meta.modified().ok();
+        let eligible = matches!(created, Some(t) if t >= since)
+            || matches!(modified, Some(t) if t >= since);
+        if !eligible {
+            continue;
+        }
+        if !header_cwd_matches(&path, canon_cwd) {
+            continue;
+        }
+        out.push(AdoptionCandidate {
+            session_id: sid,
+            path,
+        });
+    }
+}
+
+/// Peek the first non-empty JSONL line and return `true` when it's a
+/// `session` header whose `cwd` (canonicalised) matches `canon_cwd`.
+/// Mirrors C# `PiSessionDiscovery.WatchHandle.HeaderMatches`.
+fn header_cwd_matches(path: &Path, canon_cwd: &str) -> bool {
+    use std::io::{BufRead, BufReader};
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let Ok(line) = line else { return false };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => return false,
+        };
+        let obj = match v.as_object() {
+            Some(o) => o,
+            None => return false,
+        };
+        if obj.get("type").and_then(serde_json::Value::as_str) != Some("session") {
+            return false;
+        }
+        let Some(cwd) = obj.get("cwd").and_then(serde_json::Value::as_str) else {
+            return false;
+        };
+        return canonicalize_path(cwd) == canon_cwd;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const SID_A: &str = "11111111-2222-3333-4444-555555555555";
+
+    fn write_session_jsonl(path: &Path, sid: &str, cwd: &str) {
+        let line = format!(
+            r#"{{"type":"session","id":"{sid}","cwd":"{cwd}","timestamp":"2026-04-22T08:00:00Z"}}"#
+        );
+        std::fs::write(path, line.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn scan_returns_empty_when_root_missing() {
+        let tmp = TempDir::new().unwrap();
+        let res = scan(
+            &tmp.path().join("does-not-exist"),
+            "/some/dir",
+            SystemTime::UNIX_EPOCH,
+        );
+        assert!(res.is_empty());
+    }
+
+    #[test]
+    fn scan_finds_jsonl_with_matching_cwd() {
+        let tmp = TempDir::new().unwrap();
+        let cwd_dir = tmp.path().join("--c-some-project--");
+        std::fs::create_dir_all(&cwd_dir).unwrap();
+        let path = cwd_dir.join(format!("2026-04-22T08-00-00-000Z_{SID_A}.jsonl"));
+        write_session_jsonl(&path, SID_A, "C:/some/project");
+
+        let res = scan(tmp.path(), "C:/some/project", SystemTime::UNIX_EPOCH);
+        assert_eq!(res.len(), 1, "got {res:?}");
+        assert_eq!(res[0].session_id, SID_A);
+    }
+
+    #[test]
+    fn scan_skips_jsonl_with_mismatched_cwd() {
+        let tmp = TempDir::new().unwrap();
+        let cwd_dir = tmp.path().join("--c-some-project--");
+        std::fs::create_dir_all(&cwd_dir).unwrap();
+        let path = cwd_dir.join(format!("2026-04-22T08-00-00-000Z_{SID_A}.jsonl"));
+        write_session_jsonl(&path, SID_A, "C:/different/project");
+
+        let res = scan(tmp.path(), "C:/some/project", SystemTime::UNIX_EPOCH);
+        assert!(res.is_empty(), "got {res:?}");
+    }
+
+    #[test]
+    fn scan_skips_files_modified_before_since() {
+        let tmp = TempDir::new().unwrap();
+        let cwd_dir = tmp.path().join("--c-some-project--");
+        std::fs::create_dir_all(&cwd_dir).unwrap();
+        let path = cwd_dir.join(format!("2026-04-22T08-00-00-000Z_{SID_A}.jsonl"));
+        write_session_jsonl(&path, SID_A, "C:/some/project");
+
+        let future = SystemTime::now() + std::time::Duration::from_secs(60 * 60 * 24 * 365 * 50);
+        let res = scan(tmp.path(), "C:/some/project", future);
+        assert!(res.is_empty(), "got {res:?}");
+    }
+}

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -118,24 +118,35 @@ struct Tab {
     /// as "this tab's session". Mirrors the `since` arg of
     /// `ClaudeSessionDiscovery.Watch`.
     spawned_at: SystemTime,
-    /// Adopted Claude session id, set once `claude_discovery::scan`
-    /// returns a fresh transcript for this tab. `None` until the agent
-    /// has written its first jsonl line — and stays `None` for plain
-    /// pwsh tabs (no `claude` auto-type). On adoption we register the
-    /// telemetry tail; on close we unregister.
+    /// Adopted agent session id, set once the agent-specific discovery
+    /// scan returns a fresh transcript / message dir / session dir for
+    /// this tab. `None` until the agent has written its first
+    /// recognisable file — and stays `None` for plain shell tabs
+    /// (no agent `auto_type`). On adoption we register the telemetry
+    /// tail via the per-`agent_id` dispatch in `register_telemetry`;
+    /// on close we unregister.
     ///
-    /// Updates again on `/clear` rotations (Claude Code mints a new
-    /// `.jsonl` and a new id under the same encoded-cwd directory).
-    /// In that case the discovery loop unregisters the previous tail
-    /// before swapping in the new id, mirroring C# `WatchHandle._fired`
-    /// + `ApplyAdoption`.
+    /// For Claude this id rotates on `/clear` (a new `.jsonl` lands
+    /// under the same encoded-cwd directory). For Pi the discovery
+    /// loop also keeps re-firing as the user re-invokes `pi`. In both
+    /// cases the loop unregisters the previous tail before swapping
+    /// in the new id, mirroring C# `WatchHandle._fired` +
+    /// `MainViewModel.ApplyAdoption`.
     adopted_session_id: Option<String>,
-    /// Every Claude session id we've already registered telemetry for
+    /// Every agent session id we've already registered telemetry for
     /// on this tab — i.e. the historical adoption set.  Kept so the
     /// discovery loop can dedupe when re-scanning after `/clear`
-    /// rotations and avoid registering the same tail twice.  Mirrors
-    /// the C# `WatchHandle._fired` HashSet.
+    /// rotations (or successive `pi` invocations) and avoid registering
+    /// the same tail twice.  Mirrors the C# `WatchHandle._fired`
+    /// HashSet.
     fired_session_ids: std::collections::HashSet<String>,
+    /// Detected agent backend, derived from `auto_type` at spawn time
+    /// via [`codescope_core::agent_id_from_auto_type`]. `None` for
+    /// plain shell tabs (no auto-type) and tabs whose first token
+    /// doesn't match a known agent. Drives discovery + telemetry
+    /// dispatch — mirrors the `agentId` string the C#
+    /// `MainViewModel.RegisterAgentTelemetry` branches on.
+    agent_id: Option<codescope_core::AgentId>,
 }
 
 /// One column in the work area: a tab strip + the currently-selected
@@ -364,6 +375,43 @@ impl Render for DraggedTab {
     }
 }
 
+/// One live telemetry tail for an adopted session. The variant is
+/// chosen by the owning tab's [`Tab::agent_id`]; all variants expose
+/// the same poll/snapshot surface so [`AppShell::telemetry_for`] can
+/// return a uniform `TelemetrySnapshot` regardless of which parser
+/// produced it.
+///
+/// Mirrors the four `*TelemetryService` instances the C#
+/// `MainViewModel` keeps as separate fields — Rust collapses them
+/// into one heterogeneous map so the discovery / poll plumbing stays
+/// agent-agnostic.
+enum AgentTail {
+    Claude(codescope_core::TranscriptTail),
+    Copilot(codescope_core::CopilotTranscriptTail),
+    OpenCode(codescope_core::OpenCodeMessageTail),
+    Pi(codescope_core::PiTranscriptTail),
+}
+
+impl AgentTail {
+    fn poll(&mut self) -> bool {
+        match self {
+            AgentTail::Claude(t) => t.poll(),
+            AgentTail::Copilot(t) => t.poll(),
+            AgentTail::OpenCode(t) => t.poll(),
+            AgentTail::Pi(t) => t.poll(),
+        }
+    }
+
+    fn snapshot(&self) -> Option<codescope_core::TelemetrySnapshot> {
+        match self {
+            AgentTail::Claude(t) => t.snapshot.clone(),
+            AgentTail::Copilot(t) => t.snapshot.clone(),
+            AgentTail::OpenCode(t) => t.snapshot().cloned(),
+            AgentTail::Pi(t) => t.snapshot.clone(),
+        }
+    }
+}
+
 pub struct AppShell {
     /// Flat list of tab groups laid out left-to-right. Always at
     /// least one entry — `close_tab` collapses an emptied group only
@@ -459,12 +507,16 @@ pub struct AppShell {
     /// `notifications.toggle()` and the render calls
     /// `render_notifications_popover` alongside `render_toasts`.
     pub(crate) notifications: crate::notifications::Notifications,
-    /// Live telemetry tails, keyed by Claude session id. Entries are
-    /// registered via `register_telemetry` and polled by the background
-    /// task spawned in `AppShell::new`. The accessor
-    /// `telemetry_for(session_id)` exposes the latest snapshot without
-    /// taking a mutable reference.
-    telemetry_tails: HashMap<String, codescope_core::TranscriptTail>,
+    /// Live telemetry tails, keyed by adopted-agent session id.
+    /// Entries are registered via `register_telemetry` (per-agent
+    /// dispatch) and polled by the background task spawned in
+    /// `AppShell::new`. The accessor `telemetry_for(session_id)`
+    /// exposes the latest snapshot without taking a mutable reference.
+    /// The map is heterogeneous via [`AgentTail`] so all four agent
+    /// backends share one lookup surface — mirrors C#
+    /// `MainViewModel.RegisterAgentTelemetry` / `UnregisterAgentTelemetry`
+    /// dispatching to four distinct `*TelemetryService` instances.
+    telemetry_tails: HashMap<String, AgentTail>,
     /// Window-coordinate bounds of the bell button as recorded by the
     /// `canvas` overlay child during the most recent layout pass.
     /// Used by `render_notifications_popover` to position the popover
@@ -808,7 +860,7 @@ impl AppShell {
             projects: projects_for_sessions,
         };
         shell.start_telemetry_poll(cx);
-        shell.start_claude_discovery_poll(cx);
+        shell.start_agent_discovery_poll(cx);
         shell.start_update_check_poll(cx);
         shell.rehydrate_or_cold_start(window, cx);
         shell
@@ -856,40 +908,86 @@ impl AppShell {
     // Claude telemetry
     // -----------------------------------------------------------------------
 
-    /// Register a Claude Code transcript tail for `session_id` under
-    /// `working_directory`.  Safe to call multiple times with the same
-    /// id — the old tail is replaced (e.g. after a session resume that
-    /// kept the same session id).
+    /// Register a transcript tail for `session_id` under
+    /// `working_directory`, dispatching by `agent_id`. Safe to call
+    /// multiple times with the same id — the old tail is replaced
+    /// (e.g. after a Claude session resume that kept the same id).
     ///
-    /// Mirrors `IClaudeTelemetryService.Register` from the C# build.
-    pub fn register_telemetry(&mut self, session_id: String, working_directory: &str) {
-        // Resolve `~/.claude/projects/`. Without USERPROFILE / HOME a
-        // `unwrap_or_default()` would yield `".claude/projects"`
-        // relative to the CWD — almost always wrong, and confusing
-        // when telemetry silently reads from a path the user doesn't
-        // own. Bail out instead so callers see "no telemetry" rather
-        // than misleading data.
-        let Some(home) = std::env::var_os("USERPROFILE")
-            .or_else(|| std::env::var_os("HOME"))
-        else {
-            eprintln!(
-                "[claude_telemetry] no USERPROFILE / HOME — skipping registration for {session_id}"
-            );
-            return;
+    /// Mirrors `MainViewModel.RegisterAgentTelemetry` in the C#
+    /// build — branches by agent id, no-ops cleanly for unknown
+    /// backends or when the per-agent root can't be resolved.
+    pub fn register_telemetry(
+        &mut self,
+        agent_id: codescope_core::AgentId,
+        session_id: String,
+        working_directory: &str,
+    ) {
+        let tail = match agent_id {
+            codescope_core::AgentId::Claude => {
+                let Some(root) = Self::claude_projects_root() else {
+                    eprintln!(
+                        "[telemetry] no USERPROFILE / HOME — skipping claude registration for {session_id}"
+                    );
+                    return;
+                };
+                AgentTail::Claude(codescope_core::TranscriptTail::for_session(
+                    &root,
+                    working_directory,
+                    &session_id,
+                ))
+            }
+            codescope_core::AgentId::Copilot => {
+                let Some(root) = codescope_core::copilot_telemetry::default_session_state_root()
+                else {
+                    eprintln!(
+                        "[telemetry] no USERPROFILE / HOME — skipping copilot registration for {session_id}"
+                    );
+                    return;
+                };
+                AgentTail::Copilot(codescope_core::CopilotTranscriptTail::for_session(
+                    &root,
+                    &session_id,
+                ))
+            }
+            codescope_core::AgentId::OpenCode => {
+                let Some(root) = codescope_core::opencode_telemetry::default_data_root() else {
+                    eprintln!(
+                        "[telemetry] no USERPROFILE / HOME — skipping opencode registration for {session_id}"
+                    );
+                    return;
+                };
+                AgentTail::OpenCode(codescope_core::OpenCodeMessageTail::new(
+                    root,
+                    session_id.clone(),
+                ))
+            }
+            codescope_core::AgentId::Pi => {
+                let Some(root) = codescope_core::pi_telemetry::default_sessions_root() else {
+                    eprintln!(
+                        "[telemetry] no USERPROFILE / HOME — skipping pi registration for {session_id}"
+                    );
+                    return;
+                };
+                // Pi locates the transcript by suffix-matching
+                // `*_<sid>.jsonl`. The file may not exist yet on the
+                // first call (the discovery loop racing the agent
+                // starting up); skip the registration in that case
+                // and let the next discovery tick retry.
+                let Some(tail) = codescope_core::PiTranscriptTail::for_session(&root, &session_id)
+                else {
+                    eprintln!(
+                        "[telemetry] pi transcript not yet on disk — skipping pi registration for {session_id}"
+                    );
+                    return;
+                };
+                AgentTail::Pi(tail)
+            }
         };
-        let projects_root = std::path::PathBuf::from(home)
-            .join(".claude")
-            .join("projects");
-        let tail = codescope_core::TranscriptTail::for_session(
-            &projects_root,
-            working_directory,
-            &session_id,
-        );
         self.telemetry_tails.insert(session_id, tail);
     }
 
-    /// Remove a tail and drop its snapshot. Mirrors `Unregister` in the
-    /// C# build.
+    /// Remove a tail and drop its snapshot. Mirrors `UnregisterAgentTelemetry`
+    /// in the C# build — agent-agnostic (we drop by id, not by type).
     pub fn unregister_telemetry(&mut self, session_id: &str) {
         self.telemetry_tails.remove(session_id);
     }
@@ -898,12 +996,13 @@ impl AppShell {
     /// when the session has not been registered or has not yet produced
     /// any parseable entries.
     ///
-    /// Callers (e.g. `render_status_bar` in a parallel agent) use this
-    /// accessor to read data without touching the poll state.
+    /// Agent-agnostic: the heterogeneous [`AgentTail`] enum normalises
+    /// every parser onto the shared
+    /// [`codescope_core::TelemetrySnapshot`] shape, so callers (e.g.
+    /// `render_status_bar`) don't need to know which backend produced
+    /// the data.
     pub fn telemetry_for(&self, session_id: &str) -> Option<codescope_core::TelemetrySnapshot> {
-        self.telemetry_tails
-            .get(session_id)
-            .and_then(|t| t.snapshot.clone())
+        self.telemetry_tails.get(session_id).and_then(|t| t.snapshot())
     }
 
     /// Spawn the background transcript-tail polling loop.
@@ -946,7 +1045,7 @@ impl AppShell {
                     for tail in this.telemetry_tails.values_mut() {
                         tail.poll();
                         if matches!(
-                            tail.snapshot.as_ref().map(|s| s.state),
+                            tail.snapshot().map(|s| s.state),
                             Some(codescope_core::SessionState::Busy)
                                 | Some(codescope_core::SessionState::PendingToolUse)
                         ) {
@@ -977,45 +1076,54 @@ impl AppShell {
         Some(std::path::PathBuf::from(home).join(".claude").join("projects"))
     }
 
-    /// Spawn the background per-tab Claude session adoption loop.
+    /// Spawn the background per-tab agent session adoption loop.
     ///
-    /// Mirrors `ClaudeSessionDiscovery.Watch` from the C# build: every
-    /// 350 ms while at least one Claude tab is alive, scan
-    /// `~/.claude/projects/<encoded-cwd>/` for `.jsonl` transcripts
-    /// written at or after `spawned_at`. The watch stays armed for
-    /// the tab's full lifetime (`/clear` rotates the session id and
-    /// writes a fresh `.jsonl`; the C# `WatchHandle._fired` HashSet
-    /// remembers paths already fired so each new id triggers exactly
-    /// one re-adoption). On rotation we unregister the previous
-    /// tail before registering the new one so `telemetry_tails`
-    /// doesn't accumulate stale entries. With no Claude tabs the
-    /// cadence drops to 5 s.
+    /// Mirrors C# `MainViewModel.BeginAgentAdoption`: every tick, scan
+    /// each agent's filesystem layout for transcripts whose
+    /// `created_at` or `last_modified` is at or after the tab's
+    /// `spawned_at`, then dedupe per-tab via `fired_session_ids` and
+    /// register the corresponding telemetry tail. Each tab's
+    /// `agent_id` selects which discovery scan runs:
+    ///
+    /// * Claude — `~/.claude/projects/<encoded-cwd>/<sid>.jsonl`
+    /// * Pi      — `~/.pi/agent/sessions/.../*_<sid>.jsonl` (recursive)
+    /// * OpenCode — `~/.local/share/opencode/.../message/<sid>/msg_*.json`
+    /// * Copilot  — `~/.copilot/session-state/<sid>/`
+    ///
+    /// All four scans match by canonicalised cwd (Claude uses an
+    /// encoded-cwd directory; the others peek at a header field) so
+    /// transcripts from a different workspace don't get adopted into
+    /// the wrong tab.
+    ///
+    /// The watch stays armed for the tab's full lifetime so Claude's
+    /// `/clear` rotations and Pi's per-invocation session ids both
+    /// flow through cleanly. Tabs without a recognised `agent_id`
+    /// (plain shell, unknown command) are skipped.
+    ///
+    /// Cadence: the fastest of the four agent-specific intervals
+    /// (350 ms — Claude / Pi / Copilot all match) while any agent
+    /// tab is alive, dropping to 5 s when none are.
     ///
     /// Called from `AppShell::new` after the struct is constructed.
-    fn start_claude_discovery_poll(&self, cx: &mut Context<Self>) {
+    fn start_agent_discovery_poll(&self, cx: &mut Context<Self>) {
         cx.spawn(async move |this, cx| {
-            let mut interval =
-                Duration::from_millis(codescope_core::CLAUDE_DISCOVERY_POLL_MS);
+            let active = Duration::from_millis(codescope_core::CLAUDE_DISCOVERY_POLL_MS);
             let idle = Duration::from_secs(5);
+            let mut interval = active;
             loop {
                 cx.background_executor().timer(interval).await;
                 if this.upgrade().is_none() {
                     break;
                 }
                 let result = this.update(cx, |this, _cx| {
-                    let Some(root) = Self::claude_projects_root() else {
-                        return idle;
-                    };
                     // Two-pass scan/mutate so we can't deadlock on
                     // `register_telemetry`'s `&mut self` borrow:
-                    // collect candidates first (ids the tab hasn't
-                    // fired yet), then perform the register / un-
-                    // register dance. Keeps the watch alive for the
-                    // tab's full lifetime so `/clear` rotations are
-                    // adopted as new id-paths appear.
+                    // collect candidates first, then perform the
+                    // register / un-register dance.
                     struct Found {
                         group_idx: usize,
                         tab_idx: usize,
+                        agent_id: codescope_core::AgentId,
                         previous_session_id: Option<String>,
                         new_session_id: String,
                         working_directory: String,
@@ -1024,28 +1132,75 @@ impl AppShell {
                     let mut any_active = false;
                     for (g_idx, group) in this.groups.iter().enumerate() {
                         for (t_idx, tab) in group.tabs.iter().enumerate() {
-                            if !codescope_core::claude_discovery::is_claude_auto_type(
-                                tab.auto_type.as_ref().map(|s| s.as_ref()),
-                            ) {
-                                continue;
-                            }
+                            let Some(agent_id) = tab.agent_id else { continue };
                             let Some(ref wd) = tab.working_directory else { continue };
                             any_active = true;
                             let wd_str = wd.to_string_lossy().into_owned();
-                            let hits = codescope_core::claude_discovery::scan(
-                                &root, &wd_str, tab.spawned_at,
-                            );
-                            // Pick the newest unseen candidate by
-                            // last-modified mtime so a `/clear`
-                            // rotation supplants the previous id
-                            // rather than the loop oscillating
-                            // between concurrent transcripts.
-                            let mut newest: Option<(SystemTime, codescope_core::AdoptionCandidate)> = None;
-                            for c in hits {
-                                if tab.fired_session_ids.contains(&c.session_id) {
+                            // Each agent scan returns
+                            // `(session_id, mtime_source_path)` so we
+                            // can pick the newest unseen candidate per
+                            // tab — the "/clear rotation supplants the
+                            // previous id" rule from PR #98 still
+                            // applies for Claude, and the same logic
+                            // covers Pi's per-invocation ids.
+                            let hits: Vec<(String, std::path::PathBuf)> = match agent_id {
+                                codescope_core::AgentId::Claude => {
+                                    let Some(root) = Self::claude_projects_root() else {
+                                        continue;
+                                    };
+                                    codescope_core::claude_discovery::scan(
+                                        &root, &wd_str, tab.spawned_at,
+                                    )
+                                    .into_iter()
+                                    .map(|c| (c.session_id, c.path))
+                                    .collect()
+                                }
+                                codescope_core::AgentId::Pi => {
+                                    let Some(root) =
+                                        codescope_core::pi_telemetry::default_sessions_root()
+                                    else {
+                                        continue;
+                                    };
+                                    codescope_core::pi_discovery::scan(
+                                        &root, &wd_str, tab.spawned_at,
+                                    )
+                                    .into_iter()
+                                    .map(|c| (c.session_id, c.path))
+                                    .collect()
+                                }
+                                codescope_core::AgentId::OpenCode => {
+                                    let Some(root) =
+                                        codescope_core::opencode_telemetry::default_data_root()
+                                    else {
+                                        continue;
+                                    };
+                                    codescope_core::opencode_discovery::scan(
+                                        &root, &wd_str, tab.spawned_at,
+                                    )
+                                    .into_iter()
+                                    .map(|c| (c.session_id, c.message_path))
+                                    .collect()
+                                }
+                                codescope_core::AgentId::Copilot => {
+                                    let Some(root) =
+                                        codescope_core::copilot_telemetry::default_session_state_root()
+                                    else {
+                                        continue;
+                                    };
+                                    codescope_core::copilot_discovery::scan(
+                                        &root, &wd_str, tab.spawned_at,
+                                    )
+                                    .into_iter()
+                                    .map(|c| (c.session_id, c.session_dir))
+                                    .collect()
+                                }
+                            };
+                            let mut newest: Option<(SystemTime, String)> = None;
+                            for (sid, path) in hits {
+                                if tab.fired_session_ids.contains(&sid) {
                                     continue;
                                 }
-                                let mtime = std::fs::metadata(&c.path)
+                                let mtime = std::fs::metadata(&path)
                                     .ok()
                                     .and_then(|m| m.modified().ok())
                                     .unwrap_or(SystemTime::UNIX_EPOCH);
@@ -1054,15 +1209,16 @@ impl AppShell {
                                     .map(|(prev, _)| mtime >= *prev)
                                     .unwrap_or(true);
                                 if take {
-                                    newest = Some((mtime, c));
+                                    newest = Some((mtime, sid));
                                 }
                             }
-                            if let Some((_, c)) = newest {
+                            if let Some((_, sid)) = newest {
                                 found.push(Found {
                                     group_idx: g_idx,
                                     tab_idx: t_idx,
+                                    agent_id,
                                     previous_session_id: tab.adopted_session_id.clone(),
-                                    new_session_id: c.session_id,
+                                    new_session_id: sid,
                                     working_directory: wd_str,
                                 });
                             }
@@ -1075,6 +1231,7 @@ impl AppShell {
                             }
                         }
                         this.register_telemetry(
+                            f.agent_id,
                             f.new_session_id.clone(),
                             &f.working_directory,
                         );
@@ -1085,11 +1242,7 @@ impl AppShell {
                             }
                         }
                     }
-                    if any_active {
-                        Duration::from_millis(codescope_core::CLAUDE_DISCOVERY_POLL_MS)
-                    } else {
-                        idle
-                    }
+                    if any_active { active } else { idle }
                 });
                 match result {
                     Ok(next) => interval = next,
@@ -1563,6 +1716,9 @@ impl AppShell {
         // Capture the entity so an `auto_type` job can write to it
         // without re-borrowing `self.groups` after the await point.
         let terminal_for_autotype = terminal.clone();
+        let agent_id = codescope_core::agent_id_from_auto_type(
+            auto_type.as_ref().map(|s| s.as_ref()),
+        );
         group.tabs.push(Tab {
             id,
             session_id,
@@ -1573,6 +1729,7 @@ impl AppShell {
             spawned_at: SystemTime::now(),
             adopted_session_id: None,
             fired_session_ids: std::collections::HashSet::new(),
+            agent_id,
         });
         let new_idx = group.tabs.len() - 1;
         self.activate_tab(group_idx, new_idx, window, cx);
@@ -2502,11 +2659,13 @@ impl AppShell {
     ///   are present); remote ahead/behind (`↑N` / `↓N` / `↑N ↓N`).
     ///   Hidden entirely on tabs with no working directory (e.g.
     ///   plain pwsh launched without a project).
-    /// - **Right cluster** — Claude transcript-derived slots (model,
+    /// - **Right cluster** — agent-transcript-derived slots (model,
     ///   tokens + percent, turn count, last turn duration), agent
-    ///   rollup `N busy · M idle` across all adopted Claude tabs,
-    ///   optional `N groups` label, workspace summary, and the
-    ///   notifications bell with a 4 px unread dot.
+    ///   rollup `N busy · M idle` across all adopted agent tabs
+    ///   (Claude / Copilot / OpenCode / Pi — whichever the active
+    ///   tab's `agent_id` selected at spawn), optional `N groups`
+    ///   label, workspace summary, and the notifications bell with
+    ///   a 4 px unread dot.
     ///
     /// Data sources: [`Sidebar::git_status_for`] (branch + numstat +
     /// ahead/behind), [`AppShell::telemetry_for`] (per-session model
@@ -2932,11 +3091,12 @@ impl AppShell {
         bar
     }
 
-    /// Walk every tab across every group and count adopted Claude
-    /// sessions by activity state. Mirrors C#'s `StatusAgentBusy` /
-    /// `StatusAgentIdle`. Tabs without an `adopted_session_id`
-    /// (plain pwsh, or Claude tabs whose `.jsonl` hasn't surfaced
-    /// yet) don't contribute to either count.
+    /// Walk every tab across every group and count adopted agent
+    /// sessions by activity state, regardless of agent backend.
+    /// Mirrors C#'s `StatusAgentBusy` / `StatusAgentIdle`. Tabs without
+    /// an `adopted_session_id` (plain pwsh, or agent tabs whose
+    /// transcript hasn't surfaced yet) don't contribute to either
+    /// count.
     fn agent_rollup_counts(&self) -> (u32, u32) {
         let mut busy = 0;
         let mut idle = 0;


### PR DESCRIPTION
## Summary

The Rust port already had transcript parsers for Claude (#98), Copilot (#117), OpenCode (#120), and Pi (#119), but only Claude was wired into the AppShell discovery + status-bar render path. This PR plumbs the other three so the status bar's session dot, model name, tokens, turn count, last-turn duration, and the busy/idle agent rollup all flow regardless of which agent the active tab is running. Mirrors the C# `MainViewModel.RegisterAgentTelemetry` / `BeginAgentAdoption` dispatch shape.

## Agent-type detection

- New `core::agent::AgentId` enum (`Claude` / `Copilot` / `OpenCode` / `Pi`) and `agent_id_from_auto_type` helper.
- Detection is from the auto-typed launch command's first whitespace-delimited token (case-insensitive, anti-substring — `claudeflare` does **not** match Claude). Same signal `claude_discovery::is_claude_auto_type` used pre-PR, generalised to all four backends.
- `Tab` gets an `agent_id: Option<AgentId>` set at `spawn_tab_in`. `None` for plain shell tabs / unknown commands — those skip discovery silently, matching the C# `agentId == null` no-op.

## Discovery hookup

- New per-agent poll-only modules in `core`: `pi_discovery`, `opencode_discovery`, `copilot_discovery`. Each exposes `scan(root, cwd, since) -> Vec<AdoptionCandidate>`, the same shape as the existing `claude_discovery::scan`. They mirror the C# `*SessionDiscovery` services (header-cwd peek, canonicalised path comparison, recursive walk where needed).
- Single shared cwd helper in `core::path_canon::canonicalize_path` (mirrors C# `PiSessionDiscovery.CanonicalizePath`).
- `start_claude_discovery_poll` -> `start_agent_discovery_poll`, fanning out per `tab.agent_id` and reusing the existing two-pass scan/mutate dance, `_fired` dedupe, and newest-mtime-wins selection so Claude `/clear` rotations + Pi's per-invocation ids both adopt cleanly. 350 ms cadence while any agent tab is alive, 5 s idle.

## Status-bar render flow

- `AgentTail` enum collapses `TranscriptTail` / `CopilotTranscriptTail` / `OpenCodeMessageTail` / `PiTranscriptTail` behind a uniform `poll()` + `snapshot() -> Option<TelemetrySnapshot>`.
- `telemetry_for(session_id)` stays agent-agnostic; `render_status_bar` and `agent_rollup_counts` need no per-agent branching — every adopted tab feeds the same map.
- `register_telemetry` now takes an `AgentId` and dispatches to the right per-agent root. Pi additionally skips when its `*_<sid>.jsonl` hasn't been written yet (retry on the next discovery tick — same posture as the OpenCode locator's `LOCATE_NOT_FOUND_TTL`).

## Follow-ups

- Sidebar still only ships a "New Claude session" menu row; surfacing Copilot/OpenCode/Pi rows belongs with the agent-picker / settings story.
- Discovery is poll-only (no `notify` dep), matching the existing Claude discovery decision in PR #98.
- Pi discovery's recursive walk is depth-bounded to 4 to terminate on stray symlink loops; OpenCode's is depth-bounded to 6 (the layout is `project/<slug>/storage/message/<sid>/<msg>.json`).

## Test plan

- [x] `cargo check --workspace` — clean.
- [x] `cargo test --workspace` — 388 tests pass (326 core + 42 sidebar + 19 terminal + 1 doc).
- [x] Unit tests for `agent_id_from_auto_type` (case sensitivity, args after the binary, anti-substring rule).
- [x] Unit tests for `path_canon::canonicalize_path` (Windows + POSIX collapse).
- [x] Unit tests for each new `*_discovery::scan` (cwd match / mismatch / since filter / dedupe / yaml-fallback to events.jsonl for Copilot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)