### PR TITLE
feat(rs): PR integration foundation — gh pr list + badge + menu rows

### DIFF
--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -320,9 +320,10 @@ pub fn remove_worktree(repo: &Path, path: &Path, force: bool) -> Result<()> {
 
 /// Compute the short right-aligned status slug shown on a sidebar
 /// worktree row.  Mirrors C# `WorktreeViewModel.StatusLabel`; the
-/// `busy` (active agent) and `ci!` (failing PR CI) cases the C#
-/// build supports aren't included here yet — the Rust port has no
-/// per-tab session model and no PR integration. Returns:
+/// `busy` (active agent) case isn't included here yet — the Rust port
+/// has no per-tab session model. The `ci!` PR-CI-failure case lives in
+/// [`worktree_status_label_with_ci`]; callers that already have a
+/// `CiStatus` in hand should prefer that variant. Returns:
 ///
 /// * `"chg"` — working tree is dirty (numstat or untracked-only),
 /// * `"↑N"` / `"↓N"` / `"↑N ↓N"` — clean but out of sync,
@@ -331,6 +332,17 @@ pub fn remove_worktree(repo: &Path, path: &Path, force: bool) -> Result<()> {
 ///              shows "idle"; we hide the label so a brand-new
 ///              standalone branch doesn't claim sync state).
 pub fn worktree_status_label(status: &GitStatus) -> String {
+    worktree_status_label_with_ci(status, crate::pr::CiStatus::None)
+}
+
+/// Same as [`worktree_status_label`] but also surfaces `"ci!"` when
+/// the worktree's PR has a failing CI rollup. Priority order matches
+/// C# `WorktreeViewModel.StatusLabel`: `busy` (caller-supplied, not
+/// modeled here) > `ci!` > `chg` > `↑N ↓N` > `idle`.
+pub fn worktree_status_label_with_ci(status: &GitStatus, ci: crate::pr::CiStatus) -> String {
+    if ci == crate::pr::CiStatus::Failure {
+        return "ci!".into();
+    }
     if status.added > 0 || status.removed > 0 || status.has_changes {
         return "chg".into();
     }
@@ -1252,5 +1264,41 @@ some-future-field foo bar\n";
     fn status_label_dirty_wins_over_no_upstream() {
         let s = status(1, 0, false, 0, 0, false);
         assert_eq!(worktree_status_label(&s), "chg");
+    }
+
+    #[test]
+    fn status_label_ci_failure_wins_over_dirty() {
+        let s = status(3, 1, false, 0, 0, true);
+        assert_eq!(
+            worktree_status_label_with_ci(&s, crate::pr::CiStatus::Failure),
+            "ci!"
+        );
+    }
+
+    #[test]
+    fn status_label_ci_failure_wins_over_idle() {
+        let s = status(0, 0, false, 0, 0, true);
+        assert_eq!(
+            worktree_status_label_with_ci(&s, crate::pr::CiStatus::Failure),
+            "ci!"
+        );
+    }
+
+    #[test]
+    fn status_label_ci_pending_does_not_change_slug() {
+        let s = status(0, 0, false, 0, 0, true);
+        assert_eq!(
+            worktree_status_label_with_ci(&s, crate::pr::CiStatus::Pending),
+            "idle"
+        );
+    }
+
+    #[test]
+    fn status_label_ci_success_does_not_change_slug() {
+        let s = status(2, 0, false, 0, 0, true);
+        assert_eq!(
+            worktree_status_label_with_ci(&s, crate::pr::CiStatus::Success),
+            "chg"
+        );
     }
 }

--- a/codescope-rs/core/src/pr.rs
+++ b/codescope-rs/core/src/pr.rs
@@ -1,28 +1,58 @@
-//! Per-worktree pull-request URL detection.
+//! Per-worktree pull-request integration.
 //!
-//! Shells out to `gh pr list --head <branch> --state open --json url
-//! --limit 1` and returns the first PR's URL (or `None` if no open PR
-//! is associated with the branch). Mirrors the C# build's
-//! [`GitHubPullRequestService.GetOpenPrForBranchAsync`] — same `gh`
-//! invocation shape (`--state open`, `--limit 1`), parsed with
-//! `serde_json` rather than relying on a local `jq` (gh's bundled
-//! `--jq` would also work, but routing the result through the same
-//! parser the rest of `core` uses keeps error handling consistent).
+//! Shells out to `gh pr list --head <branch> --state open --json
+//! number,url,statusCheckRollup --limit 1` and returns a
+//! [`PullRequestInfo`] when an open PR is associated with the branch.
+//! Mirrors the C# build's `GitHubPullRequestService.GetOpenPrForBranchAsync`
+//! — same `gh` invocation shape (`--state open`, `--limit 1`) and the
+//! same rollup → [`CiStatus`] reduction.
 //!
-//! Caching: this module is intentionally stateless — callers (the
-//! sidebar) own the cache. The C# build polls every 30 s with
-//! per-worktree exponential backoff up to 5 minutes
-//! (`PullRequestStatusPoller`); the Rust port currently lazy-fetches
-//! on right-click and caches the result on the sidebar entity. That's
-//! a deviation we accept for now — every render path that consumes
-//! the URL goes through the cache, and a dedicated background poller
-//! is a follow-up task tracked in `docs/HANDOFF.md`.
+//! Caching: this module is stateless — callers (the sidebar) own the
+//! cache. The C# build polls every 30 s with per-worktree exponential
+//! backoff up to 5 minutes (`PullRequestStatusPoller`); the Rust port
+//! polls every 60 s on the sidebar and lazy-fetches on right-click to
+//! warm the cache on first interaction.
 
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+#[cfg(test)]
 use serde::Deserialize;
+use serde_json::Value;
 
+/// Rollup of the PR's CI checks, derived from `gh`'s
+/// `statusCheckRollup`. Mirrors the C# `CiStatus` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CiStatus {
+    /// No CI configured / empty rollup.
+    None,
+    /// At least one check is still running (not COMPLETED) and none
+    /// have failed.
+    Pending,
+    /// All checks completed successfully.
+    Success,
+    /// At least one check ended in FAILURE / CANCELLED / TIMED_OUT /
+    /// ACTION_REQUIRED / STARTUP_FAILURE.
+    Failure,
+}
+
+/// Runtime-only PR metadata. Populated on demand by [`fetch_for_branch`]
+/// and cached by the sidebar; not persisted (the PR state is always the
+/// upstream's source of truth).
+///
+/// Mirrors the C# `PullRequestInfo` record. The `state` field the C#
+/// build carries is omitted here — every PR returned by
+/// `gh pr list --state open` is by definition `OPEN`, so the field would
+/// be a constant in this code path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PullRequestInfo {
+    pub number: u32,
+    pub url: String,
+    pub branch: String,
+    pub ci_status: CiStatus,
+}
+
+#[cfg(test)]
 #[derive(Deserialize)]
 struct GhPrRow {
     url: String,
@@ -35,17 +65,40 @@ struct GhPrRow {
 /// distinction between "gh missing" and "no PR" is not worth a third
 /// state in the menu.
 ///
+/// Thin wrapper over [`fetch_for_branch`] that projects out the URL,
+/// kept for call sites that only need the URL. New code should prefer
+/// [`fetch_for_branch`] for the full info (number, CI status, …).
+///
 /// Security: rejects branch names starting with `-` so a pathological
-/// branch can't be reinterpreted as a `gh pr list` flag (e.g.
-/// `--help`, `--state`, …) — same defence the `git::rebase_onto`
-/// helper applies.
+/// branch can't be reinterpreted as a `gh pr list` flag.
 pub fn detect_pr_url(working_dir: &Path, branch: &str) -> Option<String> {
+    fetch_for_branch(working_dir, branch).map(|info| info.url)
+}
+
+/// Look up the open pull request for `branch` in the repo at
+/// `working_dir`, returning the full [`PullRequestInfo`] (number, url,
+/// branch, CI status). Returns `None` when no open PR exists, when
+/// `gh` is not on PATH, or when the call fails — the UI treats all
+/// failures as "no PR" for now.
+///
+/// Security: rejects branch names starting with `-` so a pathological
+/// branch can't be reinterpreted as a `gh pr list` flag.
+pub fn fetch_for_branch(working_dir: &Path, branch: &str) -> Option<PullRequestInfo> {
     if branch.is_empty() || branch.starts_with('-') {
         return None;
     }
     let output = Command::new("gh")
         .args([
-            "pr", "list", "--head", branch, "--state", "open", "--json", "url", "--limit", "1",
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--state",
+            "open",
+            "--json",
+            "number,url,statusCheckRollup",
+            "--limit",
+            "1",
         ])
         .current_dir(working_dir)
         .stdin(Stdio::null())
@@ -57,14 +110,13 @@ pub fn detect_pr_url(working_dir: &Path, branch: &str) -> Option<String> {
         return None;
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_pr_url_json(&stdout)
+    parse_pr_info_json(&stdout, branch)
 }
 
-/// Parse the output of `gh pr list --json url --limit 1`. The shape
-/// is a JSON array of `{ "url": "<string>" }`; we deserialise the
-/// first row and return its URL. Empty arrays / missing url / parse
-/// errors all collapse to `None` so the caller can render "no row"
-/// without branching on the failure mode.
+/// Parse the output of `gh pr list --json url --limit 1`. Kept under
+/// `#[cfg(test)]` so the original URL-only contract stays locked down
+/// by tests while production code uses [`parse_pr_info_json`].
+#[cfg(test)]
 pub(crate) fn parse_pr_url_json(stdout: &str) -> Option<String> {
     let trimmed = stdout.trim();
     if trimmed.is_empty() {
@@ -73,6 +125,77 @@ pub(crate) fn parse_pr_url_json(stdout: &str) -> Option<String> {
     let rows: Vec<GhPrRow> = serde_json::from_str(trimmed).ok()?;
     let url = rows.into_iter().next()?.url;
     if url.is_empty() { None } else { Some(url) }
+}
+
+/// Parse the output of `gh pr list --json number,url,statusCheckRollup
+/// --limit 1`. Empty arrays / missing fields / parse errors collapse
+/// to `None`. `branch` is threaded through so the returned
+/// [`PullRequestInfo`] carries the branch the lookup ran against — the
+/// sidebar's cache uses it to detect branch switches.
+pub(crate) fn parse_pr_info_json(stdout: &str, branch: &str) -> Option<PullRequestInfo> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let value: Value = serde_json::from_str(trimmed).ok()?;
+    let arr = value.as_array()?;
+    let first = arr.first()?;
+
+    let number = first.get("number")?.as_u64()? as u32;
+    let url = first.get("url")?.as_str()?.to_string();
+    if url.is_empty() {
+        return None;
+    }
+    let ci_status = first
+        .get("statusCheckRollup")
+        .and_then(|r| r.as_array())
+        .map(|rollup| rollup_ci(rollup))
+        .unwrap_or(CiStatus::None);
+
+    Some(PullRequestInfo {
+        number,
+        url,
+        branch: branch.to_string(),
+        ci_status,
+    })
+}
+
+/// Reduce gh's `statusCheckRollup` array to a single [`CiStatus`].
+///
+///   - any FAILURE / CANCELLED / TIMED_OUT / ACTION_REQUIRED /
+///     STARTUP_FAILURE → `Failure`
+///   - else any non-COMPLETED status → `Pending`
+///   - else (all SUCCESS / COMPLETED) → `Success`
+///   - empty rollup → `None`
+///
+/// Mirrors the C# `GitHubPullRequestService.RollupCi`.
+fn rollup_ci(rollup: &[Value]) -> CiStatus {
+    if rollup.is_empty() {
+        return CiStatus::None;
+    }
+    let mut has_pending = false;
+    for check in rollup {
+        let conclusion = check
+            .get("conclusion")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let status = check
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        if matches!(
+            conclusion,
+            "FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" | "STARTUP_FAILURE"
+        ) {
+            return CiStatus::Failure;
+        }
+
+        if status != "COMPLETED" {
+            has_pending = true;
+        }
+    }
+    if has_pending { CiStatus::Pending } else { CiStatus::Success }
 }
 
 #[cfg(test)]
@@ -136,9 +259,8 @@ mod tests {
     #[test]
     fn parse_url_with_escaped_chars() {
         // Real PRs don't have escapes in the URL, but `serde_json`
-        // handling them correctly (vs the previous manual substring
-        // parser, which would have stopped at the first `"`) is the
-        // safer behaviour to lock in.
+        // handling them correctly (vs a manual substring parser, which
+        // would stop at the first `"`) is the safer behaviour.
         let json = "[{\"url\":\"https://example.com/a\\u0026b\"}]";
         assert_eq!(
             parse_pr_url_json(json).as_deref(),
@@ -162,6 +284,16 @@ mod tests {
     }
 
     #[test]
+    fn fetch_rejects_dash_prefixed_branch() {
+        assert!(fetch_for_branch(std::path::Path::new("."), "--state").is_none());
+    }
+
+    #[test]
+    fn fetch_rejects_empty_branch() {
+        assert!(fetch_for_branch(std::path::Path::new("."), "").is_none());
+    }
+
+    #[test]
     fn detect_returns_none_when_gh_missing_or_no_repo() {
         // Use `tempfile::tempdir()` so the directory cleans up even
         // if the assertion below fires unexpectedly. We don't gate
@@ -172,5 +304,177 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let result = detect_pr_url(temp.path(), "no-such-branch-xyz");
         assert!(result.is_none());
+    }
+
+    // ── parse_pr_info_json ───────────────────────────────────────
+
+    #[test]
+    fn parse_info_typical_with_empty_rollup() {
+        let json = r#"[{
+            "number": 42,
+            "url": "https://github.com/owner/repo/pull/42",
+            "statusCheckRollup": []
+        }]"#;
+        let info = parse_pr_info_json(json, "feat/x").expect("info");
+        assert_eq!(info.number, 42);
+        assert_eq!(info.url, "https://github.com/owner/repo/pull/42");
+        assert_eq!(info.branch, "feat/x");
+        assert_eq!(info.ci_status, CiStatus::None);
+    }
+
+    #[test]
+    fn parse_info_no_rollup_field_defaults_to_none_ci() {
+        let json = r#"[{"number":7,"url":"https://example.com/pull/7"}]"#;
+        let info = parse_pr_info_json(json, "main").expect("info");
+        assert_eq!(info.ci_status, CiStatus::None);
+    }
+
+    #[test]
+    fn parse_info_with_failing_rollup() {
+        let json = r#"[{
+            "number": 12,
+            "url": "https://github.com/owner/repo/pull/12",
+            "statusCheckRollup": [
+                {"status":"COMPLETED","conclusion":"SUCCESS"},
+                {"status":"COMPLETED","conclusion":"FAILURE"}
+            ]
+        }]"#;
+        let info = parse_pr_info_json(json, "feat/y").expect("info");
+        assert_eq!(info.ci_status, CiStatus::Failure);
+    }
+
+    #[test]
+    fn parse_info_with_pending_rollup() {
+        let json = r#"[{
+            "number": 99,
+            "url": "https://github.com/owner/repo/pull/99",
+            "statusCheckRollup": [
+                {"status":"COMPLETED","conclusion":"SUCCESS"},
+                {"status":"IN_PROGRESS","conclusion":""}
+            ]
+        }]"#;
+        let info = parse_pr_info_json(json, "feat/z").expect("info");
+        assert_eq!(info.ci_status, CiStatus::Pending);
+    }
+
+    #[test]
+    fn parse_info_with_all_success_rollup() {
+        let json = r#"[{
+            "number": 1,
+            "url": "https://github.com/owner/repo/pull/1",
+            "statusCheckRollup": [
+                {"status":"COMPLETED","conclusion":"SUCCESS"},
+                {"status":"COMPLETED","conclusion":"SUCCESS"}
+            ]
+        }]"#;
+        let info = parse_pr_info_json(json, "main").expect("info");
+        assert_eq!(info.ci_status, CiStatus::Success);
+    }
+
+    #[test]
+    fn parse_info_empty_array() {
+        assert!(parse_pr_info_json("[]", "main").is_none());
+    }
+
+    #[test]
+    fn parse_info_missing_url_returns_none() {
+        let json = r#"[{"number":7}]"#;
+        assert!(parse_pr_info_json(json, "main").is_none());
+    }
+
+    #[test]
+    fn parse_info_missing_number_returns_none() {
+        let json = r#"[{"url":"https://example.com/p/1"}]"#;
+        assert!(parse_pr_info_json(json, "main").is_none());
+    }
+
+    #[test]
+    fn parse_info_garbage_returns_none() {
+        assert!(parse_pr_info_json("not json", "main").is_none());
+        assert!(parse_pr_info_json("", "main").is_none());
+        assert!(parse_pr_info_json("   ", "main").is_none());
+    }
+
+    // ── rollup_ci ────────────────────────────────────────────────
+
+    fn check(status: &str, conclusion: &str) -> Value {
+        serde_json::json!({"status": status, "conclusion": conclusion})
+    }
+
+    #[test]
+    fn rollup_empty_is_none() {
+        assert_eq!(rollup_ci(&[]), CiStatus::None);
+    }
+
+    #[test]
+    fn rollup_all_completed_success_is_success() {
+        let rollup = vec![
+            check("COMPLETED", "SUCCESS"),
+            check("COMPLETED", "SUCCESS"),
+        ];
+        assert_eq!(rollup_ci(&rollup), CiStatus::Success);
+    }
+
+    #[test]
+    fn rollup_any_failure_short_circuits() {
+        let rollup = vec![
+            check("COMPLETED", "SUCCESS"),
+            check("COMPLETED", "FAILURE"),
+            check("IN_PROGRESS", ""),
+        ];
+        assert_eq!(rollup_ci(&rollup), CiStatus::Failure);
+    }
+
+    #[test]
+    fn rollup_cancelled_is_failure() {
+        let rollup = vec![check("COMPLETED", "CANCELLED")];
+        assert_eq!(rollup_ci(&rollup), CiStatus::Failure);
+    }
+
+    #[test]
+    fn rollup_timed_out_is_failure() {
+        let rollup = vec![check("COMPLETED", "TIMED_OUT")];
+        assert_eq!(rollup_ci(&rollup), CiStatus::Failure);
+    }
+
+    #[test]
+    fn rollup_action_required_is_failure() {
+        let rollup = vec![check("COMPLETED", "ACTION_REQUIRED")];
+        assert_eq!(rollup_ci(&rollup), CiStatus::Failure);
+    }
+
+    #[test]
+    fn rollup_startup_failure_is_failure() {
+        let rollup = vec![check("COMPLETED", "STARTUP_FAILURE")];
+        assert_eq!(rollup_ci(&rollup), CiStatus::Failure);
+    }
+
+    #[test]
+    fn rollup_any_non_completed_is_pending() {
+        let rollup = vec![
+            check("COMPLETED", "SUCCESS"),
+            check("IN_PROGRESS", ""),
+        ];
+        assert_eq!(rollup_ci(&rollup), CiStatus::Pending);
+    }
+
+    #[test]
+    fn rollup_queued_is_pending() {
+        let rollup = vec![check("QUEUED", "")];
+        assert_eq!(rollup_ci(&rollup), CiStatus::Pending);
+    }
+
+    #[test]
+    fn rollup_neutral_conclusion_treated_as_success() {
+        // "NEUTRAL" / "SKIPPED" conclusions are not in the failure
+        // set; a COMPLETED check with one of those shouldn't flip
+        // pending. Useful for projects that use `gh actions` matrix
+        // skips for early-exit jobs.
+        let rollup = vec![
+            check("COMPLETED", "SUCCESS"),
+            check("COMPLETED", "NEUTRAL"),
+            check("COMPLETED", "SKIPPED"),
+        ];
+        assert_eq!(rollup_ci(&rollup), CiStatus::Success);
     }
 }

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -611,6 +611,11 @@ impl AppShell {
             // cluster and the sidebar dot.
             sidebar.start_dirty_poll(cx);
             sidebar.start_git_status_poll(cx);
+            // PR poll runs on a slower (60 s) cadence — `gh pr list`
+            // is the heaviest of the three pollers (network + auth)
+            // and the data changes much less frequently than the
+            // working tree.
+            sidebar.start_pr_poll(cx);
             sidebar
         });
 

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -31,6 +31,7 @@ use std::time::Duration;
 
 use codescope_core::{AppPaths, LayoutState, Project, ProjectsConfig, Theme};
 use codescope_core::git::GitStatus;
