### PR TITLE
fix(rs): address Copilot review on PR #145 (sidebar parity bundle)

### DIFF
--- a/codescope-rs/core/src/agent.rs
+++ b/codescope-rs/core/src/agent.rs
@@ -49,6 +49,15 @@ impl AgentId {
     /// Parse a stable string id back into the enum (case-insensitive).
     /// Mirrors `string.Equals(agentId, "...", OrdinalIgnoreCase)` in
     /// the C# dispatch.
+    ///
+    /// A handful of *executable-name aliases* are accepted alongside
+    /// the canonical ids so first-token parsing of an `auto_type`
+    /// command (`agent_id_from_auto_type`) still classifies sessions
+    /// correctly when the registry's `command` differs from the id —
+    /// Windows ships OpenCode as `opencode-cli.exe`, for instance,
+    /// because `opencode` clashes with a reserved name. The alias list
+    /// is intentionally small and explicit; unknown binaries still
+    /// resolve to `None`.
     pub fn from_str(s: &str) -> Option<Self> {
         if s.eq_ignore_ascii_case("claude") {
             Some(AgentId::Claude)
@@ -56,7 +65,11 @@ impl AgentId {
             Some(AgentId::Codex)
         } else if s.eq_ignore_ascii_case("copilot") {
             Some(AgentId::Copilot)
-        } else if s.eq_ignore_ascii_case("opencode") {
+        } else if s.eq_ignore_ascii_case("opencode") || s.eq_ignore_ascii_case("opencode-cli") {
+            // `opencode-cli` is the Windows npm-package binary name —
+            // the built-in profile uses it as `command`, and
+            // `agent_id_from_auto_type` would otherwise classify
+            // OpenCode sessions as `None`.
             Some(AgentId::OpenCode)
         } else if s.eq_ignore_ascii_case("pi") {
             Some(AgentId::Pi)
@@ -165,5 +178,23 @@ mod tests {
         // `claudeflare` must NOT match Claude — same anti-substring rule
         // `is_claude_auto_type` enforced.
         assert_eq!(agent_id_from_auto_type(Some("claudeflare")), None);
+    }
+
+    #[test]
+    fn opencode_cli_alias_resolves_to_opencode() {
+        // Windows OpenCode npm package ships the binary as
+        // `opencode-cli.exe`; the alias keeps
+        // `agent_id_from_auto_type` honest when the sidebar's
+        // "New OpenCode session" row launches `opencode-cli`.
+        assert_eq!(AgentId::from_str("opencode-cli"), Some(AgentId::OpenCode));
+        assert_eq!(AgentId::from_str("OPENCODE-CLI"), Some(AgentId::OpenCode));
+        assert_eq!(
+            agent_id_from_auto_type(Some("opencode-cli")),
+            Some(AgentId::OpenCode),
+        );
+        assert_eq!(
+            agent_id_from_auto_type(Some("opencode-cli --continue")),
+            Some(AgentId::OpenCode),
+        );
     }
 }

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1831,15 +1831,31 @@ impl AppShell {
             }
         };
 
-        // `agent_id` → auto-type command. Only the `claude*` family
-        // round-trips today; future agent profiles can extend this
-        // map as their auto-launch verbs are added. Plain shell
-        // sessions (no agent_id) come back as plain shells.
+        // `agent_id` → auto-type command. Looks up the persisted id
+        // in `agent_registry` so non-Claude reopens
+        // (Codex / OpenCode / Copilot / Pi, plus any
+        // `settings.agents` overrides) come back with the right
+        // command instead of dropping to a plain shell. Resume args
+        // are preferred when present (`claude --resume <id>`,
+        // `pi -c`, `copilot --continue`, …) so the agent reattaches
+        // to the previous conversation; falls back to `new_session_args`
+        // when the profile has no resume verb. Plain shell sessions
+        // (no `agent_id`) come back as plain shells.
         let auto_type: Option<SharedString> = restored
             .agent_id
             .as_deref()
-            .filter(|id| id.starts_with("claude"))
-            .map(|_| "claude".into());
+            .and_then(|id| self.agent_registry.get_by_id(id))
+            .map(|profile| {
+                let resume_args = if profile.resume_args.is_empty() {
+                    profile.new_session_args.as_slice()
+                } else {
+                    profile.resume_args.as_slice()
+                };
+                let mut argv: Vec<&str> = Vec::with_capacity(1 + resume_args.len());
+                argv.push(profile.command.as_str());
+                argv.extend(resume_args.iter().map(|s| s.as_str()));
+                SharedString::from(argv.join(" "))
+            });
 
         self.spawn_tab_in(
             Some(working_directory),

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -1745,10 +1745,14 @@ impl Sidebar {
     /// row that disappears on relaunch — and (worse) a `layout.json`
     /// pointing at a project id that never made it to `projects.json`.
     pub fn add_project(&mut self, path: String, cx: &mut Context<Self>) {
-        // Refuse exact duplicates by path. Two rows pointing at the
-        // same directory would let a user "add" the same project
-        // twice and then wonder why both rows behave identically.
-        if let Some(idx) = self.projects.projects.iter().position(|p| p.path == path) {
+        // Refuse duplicates. Normalising-aware lookup (slash style,
+        // trailing separators, ASCII case) so different spellings of
+        // the same folder route to the same existing row instead of
+        // piling up duplicate entries — same rule the New Project
+        // dialog applies. Drag-dropping a folder with a trailing
+        // slash after it was added via the picker would otherwise
+        // create a parallel row that points at the same directory.
+        if let Some(idx) = self.projects.find_project_index_by_path(&path) {
             self.select(idx, cx);
             return;
         }
@@ -3889,15 +3893,27 @@ fn open_path_in_windows_terminal(path: &str) {
 /// `new_project_dialog::handle_key_down` pattern: backspace pops a
 /// char, escape clears the field, printable characters append. No
 /// "submit" key — filtering is live as the user types.
+///
+/// Chords with Ctrl / Cmd (= `platform` on gpui) / Alt held are
+/// intentionally *not* consumed. App-level shortcuts (Ctrl+B to
+/// toggle sidebar, Ctrl+T to spawn a tab, …) keep working while
+/// the filter has focus — without this gate `stop_propagation()`
+/// would swallow the chord at the filter and the shortcut would
+/// silently turn into a stray `b` / `t` in the filter buffer.
 fn handle_filter_key_down(
     sidebar: &mut Sidebar,
     event: &KeyDownEvent,
     _window: &mut Window,
     cx: &mut Context<Sidebar>,
 ) {
+    let mods = &event.keystroke.modifiers;
+    let app_chord = mods.control || mods.platform || mods.alt;
     let key = event.keystroke.key.as_str();
     match key {
         "escape" => {
+            if app_chord {
+                return;
+            }
             if !sidebar.filter.is_empty() {
                 sidebar.filter.clear();
                 cx.notify();
@@ -3906,6 +3922,9 @@ fn handle_filter_key_down(
             return;
         }
         "backspace" => {
+            if app_chord {
+                return;
+            }
             if sidebar.filter.pop().is_some() {
                 cx.notify();
             }
@@ -3913,6 +3932,11 @@ fn handle_filter_key_down(
             return;
         }
         _ => {}
+    }
+    if app_chord {
+        // Let app-level handlers (e.g. Ctrl+B / Ctrl+T in
+        // `AppShell::on_key_down`) see the chord.
+        return;
     }
     let Some(key_char) = event.keystroke.key_char.as_deref() else {
         return;


### PR DESCRIPTION
## Summary

Follow-up to PR #145 — addresses the four Copilot review comments that landed *after* the squash-merge, so they couldn't be folded into the original PR.

- **`AgentId::from_str` aliases `opencode-cli`** — Windows OpenCode binary name. Without this, sidebar-launched OpenCode sessions classified as `agent_id = None`, breaking telemetry / discovery / restore. New unit tests cover the alias.
- **`Sidebar::add_project` uses `find_project_index_by_path`** — normalises slash style / trailing separators / case so the drag-drop entry point dedups consistently with the New Project dialog.
- **Filter input ignores Ctrl/Cmd/Alt chords** — app-level shortcuts (Ctrl+B sidebar toggle, Ctrl+T new tab, …) keep working while the filter has focus. Previously `stop_propagation()` swallowed them and the chord turned into a stray character in the filter buffer.
- **`AppShell::reopen_session` derives `auto_type` from the agent registry** — reopening a closed Codex / OpenCode / Copilot / Pi session now round-trips with the right CLI (`command + resume_args` joined) instead of dropping to a plain shell.

## Test plan

- [x] `cargo build --workspace` clean, no new warnings
- [x] `cargo test --workspace` — all 496 tests pass (new `opencode_cli_alias_resolves_to_opencode`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)