### PR TITLE
Fix codescope-rs MSVC environment detection

### DIFF
--- a/codescope-rs/scripts/build.ps1
+++ b/codescope-rs/scripts/build.ps1
@@ -1,13 +1,12 @@
 #requires -Version 5
 <#
 .SYNOPSIS
-    Wraps cargo with the VS 2022 Build Tools environment.
+    Wraps cargo with a Visual Studio x64 MSVC environment.
 
 .DESCRIPTION
-    On this machine the auto-detected VS 18 (2026) Community install ships
-    only the onecore CRT variants — the regular desktop msvcrt.lib lives in
-    the VS 2022 BuildTools install. Sourcing vcvars64.bat from there sets
-    VCINSTALLDIR / WindowsSdkDir so rustc and link.exe find the right libs.
+    Locates vcvars64.bat via CODESCOPE_VCVARS64, VSINSTALLDIR, vswhere, or
+    common Visual Studio install paths. Sourcing vcvars64.bat sets VCINSTALLDIR
+    / WindowsSdkDir so rustc and link.exe find the right desktop MSVC libs.
 
 .EXAMPLE
     .\scripts\build.ps1 build
@@ -17,10 +16,67 @@
 
 $ErrorActionPreference = 'Stop'
 
-$vcvars = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-if (-not (Test-Path $vcvars)) {
-    throw "vcvars64.bat not found at $vcvars. Install VS 2022 Build Tools with the C++ workload."
+function Resolve-VcVars64 {
+    if ($env:CODESCOPE_VCVARS64) {
+        if (Test-Path $env:CODESCOPE_VCVARS64) {
+            return $env:CODESCOPE_VCVARS64
+        }
+
+        throw "CODESCOPE_VCVARS64 points to '$env:CODESCOPE_VCVARS64', but that file does not exist."
+    }
+
+    $candidates = [System.Collections.Generic.List[string]]::new()
+
+    if ($env:VSINSTALLDIR) {
+        $candidates.Add((Join-Path $env:VSINSTALLDIR 'VC\Auxiliary\Build\vcvars64.bat'))
+    }
+
+    $programFilesX86 = [Environment]::GetFolderPath('ProgramFilesX86')
+    $vswhere = Join-Path $programFilesX86 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (Test-Path $vswhere) {
+        $installations = @(& $vswhere -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath `
+            -format value)
+        if (-not $installations) {
+            $installations = @(& $vswhere -all -products * -property installationPath -format value)
+        }
+
+        foreach ($installation in $installations) {
+            if ([string]::IsNullOrWhiteSpace($installation)) {
+                continue
+            }
+
+            $candidates.Add((Join-Path $installation 'VC\Auxiliary\Build\vcvars64.bat'))
+        }
+    }
+
+    $commonRoots = @(
+        'C:\Program Files\Microsoft Visual Studio\18\Professional',
+        'C:\Program Files\Microsoft Visual Studio\18\Enterprise',
+        'C:\Program Files\Microsoft Visual Studio\18\Community',
+        'C:\Program Files\Microsoft Visual Studio\18\BuildTools',
+        'C:\Program Files\Microsoft Visual Studio\2022\Professional',
+        'C:\Program Files\Microsoft Visual Studio\2022\Enterprise',
+        'C:\Program Files\Microsoft Visual Studio\2022\Community',
+        'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+    )
+
+    foreach ($root in $commonRoots) {
+        $candidates.Add((Join-Path $root 'VC\Auxiliary\Build\vcvars64.bat'))
+    }
+
+    foreach ($candidate in ($candidates | Select-Object -Unique)) {
+        if (Test-Path $candidate) {
+            return $candidate
+        }
+    }
+
+    throw "vcvars64.bat not found. Install Visual Studio/Build Tools with the 'Desktop development with C++' workload, or set CODESCOPE_VCVARS64 to the full vcvars64.bat path. Checked: $($candidates -join '; ')"
 }
+
+$vcvars = Resolve-VcVars64
+Write-Host "Using MSVC environment: $vcvars"
 
 # Source vcvars by running it under cmd and capturing its environment.
 cmd.exe /c "`"$vcvars`" >NUL 2>&1 && set" | ForEach-Object {
@@ -29,7 +85,15 @@ cmd.exe /c "`"$vcvars`" >NUL 2>&1 && set" | ForEach-Object {
     }
 }
 
-# Run cargo at the spike's manifest, forwarding all script args.
-$manifest = Join-Path $PSScriptRoot '..\Cargo.toml'
-& cargo --manifest-path $manifest @args
-exit $LASTEXITCODE
+# Run cargo from the spike root, forwarding all script args verbatim.
+# Changing directory keeps zero-arg, global-option, and `+toolchain` invocations valid while still
+# targeting codescope-rs.
+$manifestDir = Resolve-Path (Join-Path $PSScriptRoot '..')
+Push-Location $manifestDir
+try {
+    & cargo @args
+    $exitCode = $LASTEXITCODE
+} finally {
+    Pop-Location
+}
+exit $exitCode


### PR DESCRIPTION
## Summary
- detect vcvars64.bat via CODESCOPE_VCVARS64, VSINSTALLDIR, vswhere, and common VS install paths
- support VS 2026/18 Professional installs instead of hardcoding VS 2022 BuildTools
- keep cargo commands pinned to the codescope-rs manifest with the manifest flag placed after the cargo subcommand

## Verification
- powershell.exe -NoProfile -ExecutionPolicy Bypass -File "D:\Dev\private\CodeScope\codescope-rs\scripts\build.ps1" check