### PR TITLE
feat(rs): port AgentRegistry + default-agent setting

### DIFF
--- a/codescope-rs/core/src/agent.rs
+++ b/codescope-rs/core/src/agent.rs
@@ -2,11 +2,14 @@
 //!
 //! Mirrors the `agentId` strings the C# build threads through
 //! `MainViewModel.RegisterAgentTelemetry` / `BeginAgentAdoption`:
-//! `"claude"`, `"copilot"`, `"opencode"`, `"pi"`. The Rust port doesn't
-//! yet have a settings-driven agent picker (the sidebar today only
-//! offers a "New Claude session" menu row), but the dispatch surface
-//! needs an enum so the telemetry / discovery layer can fan out
-//! correctly when other agents land.
+//! `"claude"`, `"codex"`, `"copilot"`, `"opencode"`, `"pi"`. The Rust
+//! port doesn't yet have a settings-driven agent picker (the sidebar
+//! today only offers a "New Claude session" menu row), but the
+//! dispatch surface needs an enum so the telemetry / discovery layer
+//! can fan out correctly when other agents land. The [`crate::agent_registry`]
+//! module owns the richer `AgentProfile` shape (argv, icons,
+//! context-window tokens); this enum is the narrow id used by the
+//! per-agent telemetry dispatch.
 //!
 //! Detection is currently based on the auto-typed launch command
 //! recorded on each [`crate::projects::Session`]'s tab — the same
@@ -14,13 +17,17 @@
 //! Anything else (plain `pwsh`, no auto-type, an unknown agent) maps
 //! to `None`, leaving the tab telemetry-less just like a shell tab.
 
-/// One of the four supported agent backends. Names match the
+/// One of the five supported agent backends. Names match the
 /// `agentId` strings the C# `MainViewModel` branches on; keep them
 /// stable so on-disk session records (which carry `AgentId` as a
-/// plain string) round-trip cleanly between builds.
+/// plain string) round-trip cleanly between builds. Codex was added
+/// alongside the [`crate::agent_registry::AgentRegistry`] port — the
+/// telemetry/discovery layer for it is a follow-up, but the id needs
+/// to round-trip now so registry consumers can use it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AgentId {
     Claude,
+    Codex,
     Copilot,
     OpenCode,
     Pi,
