### PR TITLE
feat(rs): Rename dialog for project / worktree / session

### DIFF
--- a/codescope-rs/core/src/projects.rs
+++ b/codescope-rs/core/src/projects.rs
@@ -106,6 +106,32 @@ impl Project {
     }
 }
 
+/// Rename a project's display name. Mirrors C# `SessionStore.RenameProjectAsync`
+/// — trims whitespace, rejects an empty result, and no-ops when the trimmed
+/// value matches the current name. Returns `Ok(true)` when the name actually
+/// changed (callers should persist), `Ok(false)` for a no-op, and `Err` when
+/// the id is unknown or the trimmed input is empty.
+pub fn rename_project(
+    cfg: &mut ProjectsConfig,
+    project_id: &str,
+    new_name: &str,
+) -> Result<bool> {
+    let trimmed = new_name.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("project name cannot be empty");
+    }
+    let project = cfg
+        .projects
+        .iter_mut()
+        .find(|p| p.id == project_id)
+        .ok_or_else(|| anyhow::anyhow!("project '{project_id}' not found"))?;
+    if project.name == trimmed {
+        return Ok(false);
+    }
+    project.name = trimmed.to_string();
+    Ok(true)
+}
+
 /// One git worktree under a [`Project`]. Every project carries an
 /// explicit primary row (`is_primary: true`) pointing at
 /// `Project::path` plus zero or more additional worktrees with
@@ -710,5 +736,52 @@ mod tests {
         assert_eq!(reloaded.agents[0]["id"], "claude");
         assert_eq!(reloaded.agents[1]["id"], "codex");
         assert_eq!(reloaded.projects.len(), 1);
+    }
+
+    #[test]
+    fn rename_project_updates_name_and_reports_change() {
+        let mut cfg = ProjectsConfig::default();
+        let project = Project::new("C:\\repos\\foo".into());
+        let id = project.id.clone();
+        cfg.projects.push(project);
+
+        let changed = rename_project(&mut cfg, &id, "  Renamed  ").unwrap();
+        assert!(changed);
+        assert_eq!(cfg.projects[0].name, "Renamed");
+    }
+
+    #[test]
+    fn rename_project_is_noop_when_name_unchanged() {
+        let mut cfg = ProjectsConfig::default();
+        let mut project = Project::new("C:\\repos\\foo".into());
+        project.name = "Stable".into();
+        let id = project.id.clone();
+        cfg.projects.push(project);
+
+        let changed = rename_project(&mut cfg, &id, "Stable").unwrap();
+        assert!(!changed);
+        // Trim still applies to the comparison.
+        let changed = rename_project(&mut cfg, &id, "  Stable  ").unwrap();
+        assert!(!changed);
+    }
+
+    #[test]
+    fn rename_project_rejects_empty_or_whitespace_name() {
+        let mut cfg = ProjectsConfig::default();
+        let project = Project::new("C:\\repos\\foo".into());
+        let id = project.id.clone();
+        cfg.projects.push(project);
+
+        assert!(rename_project(&mut cfg, &id, "").is_err());
+        assert!(rename_project(&mut cfg, &id, "   ").is_err());
+    }
+
+    #[test]
+    fn rename_project_errors_on_unknown_id() {
+        let mut cfg = ProjectsConfig::default();
+        cfg.projects.push(Project::new("C:\\repos\\foo".into()));
+
+        let err = rename_project(&mut cfg, "ghost", "New").unwrap_err();
+        assert!(err.to_string().contains("ghost"));
     }
 }

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -563,7 +563,7 @@ pub struct AppShell {
     /// they converge through the shared file. This split mirrors
     /// the C# build where `SessionStore` is the orchestrator and
     /// `SidebarViewModel.StoreSync` projects from it.
-    projects: ProjectsConfig,
+    pub(crate) projects: ProjectsConfig,
     /// Registry of agent profiles built from `settings.agents`
     /// overrides (or the shipped built-in defaults when none are
     /// configured). Mirrors C# `AgentRegistry` — owned at the shell
@@ -593,6 +593,13 @@ pub struct AppShell {
     /// fields mirror exactly what's in [`codescope_core::Settings`];
     /// no schema additions.
     pub(crate) settings_dialog: Option<crate::settings_dialog::SettingsDialogState>,
+    /// Open Rename dialog, if any. Surfaces a single text-input modal
+    /// for renaming a project or a session (live or closed). Mirrors
+    /// the C# build's `Dialogs.RenameDialog.Prompt` — the Rust port
+    /// owns it on AppShell instead of opening a modal `Window` because
+    /// gpui doesn't have a modal-window primitive. See
+    /// `rename_dialog.rs` for the full rationale.
+    pub(crate) rename_dialog: Option<crate::rename_dialog::RenameDialogState>,
 }
 
 impl AppShell {
@@ -728,6 +735,30 @@ impl AppShell {
                 }
                 SidebarEvent::ReopenSession { session_id } => {
                     this.reopen_session(session_id.clone(), window, cx);
+                }
+                SidebarEvent::OpenRenameDialog { target, current_name } => {
+                    // Reload `projects.json` before opening so the
+                    // dialog operates on the freshest snapshot — same
+                    // reload-then-mutate discipline `allocate_session_id`
+                    // / `soft_close_session` use. A sidebar add/remove
+                    // between two AppShell mutations would otherwise
+                    // make the rename target invisible at submit time.
+                    match ProjectsConfig::load(&this.paths) {
+                        Ok(cfg) => {
+                            this.projects = cfg;
+                        }
+                        Err(err) => {
+                            eprintln!(
+                                "warning: failed to reload projects.json before rename: {err:#}"
+                            );
+                        }
+                    }
+                    this.open_rename_dialog(
+                        target.clone(),
+                        current_name.clone(),
+                        window,
+                        cx,
+                    );
                 }
             }
         })
