### PR TITLE
fix(rs): address Copilot review on PR #127 (session-state UI followups)

### DIFF
--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1624,11 +1624,16 @@ impl AppShell {
             }
             Err(err) => {
                 eprintln!("warning: failed to reload projects.json before reopen: {err:#}");
+                // `{err:#}` matches the rest of the toast surface
+                // (e.g. the agent-launch error path) — pretty-formats
+                // the full anyhow error chain so the user sees the
+                // root cause, not just the outer "could not read"
+                // wrapper.
                 self.push_toast(
                     ToastKind::Err,
                     SharedString::from("Reopen failed"),
                     Some(SharedString::from(format!(
-                        "could not read projects.json: {err}"
+                        "Could not read projects.json: {err:#}"
                     ))),
                     cx,
                 );
@@ -1686,17 +1691,17 @@ impl AppShell {
         let title: SharedString = if restored.display_name.is_some() {
             descriptor.title.clone().into()
         } else {
-            let project_name = self
-                .sidebar
-                .read(cx)
+            // Single sidebar snapshot for both lookups so they share
+            // the same in-memory state and we don't pay the entity
+            // borrow twice for one decision.
+            let sidebar = self.sidebar.read(cx);
+            let project_name = sidebar
                 .projects()
                 .projects
                 .iter()
                 .find(|p| p.sessions.iter().any(|s| s.id == restored.id))
                 .map(|p| p.name.clone());
-            let branch_label = self
-                .sidebar
-                .read(cx)
+            let branch_label = sidebar
                 .git_status_for(&descriptor.working_directory)
                 .map(|g| g.branch.clone())
                 .or_else(|| restored.branch.clone());

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1613,13 +1613,26 @@ impl AppShell {
         // Reload-then-mutate-then-save mirrors the pattern around
         // `allocate_session_id` / `soft_close_session`: a sidebar
         // write between two of ours can otherwise clobber the
-        // sessions array.
+        // sessions array. Bail on load failure rather than mutating
+        // a stale snapshot and persisting it on top of newer disk
+        // state — surfaces the failure as a toast so the user sees
+        // the row stay in the history disclosure instead of silently
+        // racing the on-disk file.
         match ProjectsConfig::load(&self.paths) {
             Ok(cfg) => {
                 self.projects = cfg;
             }
             Err(err) => {
                 eprintln!("warning: failed to reload projects.json before reopen: {err:#}");
+                self.push_toast(
+                    ToastKind::Err,
+                    SharedString::from("Reopen failed"),
+                    Some(SharedString::from(format!(
+                        "could not read projects.json: {err}"
+                    ))),
+                    cx,
+                );
+                return;
             }
         }
         let restored = match SessionManager::reopen(
@@ -1641,10 +1654,13 @@ impl AppShell {
         // frame as the new tab opens. Without this push the sidebar
         // would still see the row in its `closed_at = Some(_)` state
         // until the next sidebar-side mutation (add/remove project)
-        // refreshes the snapshot.
+        // refreshes the snapshot. `cx.notify()` inside the update
+        // forces a redraw — `Sidebar::replace_projects` is data-only
+        // and does not notify on its own.
         let projects_for_sidebar = self.projects.clone();
-        self.sidebar.update(cx, |sidebar, _| {
+        self.sidebar.update(cx, |sidebar, cx| {
             sidebar.replace_projects(projects_for_sidebar);
+            cx.notify();
         });
 
         // Build a working SessionDescriptor for the spawn. The shell
@@ -1659,7 +1675,36 @@ impl AppShell {
             Vec::new(),
         );
         let working_directory = std::path::PathBuf::from(&descriptor.working_directory);
-        let title: SharedString = descriptor.title.clone().into();
+
+        // Prefer the same `<Project> · <branch>` convention plain
+        // worktree clicks produce — falling back to the descriptor's
+        // own title (display_name → branch → id) only when the
+        // project / branch pair can't be resolved. An explicit
+        // `display_name` override on the persisted row still wins
+        // (descriptor's `for_session` already tries that first), so
+        // user-renamed sessions come back with their custom name.
+        let title: SharedString = if restored.display_name.is_some() {
+            descriptor.title.clone().into()
+        } else {
+            let project_name = self
+                .sidebar
+                .read(cx)
+                .projects()
+                .projects
+                .iter()
+                .find(|p| p.sessions.iter().any(|s| s.id == restored.id))
+                .map(|p| p.name.clone());
+            let branch_label = self
+                .sidebar
+                .read(cx)
+                .git_status_for(&descriptor.working_directory)
+                .map(|g| g.branch.clone())
+                .or_else(|| restored.branch.clone());
+            match (project_name, branch_label) {
+                (Some(p), Some(b)) => format!("{p} · {b}").into(),
+                _ => descriptor.title.clone().into(),
+            }
+        };
 
         // `agent_id` → auto-type command. Only the `claude*` family
         // round-trips today; future agent profiles can extend this

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -1489,7 +1489,7 @@ impl Render for Sidebar {
                         kb.partial_cmp(&ka).unwrap_or(std::cmp::Ordering::Equal)
                     });
                 }
-                let worktrees = p
+                let mut worktrees: Vec<WorktreeRowData> = p
                     .worktrees
                     .iter()
                     .map(|wt| {
@@ -1502,6 +1502,47 @@ impl Render for Sidebar {
                         }
                     })
                     .collect();
+                // Orphan / stale-worktree closed sessions — rows
+                // whose `worktree_id` is `None` (collapses to "")
+                // or refers to a worktree that no longer exists in
+                // `p.worktrees` would otherwise drop off the UI
+                // entirely (Copilot review on PR #127). Fold them
+                // into the primary worktree's bucket so the user
+                // can still reopen them; re-sort so the merged set
+                // stays newest-first.
+                if !closed_by_wt.is_empty() {
+                    let leftover: Vec<ClosedSessionRow> = closed_by_wt
+                        .into_values()
+                        .flatten()
+                        .collect();
+                    // Resolve the target index in two steps so the
+                    // primary lookup and the `first_mut` fallback
+                    // don't both hold a `&mut` to `worktrees`.
+                    let target_idx = worktrees
+                        .iter()
+                        .position(|w| w.id == "primary")
+                        .or_else(|| (!worktrees.is_empty()).then_some(0));
+                    if let Some(idx) = target_idx {
+                        let target = &mut worktrees[idx];
+                        target.closed_sessions.extend(leftover);
+                        target.closed_sessions.sort_by(|a, b| {
+                            let ka = a
+                                .closed_at
+                                .as_deref()
+                                .and_then(codescope_core::time::parse_iso8601_secs);
+                            let kb = b
+                                .closed_at
+                                .as_deref()
+                                .and_then(codescope_core::time::parse_iso8601_secs);
+                            kb.partial_cmp(&ka).unwrap_or(std::cmp::Ordering::Equal)
+                        });
+                    }
+                    // If the project has zero worktrees the leftover
+                    // rows still vanish — but that's a malformed
+                    // projects.json (every project gets a synthetic
+                    // primary at migration time), so we don't carve
+                    // out a separate orphan disclosure for it.
+                }
                 (
                     idx,
                     p.id.clone(),


### PR DESCRIPTION
## Summary

PR #127 was merged before the Copilot review round closed. The four
threads pointed at real bugs in the just-merged session-state UI;
this PR addresses them in a follow-up.

## Fixes

- **Orphan / stale-worktree closed sessions visible again** —
  rows with `worktree_id = None` or pointing at a removed worktree
  used to vanish from the sidebar disclosure. Now folded into the
  primary worktree's bucket (or the first worktree when no primary
  is marked), with the merged set re-sorted newest-first by
  `closed_at`.
- **`reopen_session` no longer races on load failure** — bails on
  `ProjectsConfig::load` error instead of mutating + persisting on
  top of stale state, and surfaces the failure as a `ToastKind::Err`.
- **Reopened tab title follows the `<Project> · <branch>` convention**
  used by plain worktree-row clicks. User-renamed sessions still keep
  their `display_name` override; live `git_status` branch is preferred
  over the persisted `Session.branch` so a renamed branch round-trips.
- **Sidebar redraws immediately after reopen** — the
  `sidebar.update(cx, ...)` closure now calls `cx.notify()` so the
  closed row leaves the history list on the same frame the new tab
  opens.

## Test plan

- [ ] Soft-close a session with `worktree_id = None` (legacy data),
      confirm it appears under the primary worktree's history.
- [ ] Move `projects.json` to a directory the process can't read,
      try to reopen — toast appears, history row stays put.
- [ ] Reopen a closed session, confirm the new tab is titled
      `MyProject · main` and that the history row vanishes
      immediately (no stale view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)