### PR TITLE
chore(rs): rename bin from window to codescope-rs

### DIFF
--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -15,7 +15,7 @@ name = "spike"
 path = "src/main.rs"
 
 [[bin]]
-name = "window"
+name = "codescope-rs"
 path = "src/window.rs"
 
 [[example]]

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -1,4 +1,4 @@
-//! `cargo run --bin window` — launches the gpui app shell.
+//! `cargo run --bin codescope-rs` — launches the gpui app shell.
 //!
 //! Boot sequence:
 //!


### PR DESCRIPTION
## Summary
- Rename `[[bin]] name = \"window\"` → `\"codescope-rs\"` in `codescope-rs/Cargo.toml`
- Update doc-comment + HANDOFF references

## Why
Distinguishes the Rust dev exe from generic `window.exe` in tasklist / Alt-Tab and aligns with the workspace naming (codescope-core / codescope-terminal / codescope-rs-spike).

## Test plan
- [x] cargo check --workspace
- [ ] cargo run --bin codescope-rs launches as before
- [ ] target/release/codescope-rs.exe shows up in Task Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)