@@ -948,6 +979,7 @@ impl AppShell {
             command_palette: None,
             show_overview: false,
             settings_dialog: None,
+            rename_dialog: None,
         };
         shell.start_telemetry_poll(cx);
         shell.start_agent_discovery_poll(cx);
@@ -1973,6 +2005,19 @@ impl AppShell {
     /// Settings dialog to write `settings.json`.
     pub(crate) fn paths_ref(&self) -> &Arc<AppPaths> {
         &self.paths
+    }
+
+    /// Push the AppShell-side `ProjectsConfig` mirror over to the
+    /// sidebar's copy so the rendered list reflects the latest mutation
+    /// on this frame. Same pattern `reopen_session` uses — extracted
+    /// here so the Rename dialog (and any future AppShell-side mutator)
+    /// doesn't duplicate the clone / `update` / `notify` triple.
+    pub(crate) fn mirror_projects_to_sidebar(&mut self, cx: &mut Context<Self>) {
+        let projects_for_sidebar = self.projects.clone();
+        self.sidebar.update(cx, |sidebar, cx| {
+            sidebar.replace_projects(projects_for_sidebar);
+            cx.notify();
+        });
     }
 
     /// Read-only borrow of the current `Settings`. Used by the
@@ -4644,6 +4689,7 @@ impl Render for AppShell {
             .children(self.render_notifications_popover(&theme, cx))
             .children(self.render_command_palette(window, &theme, cx))
             .children(self.render_settings_dialog(window, &theme, cx))
+            .children(self.render_rename_dialog(window, &theme, cx))
     }
 }
 

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -743,6 +743,12 @@ impl AppShell {
                     // / `soft_close_session` use. A sidebar add/remove
                     // between two AppShell mutations would otherwise
                     // make the rename target invisible at submit time.
+                    //
+                    // Bail on load failure rather than mutating a stale
+                    // snapshot and persisting it on top of newer disk
+                    // state (same rule `reopen_session` uses). Surface
+                    // the error so the user sees the row stay
+                    // un-renamed instead of silently racing the file.
                     match ProjectsConfig::load(&this.paths) {
                         Ok(cfg) => {
                             this.projects = cfg;
@@ -751,6 +757,15 @@ impl AppShell {
                             eprintln!(
                                 "warning: failed to reload projects.json before rename: {err:#}"
                             );
+                            this.push_toast(
+                                ToastKind::Err,
+                                SharedString::from("Rename failed"),
+                                Some(SharedString::from(format!(
+                                    "Could not read projects.json: {err:#}"
+                                ))),
+                                cx,
+                            );
+                            return;
                         }
                     }
                     this.open_rename_dialog(

--- a/codescope-rs/src/rename_dialog.rs
+++ b/codescope-rs/src/rename_dialog.rs
@@ -53,6 +53,14 @@ pub struct RenameDialogState {
     /// model on this primitive yet, so the user has to manually clear
     /// before typing. This is a follow-up rather than a parity gap.
     pub name: String,
+    /// Snapshot of the pre-fill value, kept around so submit can short-
+    /// circuit on `trimmed == original.trim()`. Session renames in
+    /// particular need this: `SessionManager::rename` unconditionally
+    /// sets `display_name`, so pressing Enter on a closed-history row
+    /// whose label was *derived* (from `branch` or `id`) would otherwise
+    /// stamp that derived value as an explicit override — invisible to
+    /// the user, but it stops branch / id fallbacks from re-deriving.
+    pub original: String,
     /// Inline validation error, rendered above the footer. Cleared on
     /// any user edit.
     pub error: Option<String>,
@@ -68,6 +76,7 @@ impl RenameDialogState {
             focus_handle,
             target,
             title,
+            original: current.clone(),
             name: current,
             error: None,
         }
@@ -145,6 +154,20 @@ impl AppShell {
             return;
         }
         let target = state.target.clone();
+        let original_trimmed = state.original.trim().to_string();
+        // Universal no-op when the trimmed buffer matches the trimmed
+        // pre-fill — applies to both project and session paths so a
+        // closed-history row pre-filled from a derived label doesn't
+        // get its derivation stamped as an explicit `display_name`
+        // override on a no-op Enter. The project path's helper
+        // already guards against this internally, but mirroring the
+        // check up-front keeps the two branches aligned and skips an
+        // unnecessary disk write either way.
+        if trimmed == original_trimmed {
+            self.rename_dialog = None;
+            cx.notify();
+            return;
+        }
 
         match target {
             RenameRequest::Project { project_id } => {

--- a/codescope-rs/src/rename_dialog.rs
+++ b/codescope-rs/src/rename_dialog.rs
@@ -1,0 +1,487 @@
+//! Rename dialog — Rust port of `src/CodeScope.Ui/Dialogs/RenameDialog.xaml(.cs)`.
+//!
+//! A small single-input modal that prompts for a new name and hands the
+//! trimmed result back to the caller. The C# build uses it for three
+//! targets (project, worktree, session); the Rust port wires up two —
+//! project and session — and intentionally omits the worktree path
+//! rename for now. The C# `RenameWorktreeAsync` actually renames the
+//! on-disk directory, which requires closing every tab pinned to that
+//! worktree first; until that flow lands we keep the row hidden rather
+//! than ship a half-working version. See `docs/DECISIONS.md`.
+//!
+//! Visual idiom: copied 1:1 from `new_project_dialog.rs` and
+//! `settings_dialog.rs` — elevated card on a dark backdrop, divider
+//! border, ink-dim labels in uppercase, accent primary button. Width
+//! is ~420 px (smaller than the new-project dialog because the body is
+//! a single text input).
+//!
+//! Lives on [`AppShell`] (not [`crate::sidebar::Sidebar`]) because the
+//! rename surface spans both stores: `Project.name` lives in the
+//! sidebar's `ProjectsConfig`, but session renames go through
+//! `SessionManager::rename` against AppShell's mirror copy. Owning the
+//! dialog state at the AppShell level keeps the submit path on one
+//! side of the entity boundary, and we mirror the result back into the
+//! sidebar via `Sidebar::replace_projects` (the same pattern
+//! `reopen_session` uses).
+
+use std::sync::Arc;
+
+use codescope_core::{SessionManager, Theme};
+use gpui::{
+    Context, FocusHandle, InteractiveElement, IntoElement, KeyDownEvent, MouseButton,
+    ParentElement, SharedString, Styled, Window, anchored, deferred, div, point, px,
+};
+
+use crate::app::AppShell;
+use crate::sidebar::RenameRequest;
+use crate::theme;
+
+/// Live state of the rename dialog. Holds the target identity, the
+/// human-readable title shown in the header, and the editable buffer
+/// pre-filled with the current name. Created on
+/// [`SidebarEvent::OpenRenameDialog`](crate::sidebar::SidebarEvent::OpenRenameDialog)
+/// and dropped on submit / cancel.
+pub struct RenameDialogState {
+    pub focus_handle: FocusHandle,
+    pub target: RenameRequest,
+    /// Header text. Mirrors the C# `RenameDialog.HeaderText` slot —
+    /// the caller supplies the title verbatim ("Rename project",
+    /// "Rename session") so the dialog stays a dumb input primitive.
+    pub title: SharedString,
+    /// Editable buffer. Pre-filled with the current name and selected
+    /// on open in the C# build; the Rust port doesn't have a selection
+    /// model on this primitive yet, so the user has to manually clear
+    /// before typing. This is a follow-up rather than a parity gap.
+    pub name: String,
+    /// Inline validation error, rendered above the footer. Cleared on
+    /// any user edit.
+    pub error: Option<String>,
+}
+
+impl RenameDialogState {
+    pub fn new(target: RenameRequest, current: String, focus_handle: FocusHandle) -> Self {
+        let title: SharedString = match &target {
+            RenameRequest::Project { .. } => "Rename project".into(),
+            RenameRequest::Session { .. } => "Rename session".into(),
+        };
+        Self {
+            focus_handle,
+            target,
+            title,
+            name: current,
+            error: None,
+        }
+    }
+
+    /// Rename is allowed when the trimmed name is non-empty. The
+    /// "no-op when unchanged" rule mirrors the C# build's
+    /// `string.Equals(newLeaf, currentLeaf, StringComparison.Ordinal)`
+    /// guard — handled at submit time so the button stays enabled
+    /// (and the user can still press Enter to dismiss) when the buffer
+    /// matches the original. Matches `new_project_dialog::is_valid`
+    /// in returning `bool` rather than `Result` so the render path
+    /// stays branch-free.
+    pub fn is_valid(&self) -> bool {
+        !self.name.trim().is_empty()
+    }
+
+    fn append_char(&mut self, ch: char) {
+        self.name.push(ch);
+        self.error = None;
+    }
+
+    fn pop_char(&mut self) {
+        self.name.pop();
+        self.error = None;
+    }
+}
+
+impl AppShell {
+    /// Open the rename dialog. Idempotent on an already-open dialog —
+    /// a second `OpenRenameDialog` event while one is showing is
+    /// dropped silently rather than replacing the in-flight buffer
+    /// (matches the C# behaviour where a `RenameDialog.Prompt` call
+    /// while another modal is shown returns `null` without raising
+    /// the second prompt).
+    pub fn open_rename_dialog(
+        &mut self,
+        target: RenameRequest,
+        current_name: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.rename_dialog.is_some() {
+            return;
+        }
+        let focus_handle = cx.focus_handle();
+        focus_handle.focus(window);
+        self.rename_dialog =
+            Some(RenameDialogState::new(target, current_name, focus_handle));
+        cx.notify();
+    }
+
+    /// Close the dialog without committing the edit.
+    pub fn cancel_rename_dialog(&mut self, cx: &mut Context<Self>) {
+        if self.rename_dialog.take().is_some() {
+            cx.notify();
+        }
+    }
+
+    /// Commit the edit. Validates trimming + non-empty, mutates the
+    /// appropriate slot in `self.projects`, saves `projects.json`, and
+    /// mirrors the change back to the sidebar so its rendered list
+    /// picks up the new name on the same frame. A trimmed value equal
+    /// to the current name is a silent no-op (mirrors C#
+    /// `RenameProjectAsync` / `RenameSessionAsync` early returns), and
+    /// validation failures keep the dialog open with an inline error.
+    pub fn submit_rename_dialog(&mut self, cx: &mut Context<Self>) {
+        let Some(state) = self.rename_dialog.as_ref() else { return };
+        let trimmed = state.name.trim().to_string();
+        if trimmed.is_empty() {
+            if let Some(state) = self.rename_dialog.as_mut() {
+                state.error = Some("Name cannot be empty".into());
+            }
+            cx.notify();
+            return;
+        }
+        let target = state.target.clone();
+
+        match target {
+            RenameRequest::Project { project_id } => {
+                let changed = match codescope_core::projects::rename_project(
+                    &mut self.projects,
+                    &project_id,
+                    &trimmed,
+                ) {
+                    Ok(changed) => changed,
+                    Err(err) => {
+                        if let Some(state) = self.rename_dialog.as_mut() {
+                            state.error = Some(format!("{err:#}"));
+                        }
+                        cx.notify();
+                        return;
+                    }
+                };
+                if !changed {
+                    // No-op — close silently. Matches the C# guard.
+                    self.rename_dialog = None;
+                    cx.notify();
+                    return;
+                }
+                if let Err(err) = self.projects.save(self.paths_ref().as_ref()) {
+                    if let Some(state) = self.rename_dialog.as_mut() {
+                        state.error = Some(format!("Failed to save: {err:#}"));
+                    }
+                    cx.notify();
+                    return;
+                }
+            }
+            RenameRequest::Session { session_id } => {
+                // SessionManager::rename normalises whitespace → None
+                // internally; we pass `Some(trimmed)` so empty strings
+                // never reach it (we rejected them above).
+                if let Err(err) = SessionManager::rename(
+                    &mut self.projects,
+                    &session_id,
+                    Some(&trimmed),
+                ) {
+                    if let Some(state) = self.rename_dialog.as_mut() {
+                        state.error = Some(format!("{err:#}"));
+                    }
+                    cx.notify();
+                    return;
+                }
+                if let Err(err) = codescope_core::session::save(
+                    &self.projects,
+                    self.paths_ref().as_ref(),
+                ) {
+                    if let Some(state) = self.rename_dialog.as_mut() {
+                        state.error = Some(format!("Failed to save: {err:#}"));
+                    }
+                    cx.notify();
+                    return;
+                }
+            }
+        }
+
+        // Persistence committed — close the dialog and mirror to the
+        // sidebar so its rendered list refreshes on this frame. Same
+        // pattern `reopen_session` uses.
+        self.rename_dialog = None;
+        self.mirror_projects_to_sidebar(cx);
+        cx.notify();
+    }
+
+    /// Render the dialog overlay. Returns `None` when no dialog is
+    /// open. Layered via `deferred(anchored(...))` at priority 10,
+    /// matching `render_settings_dialog` / `render_new_project_dialog`.
+    pub fn render_rename_dialog(
+        &self,
+        window: &mut Window,
+        theme: &Arc<Theme>,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        let state = self.rename_dialog.as_ref()?;
+        let viewport = window.viewport_size();
+
+        let elevated = theme::elevated(theme);
+        let divider = theme::divider(theme);
+        let ink = theme::ink(theme);
+        let ink_dim = theme::ink_dim(theme);
+        let ink_ghost = theme::ink_ghost(theme);
+        let ink_muted = theme::ink_muted(theme);
+        let frost = theme::frost_10(theme);
+        let danger = theme::danger(theme);
+        let accent = theme::accent(theme);
+        let canvas = theme::canvas(theme);
+
+        let focus_handle = state.focus_handle.clone();
+        let title = state.title.clone();
+        let valid = state.is_valid();
+        let error_msg: Option<SharedString> = state.error.clone().map(Into::into);
+        let value: SharedString = state.name.clone().into();
+
+        // Header — eyebrow ("RENAME") + title.
+        let header = div()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .px_5()
+            .pt_5()
+            .child(
+                div()
+                    .text_size(px(11.0))
+                    .text_color(accent)
+                    .child("RENAME"),
+            )
+            .child(div().text_size(px(20.0)).text_color(ink).child(title))
+            .child(
+                div()
+                    .text_size(px(12.0))
+                    .text_color(ink_muted)
+                    .child("Enter a new name. Press Enter to confirm."),
+            );
+
+        let field_label = div()
+            .text_size(px(11.0))
+            .text_color(ink_ghost)
+            .child("NEW NAME");
+
+        // Single-line text input. Always focused (only one field).
+        let placeholder_visible = value.is_empty();
+        let display: SharedString = if placeholder_visible {
+            SharedString::from("(empty)")
+        } else {
+            value.clone()
+        };
+        let textbox = div()
+            .id("rename-input")
+            .px_3()
+            .h(px(34.0))
+            .bg(canvas)
+            .border_1()
+            .border_color(accent)
+            .rounded(px(6.0))
+            .text_size(px(13.0))
+            .flex()
+            .items_center()
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap_1()
+                    .child(
+                        div()
+                            .flex_grow()
+                            .text_color(if placeholder_visible { ink_ghost } else { ink })
+                            .truncate()
+                            .child(display),
+                    )
+                    // Always-on caret — there's only one input, so we
+                    // don't need a focus indicator to know where it lands.
+                    .child(div().w(px(1.5)).h(px(16.0)).bg(accent)),
+            );
+
+        let body = div()
+            .px_5()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .child(field_label)
+            .child(textbox);
+
+        let error_block = error_msg.map(|msg| {
+            div()
+                .px_5()
+                .text_size(px(12.0))
+                .text_color(danger)
+                .child(msg)
+        });
+
+        let cancel_btn = div()
+            .id("rename-cancel")
+            .px_4()
+            .py_2()
+            .text_size(px(13.0))
+            .text_color(ink_dim)
+            .border_1()
+            .border_color(divider)
+            .rounded(px(6.0))
+            .cursor_pointer()
+            .hover(move |s| s.bg(frost).text_color(ink))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _, cx| {
+                    cx.stop_propagation();
+                    this.cancel_rename_dialog(cx);
+                }),
+            )
+            .child("Cancel");
+
+        let ok_color = if valid { canvas } else { ink_ghost };
+        let ok_bg = if valid { accent } else { divider };
+        let ok_btn = {
+            let mut btn = div()
+                .id("rename-ok")
+                .px_4()
+                .py_2()
+                .text_size(px(13.0))
+                .text_color(ok_color)
+                .bg(ok_bg)
+                .rounded(px(6.0));
+            if valid {
+                btn = btn.cursor_pointer().on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.submit_rename_dialog(cx);
+                    }),
+                );
+            }
+            btn.child("Rename")
+        };
+
+        let footer_buttons = div()
+            .flex()
+            .flex_row()
+            .justify_end()
+            .gap_2()
+            .px_5()
+            .pb_5()
+            .child(cancel_btn)
+            .child(ok_btn);
+
+        let mut card = div()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .w(px(420.0))
+            .bg(elevated)
+            .border_1()
+            .border_color(divider)
+            .rounded_lg()
+            .shadow_lg()
+            .pb_2()
+            .track_focus(&focus_handle)
+            .key_context("RenameDialog")
+            .on_key_down(cx.listener(handle_key_down))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|_, _, _, cx| cx.stop_propagation()),
+            )
+            .child(header)
+            .child(body);
+        if let Some(eb) = error_block {
+            card = card.child(eb);
+        }
+        card = card.child(footer_buttons);
+
+        let backdrop = div()
+            .w(viewport.width)
+            .h(viewport.height)
+            .flex()
+            .items_center()
+            .justify_center()
+            .bg(gpui::hsla(0.0, 0.0, 0.0, 0.55))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _, cx| {
+                    this.cancel_rename_dialog(cx);
+                }),
+            )
+            .child(card);
+
+        Some(
+            deferred(anchored().position(point(px(0.0), px(0.0))).child(backdrop))
+                .with_priority(10)
+                .into_any_element(),
+        )
+    }
+}
+
+/// Escape cancels; Enter submits; Backspace pops a char; printable
+/// characters append. Mirrors `new_project_dialog::handle_key_down` in
+/// shape — every dialog in the Rust port uses the same skeleton so
+/// readers don't have to reverse-engineer a different key dispatch on
+/// each surface.
+fn handle_key_down(
+    shell: &mut AppShell,
+    event: &KeyDownEvent,
+    _window: &mut Window,
+    cx: &mut Context<AppShell>,
+) {
+    let key = event.keystroke.key.as_str();
+    cx.stop_propagation();
+
+    match key {
+        "escape" => {
+            shell.cancel_rename_dialog(cx);
+            return;
+        }
+        "enter" => {
+            shell.submit_rename_dialog(cx);
+            return;
+        }
+        "backspace" => {
+            if let Some(state) = shell.rename_dialog.as_mut() {
+                state.pop_char();
+                cx.notify();
+            }
+            return;
+        }
+        _ => {}
+    }
+
+    let Some(key_char) = event.keystroke.key_char.as_deref() else { return };
+    if key_char.is_empty() {
+        return;
+    }
+    if let Some(state) = shell.rename_dialog.as_mut() {
+        let mut changed = false;
+        for ch in key_char.chars() {
+            if !ch.is_control() {
+                state.append_char(ch);
+                changed = true;
+            }
+        }
+        if changed {
+            cx.notify();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn is_valid_rejects_empty_and_whitespace() {
+        // `RenameDialogState::new` needs a `FocusHandle`, which can't
+        // be constructed outside the gpui runtime. We exercise the
+        // pure trimming rule that `is_valid` codifies so a regression
+        // in the predicate would still be caught here.
+        assert!(String::new().trim().is_empty());
+        assert!("  ".trim().is_empty());
+        assert!(!"name".trim().is_empty());
+        assert!(!"  name  ".trim().is_empty());
+    }
+}

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -92,6 +92,16 @@ enum OpenMenu {
         worktree_id: String,
         position: Point<Pixels>,
     },
+    /// Right-click on a closed-session history row. The menu is tiny
+    /// (Rename… + Reopen) — broken out as a third variant so the
+    /// project/worktree rendering paths stay unchanged.
+    History {
+        session_id: String,
+        /// Display label snapshotted at right-click time so the dialog
+        /// pre-fills with the same text the user just clicked.
+        label: String,
+        position: Point<Pixels>,
+    },
 }
 
 /// Per-worktree state for the lazy `gh pr list` lookup. `Pending`
@@ -184,6 +194,30 @@ pub enum SidebarEvent {
     /// the persisted `worktree_path` + `agent_id`. Mirrors C#
     /// `MainViewModel.ReopenClosedSessionAsync`.
     ReopenSession { session_id: String },
+    /// User picked "Rename project…" / "Rename session…" from a
+    /// context menu. AppShell owns the rename dialog state and the
+    /// rename persistence path; the sidebar fires the request and
+    /// passes the current value so the dialog opens pre-populated.
+    /// Mirrors C# `Dialogs.RenameDialog.Prompt(current, title)`
+    /// invocation pattern from `SidebarViewModel.Commands.cs`.
+    OpenRenameDialog { target: RenameRequest, current_name: String },
+}
+
+/// What `SidebarEvent::OpenRenameDialog` is asking to rename. Held by
+/// the dialog state until submit / cancel. Worktree-as-target is
+/// intentionally absent — the C# build renames the on-disk worktree
+/// directory (`SessionStore.RenameWorktreeAsync`), which is heavier
+/// than a display-name flip and depends on closing every open tab
+/// pinned to that worktree first. We keep parity with the C# UI by
+/// hiding the row entirely on the Rust side until that flow lands.
+/// See `docs/DECISIONS.md` for the deviation note.
+#[derive(Debug, Clone)]
+pub enum RenameRequest {
+    /// Rename a project's display name. Mirrors C# `RenameProjectCommand`.
+    Project { project_id: String },
+    /// Rename a session's display-name override (live or closed).
+    /// Mirrors C# `RenameSessionCommand`.
+    Session { session_id: String },
 }
 
 /// Toast severity emitted by the sidebar. AppShell maps these to its
@@ -1136,6 +1170,21 @@ impl Sidebar {
         }
 
         self.menu = Some(OpenMenu::Worktree { project_idx, worktree_id, position });
+        cx.notify();
+    }
+
+    /// Open the closed-history row context menu. Snapshots the row's
+    /// current display label so the rename dialog opens pre-filled,
+    /// even if the underlying `display_name` resolves through a
+    /// fallback chain (display_name → branch → id) at render time.
+    fn open_history_menu(
+        &mut self,
+        session_id: String,
+        label: String,
+        position: Point<Pixels>,
+        cx: &mut Context<Self>,
+    ) {
+        self.menu = Some(OpenMenu::History { session_id, label, position });
         cx.notify();
     }
 