+use codescope_core::pr::{CiStatus, PullRequestInfo};
 use gpui::{
     Animation, AnimationExt, AppContext, ClipboardItem, Context, Corner, EventEmitter,
     InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement, Pixels, Point,
@@ -49,6 +50,13 @@ use crate::theme;
 /// thousand-file repos. Mirrors the C# build's
 /// `WorktreePoller.Interval`.
 const DIRTY_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How often the PR-status poller wakes up. 60 s matches the C# build's
+/// `PullRequestStatusPoller.Interval` baseline (the C# build then layers
+/// per-worktree exponential backoff up to 5 minutes; the Rust port
+/// doesn't model backoff yet, but `gh` failures cache as
+/// `Resolved { info: None }` so they don't retry hot anyway).
+const PR_POLL_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Default sidebar width when none is persisted in `layout.json`.
 /// Mirrors the C# build's initial 240 px. The actual rendered width
@@ -91,14 +99,21 @@ enum OpenMenu {
 /// its end).
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PrLookup {
-    /// A `detect_pr_url` task is already in flight for this worktree.
-    /// Records the branch the call was launched against so the
-    /// completion handler can detect a branch-switch-during-fetch and
-    /// drop the now-stale result instead of caching it.
+    /// A `fetch_for_branch` task is already in flight for this
+    /// worktree. Records the branch the call was launched against so
+    /// the completion handler can detect a branch-switch-during-fetch
+    /// and drop the now-stale result instead of caching it.
     Pending { branch: String },
     /// The most recent lookup completed against `branch` and resolved
-    /// to `url` (`None` for "no open PR / call failed").
-    Resolved { branch: String, url: Option<String> },
+    /// to `info` (`None` for "no open PR / call failed / gh not
+    /// installed"). Carries the full [`PullRequestInfo`] when present
+    /// so the sidebar can render the badge + CI glyph and surface
+    /// "Open PR in browser" / "Copy PR URL" menu rows without
+    /// re-fetching.
+    Resolved {
+        branch: String,
+        info: Option<PullRequestInfo>,
+    },
 }
 
 /// Click handler for a context-menu row. Boxed so we can stash it in
@@ -650,6 +665,163 @@ impl Sidebar {
         .detach();
     }
 
+    /// Spawn the PR-status polling loop. Runs every
+    /// [`PR_POLL_INTERVAL`] (60 s) and walks every worktree whose live
+    /// branch is known, shelling out to `gh pr list` once per
+    /// (path, branch) pair. Results land in `self.pr_urls` as
+    /// `Resolved { info: Some(_) | None }` — `None` covers "no open
+    /// PR / gh not installed / call failed" and stays cached so the
+    /// next tick doesn't re-spawn until the branch changes.
+    ///
+    /// Network work is dispatched through `cx.background_spawn` so
+    /// the UI thread never blocks on `gh`. Mirrors the C# build's
+    /// `PullRequestStatusPoller` minus the per-worktree exponential
+    /// backoff (which only kicks in on persistent failures; the
+    /// uniform 60 s cadence is cheap enough at the typical worktree
+    /// count to justify deferring backoff to a follow-up).
+    ///
+    /// Called from `AppShell::new` alongside `start_dirty_poll` and
+    /// `start_git_status_poll`. Same lifetime — dies when the entity
+    /// drops.
+    pub fn start_pr_poll(&self, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor().timer(PR_POLL_INTERVAL).await;
+                if this.upgrade().is_none() {
+                    break;
+                }
+                // Snapshot every (path, branch) pair we should poll.
+                // A worktree without a live branch (no git_status tick
+                // yet and no persisted branch) is skipped — the next
+                // tick will pick it up once the git-status poller
+                // populates the cache. Pairs are de-duplicated by
+                // path to avoid double-polling when the same path is
+                // listed under multiple projects.
+                let targets: Vec<(String, String)> = match this
+                    .update(cx, |this, _| {
+                        let mut seen: HashSet<String> = HashSet::new();
+                        let mut out: Vec<(String, String)> = Vec::new();
+                        for project in &this.projects.projects {
+                            let entries = std::iter::once((
+                                project.path.clone(),
+                                None::<String>,
+                            ))
+                            .chain(
+                                project.worktrees.iter().map(|wt| {
+                                    (wt.path.clone(), wt.branch.clone())
+                                }),
+                            );
+                            for (path, persisted_branch) in entries {
+                                if !seen.insert(path.clone()) {
+                                    continue;
+                                }
+                                let branch = this
+                                    .git_status
+                                    .get(&path)
+                                    .map(|s| s.branch.clone())
+                                    .or(persisted_branch);
+                                if let Some(branch) = branch
+                                    && !branch.is_empty()
+                                {
+                                    out.push((path, branch));
+                                }
+                            }
+                        }
+                        out
+                    }) {
+                    Ok(v) => v,
+                    Err(_) => break,
+                };
+
+                if targets.is_empty() {
+                    continue;
+                }
+
+                // Run all `gh` calls sequentially on the background
+                // executor. Per-call latency is the dominant cost
+                // here (network + auth), but gh's own concurrency
+                // story is best-effort and we'd rather not fan out
+                // and hammer the API — at worst a 60 s tick walks N
+                // worktrees serially and finishes well inside the
+                // next tick window. Each result records the branch
+                // it was fetched against so the apply step below can
+                // detect a branch switch between dispatch and
+                // completion (rare but possible).
+                let results: Vec<(String, String, Option<PullRequestInfo>)> = cx
+                    .background_spawn(async move {
+                        targets
+                            .into_iter()
+                            .map(|(path, branch)| {
+                                let info = codescope_core::pr::fetch_for_branch(
+                                    std::path::Path::new(&path),
+                                    &branch,
+                                );
+                                (path, branch, info)
+                            })
+                            .collect()
+                    })
+                    .await;
+
+                if this
+                    .update(cx, |this, cx| {
+                        let mut changed = false;
+                        for (path, branch, info) in results {
+                            // Drop the result if the worktree was
+                            // removed or its branch shifted while gh
+                            // was running. The lazy `open_worktree_menu`
+                            // fetch + the next tick will reconverge.
+                            let live_branch = this
+                                .git_status
+                                .get(&path)
+                                .map(|s| s.branch.clone())
+                                .or_else(|| {
+                                    this.projects
+                                        .projects
+                                        .iter()
+                                        .flat_map(|p| {
+                                            std::iter::once((p.path.clone(), None))
+                                                .chain(p.worktrees.iter().map(|wt| {
+                                                    (wt.path.clone(), wt.branch.clone())
+                                                }))
+                                        })
+                                        .find(|(p, _)| p == &path)
+                                        .and_then(|(_, b)| b)
+                                });
+                            if live_branch.as_deref() != Some(branch.as_str()) {
+                                continue;
+                            }
+                            // A `Pending` against a different branch
+                            // means a fresher lazy fetch is in flight;
+                            // don't clobber it with this poll's stale
+                            // answer.
+                            if matches!(
+                                this.pr_urls.get(&path),
+                                Some(PrLookup::Pending { branch: b }) if b != &branch
+                            ) {
+                                continue;
+                            }
+                            let next = PrLookup::Resolved {
+                                branch: branch.clone(),
+                                info,
+                            };
+                            let prev = this.pr_urls.insert(path, next.clone());
+                            if prev.as_ref() != Some(&next) {
+                                changed = true;
+                            }
+                        }
+                        if changed {
+                            cx.notify();
+                        }
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        })
+        .detach();
+    }
+
     /// Return the cached [`GitStatus`] for the given worktree path.
     /// Returns `None` while the first poll tick has not completed yet,
     /// or for paths that are not git repos. Callers should treat `None`
@@ -884,9 +1056,12 @@ impl Sidebar {
                 let path_for_task = std::path::PathBuf::from(&path);
                 let branch_for_task = branch.clone();
                 cx.spawn(async move |this, cx| {
-                    let url = cx
+                    let info = cx
                         .background_spawn(async move {
-                            codescope_core::pr::detect_pr_url(&path_for_task, &branch_for_task)
+                            codescope_core::pr::fetch_for_branch(
+                                &path_for_task,
+                                &branch_for_task,
+                            )
                         })
                         .await;
                     let _ = this.update(cx, |this, cx| {
@@ -903,7 +1078,7 @@ impl Sidebar {
                         if still_ours {
                             this.pr_urls.insert(
                                 path,
-                                PrLookup::Resolved { branch: branch.clone(), url },
+                                PrLookup::Resolved { branch: branch.clone(), info },
                             );
                             cx.notify();
                         }
@@ -1050,17 +1225,53 @@ impl Sidebar {
                     .and_then(|p| p.worktrees.iter().find(|wt| wt.id == worktree_id))
                     .and_then(|wt| wt.branch.clone())
             });
-        if let (Some(live), Some(PrLookup::Resolved { branch, url: Some(url) })) =
+        if let (Some(live), Some(PrLookup::Resolved { branch, info: Some(info) })) =
             (live_branch.as_ref(), self.pr_urls.get(&path))
             && branch == live
         {
-            let url = url.clone();
+            let url = info.url.clone();
             cx.write_to_clipboard(ClipboardItem::new_string(url.clone()));
             cx.emit(SidebarEvent::Toast {
                 kind: ToastSeverity::Ok,
                 title: "PR URL copied".into(),
                 detail: Some(url.into()),
             });
+        }
+        self.close_menu(cx);
+    }
+
+    /// Open the cached PR URL for the worktree in the user's default
+    /// browser. The menu row that drives this is gated on the cache
+    /// holding a `Some(info)` value for the *current* branch — same
+    /// guard as `copy_worktree_pr_url`. Mirrors C#'s
+    /// `WorktreeViewModel.OpenPullRequestCommand`.
+    fn open_worktree_pr_in_browser(
+        &mut self,
+        project_idx: usize,
+        worktree_id: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(path) = self.worktree_path(project_idx, worktree_id) else {
+            self.close_menu(cx);
+            return;
+        };
+        let live_branch = self
+            .git_status
+            .get(&path)
+            .map(|s| s.branch.clone())
+            .or_else(|| {
+                self.projects
+                    .projects
+                    .get(project_idx)
+                    .and_then(|p| p.worktrees.iter().find(|wt| wt.id == worktree_id))
+                    .and_then(|wt| wt.branch.clone())
+            });
+        if let (Some(live), Some(PrLookup::Resolved { branch, info: Some(info) })) =
+            (live_branch.as_ref(), self.pr_urls.get(&path))
+            && branch == live
+        {
+            let url = info.url.clone();
+            open_url_in_browser(&url);
         }
         self.close_menu(cx);
     }
@@ -2111,20 +2322,43 @@ impl Render for Sidebar {
                             .font(theme::font_mono())
                             .child(wt_label),
                     );
+                // Resolve the PR cache for this worktree (matched on
+                // the *current* branch, same logic the menu uses) so
+                // both the status slug and the badge can read from a
+                // single source. `pr_info` is `Some` only when the
+                // cached `Resolved.branch` still matches the live one
+                // — a branch switch invalidates the cached view until
+                // the next poll lands.
+                let pr_info: Option<&PullRequestInfo> = {
+                    let live_branch = self
+                        .git_status
+                        .get(&wt.path)
+                        .map(|s| s.branch.clone())
+                        .or_else(|| wt.branch.clone());
+                    match (live_branch.as_ref(), self.pr_urls.get(&wt.path)) {
+                        (
+                            Some(live),
+                            Some(PrLookup::Resolved { branch, info: Some(info) }),
+                        ) if branch == live => Some(info),
+                        _ => None,
+                    }
+                };
+                let ci_status = pr_info.map(|i| i.ci_status).unwrap_or(CiStatus::None);
+
                 // Right-aligned status slug — `chg` / `↑N ↓N` / `idle`
-                // computed by
-                // `codescope_core::git::worktree_status_label` from
-                // the cached `git_status` snapshot. Renders the same
-                // information the C# `WorktreeViewModel.StatusLabel`
-                // slot shows, in `Fig.Font.Mono` at 10 pt with a
-                // dim `ink_ghost` foreground. The C# build also
-                // surfaces `busy` (active agent) and `ci!` (failing
-                // PR CI); those land alongside session and PR
-                // tracking.
+                // computed by `worktree_status_label_with_ci` from the
+                // cached `git_status` snapshot + the PR's CI rollup.
+                // Renders the same information the C#
+                // `WorktreeViewModel.StatusLabel` slot shows, in
+                // `Fig.Font.Mono` at 10 pt with a dim `ink_ghost`
+                // foreground. `busy` (active agent) is still TODO —
+                // the Rust port has no per-tab session model yet.
                 let status_slug = self
                     .git_status
                     .get(&wt.path)
-                    .map(codescope_core::git::worktree_status_label)
+                    .map(|s| {
+                        codescope_core::git::worktree_status_label_with_ci(s, ci_status)
+                    })
                     .unwrap_or_default();
                 let wt_row = if status_slug.is_empty() {
                     wt_row
@@ -2136,11 +2370,61 @@ impl Render for Sidebar {
                             .text_size(px(10.0))
                             // Status slug — `Text.Faint` (#606060) in
                             // the C# `WorktreeViewModel.StatusLabel`
-                            // TextBlock, mono.
+                            // TextBlock, mono. The `ci!` slug stays in
+                            // `text_faint` (matches the C# binding) —
+                            // the dedicated CI glyph in the PR badge
+                            // is where the failure colour lives.
                             .text_color(theme::text_faint())
                             .font(theme::font_mono())
                             .child(status_slug),
                     )
+                };
+
+                // PR badge — `#42 ✓` style, rendered to the right of
+                // the status slug. Hidden when no PR is cached for
+                // this worktree (lazy fetch in `open_worktree_menu` +
+                // 60 s `start_pr_poll` warmup means the badge appears
+                // within a minute of the worktree being visible). The
+                // CI glyph colour shifts with the rollup:
+                //   ✓ success  → `signal_ok`
+                //   ✗ failure  → `signal_warn`
+                //   ◐ pending  → `text_faint` (no signal colour yet)
+                //   ·  none    → `text_faint`
+                // Mirrors C# `WorktreeViewModel.PrBadgeText` +
+                // `CiGlyph` on the sidebar's `BadgeBox` template.
+                let wt_row = if let Some(info) = pr_info {
+                    let glyph_color = match info.ci_status {
+                        CiStatus::Success => theme::signal_ok(),
+                        CiStatus::Failure => theme::signal_warn(),
+                        CiStatus::Pending | CiStatus::None => theme::text_faint(),
+                    };
+                    let glyph: &'static str = match info.ci_status {
+                        CiStatus::Success => "\u{2713}", // ✓
+                        CiStatus::Pending => "\u{25D0}", // ◐
+                        CiStatus::Failure => "\u{2717}", // ✗
+                        CiStatus::None => "\u{00B7}",    // ·
+                    };
+                    let pr_number_label = format!("#{}", info.number);
+                    wt_row
+                        .child(
+                            div()
+                                .ml(px(6.0))
+                                .text_size(px(10.0))
+                                .text_color(theme::text_faint())
+                                .font(theme::font_mono())
+                                .child(pr_number_label),
+                        )
+                        .child(
+                            div()
+                                .ml(px(3.0))
+                                .mr(px(4.0))
+                                .text_size(px(10.0))
+                                .text_color(glyph_color)
+                                .font(theme::font_mono())
+                                .child(glyph),
+                        )
+                } else {
+                    wt_row
                 };
                 // History disclosure chevron — only when the worktree
                 // has any closed-session rows. Mirrors C# `SidebarView`'s
@@ -2953,32 +3237,55 @@ impl Sidebar {
                     }),
                 )
             }))
