### PR TITLE
fix(rs): close status-bar parity gaps with C# StatusBarView

### DIFF
--- a/codescope-rs/core/src/claude_telemetry.rs
+++ b/codescope-rs/core/src/claude_telemetry.rs
@@ -526,15 +526,30 @@ impl TranscriptTail {
         }
     }
 
-    /// Format `last_turn_duration` as `m:ss` or `Xs` (mirrors the
-    /// C# status-bar formatting).
+    /// Format `last_turn_duration` for the status-bar turn-time
+    /// segment. Mirrors C# `MainViewModel.FormatDuration`:
+    /// - `< 10s` → one decimal, e.g. `"3.1s"`
+    /// - `< 60s` → integer seconds, e.g. `"42s"`
+    /// - `< 1h`  → `"2m 12s"`
+    /// - else   → `"1h 4m"`
     pub fn format_duration(d: Duration) -> String {
-        let total = d.as_secs();
-        if total < 60 {
-            format!("{total}s")
-        } else {
-            format!("{}:{:02}", total / 60, total % 60)
+        let secs = d.as_secs_f64();
+        if secs < 10.0 {
+            // C#'s `0.0` format uses banker's rounding but at this scale
+            // the difference is invisible — keep it simple.
+            return format!("{:.1}s", secs);
         }
+        if secs < 60.0 {
+            return format!("{}s", secs.floor() as u64);
+        }
+        if secs < 3600.0 {
+            let m = (secs / 60.0).floor() as u64;
+            let s = (secs % 60.0).floor() as u64;
+            return format!("{m}m {s}s");
+        }
+        let h = (secs / 3600.0).floor() as u64;
+        let m = ((secs % 3600.0) / 60.0).floor() as u64;
+        format!("{h}h {m}m")
     }
 }
 
@@ -952,23 +967,59 @@ mod tests {
     }
 
     #[test]