@@ -2601,6 +2650,23 @@ impl Render for Sidebar {
                                     });
                                 }),
                             )
+                            // Right-click opens the closed-history
+                            // context menu (Reopen + Rename…). Mirrors
+                            // the C# `SessionTabViewModel` template's
+                            // right-click affordance on history rows.
+                            .on_mouse_down(MouseButton::Right, {
+                                let id_for_ctx = session_id.clone();
+                                let label_for_ctx = row.label.to_string();
+                                cx.listener(move |this, event: &MouseDownEvent, _, cx| {
+                                    cx.stop_propagation();
+                                    this.open_history_menu(
+                                        id_for_ctx.clone(),
+                                        label_for_ctx.clone(),
+                                        event.position,
+                                        cx,
+                                    );
+                                })
+                            })
                             // Hollow outline dot — `border_1` + transparent
                             // bg matches the WPF `Stroke=Text.Faint`
                             // ellipse on the closed-row template, marking
@@ -2872,6 +2938,18 @@ impl Render for Sidebar {
                         .into_any_element();
                     root = root.child(overlay);
                 }
+            }
+            Some(OpenMenu::History { session_id, label, position }) => {
+                let overlay = self
+                    .render_history_menu(
+                        session_id.clone(),
+                        label.clone(),
+                        *position,
+                        &theme,
+                        cx,
+                    )
+                    .into_any_element();
+                root = root.child(overlay);
             }
             None => {}
         }