@@ -32,6 +39,7 @@ impl AgentId {
     pub const fn as_str(self) -> &'static str {
         match self {
             AgentId::Claude => "claude",
+            AgentId::Codex => "codex",
             AgentId::Copilot => "copilot",
             AgentId::OpenCode => "opencode",
             AgentId::Pi => "pi",
@@ -44,6 +52,8 @@ impl AgentId {
     pub fn from_str(s: &str) -> Option<Self> {
         if s.eq_ignore_ascii_case("claude") {
             Some(AgentId::Claude)
+        } else if s.eq_ignore_ascii_case("codex") {
+            Some(AgentId::Codex)
         } else if s.eq_ignore_ascii_case("copilot") {
             Some(AgentId::Copilot)
         } else if s.eq_ignore_ascii_case("opencode") {
@@ -80,7 +90,13 @@ mod tests {
 
     #[test]
     fn from_str_round_trip() {
-        for id in [AgentId::Claude, AgentId::Copilot, AgentId::OpenCode, AgentId::Pi] {
+        for id in [
+            AgentId::Claude,
+            AgentId::Codex,
+            AgentId::Copilot,
+            AgentId::OpenCode,
+            AgentId::Pi,
+        ] {
             assert_eq!(AgentId::from_str(id.as_str()), Some(id));
         }
     }
@@ -88,6 +104,7 @@ mod tests {
     #[test]
     fn from_str_is_case_insensitive() {
         assert_eq!(AgentId::from_str("CLAUDE"), Some(AgentId::Claude));
+        assert_eq!(AgentId::from_str("Codex"), Some(AgentId::Codex));
         assert_eq!(AgentId::from_str("Copilot"), Some(AgentId::Copilot));
         assert_eq!(AgentId::from_str("OPENCODE"), Some(AgentId::OpenCode));
         assert_eq!(AgentId::from_str("Pi"), Some(AgentId::Pi));
@@ -112,6 +129,7 @@ mod tests {
     #[test]
     fn auto_type_resolves_each_agent() {
         assert_eq!(agent_id_from_auto_type(Some("claude")), Some(AgentId::Claude));
+        assert_eq!(agent_id_from_auto_type(Some("codex")), Some(AgentId::Codex));
         assert_eq!(agent_id_from_auto_type(Some("copilot")), Some(AgentId::Copilot));
         assert_eq!(agent_id_from_auto_type(Some("opencode")), Some(AgentId::OpenCode));
         assert_eq!(agent_id_from_auto_type(Some("pi")), Some(AgentId::Pi));

--- a/codescope-rs/core/src/agent_registry.rs
+++ b/codescope-rs/core/src/agent_registry.rs
@@ -1,0 +1,395 @@
+//! Agent profile registry — Rust port of C# `AgentRegistry` + `AgentProfile`.
+//!
+//! Mirrors `src/CodeScope.Core/Services/AgentRegistry.cs` and
+//! `src/CodeScope.Core/Models/AgentProfile.cs`. The C# build exposes
+//! these via DI so views/view-models can list available agents, pick
+//! the user-flagged default for "new tab", and look up by id when
+//! restoring sessions. This port keeps the same shape so the eventual
+//! Rust sidebar / new-session menu can consume it 1:1.
+//!
+//! The registry is read-only after construction. Built-in defaults
+//! cover the five agents shipped in the C# build:
+//! `claude`, `codex`, `opencode`, `copilot`, `pi`.
+//!
+//! Built defaults intentionally match the C# arrays — argv, session-id
+//! flags, resume-by-id args, icons, and context-window tokens — byte
+//! for byte so on-disk session records stay round-trippable between
+//! the C# build and the Rust port.
+
+use serde::{Deserialize, Serialize};
+
+use crate::settings::Settings;
+
+/// One coding-agent CLI profile.
+///
+/// Field order and naming mirrors the C# `AgentProfile` record. The
+/// JSON shape on disk uses camelCase to match the C# build's
+/// `JsonSerializerOptions` (and what `projects.json` already writes).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentProfile {
+    /// Stable id used in config and cross-references.
+    pub id: String,
+
+    /// Human-readable name (e.g. "Claude Code").
+    pub display_name: String,
+
+    /// Executable name resolved via PATH (e.g. "claude").
+    pub command: String,
+
+    /// Args passed when resuming an existing session (e.g. `["--continue"]`).
+    #[serde(default)]
+    pub resume_args: Vec<String>,
+
+    /// Args passed when starting a brand-new session.
+    #[serde(default)]
+    pub new_session_args: Vec<String>,
+
+    /// Optional CLI flag that accepts a caller-supplied session id on
+    /// launch (e.g. `--session-id` for Claude Code). When `Some`,
+    /// CodeScope generates a UUID per new session, passes it to the
+    /// CLI with this flag, and persists it so later resumes can target
+    /// that specific conversation. `None` for CLIs that don't support
+    /// deterministic session ids.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id_flag: Option<String>,
+
+    /// Args used to resume a specific session id (e.g. `["--resume"]`
+    /// for Claude Code — the stored UUID is appended as the next
+    /// token). Empty falls back to `resume_args`.
+    #[serde(default)]
+    pub resume_by_id_args: Vec<String>,
+
+    /// True for the default agent picked when creating a tab without
+    /// explicit selection.
+    #[serde(default)]
+    pub is_default: bool,
+
+    /// Optional single-glyph icon (emoji or symbol) used by the UI to
+    /// decorate sessions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+
+    /// Nominal context-window capacity (in tokens) for the model this
+    /// agent runs, or `0` when unknown. Drives the status-bar token
+    /// progress read-out. Claude Code defaults to Opus 4.7 with the
+    /// 1M-context variant in this setup, so the baked default there is
+    /// 1_000_000. Users can override via settings.
+    #[serde(default)]
+    pub context_window_tokens: u32,
+}
+
+/// In-memory registry backed by a list passed at construction time.
+///
+/// Mirrors `AgentRegistry` from the C# build. The list is cheaply
+/// cloneable but is normally held by `AppShell` once and consulted on
+/// demand.
+#[derive(Debug, Clone)]
+pub struct AgentRegistry {
+    agents: Vec<AgentProfile>,
+}
+
+impl AgentRegistry {
+    /// Build a registry from an explicit profile list. An empty list
+    /// is technically valid — the consumer just gets no agents — but
+    /// most callers should prefer [`AgentRegistry::with_built_ins`] or
+    /// [`AgentRegistry::from_settings`].
+    pub fn new(agents: Vec<AgentProfile>) -> Self {
+        Self { agents }
+    }
+
+    /// Construct the registry with the shipped built-in defaults
+    /// (claude / codex / opencode / copilot / pi). Equivalent to the
+    /// C# parameterless `new AgentRegistry()` constructor.
+    pub fn with_built_ins() -> Self {
+        Self::new(built_in_defaults())
+    }
+
+    /// Build a registry from the user's settings. If
+    /// `settings.agents` is non-empty those overrides are used as-is;
+    /// otherwise the built-in defaults are returned. Mirrors C#
+    /// `AgentRegistry.FromConfig`.
+    pub fn from_settings(settings: &Settings) -> Self {
+        if settings.agents.is_empty() {
+            Self::with_built_ins()
+        } else {
+            Self::new(settings.agents.clone())
+        }
+    }
+
+    /// All registered profiles, in registration order.
+    pub fn get_all(&self) -> &[AgentProfile] {
+        &self.agents
+    }
+
+    /// The first profile flagged `is_default`. Falls back to the first
+    /// overall profile when no explicit default is set — same fallback
+    /// rule as the C# `GetDefault()`.
+    pub fn get_default(&self) -> Option<&AgentProfile> {
+        self.agents
+            .iter()
+            .find(|a| a.is_default)
+            .or_else(|| self.agents.first())
+    }
+
+    /// Look up a profile by stable id. Case-insensitive to match the
+    /// `StringComparison.OrdinalIgnoreCase` used in C#.
+    pub fn get_by_id(&self, id: &str) -> Option<&AgentProfile> {
+        self.agents
+            .iter()
+            .find(|a| a.id.eq_ignore_ascii_case(id))
+    }
+}
+
+/// Built-in profiles shipped with the app. Mirrors the C#
+/// `AgentRegistry.BuildDefaults()` list 1:1 — argv, flags, icons, and
+/// context-window tokens all kept identical so the Rust port behaves
+/// like the C# build for the same agent binaries.
+pub fn built_in_defaults() -> Vec<AgentProfile> {
+    vec![
+        AgentProfile {
+            id: "claude".into(),
+            display_name: "Claude Code".into(),
+            command: "claude".into(),
+            // Fresh launches: bare `claude`; Claude Code mints its own UUID
+            // and the discovery layer adopts it. When we already know the
+            // session id (cross-group drag, layout hydrate) we resume via
+            // `claude --resume <id>` so the conversation continues instead
+            // of the user landing on a fresh agent.
+            resume_args: vec![],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec!["--resume".into()],
+            is_default: true,
+            icon: Some("✶".into()),
+            context_window_tokens: 1_000_000,
+        },
+        AgentProfile {
+            id: "codex".into(),
+            display_name: "Codex".into(),
+            command: "codex".into(),
+            resume_args: vec!["resume".into()],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec![],
+            is_default: false,
+            icon: Some("◇".into()),
+            context_window_tokens: 0,
+        },
+        AgentProfile {
+            id: "opencode".into(),
+            display_name: "OpenCode".into(),
+            // Windows ships the binary as `opencode-cli.exe` (npm
+            // `opencode-ai` package installs that name on Win to dodge a
+            // Windows reserved/conflicting name). macOS/Linux use
+            // `opencode`; flip this default if we ever cross-compile.
+            command: "opencode-cli".into(),
+            // `opencode -c` (= `--continue`) resumes the most recent
+            // session in the cwd. `opencode --session <id>` (= `-s <id>`)
+            // resumes a specific id; we adopt that id from the
+            // message-file watcher once OpenCode has written its first
+            // assistant turn. SessionIdFlag stays None — OpenCode mints
+            // its own ids and doesn't accept caller-minted.
+            resume_args: vec!["--continue".into()],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec!["--session".into()],
+            is_default: false,
+            icon: Some("◈".into()),
+            context_window_tokens: 0,
+        },
+        AgentProfile {
+            id: "copilot".into(),
+            display_name: "Copilot CLI".into(),
+            command: "copilot".into(),
+            // `copilot --continue` resumes the most recent session.
+            // `copilot --resume=<id>` resumes a specific session by
+            // UUID / name / id-prefix. The `=` suffix on the last
+            // resume_by_id_args entry tells SessionManager to concat
+            // the id directly (Copilot's optional-value flag requires
+            // `=` syntax, not a space). SessionIdFlag stays None —
+            // Copilot mints its own ids; callers don't supply them.
+            resume_args: vec!["--continue".into()],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec!["--resume=".into()],
+            is_default: false,
+            icon: Some("⊛".into()),
+            context_window_tokens: 0,
+        },
+        AgentProfile {
+            id: "pi".into(),
+            display_name: "Pi".into(),
+            command: "pi".into(),
+            // Fresh launches: bare `pi`. Pi mints its own UUID + writes
+            // a session-jsonl whose header carries the cwd, which the
+            // discovery layer matches to adopt the id. Resume-by-id:
+            // `pi --session <uuid>` — Pi resolves the latest session
+            // file with that UUID suffix anywhere under
+            // `~/.pi/agent/sessions/`. Continue-most-recent: `pi -c`
+            // (used as the bare resume_args fallback when we don't
+            // have a stored id). SessionIdFlag stays None — Pi doesn't
+            // accept caller-minted ids on launch.
+            resume_args: vec!["-c".into()],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec!["--session".into()],
+            is_default: false,
+            icon: Some("π".into()),
+            context_window_tokens: 0,
+        },
+    ]
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn built_in_defaults_cover_all_five_agents() {
+        let defaults = built_in_defaults();
+        let ids: Vec<&str> = defaults.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, vec!["claude", "codex", "opencode", "copilot", "pi"]);
+    }
+
+    #[test]
+    fn get_default_returns_claude_for_built_ins() {
+        let reg = AgentRegistry::with_built_ins();
+        let def = reg.get_default().expect("default present");
+        assert_eq!(def.id, "claude");
+        assert!(def.is_default);
+    }
+
+    #[test]
+    fn get_default_falls_back_to_first_when_no_is_default_flag() {
+        let reg = AgentRegistry::new(vec![
+            AgentProfile {
+                id: "alpha".into(),
+                display_name: "Alpha".into(),
+                command: "alpha".into(),
+                resume_args: vec![],
+                new_session_args: vec![],
+                session_id_flag: None,
+                resume_by_id_args: vec![],
+                is_default: false,
+                icon: None,
+                context_window_tokens: 0,
+            },
+            AgentProfile {
+                id: "beta".into(),
+                display_name: "Beta".into(),
+                command: "beta".into(),
+                resume_args: vec![],
+                new_session_args: vec![],
+                session_id_flag: None,
+                resume_by_id_args: vec![],
+                is_default: false,
+                icon: None,
+                context_window_tokens: 0,
+            },
+        ]);
+        assert_eq!(reg.get_default().unwrap().id, "alpha");
+    }
+
+    #[test]
+    fn get_default_none_when_empty() {
+        let reg = AgentRegistry::new(vec![]);
+        assert!(reg.get_default().is_none());
+    }
+
+    #[test]
+    fn get_by_id_is_case_insensitive() {
+        let reg = AgentRegistry::with_built_ins();
+        assert_eq!(reg.get_by_id("claude").unwrap().id, "claude");
+        assert_eq!(reg.get_by_id("CLAUDE").unwrap().id, "claude");
+        assert_eq!(reg.get_by_id("Codex").unwrap().id, "codex");
+        assert_eq!(reg.get_by_id("PI").unwrap().id, "pi");
+        assert!(reg.get_by_id("gemini").is_none());
+    }
+
+    #[test]
+    fn claude_default_has_1m_context_window() {
+        let reg = AgentRegistry::with_built_ins();
+        let claude = reg.get_by_id("claude").unwrap();
+        assert_eq!(claude.context_window_tokens, 1_000_000);
+        assert_eq!(claude.resume_by_id_args, vec!["--resume".to_string()]);
+    }
+
+    #[test]
+    fn copilot_resume_by_id_uses_equals_suffix() {
+        let reg = AgentRegistry::with_built_ins();
+        let copilot = reg.get_by_id("copilot").unwrap();
+        assert_eq!(copilot.resume_by_id_args, vec!["--resume=".to_string()]);
+        assert_eq!(copilot.resume_args, vec!["--continue".to_string()]);
+    }
+
+    #[test]
+    fn from_settings_returns_built_ins_when_empty() {
+        let settings = Settings::default();
+        let reg = AgentRegistry::from_settings(&settings);
+        assert_eq!(reg.get_all().len(), built_in_defaults().len());
+        assert_eq!(reg.get_default().unwrap().id, "claude");
+    }
+
+    #[test]
+    fn from_settings_uses_overrides_when_provided() {
+        let mut settings = Settings::default();
+        settings.agents = vec![AgentProfile {
+            id: "custom".into(),
+            display_name: "Custom".into(),
+            command: "custom-cli".into(),
+            resume_args: vec![],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec![],
+            is_default: true,
+            icon: None,
+            context_window_tokens: 0,
+        }];
+        let reg = AgentRegistry::from_settings(&settings);
+        assert_eq!(reg.get_all().len(), 1);
+        assert_eq!(reg.get_default().unwrap().id, "custom");
+    }
+
+    #[test]
+    fn agent_profile_serde_round_trip() {
+        let profile = AgentProfile {
+            id: "claude".into(),
+            display_name: "Claude Code".into(),
+            command: "claude".into(),
+            resume_args: vec![],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec!["--resume".into()],
+            is_default: true,
+            icon: Some("✶".into()),
+            context_window_tokens: 1_000_000,
+        };
+        let json = serde_json::to_string(&profile).unwrap();
+        let parsed: AgentProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, profile);
+    }
+
+    #[test]
+    fn agent_profile_serde_uses_camel_case() {
+        let profile = AgentProfile {
+            id: "claude".into(),
+            display_name: "Claude Code".into(),
+            command: "claude".into(),
+            resume_args: vec![],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec!["--resume".into()],
+            is_default: true,
+            icon: Some("✶".into()),
+            context_window_tokens: 1_000_000,
+        };
+        let json = serde_json::to_string(&profile).unwrap();
+        assert!(json.contains("\"displayName\""));
+        assert!(json.contains("\"resumeByIdArgs\""));
+        assert!(json.contains("\"isDefault\""));
+        assert!(json.contains("\"contextWindowTokens\""));
+    }
+}

--- a/codescope-rs/core/src/agent_registry.rs
+++ b/codescope-rs/core/src/agent_registry.rs
@@ -109,11 +109,42 @@ impl AgentRegistry {
     /// `settings.agents` is non-empty those overrides are used as-is;
     /// otherwise the built-in defaults are returned. Mirrors C#
     /// `AgentRegistry.FromConfig`.
+    ///
+    /// `settings.default_agent` is then reconciled onto the resulting
+    /// list — the profile whose id matches (case-insensitive) is
+    /// flagged `is_default = true` and every other profile is demoted
+    /// to `false`. This keeps `get_default()` honest no matter which
+    /// of the two settings surfaces the user touched. Empty or
+    /// unknown ids leave the list untouched, so a typo in
+    /// `settings.json` doesn't silently wipe the built-in default.
     pub fn from_settings(settings: &Settings) -> Self {
-        if settings.agents.is_empty() {
-            Self::with_built_ins()
+        let agents = if settings.agents.is_empty() {
+            built_in_defaults()
         } else {
-            Self::new(settings.agents.clone())
+            settings.agents.clone()
+        };
+        let mut reg = Self::new(agents);
+        reg.apply_default_agent(&settings.default_agent);
+        reg
+    }
+
+    /// Apply a `settings.default_agent` id onto the in-memory list:
+    /// the matching profile is flagged default and all others are
+    /// demoted. No-op when the id is empty or not present in the
+    /// registry — preserves whatever `is_default` flags were already
+    /// baked in (built-in defaults flag Claude; custom overrides
+    /// might flag something else).
+    fn apply_default_agent(&mut self, default_agent_id: &str) {
+        if default_agent_id.is_empty() {
+            return;
+        }
+        let target_idx = self
+            .agents
+            .iter()
+            .position(|a| a.id.eq_ignore_ascii_case(default_agent_id));
+        let Some(idx) = target_idx else { return };
+        for (i, agent) in self.agents.iter_mut().enumerate() {
+            agent.is_default = i == idx;
         }
     }
 
@@ -351,6 +382,45 @@ mod tests {
         let reg = AgentRegistry::from_settings(&settings);
         assert_eq!(reg.get_all().len(), 1);
         assert_eq!(reg.get_default().unwrap().id, "custom");
+    }
+
+    #[test]
+    fn from_settings_honours_default_agent_setting() {
+        // `settings.default_agent = "codex"` must flip `is_default`
+        // on the codex profile and demote every other built-in
+        // (Claude included) so `get_default()` returns Codex without
+        // the caller having to hand-edit per-profile flags.
+        let mut settings = Settings::default();
+        settings.default_agent = "codex".into();
+        let reg = AgentRegistry::from_settings(&settings);
+        let def = reg.get_default().expect("default present");
+        assert_eq!(def.id, "codex");
+        assert!(def.is_default);
+        // Claude must have been demoted.
+        let claude = reg.get_by_id("claude").unwrap();
+        assert!(!claude.is_default);
+    }
+
+    #[test]
+    fn from_settings_default_agent_lookup_is_case_insensitive() {
+        // Hand-edited `settings.json` with `"defaultAgent": "Codex"`
+        // (mixed case) still resolves — matches the lookup behaviour
+        // of `get_by_id`.
+        let mut settings = Settings::default();
+        settings.default_agent = "CODEX".into();
+        let reg = AgentRegistry::from_settings(&settings);
+        assert_eq!(reg.get_default().unwrap().id, "codex");
+    }
+
+    #[test]
+    fn from_settings_unknown_default_agent_leaves_built_in_flag_intact() {
+        // Typos must not silently wipe the baked-in default — the
+        // user should still get Claude back when they fat-finger an
+        // unknown id.
+        let mut settings = Settings::default();
+        settings.default_agent = "gemini".into();
+        let reg = AgentRegistry::from_settings(&settings);
+        assert_eq!(reg.get_default().unwrap().id, "claude");
     }
 
     #[test]

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -14,6 +14,7 @@
 //! `codescope-terminal`.
 
 pub mod agent;
+pub mod agent_registry;
 pub mod claude_discovery;
 pub mod claude_telemetry;
 pub mod copilot_discovery;
@@ -38,6 +39,7 @@ pub mod update_check;
 pub mod window_state;
 
 pub use agent::{AgentId, agent_id_from_auto_type};
+pub use agent_registry::{AgentProfile, AgentRegistry, built_in_defaults};
 pub use claude_discovery::{AdoptionCandidate, POLL_INTERVAL_MS as CLAUDE_DISCOVERY_POLL_MS};
 pub use claude_telemetry::{
     SessionState, TelemetrySnapshot, TranscriptTail, context_window_for_model, encode_cwd,
@@ -53,6 +55,6 @@ pub use layout::{LayoutState, RestoreTab};
 pub use paths::AppPaths;
 pub use projects::{Project, ProjectsConfig, Session, Worktree};
 pub use session::{RetentionPolicy, SessionManager, now_iso8601};
-pub use settings::{CursorSettings, FontSettings, Settings};
+pub use settings::{CursorSettings, DEFAULT_AGENT_ID, FontSettings, Settings};
 pub use theme::{Rgb, Theme, ThemePalette, builtin};
 pub use window_state::WindowState;

--- a/codescope-rs/core/src/settings.rs
+++ b/codescope-rs/core/src/settings.rs
@@ -52,6 +52,14 @@ pub struct Settings {
     /// to match the C# build's `AgentRegistry.BuildDefaults` flag.
     /// Lookup against `AgentRegistry` is case-insensitive, so a
     /// hand-edited `"Codex"` resolves to the `codex` profile.
+    ///
+    /// Serialised as `defaultAgent` to match the camelCase shape
+    /// used by every other on-disk config in the app
+    /// (`ProjectsConfig`, `AgentProfile`). The `default_agent` alias
+    /// keeps any settings.json hand-rolled against an early build of
+    /// this PR — when the field briefly serialised as snake_case —
+    /// loading without surprise.
+    #[serde(rename = "defaultAgent", alias = "default_agent")]
     pub default_agent: String,
 
     /// Optional user-defined agent overrides. When non-empty, the
@@ -249,6 +257,33 @@ mod tests {
 
         let loaded = Settings::load_from(&path).unwrap();
         assert_eq!(loaded.default_agent, "codex");
+    }
+
+    #[test]
+    fn default_agent_serialises_as_camel_case() {
+        let mut settings = Settings::default();
+        settings.default_agent = "codex".into();
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(
+            json.contains("\"defaultAgent\""),
+            "settings.json must use camelCase for defaultAgent: {json}"
+        );
+        assert!(
+            !json.contains("\"default_agent\""),
+            "settings.json must not emit snake_case key: {json}"
+        );
+    }
+
+    #[test]
+    fn default_agent_snake_case_alias_still_loads() {
+        // Early builds of the agent-registry PR wrote `default_agent`
+        // (snake_case). The alias keeps those files round-tripping
+        // cleanly — they reload as if the key had been camelCase.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, r#"{"default_agent":"codex"}"#).unwrap();
+        let settings = Settings::load_from(&path).unwrap();
+        assert_eq!(settings.default_agent, "codex");
     }
 
     #[test]

--- a/codescope-rs/core/src/settings.rs
+++ b/codescope-rs/core/src/settings.rs
@@ -16,8 +16,14 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::agent_registry::AgentProfile;
 use crate::paths::AppPaths;
 use crate::theme::builtin::DEFAULT_NAME;
+
+/// Default stable id for the user's preferred agent when no override
+/// is set in `settings.json`. Matches the C# build's `IsDefault` flag
+/// on Claude Code so cold-start picks the same agent in both ports.
+pub const DEFAULT_AGENT_ID: &str = "claude";
 
 /// Top-level config object. Every leaf is optional so missing pieces
 /// fall back to defaults; this also means an empty `{}` is a valid
@@ -39,6 +45,22 @@ pub struct Settings {
     /// the fly; the values here are the defaults that PSReadLine /
     /// cmd.exe / bash inherit before any TUI takes over.
     pub cursor: CursorSettings,
+
+    /// Stable id of the user's preferred agent — Phase 1 wires this
+    /// at startup so the future new-session menu can default to
+    /// whichever CLI the user actually uses. Defaults to `"claude"`
+    /// to match the C# build's `AgentRegistry.BuildDefaults` flag.
+    /// Lookup against `AgentRegistry` is case-insensitive, so a
+    /// hand-edited `"Codex"` resolves to the `codex` profile.
+    pub default_agent: String,
+
+    /// Optional user-defined agent overrides. When non-empty, the
+    /// registry uses these instead of the built-in defaults — mirrors
+    /// `ProjectsConfig.Agents` in the C# build, which lets power
+    /// users hand-edit the on-disk config to add/replace agents
+    /// without a code change. Empty (the default) keeps the shipped
+    /// 5-agent defaults.
+    pub agents: Vec<AgentProfile>,
 }
 
 impl Default for Settings {
@@ -48,6 +70,8 @@ impl Default for Settings {
             font: FontSettings::default(),
             scrollback: 10_000,
             cursor: CursorSettings::default(),
+            default_agent: DEFAULT_AGENT_ID.to_string(),
+            agents: Vec::new(),
         }
     }
 }
@@ -192,6 +216,39 @@ mod tests {
         let loaded = Settings::load_from(&path).unwrap();
         assert_eq!(loaded.theme, "tokyo-night");
         assert_eq!(loaded.scrollback, 50_000);
+    }
+
+    #[test]
+    fn default_agent_defaults_to_claude() {
+        let settings = Settings::default();
+        assert_eq!(settings.default_agent, DEFAULT_AGENT_ID);
+        assert_eq!(settings.default_agent, "claude");
+        assert!(settings.agents.is_empty());
+    }
+
+    #[test]
+    fn missing_default_agent_falls_back_to_built_in() {
+        // Older settings.json files won't carry `defaultAgent`. The
+        // `#[serde(default)]` on `Settings` must keep them loading
+        // cleanly with the built-in default.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, r#"{"theme":"tokyo-night"}"#).unwrap();
+        let settings = Settings::load_from(&path).unwrap();
+        assert_eq!(settings.default_agent, DEFAULT_AGENT_ID);
+        assert!(settings.agents.is_empty());
+    }
+
+    #[test]
+    fn default_agent_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let mut settings = Settings::default();
+        settings.default_agent = "codex".into();
+        settings.save_to(&path).unwrap();
+
+        let loaded = Settings::load_from(&path).unwrap();
+        assert_eq!(loaded.default_agent, "codex");
     }
 
     #[test]

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -564,6 +564,16 @@ pub struct AppShell {
     /// the C# build where `SessionStore` is the orchestrator and
     /// `SidebarViewModel.StoreSync` projects from it.
     projects: ProjectsConfig,
+    /// Registry of agent profiles built from `settings.agents`
+    /// overrides (or the shipped built-in defaults when none are
+    /// configured). Mirrors C# `AgentRegistry` — owned at the shell
+    /// level so the future new-session menu can list agents, pick the
+    /// user's preferred default, and look up by id on session restore.
+    /// Not yet consumed by any view; held here so the registry is live
+    /// from cold-start and the sidebar integration in a follow-up PR
+    /// only has to wire the consumer side.
+    #[allow(dead_code)]
+    agent_registry: codescope_core::AgentRegistry,
 }
 
 impl AppShell {
@@ -864,6 +874,12 @@ impl AppShell {
             .focused_group_index
             .min(groups.len().saturating_sub(1));
 
+        // Build the agent registry up-front from the loaded settings so
+        // user overrides in `settings.agents` are honoured, otherwise
+        // the shipped 5-agent defaults (claude/codex/opencode/copilot/pi)
+        // are used. Cheap — just a `Vec<AgentProfile>` clone.
+        let agent_registry = codescope_core::AgentRegistry::from_settings(&settings);
+
         let mut shell = Self {
             groups,
             focused_group,
@@ -889,6 +905,7 @@ impl AppShell {
             bell_bounds: None,
             last_announced_update: None,
             projects: projects_for_sessions,
+            agent_registry,
         };
         shell.start_telemetry_poll(cx);
         shell.start_agent_discovery_poll(cx);
@@ -991,6 +1008,17 @@ impl AppShell {
                     root,
                     session_id.clone(),
                 ))
+            }
+            codescope_core::AgentId::Codex => {
+                // Codex telemetry isn't wired in the Rust port yet (the
+                // AgentRegistry entry exists ahead of the discovery
+                // layer); skip registration so the rest of the agent
+                // surface keeps working until the dedicated Codex
+                // discovery / telemetry modules land.
+                eprintln!(
+                    "[telemetry] codex telemetry not yet wired — skipping registration for {session_id}"
+                );
+                return;
             }
             codescope_core::AgentId::Pi => {
                 let Some(root) = codescope_core::pi_telemetry::default_sessions_root() else {
@@ -1224,6 +1252,12 @@ impl AppShell {
                                     .into_iter()
                                     .map(|c| (c.session_id, c.session_dir))
                                     .collect()
+                                }
+                                codescope_core::AgentId::Codex => {
+                                    // Codex discovery isn't wired in
+                                    // the Rust port yet — skip scanning
+                                    // so the polling loop keeps moving.
+                                    continue;
                                 }
                             };
                             let mut newest: Option<(SystemTime, String)> = None;

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1193,6 +1193,17 @@ impl AppShell {
                         for (t_idx, tab) in group.tabs.iter().enumerate() {
                             let Some(agent_id) = tab.agent_id else { continue };
                             let Some(ref wd) = tab.working_directory else { continue };
+                            // Codex has no discovery wired in the Rust
+                            // port yet — skip before flipping
+                            // `any_active`, otherwise an all-Codex
+                            // workspace would pin the poll at the
+                            // 350 ms active rate while the loop does
+                            // no work. Drop it through with the same
+                            // "no agent" handling so the cadence
+                            // relaxes to the 5 s idle interval.
+                            if matches!(agent_id, codescope_core::AgentId::Codex) {
+                                continue;
+                            }
                             any_active = true;
                             let wd_str = wd.to_string_lossy().into_owned();
                             // Each agent scan returns
@@ -1254,9 +1265,12 @@ impl AppShell {
                                     .collect()
                                 }
                                 codescope_core::AgentId::Codex => {
-                                    // Codex discovery isn't wired in
-                                    // the Rust port yet — skip scanning
-                                    // so the polling loop keeps moving.
+                                    // Unreachable: short-circuited
+                                    // above so the active-poll rate
+                                    // doesn't stay pinned for an
+                                    // all-Codex workspace. Kept as a
+                                    // belt-and-braces fallback in case
+                                    // someone removes the early skip.
                                     continue;
                                 }
                             };


### PR DESCRIPTION
## Summary

Ports the C# `AgentRegistry` + `AgentProfile` + `IAgentRegistry` trio into `codescope-core` so the future Rust new-session menu has a parity-level source of truth for the five shipped agents (claude / codex / opencode / copilot / pi). Also adds a configurable `default_agent` setting.

- New `agent_registry` module mirrors `src/CodeScope.Core/Services/AgentRegistry.cs` 1:1 — argv, `sessionIdFlag`, `resumeByIdArgs`, icons, and `contextWindowTokens` kept byte-for-byte. JSON shape is camelCase to match the C# `JsonSerializerOptions` so on-disk profiles round-trip between builds.
- `Settings` gains `default_agent: String` (defaults to `"claude"`) and optional `agents: Vec<AgentProfile>` override list. Both `#[serde(default)]` so older `settings.json` files keep loading.
- `AgentRegistry::from_settings` returns overrides when present, otherwise built-in defaults (mirrors C# `AgentRegistry.FromConfig`).
- `AppShell` constructs the registry at boot and stores it (allow(dead_code) — sidebar/new-session integration is a follow-up).
- `AgentId` enum gains the missing `Codex` variant so the new registry entry round-trips through the telemetry-dispatch enum. Telemetry/discovery for Codex isn't wired yet; the two `match` arms in `app.rs` skip Codex with a log line until that lands.

## Test plan

- [x] `cargo build --workspace` clean (no warnings)
- [x] `cargo test --workspace` — 346 core tests pass, including new ones:
  - `built_in_defaults_cover_all_five_agents`
  - `get_default_returns_claude_for_built_ins` + fallback-to-first
  - `get_by_id_is_case_insensitive`
  - `from_settings_returns_built_ins_when_empty` / `_uses_overrides_when_provided`
  - `agent_profile_serde_round_trip` + camelCase check
  - `default_agent_defaults_to_claude` + `_round_trip` + `missing_default_agent_falls_back_to_built_in`
- [ ] Sidebar / new-session UI consumes the registry (deliberately deferred to a follow-up PR)