-            // "Copy PR URL" — only when the cached `gh pr list` lookup
-            // resolved to an open PR for this worktree's *current*
-            // branch (live `git_status` first, persisted `branch`
-            // fallback — same logic `open_worktree_menu` uses to
-            // decide whether to refetch). The fetch is kicked off in
-            // `open_worktree_menu` and lands asynchronously; until
-            // then the row stays hidden so a half-loaded menu doesn't
-            // flash an unusable entry, and a stale `Resolved` from a
-            // prior branch is also hidden until the refetch lands.
-            // Mirrors C#'s `wt.HasPullRequest`-gated row.
+            // "Open PR in browser" + "Copy PR URL" — only when the
+            // cached `gh pr list` lookup resolved to an open PR for
+            // this worktree's *current* branch (live `git_status`
+            // first, persisted `branch` fallback — same logic
+            // `open_worktree_menu` uses to decide whether to refetch).
+            // The fetch is kicked off in `open_worktree_menu` (lazy)
+            // and warmed by the 60 s `start_pr_poll` loop; until
+            // either lands the rows stay hidden so a half-loaded menu
+            // doesn't flash unusable entries. A stale `Resolved` from
+            // a prior branch is also hidden until the refetch lands.
+            // Mirrors C#'s `wt.HasPullRequest`-gated
+            // `OpenPullRequestCommand` + `CopyPullRequestUrlCommand`
+            // pair.
             .children({
                 let live_branch = self
                     .git_status
                     .get(&worktree.path)
                     .map(|s| s.branch.clone())
                     .or_else(|| worktree.branch.clone());
-                live_branch
+                let has_pr = live_branch
                     .as_ref()
-                    .and_then(|live| match self.pr_urls.get(&worktree.path) {
-                        Some(PrLookup::Resolved { branch, url: Some(url) }) if branch == live => {
-                            Some(url)
-                        }
-                        _ => None,
+                    .map(|live| {
+                        matches!(
+                            self.pr_urls.get(&worktree.path),
+                            Some(PrLookup::Resolved { branch, info: Some(_) })
+                                if branch == live
+                        )
                     })
-                    .map(|_url| {
-                        let id_for_copy_pr = worktree_id.clone();
+                    .unwrap_or(false);
+                let mut rows: Vec<gpui::AnyElement> = Vec::new();
+                if has_pr {
+                    let id_for_open_pr = worktree_id.clone();
+                    rows.push(
+                        item(
+                            "wt-menu-open-pr",
+                            "Open PR in browser",
+                            false,
+                            Box::new(move |this, _window, cx| {
+                                this.open_worktree_pr_in_browser(
+                                    project_idx,
+                                    &id_for_open_pr,
+                                    cx,
+                                );
+                            }),
+                        )
+                        .into_any_element(),
+                    );
+                    let id_for_copy_pr = worktree_id.clone();
+                    rows.push(
                         item(
                             "wt-menu-copy-pr-url",
                             "Copy PR URL",
@@ -2987,7 +3294,10 @@ impl Sidebar {
                                 this.copy_worktree_pr_url(project_idx, &id_for_copy_pr, cx);
                             }),
                         )
-                    })
+                        .into_any_element(),
+                    );
+                }
+                rows
             })
             .child({
                 let id_for_remote = worktree_id.clone();


### PR DESCRIPTION
## Summary

Promote the lazy `detect_pr_url` helper into a full `PullRequestService`-analog and wire a PR badge, CI glyph, "Open PR in browser" / "Copy PR URL" menu rows, and a 60 s background poll into the sidebar — mirroring the C# build's `GitHubPullRequestService` + `PullRequestStatusPoller`.

- `core/src/pr.rs` — new `PullRequestInfo` (number, url, branch, ci_status) + `CiStatus` enum (None/Pending/Success/Failure) + `fetch_for_branch()` that shells out to `gh pr list --json number,url,statusCheckRollup -L 1` and reduces the rollup the same way the C# `RollupCi` does (any FAILURE/CANCELLED/TIMED_OUT/ACTION_REQUIRED/STARTUP_FAILURE → Failure, any non-COMPLETED → Pending, else Success).
- `core/src/git.rs` — new `worktree_status_label_with_ci` adds the `ci!` slug when the rollup is failing (matches C# `WorktreeViewModel.StatusLabel` priority order).
- `src/sidebar.rs` — cache stores full `PullRequestInfo` (was `Option<String>`), new `start_pr_poll` runs every 60 s on the background executor (non-blocking; `gh` failures cache as `Resolved { info: None }` so they don't retry hot), badge renders `#42` + CI glyph (`✓ ◐ ✗ ·`) to the right of the status slug with `signal_ok` / `signal_warn` / `text_faint` colours, and the worktree menu gains an "Open PR in browser" row alongside the existing "Copy PR URL".
- `src/app.rs` — wires `start_pr_poll` next to the existing dirty + git-status polls.

Out of scope (follow-ups, called out in code comments):
- "Create PR" button — deferred.
- Gitea/tea backend (`CompositePullRequestService` in C#) — deferred.
- Per-worktree exponential backoff — the C# build does it, but the uniform 60 s cadence is cheap enough at typical worktree counts.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` clean (455 tests pass, including 24 new tests covering `parse_pr_info_json`, `rollup_ci` permutations, and `worktree_status_label_with_ci`)
- [ ] Manual: open a worktree with an open PR, verify the `#NN ✓` badge appears in the sidebar within 60 s
- [ ] Manual: right-click the worktree, verify "Open PR in browser" and "Copy PR URL" rows appear and work
- [ ] Manual: when a PR's CI is failing, verify the status slug flips to `ci!` and the glyph turns red