-    fn format_duration_under_minute() {
-        assert_eq!(TranscriptTail::format_duration(Duration::from_secs(45)), "45s");
-    }
-
-    #[test]
-    fn format_duration_minutes() {
+    fn format_duration_under_10s_keeps_one_decimal() {
+        // Mirrors C# `FormatDuration` "{seconds:0.0}s" branch.
         assert_eq!(
-            TranscriptTail::format_duration(Duration::from_secs(134)),
-            "2:14"
+            TranscriptTail::format_duration(Duration::from_millis(0)),
+            "0.0s"
+        );
+        assert_eq!(
+            TranscriptTail::format_duration(Duration::from_millis(3_100)),
+            "3.1s"
+        );
+        assert_eq!(
+            TranscriptTail::format_duration(Duration::from_millis(9_999)),
+            "10.0s"
         );
     }
 
     #[test]
-    fn format_duration_exactly_one_minute() {
+    fn format_duration_under_minute_uses_integer_seconds() {
+        assert_eq!(TranscriptTail::format_duration(Duration::from_secs(10)), "10s");
+        assert_eq!(TranscriptTail::format_duration(Duration::from_secs(45)), "45s");
+        assert_eq!(TranscriptTail::format_duration(Duration::from_secs(59)), "59s");
+    }
+
+    #[test]
+    fn format_duration_minutes_use_m_s_format() {
+        // C# emits `"{m}m {s}s"` — no leading zeros on seconds.
         assert_eq!(
             TranscriptTail::format_duration(Duration::from_secs(60)),
-            "1:00"
+            "1m 0s"
+        );
+        assert_eq!(
+            TranscriptTail::format_duration(Duration::from_secs(134)),
+            "2m 14s"
+        );
+        assert_eq!(
+            TranscriptTail::format_duration(Duration::from_secs(3_599)),
+            "59m 59s"
+        );
+    }
+
+    #[test]
+    fn format_duration_hours_use_h_m_format() {
+        assert_eq!(
+            TranscriptTail::format_duration(Duration::from_secs(3_600)),
+            "1h 0m"
+        );
+        assert_eq!(
+            TranscriptTail::format_duration(Duration::from_secs(3_900)),
+            "1h 5m"
+        );
+        assert_eq!(
+            TranscriptTail::format_duration(Duration::from_secs(7_265)),
+            "2h 1m"
         );
     }
 
@@ -989,6 +1040,14 @@ mod tests {
     fn model_display_name_empty_falls_back_to_claude() {
         assert_eq!(model_display_name(""), "claude");
         assert_eq!(model_display_name("   "), "claude");
+    }
+
+    #[test]
+    fn model_display_name_trims_trailing_dash_before_bracket() {
+        // A trailing `-` directly before the `[1m]` tag would otherwise
+        // produce `"opus-"` — guard against that for any future ids
+        // that hyphenate before the context-window suffix.
+        assert_eq!(model_display_name("claude-opus-[1m]"), "opus");
     }
 
     // --- format_tokens ---
@@ -1018,6 +1077,21 @@ mod tests {
         assert_eq!(format_tokens(1_000_000), "1.00M");
         assert_eq!(format_tokens(1_234_567), "1.23M");
         assert_eq!(format_tokens(12_345_678), "12.3M");
+    }
+
+    #[test]
+    fn format_tokens_at_thousands_boundary_stays_raw() {
+        // Rust port keeps small values raw — the `k` switchover is at
+        // 10k, *not* 1k like the C# build (documented deviation).
+        assert_eq!(format_tokens(1_000), "1000");
+        assert_eq!(format_tokens(5_500), "5500");
+    }
+
+    #[test]
+    fn format_tokens_extremely_large_uses_one_decimal_m() {
+        // Far above the largest known context window — must still
+        // produce a stable two-or-three-char-with-suffix string.
+        assert_eq!(format_tokens(999_999_999), "1000.0M");
     }
 
     // --- format_context_pct ---

--- a/codescope-rs/core/src/claude_telemetry.rs
+++ b/codescope-rs/core/src/claude_telemetry.rs
@@ -1089,8 +1089,10 @@ mod tests {
 
     #[test]
     fn format_tokens_extremely_large_uses_one_decimal_m() {
-        // Far above the largest known context window — must still
-        // produce a stable two-or-three-char-with-suffix string.
+        // Far above the largest known context window — the function
+        // must still produce a non-panicking, consistent `<value>M`
+        // string with a single fractional digit (no scientific
+        // notation, no trailing zero stripping). Length isn't bounded.
         assert_eq!(format_tokens(999_999_999), "1000.0M");
     }
 

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -2890,11 +2890,10 @@ impl AppShell {
         let sep = move || div().w_px().h(px(14.0)).bg(divider_clr);
 
         // ─── Left cluster ───────────────────────────────────────
-        // Only render the session dot + branch when we actually have
-        // a git context (worktree resolved → `GitStatus` cached).
-        // Plain shell tabs and tabs whose working directory has not
-        // yet surfaced fall through to the title-only branch below,
-        // matching the docstring's `StatusHasSession` rule.
+        // The session dot + branch/title renders whenever any tab is
+        // focused — matches C# `StatusHasSession = SelectedTab is not
+        // null`. The dot itself is coloured by telemetry state below;
+        // shell tabs without a snapshot fall through to `signal_ok`.
         let session_dot_color = match snapshot.as_ref().map(|s| s.state) {
             Some(codescope_core::SessionState::Busy)
             | Some(codescope_core::SessionState::PendingToolUse) => signal_warn,
@@ -2925,7 +2924,13 @@ impl AppShell {
                         .bg(session_dot_color),
                 )
                 .child(
+                    // `flex_grow` + `truncate` so a long tab title /
+                    // branch name doesn't shove the right cluster off
+                    // the bar — matches the WPF `TextTrimming` on the
+                    // C# `StatusBranch` TextBlock.
                     div()
+                        .flex_grow()
+                        .truncate()
                         .text_color(ink)
                         .font_weight(gpui::FontWeight::MEDIUM)
                         .child(branch_text),
@@ -3119,10 +3124,12 @@ impl AppShell {
             row
         });
 
-        // Empty-state tagline — `StatusEmptyVisible` in C#. Shown in
-        // the left cluster only when the user hasn't added any
-        // projects yet (no tabs to focus, no git context to surface).
-        let empty_state = (projects_empty && active_tab.is_none()).then(|| {
+        // Empty-state tagline — `StatusEmptyVisible` in C# is
+        // `Projects.Count == 0`, regardless of whether a tab is
+        // focused. The session cluster yields to it below so the
+        // status bar reads as the empty-state hint even if a stray
+        // shell tab is open.
+        let empty_state = projects_empty.then(|| {
             div()
                 .text_color(ink_dim)
                 .child("CodeScope — add a project to begin.")
@@ -3228,9 +3235,12 @@ impl AppShell {
         //   | [workspace summary] | [bell]
         let left_clusters: Vec<Vec<gpui::AnyElement>> = {
             let mut clusters: Vec<Vec<gpui::AnyElement>> = Vec::new();
-            if let Some(seg) = session_cluster {
+            // Empty-state wins over the session cluster — matches
+            // C#: with 0 projects the bar reads "add a project to
+            // begin." even if a shell tab happens to be open.
+            if let Some(seg) = empty_state {
                 clusters.push(vec![seg.into_any_element()]);
-            } else if let Some(seg) = empty_state {
+            } else if let Some(seg) = session_cluster {
                 clusters.push(vec![seg.into_any_element()]);
             }
             let mut git_cluster: Vec<gpui::AnyElement> = Vec::new();

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -2848,9 +2848,7 @@ impl AppShell {
         // ─── Inputs ──────────────────────────────────────────────
         let group_count = self.groups.len();
         let focused_group = self.focused_group();
-        let tab_count = focused_group.tabs.len();
-        let active_tab_idx = focused_group.active_tab;
-        let active_tab = focused_group.tabs.get(active_tab_idx);
+        let active_tab = focused_group.tabs.get(focused_group.active_tab);
 
         let active_working_dir: Option<String> = active_tab
             .and_then(|t| t.working_directory.as_ref())
@@ -2859,14 +2857,15 @@ impl AppShell {
             .and_then(|t| t.adopted_session_id.clone());
         let active_title: Option<SharedString> = active_tab.map(|t| t.title.clone());
 
-        let (git, worktree_total, worktree_dirty) = {
+        let (git, worktree_total, worktree_dirty, projects_empty) = {
             let sidebar = self.sidebar.read(cx);
             let g = active_working_dir
                 .as_deref()
                 .and_then(|p| sidebar.git_status_for(p))
                 .cloned();
             let (t, d) = sidebar.worktree_counts();
-            (g, t, d)
+            let empty = sidebar.projects().projects.is_empty();
+            (g, t, d, empty)
         };
 
         let snapshot = active_session_id
@@ -2901,8 +2900,18 @@ impl AppShell {
             | Some(codescope_core::SessionState::PendingToolUse) => signal_warn,
             _ => signal_ok,
         };
-        let session_cluster = git.as_ref().map(|g| {
-            let branch: SharedString = g.branch.clone().into();
+        // C# `StatusHasSession` = `SelectedTab is not null` — so the
+        // session cluster (dot + branch/title) renders whenever there's
+        // any focused tab, even when no git context has surfaced yet
+        // (shell tabs, unresolved working dir). Branch comes from the
+        // worktree's `DisplayBranch` when available; otherwise we fall
+        // back to the tab title, exactly like the C# `StatusBranch`.
+        let session_cluster = active_tab.map(|_| {
+            let branch_text: SharedString = match (git.as_ref(), active_title.clone()) {
+                (Some(g), _) => g.branch.clone().into(),
+                (None, Some(t)) => t,
+                (None, None) => SharedString::from(""),
+            };
             div()
                 .flex()
                 .flex_row()
@@ -2919,7 +2928,7 @@ impl AppShell {
                     div()
                         .text_color(ink)
                         .font_weight(gpui::FontWeight::MEDIUM)
-                        .child(branch),
+                        .child(branch_text),
                 )
         });
 
@@ -3081,31 +3090,43 @@ impl AppShell {
         } else {
             None
         };
-        let tab_label = if tab_count == 0 {
-            "no tabs".to_string()
-        } else {
-            format!("tab {}/{}", active_tab_idx + 1, tab_count)
-        };
+        // C# `StatusBarView` has no tab counter — the count is implied
+        // by the tab strip itself, so we no longer render a "tab N/M"
+        // segment here.
 
-        // Workspace summary — `N worktrees · M dirty`. The middle
-        // dot only appears when the dirty segment is visible.
-        let worktree_text = format!(
-            "{} {}",
-            worktree_total,
-            if worktree_total == 1 { "worktree" } else { "worktrees" }
-        );
-        let mut workspace_summary = div()
-            .flex()
-            .flex_row()
-            .items_center()
-            .gap(px(6.0))
-            .text_color(ink_dim)
-            .child(div().child(worktree_text));
-        if worktree_dirty > 0 {
-            workspace_summary = workspace_summary
-                .child(div().child("·"))
-                .child(div().child(format!("{} dirty", worktree_dirty)));
-        }
+        // Workspace summary — `N worktrees · M dirty`. Only rendered
+        // when at least one worktree is tracked; the middle dot only
+        // appears when the dirty segment is visible. Mirrors
+        // C# `StatusWorkspaceVisible` / `StatusDirtyVisible`.
+        let workspace_summary = (worktree_total > 0).then(|| {
+            let worktree_text = format!(
+                "{} {}",
+                worktree_total,
+                if worktree_total == 1 { "worktree" } else { "worktrees" }
+            );
+            let mut row = div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(6.0))
+                .text_color(ink_dim)
+                .child(div().child(worktree_text));
+            if worktree_dirty > 0 {
+                row = row
+                    .child(div().child("·"))
+                    .child(div().child(format!("{} dirty", worktree_dirty)));
+            }
+            row
+        });
+
+        // Empty-state tagline — `StatusEmptyVisible` in C#. Shown in
+        // the left cluster only when the user hasn't added any
+        // projects yet (no tabs to focus, no git context to surface).
+        let empty_state = (projects_empty && active_tab.is_none()).then(|| {
+            div()
+                .text_color(ink_dim)
+                .child("CodeScope — add a project to begin.")
+        });
 
         // ─── Bell button ─────────────────────────────────────────
         let has_unread = self.notifications.has_unread();
@@ -3193,69 +3214,85 @@ impl AppShell {
             .text_size(px(11.5))
             .text_color(ink_dim);
 
-        // Build the left cluster as a list of optional segments,
-        // then intersperse `sep()` so a missing segment never leaves
-        // a stray separator behind. Same pattern for the right
-        // cluster — both mirror the C# `StatusBarView` 1×14 rule
-        // placement: rules sit *between* visible items only.
-        let left_segments: Vec<gpui::AnyElement> = {
-            let mut v: Vec<gpui::AnyElement> = Vec::new();
+        // Segments are grouped into *clusters*; separators sit
+        // between non-empty clusters only, matching the C#
+        // `StatusBarView` layout where Rectangle separators appear at
+        // specific boundaries (session→git, model-cluster→agents,
+        // agents→groups, groups/workspace→bell) rather than between
+        // every neighbouring segment.
+        //
+        // Left clusters:
+        //   [session dot + branch] | [git diff, remote sync]
+        // Right clusters:
+        //   [model, tokens, turns, duration] | [agents] | [groups]
+        //   | [workspace summary] | [bell]
+        let left_clusters: Vec<Vec<gpui::AnyElement>> = {
+            let mut clusters: Vec<Vec<gpui::AnyElement>> = Vec::new();
             if let Some(seg) = session_cluster {
-                v.push(seg.into_any_element());
-            } else {
-                let title_text: SharedString = active_title
-                    .unwrap_or_else(|| SharedString::from("(empty group)"));
-                v.push(
-                    div()
-                        .truncate()
-                        .text_color(ink)
-                        .child(title_text)
-                        .into_any_element(),
-                );
+                clusters.push(vec![seg.into_any_element()]);
+            } else if let Some(seg) = empty_state {
+                clusters.push(vec![seg.into_any_element()]);
             }
+            let mut git_cluster: Vec<gpui::AnyElement> = Vec::new();
             if let Some(seg) = diff_segment {
-                v.push(seg.into_any_element());
+                git_cluster.push(seg.into_any_element());
             }
             if let Some(seg) = remote_segment {
-                v.push(seg.into_any_element());
+                git_cluster.push(seg.into_any_element());
             }
-            v
+            if !git_cluster.is_empty() {
+                clusters.push(git_cluster);
+            }
+            clusters
         };
-        let mut right_segments: Vec<gpui::AnyElement> = Vec::new();
-        if let Some(seg) = model_segment {
-            right_segments.push(seg.into_any_element());
-        }
-        if let Some(seg) = tokens_segment {
-            right_segments.push(seg.into_any_element());
-        }
-        if let Some(seg) = turns_segment {
-            right_segments.push(seg.into_any_element());
-        }
-        if let Some(seg) = duration_segment {
-            right_segments.push(seg.into_any_element());
-        }
-        if let Some(seg) = agent_segment {
-            right_segments.push(seg.into_any_element());
-        }
-        if let Some(gl) = group_label {
-            right_segments.push(div().child(gl).into_any_element());
-        }
-        right_segments.push(workspace_summary.into_any_element());
-        right_segments.push(div().child(tab_label).into_any_element());
-        right_segments.push(bell_btn.into_any_element());
 
-        for (i, seg) in left_segments.into_iter().enumerate() {
-            if i > 0 {
+        let right_clusters: Vec<Vec<gpui::AnyElement>> = {
+            let mut clusters: Vec<Vec<gpui::AnyElement>> = Vec::new();
+            let mut model_cluster: Vec<gpui::AnyElement> = Vec::new();
+            if let Some(seg) = model_segment {
+                model_cluster.push(seg.into_any_element());
+            }
+            if let Some(seg) = tokens_segment {
+                model_cluster.push(seg.into_any_element());
+            }
+            if let Some(seg) = turns_segment {
+                model_cluster.push(seg.into_any_element());
+            }
+            if let Some(seg) = duration_segment {
+                model_cluster.push(seg.into_any_element());
+            }
+            if !model_cluster.is_empty() {
+                clusters.push(model_cluster);
+            }
+            if let Some(seg) = agent_segment {
+                clusters.push(vec![seg.into_any_element()]);
+            }
+            if let Some(gl) = group_label {
+                clusters.push(vec![div().child(gl).into_any_element()]);
+            }
+            if let Some(seg) = workspace_summary {
+                clusters.push(vec![seg.into_any_element()]);
+            }
+            clusters.push(vec![bell_btn.into_any_element()]);
+            clusters
+        };
+
+        for (ci, cluster) in left_clusters.into_iter().enumerate() {
+            if ci > 0 {
                 bar = bar.child(sep());
             }
-            bar = bar.child(seg);
+            for seg in cluster {
+                bar = bar.child(seg);
+            }
         }
         bar = bar.child(div().flex_grow());
-        for (i, seg) in right_segments.into_iter().enumerate() {
-            if i > 0 {
+        for (ci, cluster) in right_clusters.into_iter().enumerate() {
+            if ci > 0 {
                 bar = bar.child(sep());
             }
-            bar = bar.child(seg);
+            for seg in cluster {
+                bar = bar.child(seg);
+            }
         }
         bar
     }


### PR DESCRIPTION
## Summary

Audit of the Rust `render_status_bar` against C# `StatusBarView.xaml` + `MainViewModel.StatusBar.cs` surfaced four real divergences. This PR closes them and adds edge-case coverage for the formatters that drive the bar.

### Gaps closed
- **`format_duration`** was emitting `"2:14"` for minute-scale durations. C# emits `"{m}m {s}s"`, integer seconds for `10s..60s`, and `"3.1s"` for sub-10s turns. Rewrote the Rust function to mirror the C# branches exactly. Existing tests updated; new tests cover all four branches.
- **Separator placement.** Status bar was inserting a 1×14 rule between every neighbouring segment. C# places separators only between *clusters*: session → git, model cluster → agents → groups → workspace → bell. Regrouped the segment build so separators only land at cluster boundaries.
- **Session cluster activation.** Previously only rendered when a `GitStatus` was cached. C# `StatusHasSession = SelectedTab is not null` — so it also shows for shell tabs and tabs whose working dir hasn't resolved yet, with the tab title as the branch fallback (matches C# `StatusBranch`).
- **Tab counter removed.** The right-cluster `"tab N/M"` segment had no equivalent in the C# bar.
- **Empty-state tagline added.** Left cluster now shows `"CodeScope — add a project to begin."` when no projects are tracked (mirrors `StatusEmptyVisible`).
- **Workspace summary** now gates on `worktree_total > 0`; was previously rendering `"0 worktrees"` forever on an empty workspace.

### Tests added
- `format_duration`: sub-10s decimal, integer-seconds branch, m/s rollover, h/m rollover.
- `model_display_name`: trailing-dash-before-bracket trim case.
- `format_tokens`: thousands-boundary (documented Rust deviation from C#) + very-large-input stability.

### Out of scope
- The pulsing halo animation on the session dot (C# uses a 1.4s storyboard). Static dot stays for now — gpui animation infra is a separate workstream.
- PR / CI-fail counts in the workspace summary. The C# build has a per-worktree `PullRequestStatusPoller`; the Rust port only fetches PR URLs on-demand from the context menu, so the data layer isn't in place to surface counts in the bar yet.

## Test plan
- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace` clean (336 + 45 + 19 + 1 = 401 tests pass).
- [x] No new clippy warnings introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)