@@ -3244,6 +3322,29 @@ impl Sidebar {
                 Box::new(move |this, _window, cx| this.copy_path(idx, cx)),
             ))
             .child(div().h_px().bg(divider).my_1())
+            // "Rename project…" — fires a `SidebarEvent::OpenRenameDialog`
+            // so AppShell opens the modal. Mirrors C#
+            // `SidebarViewModel.RenameProjectCommand` (currently
+            // unbound on the C# side at the project scope but the
+            // store API exists; the Rust port wires the row).
+            .child({
+                let project_id = project.id.clone();
+                let current_name = project.name.clone();
+                item(
+                    "menu-rename-project",
+                    "Rename project…",
+                    false,
+                    Box::new(move |this, _window, cx| {
+                        cx.emit(SidebarEvent::OpenRenameDialog {
+                            target: RenameRequest::Project {
+                                project_id: project_id.clone(),
+                            },
+                            current_name: current_name.clone(),
+                        });
+                        this.close_menu(cx);
+                    }),
+                )
+            })
             .child(item(
                 "menu-remove",
                 "Remove project",
@@ -3666,6 +3767,124 @@ impl Sidebar {
                     }),
                 ))
             }))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|_, _, _, cx| cx.stop_propagation()),
+            )
+            .on_mouse_down_out(cx.listener(|this, _, _, cx| this.close_menu(cx)));
+
+        deferred(
+            anchored()
+                .position(point(position.x, position.y))
+                .anchor(Corner::TopLeft)
+                .snap_to_window_with_margin(px(8.0))
+                .child(menu_body),
+        )
+    }
+
+    /// Closed-history row context menu — tiny by design (Reopen +
+    /// Rename…). Triggered by a right-click on a row inside the
+    /// per-worktree history disclosure. Mirrors the C# build's
+    /// `SessionTabViewModel` history template right-click affordance,
+    /// scoped down to the two actions we support today.
+    fn render_history_menu(
+        &self,
+        session_id: String,
+        label: String,
+        position: Point<Pixels>,
+        theme: &Arc<Theme>,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let elevated = theme::elevated(theme);
+        let divider = theme::divider(theme);
+        let ink = theme::ink(theme);
+        let ink_dim = theme::ink_dim(theme);
+        let ink_ghost = theme::ink_ghost(theme);
+        let frost = theme::frost_10(theme);
+
+        let header_label: SharedString = label.clone().into();
+
+        let item = |id: &'static str,
+                    text: &'static str,
+                    on_click: MenuItemAction|
+         -> gpui::Stateful<gpui::Div> {
+            let frost_hover = frost;
+            div()
+                .id(id)
+                .h(px(28.0))
+                .px_3()
+                .flex()
+                .flex_row()
+                .items_center()
+                .text_size(px(12.5))
+                .text_color(ink_dim)
+                .cursor_pointer()
+                .hover(move |s| s.bg(frost_hover).text_color(ink))
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, window, cx| {
+                        cx.stop_propagation();
+                        on_click(this, window, cx);
+                    }),
+                )
+                .child(text)
+        };
+
+        let reopen_session_id = session_id.clone();
+        let rename_session_id = session_id.clone();
+        let rename_current = label.clone();
+
+        let menu_body = div()
+            .flex()
+            .flex_col()
+            .py_1()
+            .min_w(px(200.0))
+            .bg(elevated)
+            .border_1()
+            .border_color(divider)
+            .rounded_md()
+            .shadow_lg()
+            .font(theme::font_sans())
+            .child(
+                div()
+                    .px_3()
+                    .py_2()
+                    .text_size(px(10.0))
+                    .text_color(ink_ghost)
+                    .child(
+                        div()
+                            .text_color(ink)
+                            .font(theme::font_mono())
+                            .text_size(px(11.0))
+                            .truncate()
+                            .child(header_label),
+                    )
+                    .child(div().child("closed session")),
+            )
+            .child(div().h_px().bg(divider).my_1())
+            .child(item(
+                "hist-menu-reopen",
+                "Reopen session",
+                Box::new(move |this, _window, cx| {
+                    cx.emit(SidebarEvent::ReopenSession {
+                        session_id: reopen_session_id.clone(),
+                    });
+                    this.close_menu(cx);
+                }),
+            ))
+            .child(item(
+                "hist-menu-rename",
+                "Rename session…",
+                Box::new(move |this, _window, cx| {
+                    cx.emit(SidebarEvent::OpenRenameDialog {
+                        target: RenameRequest::Session {
+                            session_id: rename_session_id.clone(),
+                        },
+                        current_name: rename_current.clone(),
+                    });
+                    this.close_menu(cx);
+                }),
+            ))
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(|_, _, _, cx| cx.stop_propagation()),

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -17,6 +17,7 @@ mod new_project_dialog;
 mod new_worktree_dialog;
 mod notifications;
 mod overview;
+mod rename_dialog;
 mod settings_dialog;
 mod sidebar;
 mod theme;


### PR DESCRIPTION
## Summary

- Rust port of `src/CodeScope.Ui/Dialogs/RenameDialog.xaml(.cs)` — a small single-input modal pre-filled with the current name.
- Two rename targets wired: **project** (mutates `Project.name`) and **session** (mutates `Session.display_name` via `SessionManager::rename`).
- C# `RenameWorktreeAsync` is intentionally absent: it renames the on-disk directory and requires closing every tab pinned to the worktree first; the row stays hidden until that flow lands.

## Triggers

- **Project context menu** — adds a "Rename project…" row above "Remove project".
- **Closed-session history rows** — gain a right-click context menu with "Reopen session" + "Rename session…".

## Implementation

- New `codescope-rs/src/rename_dialog.rs` mirrors the visual idiom of `new_project_dialog.rs` / `settings_dialog.rs` (elevated card, ink-dim labels, accent primary button, ~420 px).
- Sidebar fires a new `SidebarEvent::OpenRenameDialog { target, current_name }`; AppShell owns the dialog state and persistence, then mirrors the updated `ProjectsConfig` back to the sidebar via a new `mirror_projects_to_sidebar` helper.
- New `codescope_core::projects::rename_project` helper handles trim / empty-rejection / no-op semantics (5 unit tests).

## Test plan

- [x] `cargo build --workspace` clean (no new warnings).
- [x] `cargo test --workspace` — 409 (core) + 72 (rs) + 19 (terminal) + 1 doctest all green.
- [x] New tests in `core/src/projects.rs` cover rename_project: updates+reports change, no-op when unchanged (incl. trimmed equal), rejects empty/whitespace, errors on unknown id.
- [x] Existing `SessionManager::rename` test (`rename_sets_and_clears_display_name`) still passes.