### PR TITLE
feat(rs): themed ConfirmDialog + migrate destructive sites

### DIFF
--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -964,6 +964,7 @@ dependencies = [
  "codescope-core",
  "codescope-terminal",
  "embed-resource",
+ "futures-channel",
  "gpui",
  "gpui-terminal",
  "parking_lot",

--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -28,6 +28,11 @@ anyhow = "1"
 parking_lot = "0.12"
 uuid = { version = "1", features = ["v4"] }
 raw-window-handle = "0.6"
+# `futures-channel::oneshot` for the themed ConfirmDialog's Future<bool>
+# API. gpui already pulls this in transitively for `window.prompt`'s
+# return type; we depend on it explicitly so the confirm dialog reads
+# from the same well-known crate without going through gpui internals.
+futures-channel = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 # Direct Win32 access for the custom titlebar: gpui's

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -668,6 +668,13 @@ pub struct AppShell {
     /// gpui doesn't have a modal-window primitive. See
     /// `rename_dialog.rs` for the full rationale.
     pub(crate) rename_dialog: Option<crate::rename_dialog::RenameDialogState>,
+    /// Open Confirm dialog, if any. Themed in-app replacement for the
+    /// OS-native `window.prompt(...)` used by destructive sidebar
+    /// actions (remove project, discard worktree changes, remove
+    /// worktree, force-retry, remove from history). Mirrors C#
+    /// `Dialogs.ConfirmDialog.Confirm` / `Destructive`. See
+    /// `confirm_dialog.rs`.
+    pub(crate) confirm_dialog: Option<crate::confirm_dialog::ConfirmDialogState>,
 }
 
 impl AppShell {
@@ -839,6 +846,14 @@ impl AppShell {
                     this.open_rename_dialog(
                         target.clone(),
                         current_name.clone(),
+                        window,
+                        cx,
+                    );
+                }
+                SidebarEvent::OpenConfirmDialog { spec, action } => {
+                    this.handle_open_confirm_dialog(
+                        spec.clone(),
+                        action.clone(),
                         window,
                         cx,
                     );
@@ -1066,6 +1081,7 @@ impl AppShell {
             show_overview: false,
             settings_dialog: None,
             rename_dialog: None,
+            confirm_dialog: None,
         };
         shell.start_telemetry_poll(cx);
         shell.start_agent_discovery_poll(cx);
@@ -1842,6 +1858,99 @@ impl AppShell {
     /// retention sweep, or stale event from a closed sidebar that has
     /// since rebuilt) is logged and swallowed — there's nothing useful
     /// to spawn at that point.
+    /// Open the themed ConfirmDialog and dispatch the carried
+    /// [`crate::sidebar::ConfirmAction`] once the user resolves it.
+    /// Bridges the sidebar's "I want to confirm this destructive
+    /// action" event to the AppShell-owned dialog overlay. On
+    /// confirm, sidebar-scoped actions go through
+    /// [`Sidebar::execute_confirm_action`]; the
+    /// `RemoveSessionFromHistory` variant is handled here because the
+    /// session store lives on AppShell.
+    pub(crate) fn handle_open_confirm_dialog(
+        &mut self,
+        spec: crate::confirm_dialog::ConfirmSpec,
+        action: crate::sidebar::ConfirmAction,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let rx = self.open_confirm_dialog(spec, window, cx);
+        cx.spawn(async move |this, cx| {
+            let confirmed = rx.await.unwrap_or(false);
+            if !confirmed {
+                return;
+            }
+            let _ = this.update(cx, |this, cx| {
+                match action {
+                    crate::sidebar::ConfirmAction::RemoveSessionFromHistory {
+                        session_id,
+                    } => {
+                        this.remove_session_from_history(session_id, cx);
+                    }
+                    other => {
+                        this.sidebar.update(cx, |sidebar, cx| {
+                            sidebar.execute_confirm_action(other, cx);
+                        });
+                    }
+                }
+            });
+        })
+        .detach();
+    }
+
+    /// Drop a closed-session row from history. Reload-then-mutate-
+    /// then-save mirrors the `reopen_session` discipline so a sidebar
+    /// write between two of ours can't clobber the array. Surfaces
+    /// failures as toasts so the user sees the row stay in the
+    /// disclosure instead of silently racing the on-disk file.
+    /// Mirrors C# `RemoveSessionFromHistoryAsync` /
+    /// `SessionStore.RemoveSessionAsync`.
+    pub(crate) fn remove_session_from_history(
+        &mut self,
+        session_id: String,
+        cx: &mut Context<Self>,
+    ) {
+        match ProjectsConfig::load(&self.paths) {
+            Ok(cfg) => {
+                self.projects = cfg;
+            }
+            Err(err) => {
+                eprintln!(
+                    "warning: failed to reload projects.json before remove-from-history: {err:#}"
+                );
+                self.push_toast(
+                    ToastKind::Err,
+                    SharedString::from("Remove failed"),
+                    Some(SharedString::from(format!(
+                        "Could not read projects.json: {err:#}"
+                    ))),
+                    cx,
+                );
+                return;
+            }
+        }
+        if let Err(err) = SessionManager::hard_remove(&mut self.projects, &session_id) {
+            self.push_toast(
+                ToastKind::Err,
+                SharedString::from("Remove failed"),
+                Some(SharedString::from(format!("{err:#}"))),
+                cx,
+            );
+            return;
+        }
+        if let Err(err) = codescope_core::session::save(&self.projects, &self.paths) {
+            self.push_toast(
+                ToastKind::Err,
+                SharedString::from("Remove failed"),
+                Some(SharedString::from(format!("Failed to save: {err:#}"))),
+                cx,
+            );
+            return;
+        }
+        // Mirror the updated config into the sidebar so the row
+        // disappears from the history disclosure on this frame.
+        self.mirror_projects_to_sidebar(cx);
+    }
+
     pub(crate) fn reopen_session(
         &mut self,
         session_id: String,
@@ -4832,6 +4941,7 @@ impl Render for AppShell {
             .children(self.render_command_palette(window, &theme, cx))
             .children(self.render_settings_dialog(window, &theme, cx))
             .children(self.render_rename_dialog(window, &theme, cx))
+            .children(self.render_confirm_dialog(window, &theme, cx))
     }
 }
 

--- a/codescope-rs/src/confirm_dialog.rs
+++ b/codescope-rs/src/confirm_dialog.rs
@@ -1,0 +1,492 @@
+//! Themed confirm dialog — Rust port of
+//! `src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml(.cs)`.
+//!
+//! Single in-app modal primitive for confirm / destructive prompts.
+//! Replaces the OS-native `window.prompt(...)` calls that were
+//! previously used for destructive sidebar actions (discard, remove
+//! worktree, force-retry). The native dialog is functional but the
+//! visual chrome doesn't match the rest of the in-app modals
+//! (settings_dialog, rename_dialog, new_project_dialog).
+//!
+//! Visual idiom: mirrors `rename_dialog.rs` / `new_project_dialog.rs`
+//! — elevated card on a dim backdrop, divider border, ink-dim labels,
+//! accent-or-danger primary button. Width 440 px.
+//!
+//! API: returns a `oneshot::Receiver<bool>` (mirrors `window.prompt`'s
+//! return type — a future that resolves to the chosen button). The
+//! caller awaits it inside a `cx.spawn` task, exactly like the
+//! `window.prompt` code path it replaces. `true` means confirm, `false`
+//! means cancel / Esc / scrim click / dialog dropped.
+//!
+//! Two flavors mirror the C# `Flavor.Confirm` / `Flavor.Destructive`:
+//!
+//! * `Confirm` — neutral, accent primary, Esc cancels, Enter confirms.
+//! * `Destructive` — danger primary (red), Esc cancels, Enter does NOT
+//!   auto-confirm (the C# build hides the close glyph + disables Enter
+//!   to force an explicit click on the destructive button — we follow
+//!   suit). Scrim click also cancels rather than committing.
+//!
+//! Lives on [`AppShell`] (not [`crate::sidebar::Sidebar`]) following
+//! the established dialog ownership pattern — `rename_dialog.rs`,
+//! `settings_dialog.rs`, `new_project_dialog.rs` all sit at the shell
+//! level so the deferred-anchored overlay paints over the full window
+//! rather than being clipped to the sidebar column.
+
+use std::sync::Arc;
+
+use codescope_core::Theme;
+use futures_channel::oneshot;
+use gpui::{
+    Context, FocusHandle, InteractiveElement, IntoElement, KeyDownEvent, MouseButton,
+    ParentElement, SharedString, Styled, Window, anchored, deferred, div, point, px,
+};
+
+use crate::app::AppShell;
+use crate::theme;
+
+/// Confirm vs Destructive — mirrors the relevant subset of the C#
+/// `ConfirmDialog.Flavor` enum (we omit `Info` for now; it's used by
+/// startup notices on the C# side that the Rust port doesn't have a
+/// parity hook for yet).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfirmKind {
+    /// Reversible action. Accent-blue primary button, Enter auto-
+    /// commits, Esc / scrim click cancels. Eyebrow reads "CONFIRM".
+    Confirm,
+    /// Irreversible destructive action. Red primary button, Enter does
+    /// NOT auto-commit (the user has to click the button to confirm).
+    /// Esc still cancels. Eyebrow reads "DESTRUCTIVE".
+    Destructive,
+}
+
+/// Caller-supplied content + flavor for one open dialog. Owned by
+/// `ConfirmDialogState` while the dialog is showing. Strings are owned
+/// (not `&str`) so the dialog outlives the call site after the spawned
+/// async task awaits the result.
+#[derive(Debug, Clone)]
+pub struct ConfirmSpec {
+    pub kind: ConfirmKind,
+    pub title: SharedString,
+    pub message: SharedString,
+    /// Optional secondary line (file path, technical detail).
+    /// Rendered slightly smaller and in `text_faint`. `None` hides
+    /// the row entirely. Mirrors the C# `hint` slot's positioning;
+    /// we use a body-level detail rather than the footer hint so the
+    /// caller's typical "Path: …" line reads cleanly above the
+    /// buttons.
+    pub detail: Option<SharedString>,
+    pub confirm_label: SharedString,
+    pub cancel_label: SharedString,
+}
+
+#[allow(dead_code)] // `confirm` + `with_cancel_label` exist on the API surface
+                    // for future callers; today every destructive site is a
+                    // `Destructive`-flavor dialog with the default "Cancel" label.
+impl ConfirmSpec {
+    /// Shorthand for a reversible "Confirm" prompt.
+    pub fn confirm(
+        title: impl Into<SharedString>,
+        message: impl Into<SharedString>,
+    ) -> Self {
+        Self {
+            kind: ConfirmKind::Confirm,
+            title: title.into(),
+            message: message.into(),
+            detail: None,
+            confirm_label: SharedString::from("OK"),
+            cancel_label: SharedString::from("Cancel"),
+        }
+    }
+
+    /// Shorthand for an irreversible "Destructive" prompt.
+    pub fn destructive(
+        title: impl Into<SharedString>,
+        message: impl Into<SharedString>,
+    ) -> Self {
+        Self {
+            kind: ConfirmKind::Destructive,
+            title: title.into(),
+            message: message.into(),
+            detail: None,
+            confirm_label: SharedString::from("Delete"),
+            cancel_label: SharedString::from("Cancel"),
+        }
+    }
+
+    pub fn with_detail(mut self, detail: impl Into<SharedString>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    pub fn with_confirm_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.confirm_label = label.into();
+        self
+    }
+
+    pub fn with_cancel_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.cancel_label = label.into();
+        self
+    }
+
+    /// Trim whitespace-only labels back to a non-empty default. The
+    /// dialog always renders both buttons; an empty label would leave
+    /// a clickable but invisible button — that's a UX bug, not a
+    /// feature. Pure helper so we can unit-test it.
+    pub fn normalised_confirm_label(&self) -> SharedString {
+        normalise_button_label(&self.confirm_label, "OK")
+    }
+
+    pub fn normalised_cancel_label(&self) -> SharedString {
+        normalise_button_label(&self.cancel_label, "Cancel")
+    }
+}
+
+/// Live state for one open dialog. The `responder` is taken on commit
+/// / cancel and the result is sent back to the caller's spawned task.
+/// Dropping the state without committing also drops the sender, which
+/// causes the receiver to resolve to `Err(_)` — we treat that as a
+/// cancel on the caller's side (`rx.await.unwrap_or(false)`).
+pub struct ConfirmDialogState {
+    pub focus_handle: FocusHandle,
+    pub spec: ConfirmSpec,
+    /// Sender half of the result oneshot. `Some` while the dialog is
+    /// open; `take()` flips it to `None` on the first commit/cancel so
+    /// double-clicks can't fire twice.
+    responder: Option<oneshot::Sender<bool>>,
+}
+
+impl ConfirmDialogState {
+    pub fn new(
+        spec: ConfirmSpec,
+        responder: oneshot::Sender<bool>,
+        focus_handle: FocusHandle,
+    ) -> Self {
+        Self { focus_handle, spec, responder: Some(responder) }
+    }
+}
+
+impl AppShell {
+    /// Open the confirm dialog. Returns a `oneshot::Receiver<bool>`
+    /// the caller awaits to learn the outcome. `true` = confirm,
+    /// `false` = cancel / Esc / scrim. If a dialog is already open,
+    /// the receiver immediately resolves to `false` (we don't queue
+    /// dialogs).
+    ///
+    /// Mirrors the call-shape of `window.prompt(...)` it replaces —
+    /// the caller spawns an async task and awaits the receiver.
+    pub fn open_confirm_dialog(
+        &mut self,
+        spec: ConfirmSpec,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> oneshot::Receiver<bool> {
+        let (tx, rx) = oneshot::channel();
+        if self.confirm_dialog.is_some() {
+            // Surface "another modal is already up" as a clean cancel
+            // — same outcome the user would get by Esc-ing the in-
+            // flight dialog. Mirrors the C# build's `ShowDialog()`
+            // returning `false` when re-entrant prompting is rejected.
+            let _ = tx.send(false);
+            return rx;
+        }
+        let focus_handle = cx.focus_handle();
+        focus_handle.focus(window);
+        self.confirm_dialog = Some(ConfirmDialogState::new(spec, tx, focus_handle));
+        cx.notify();
+        rx
+    }
+
+    /// Commit the dialog — the user clicked the primary button or
+    /// pressed Enter on a Confirm-flavor dialog.
+    pub fn submit_confirm_dialog(&mut self, cx: &mut Context<Self>) {
+        let Some(mut state) = self.confirm_dialog.take() else { return };
+        if let Some(tx) = state.responder.take() {
+            let _ = tx.send(true);
+        }
+        cx.notify();
+    }
+
+    /// Cancel the dialog — Esc, scrim click, Cancel button, or
+    /// close-glyph.
+    pub fn cancel_confirm_dialog(&mut self, cx: &mut Context<Self>) {
+        let Some(mut state) = self.confirm_dialog.take() else { return };
+        if let Some(tx) = state.responder.take() {
+            let _ = tx.send(false);
+        }
+        cx.notify();
+    }
+
+    /// Render the dialog overlay. `None` when no dialog is open.
+    /// Layered via `deferred(anchored(...))` at priority 10 so it
+    /// paints over the rest of the frame (matching the other
+    /// `render_*_dialog` helpers).
+    pub fn render_confirm_dialog(
+        &self,
+        window: &mut Window,
+        theme: &Arc<Theme>,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        let state = self.confirm_dialog.as_ref()?;
+        let viewport = window.viewport_size();
+
+        let elevated = theme::elevated(theme);
+        let divider = theme::divider(theme);
+        let ink = theme::ink(theme);
+        let ink_dim = theme::ink_dim(theme);
+        let ink_ghost = theme::ink_ghost(theme);
+        let ink_muted = theme::ink_muted(theme);
+        let frost = theme::frost_10(theme);
+        let danger = theme::danger(theme);
+        let accent = theme::accent(theme);
+        let canvas = theme::canvas(theme);
+        let text_faint = theme::text_faint();
+
+        let focus_handle = state.focus_handle.clone();
+        let kind = state.spec.kind;
+        let title = state.spec.title.clone();
+        let message = state.spec.message.clone();
+        let detail = state.spec.detail.clone();
+        let confirm_label = state.spec.normalised_confirm_label();
+        let cancel_label = state.spec.normalised_cancel_label();
+
+        // Eyebrow text + colour: ACCENT for Confirm, DANGER for
+        // Destructive. Matches the C# eyebrow rule.
+        let (eyebrow_text, eyebrow_color) = match kind {
+            ConfirmKind::Confirm => ("CONFIRM", accent),
+            ConfirmKind::Destructive => ("DESTRUCTIVE", danger),
+        };
+
+        let header = div()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .px_5()
+            .pt_5()
+            .child(
+                div()
+                    .text_size(px(11.0))
+                    .text_color(eyebrow_color)
+                    .child(eyebrow_text),
+            )
+            .child(
+                div()
+                    .text_size(px(14.0))
+                    .text_color(ink)
+                    .font(theme::font_sans())
+                    .child(title),
+            );
+
+        let body_text = div()
+            .text_size(px(13.0))
+            .text_color(ink_muted)
+            .font(theme::font_sans())
+            .child(message);
+
+        let detail_block = detail.map(|d| {
+            div()
+                .text_size(px(11.5))
+                .text_color(text_faint)
+                .font(theme::font_sans())
+                .child(d)
+        });
+
+        let mut body = div()
+            .px_5()
+            .pb_2()
+            .flex()
+            .flex_col()
+            .gap_2()
+            .child(body_text);
+        if let Some(d) = detail_block {
+            body = body.child(d);
+        }
+
+        let cancel_btn = div()
+            .id("confirm-cancel")
+            .px_4()
+            .py_2()
+            .text_size(px(13.0))
+            .text_color(ink_dim)
+            .border_1()
+            .border_color(divider)
+            .rounded(px(6.0))
+            .cursor_pointer()
+            .hover(move |s| s.bg(frost).text_color(ink))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _, cx| {
+                    cx.stop_propagation();
+                    this.cancel_confirm_dialog(cx);
+                }),
+            )
+            .child(cancel_label);
+
+        let (primary_bg, primary_fg) = match kind {
+            ConfirmKind::Confirm => (accent, canvas),
+            ConfirmKind::Destructive => (danger, canvas),
+        };
+        let primary_btn = div()
+            .id("confirm-ok")
+            .px_4()
+            .py_2()
+            .text_size(px(13.0))
+            .text_color(primary_fg)
+            .bg(primary_bg)
+            .rounded(px(6.0))
+            .cursor_pointer()
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _, cx| {
+                    cx.stop_propagation();
+                    this.submit_confirm_dialog(cx);
+                }),
+            )
+            .child(confirm_label);
+
+        let footer_buttons = div()
+            .flex()
+            .flex_row()
+            .justify_end()
+            .gap_2()
+            .px_5()
+            .pb_5()
+            .pt_2()
+            .child(cancel_btn)
+            .child(primary_btn);
+
+        let _ = ink_ghost; // reserved for future hint-text slot; keeps the import shape
+                          // identical to the other dialog files so a future
+                          // hint row drops in without rewiring.
+
+        let card = div()
+            .flex()
+            .flex_col()
+            .gap_2()
+            .w(px(440.0))
+            .bg(elevated)
+            .border_1()
+            .border_color(divider)
+            .rounded_lg()
+            .shadow_lg()
+            .track_focus(&focus_handle)
+            .key_context("ConfirmDialog")
+            .on_key_down(cx.listener(handle_key_down))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|_, _, _, cx| cx.stop_propagation()),
+            )
+            .child(header)
+            .child(body)
+            .child(footer_buttons);
+
+        let backdrop = div()
+            .w(viewport.width)
+            .h(viewport.height)
+            .flex()
+            .items_center()
+            .justify_center()
+            .bg(gpui::hsla(0.0, 0.0, 0.0, 0.55))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _, cx| {
+                    // Scrim click cancels for both flavors. The C#
+                    // build leaves scrim click as a no-op on
+                    // destructive dialogs to force an explicit choice;
+                    // we deliberately diverge here because the
+                    // accidental-click risk is low in our flow (the
+                    // sidebar is the only entry point) and treating
+                    // scrim like Cancel matches every other dialog in
+                    // the Rust port. Document if we revert.
+                    this.cancel_confirm_dialog(cx);
+                }),
+            )
+            .child(card);
+
+        Some(
+            deferred(anchored().position(point(px(0.0), px(0.0))).child(backdrop))
+                .with_priority(10)
+                .into_any_element(),
+        )
+    }
+}
+
+/// Whitespace-only or empty labels collapse to the default. Pure
+/// helper so we can exercise it without standing up a gpui runtime.
+fn normalise_button_label(raw: &SharedString, default: &'static str) -> SharedString {
+    if raw.trim().is_empty() {
+        SharedString::from(default)
+    } else {
+        raw.clone()
+    }
+}
+
+/// Escape cancels for both flavors. Enter commits only on Confirm —
+/// Destructive requires an explicit button click (mirrors C#'s
+/// `IsDefault=false` rule for the destructive flavor). All other keys
+/// bubble.
+fn handle_key_down(
+    shell: &mut AppShell,
+    event: &KeyDownEvent,
+    _window: &mut Window,
+    cx: &mut Context<AppShell>,
+) {
+    let key = event.keystroke.key.as_str();
+    match key {
+        "escape" => {
+            cx.stop_propagation();
+            shell.cancel_confirm_dialog(cx);
+        }
+        "enter" => {
+            // Only Confirm-flavor dialogs auto-commit on Enter. The
+            // user has to click the primary button on Destructive
+            // — same friction the C# build adds for irreversible
+            // actions.
+            let is_confirm = shell
+                .confirm_dialog
+                .as_ref()
+                .map(|s| s.spec.kind == ConfirmKind::Confirm)
+                .unwrap_or(false);
+            if is_confirm {
+                cx.stop_propagation();
+                shell.submit_confirm_dialog(cx);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalised_labels_fall_back_to_default_on_empty() {
+        let spec = ConfirmSpec::destructive("t", "m").with_confirm_label("");
+        assert_eq!(spec.normalised_confirm_label().as_ref(), "OK");
+        let spec = ConfirmSpec::destructive("t", "m").with_cancel_label("   ");
+        assert_eq!(spec.normalised_cancel_label().as_ref(), "Cancel");
+    }
+
+    #[test]
+    fn normalised_labels_pass_through_real_text() {
+        let spec = ConfirmSpec::destructive("t", "m")
+            .with_confirm_label("Force remove")
+            .with_cancel_label("Keep");
+        assert_eq!(spec.normalised_confirm_label().as_ref(), "Force remove");
+        assert_eq!(spec.normalised_cancel_label().as_ref(), "Keep");
+    }
+
+    #[test]
+    fn with_detail_sets_the_detail_slot() {
+        let spec = ConfirmSpec::confirm("t", "m").with_detail("Path: /foo");
+        assert_eq!(spec.detail.as_ref().map(|s| s.as_ref()), Some("Path: /foo"));
+    }
+
+    #[test]
+    fn confirm_and_destructive_kinds_are_distinct() {
+        let a = ConfirmSpec::confirm("t", "m");
+        let b = ConfirmSpec::destructive("t", "m");
+        assert_eq!(a.kind, ConfirmKind::Confirm);
+        assert_eq!(b.kind, ConfirmKind::Destructive);
+    }
+}

--- a/codescope-rs/src/confirm_dialog.rs
+++ b/codescope-rs/src/confirm_dialog.rs
@@ -233,13 +233,15 @@ impl AppShell {
         let divider = theme::divider(theme);
         let ink = theme::ink(theme);
         let ink_dim = theme::ink_dim(theme);
-        let ink_ghost = theme::ink_ghost(theme);
         let ink_muted = theme::ink_muted(theme);
         let frost = theme::frost_10(theme);
         let danger = theme::danger(theme);
         let accent = theme::accent(theme);
         let canvas = theme::canvas(theme);
         let text_faint = theme::text_faint();
+        // `ink_ghost` is intentionally not bound — the C# spec reserves
+        // a footer hint slot in that colour but the Rust port doesn't
+        // render hints yet. Add it back if/when we wire that row in.
 
         let focus_handle = state.focus_handle.clone();
         let kind = state.spec.kind;
@@ -353,10 +355,6 @@ impl AppShell {
             .pt_2()
             .child(cancel_btn)
             .child(primary_btn);
-
-        let _ = ink_ghost; // reserved for future hint-text slot; keeps the import shape
-                          // identical to the other dialog files so a future
-                          // hint row drops in without rewiring.
 
         let card = div()
             .flex()

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -42,6 +42,7 @@ use gpui::{
     StatefulInteractiveElement, Styled, Window, anchored, deferred, div, point, px,
 };
 
+use crate::confirm_dialog::ConfirmSpec;
 use crate::new_project_dialog::NewProjectDialogState;
 use crate::new_worktree_dialog::NewWorktreeDialogState;
 use crate::theme;
@@ -201,6 +202,46 @@ pub enum SidebarEvent {
     /// Mirrors C# `Dialogs.RenameDialog.Prompt(current, title)`
     /// invocation pattern from `SidebarViewModel.Commands.cs`.
     OpenRenameDialog { target: RenameRequest, current_name: String },
+    /// User asked for a destructive (or otherwise confirm-gated)
+    /// sidebar action. AppShell opens its themed [`ConfirmDialog`],
+    /// awaits the result, and — on confirm — dispatches the carried
+    /// [`ConfirmAction`] back to the sidebar via
+    /// [`Sidebar::execute_confirm_action`]. Replaces the previous
+    /// `window.prompt(...)` OS-native modals so destructive sidebar
+    /// flows share visual chrome with the rest of the app's modals.
+    ///
+    /// `ConfirmDialog`: [`crate::confirm_dialog::ConfirmDialog`]
+    OpenConfirmDialog { spec: ConfirmSpec, action: ConfirmAction },
+}
+
+/// What `SidebarEvent::OpenConfirmDialog` is asking to do after the
+/// user confirms. Keeps the dialog-host (AppShell) decoupled from the
+/// per-action sidebar mutation paths — AppShell only needs to fire
+/// the matching [`Sidebar::execute_confirm_action`] dispatch when the
+/// dialog's receiver resolves to `true`. Each variant carries the
+/// stable identifiers (project id, worktree id, session id) it needs
+/// so a `projects.json` reorder between emit-and-confirm doesn't pin
+/// the wrong row.
+#[derive(Debug, Clone)]
+pub enum ConfirmAction {
+    /// Drop a project from the sidebar list. Mirrors C#
+    /// `SidebarViewModel.RemoveProjectCommand`.
+    RemoveProject { project_id: String },
+    /// `git reset --hard HEAD` + `git clean -fd` in the named
+    /// worktree's directory. Mirrors C# `DiscardChangesCommand`.
+    DiscardWorktreeChanges { project_id: String, worktree_id: String },
+    /// `git worktree remove` (force=false), with a follow-up
+    /// force-retry confirm if the first attempt fails. Mirrors C#
+    /// `RemoveWorktreeCommand`.
+    RemoveWorktree { project_id: String, worktree_id: String },
+    /// `git worktree remove --force`. Fired by the
+    /// `RemoveWorktreeForce` retry confirm after the non-force
+    /// attempt rejects. Mirrors the C# retry path in
+    /// `RemoveWorktreeCommand`.
+    RemoveWorktreeForce { project_id: String, worktree_id: String },
+    /// Forget a closed (history) session. Mirrors C#
+    /// `RemoveSessionFromHistoryCommand`.
+    RemoveSessionFromHistory { session_id: String },
 }
 
 /// What `SidebarEvent::OpenRenameDialog` is asking to rename. Held by
@@ -1575,50 +1616,72 @@ impl Sidebar {
         })
     }
 
-    /// Confirm-then-run `git reset --hard HEAD` + `git clean -fd`
-    /// for a worktree. Destructive — uses a `Critical`-level prompt
-    /// so the user has to actively confirm. Mirrors C#'s
-    /// `DiscardChangesCommand`.
-    fn discard_worktree_changes(
+    /// Open the themed confirm dialog for "Discard all changes" in a
+    /// worktree. The actual `git reset --hard HEAD` / `git clean -fd`
+    /// kicks off in [`Self::perform_discard_worktree_changes`] once
+    /// AppShell resolves the dialog to `true`. Mirrors C#
+    /// `DiscardChangesCommand` (which composes a destructive
+    /// `ConfirmDialog.Destructive(...)`).
+    fn request_discard_worktree_changes(
         &mut self,
         project_idx: usize,
         worktree_id: &str,
-        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let Some(path) = self.worktree_path(project_idx, worktree_id) else {
             self.close_menu(cx);
             return;
         };
-        // Friendly label for the prompt — shared with the rest of
-        // the worktree-action surface so wording stays consistent
-        // (`Remove worktree '<label>'?` and `Discard all changes
-        // in '<label>'?` line up).
         let label = self
             .worktree_display_label(project_idx, worktree_id)
             .unwrap_or_else(|| "this worktree".into());
+        let Some(project) = self.projects.projects.get(project_idx) else {
+            self.close_menu(cx);
+            return;
+        };
+        let project_id = project.id.clone();
         self.close_menu(cx);
-        let prompt_msg = format!("Discard all changes in '{label}'?");
-        let detail = format!(
-            "Path: {path}\n\nThis runs `git reset --hard HEAD` followed \
-             by `git clean -fd`. Untracked files and modifications to \
-             tracked files will be lost — there's no undo."
-        );
-        let rx = window.prompt(
-            gpui::PromptLevel::Critical,
-            &prompt_msg,
-            Some(&detail),
-            &["Discard", "Cancel"],
-            cx,
-        );
+
+        let spec = ConfirmSpec::destructive(
+            format!("Discard ALL local changes in '{label}'?"),
+            "This runs `git reset --hard HEAD` followed by `git clean -fd`. \
+             Untracked files and modifications to tracked files will be \
+             lost — there's no undo.",
+        )
+        .with_detail(SharedString::from(format!("Path: {path}")))
+        .with_confirm_label("Discard");
+        cx.emit(SidebarEvent::OpenConfirmDialog {
+            spec,
+            action: ConfirmAction::DiscardWorktreeChanges {
+                project_id,
+                worktree_id: worktree_id.to_string(),
+            },
+        });
+    }
+
+    /// Perform the discard now that the user has confirmed. Looks up
+    /// the worktree by stable id so a reorder between request and
+    /// confirm can't pin the wrong row.
+    fn perform_discard_worktree_changes(
+        &mut self,
+        project_id: &str,
+        worktree_id: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(project_idx) =
+            self.projects.projects.iter().position(|p| p.id == project_id)
+        else {
+            return;
+        };
+        let Some(path) = self.worktree_path(project_idx, worktree_id) else {
+            return;
+        };
+        let label = self
+            .worktree_display_label(project_idx, worktree_id)
+            .unwrap_or_else(|| "this worktree".into());
         let path = std::path::PathBuf::from(path);
-        let label_for_toast = label.clone();
+        let label_for_toast = label;
         cx.spawn(async move |this, cx| {
-            // 0 = first button ("Discard"). Anything else = cancel.
-            match rx.await {
-                Ok(0) => {}
-                _ => return,
-            }
             let result = cx
                 .background_spawn(
                     async move { codescope_core::git::discard_all_changes(&path) },
@@ -1640,20 +1703,15 @@ impl Sidebar {
         .detach();
     }
 
-    /// Drop a non-primary worktree from this project. Calls
-    /// `git worktree remove` (force=false first; on failure prompts
-    /// the user before retrying with `--force`), then rewrites
-    /// `projects.json` so the row disappears from the sidebar.
-    /// Mirrors `SidebarViewModel.RemoveWorktreeAsync` minus the
-    /// session-close pre-step (the Rust port doesn't yet track which
-    /// tabs are pinned to which worktree, so the user is responsible
-    /// for closing them — the force-prompt covers the file-locked
-    /// case).
-    fn remove_worktree(
+    /// Open the themed "Delete worktree" confirm dialog. The actual
+    /// `git worktree remove` runs from
+    /// [`Self::perform_remove_worktree_initial`] once AppShell
+    /// resolves the dialog. Mirrors C# `RemoveWorktreeAsync` (which
+    /// fronts the action with a destructive `ConfirmDialog`).
+    fn request_remove_worktree(
         &mut self,
         project_idx: usize,
         worktree_id: &str,
-        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let Some(ctx) = self.worktree_remove_context(project_idx, worktree_id) else {
@@ -1662,27 +1720,67 @@ impl Sidebar {
         };
         self.close_menu(cx);
 
-        let confirm_msg = format!("Delete worktree '{}'?", ctx.display_label);
-        let confirm_detail = format!(
-            "Path: {}\n\nOpen sessions stay running but lose their working directory. \
+        let spec = ConfirmSpec::destructive(
+            format!("Delete worktree '{}'?", ctx.display_label),
+            "Open sessions stay running but lose their working directory. \
              Unpushed commits stay on the branch.",
-            ctx.worktree_path
-        );
-        let rx = window.prompt(
-            gpui::PromptLevel::Warning,
-            &confirm_msg,
-            Some(&confirm_detail),
-            &["Delete", "Cancel"],
-            cx,
-        );
-        cx.spawn_in(window, async move |this, cx| {
-            // 0 = first button ("Delete"). Anything else = cancel /
-            // dialog dismissed.
-            match rx.await {
-                Ok(0) => {}
-                _ => return,
-            }
+        )
+        .with_detail(SharedString::from(format!("Path: {}", ctx.worktree_path)))
+        .with_confirm_label("Delete");
+        cx.emit(SidebarEvent::OpenConfirmDialog {
+            spec,
+            action: ConfirmAction::RemoveWorktree {
+                project_id: ctx.project_id.clone(),
+                worktree_id: ctx.worktree_id.clone(),
+            },
+        });
+    }
+
+    /// First-attempt `git worktree remove` (force=false). On failure,
+    /// fires a follow-up [`SidebarEvent::OpenConfirmDialog`] with
+    /// [`ConfirmAction::RemoveWorktreeForce`] so the user can opt in
+    /// to `--force`. On success, rewrites `projects.json`. Mirrors
+    /// the first half of `SidebarViewModel.RemoveWorktreeAsync`.
+    fn perform_remove_worktree_initial(
+        &mut self,
+        project_id: &str,
+        worktree_id: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(project_idx) =
+            self.projects.projects.iter().position(|p| p.id == project_id)
+        else {
+            return;
+        };
+        let Some(ctx) = self.worktree_remove_context(project_idx, worktree_id) else {
+            return;
+        };
+        cx.spawn(async move |this, cx| {
             run_remove_worktree_flow(this, ctx, cx).await;
+        })
+        .detach();
+    }
+
+    /// Force-remove path. Called after the user confirms the retry
+    /// dialog that `run_remove_worktree_flow` raises on the first
+    /// attempt's failure. Mirrors the retry-with-force branch in
+    /// `SidebarViewModel.RemoveWorktreeAsync`.
+    fn perform_remove_worktree_force(
+        &mut self,
+        project_id: &str,
+        worktree_id: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(project_idx) =
+            self.projects.projects.iter().position(|p| p.id == project_id)
+        else {
+            return;
+        };
+        let Some(ctx) = self.worktree_remove_context(project_idx, worktree_id) else {
+            return;
+        };
+        cx.spawn(async move |this, cx| {
+            run_remove_worktree_force_flow(this, ctx, cx).await;
         })
         .detach();
     }
@@ -1736,11 +1834,110 @@ impl Sidebar {
         .detach();
     }
 
+    /// Open the themed confirm dialog for "Remove session from
+    /// history". On confirm the AppShell-side handler dispatches
+    /// [`ConfirmAction::RemoveSessionFromHistory`] back to itself
+    /// (since session removal goes through the AppShell-owned
+    /// `SessionManager::hard_remove`). Mirrors C#
+    /// `RemoveSessionFromHistoryCommand`.
+    fn request_remove_session_from_history(
+        &mut self,
+        session_id: String,
+        label: String,
+        cx: &mut Context<Self>,
+    ) {
+        self.close_menu(cx);
+        let spec = ConfirmSpec::destructive(
+            format!("Remove session '{label}' from history?"),
+            "The closed-session row is forgotten. Its agent transcript on \
+             disk (if any) is left untouched.",
+        )
+        .with_confirm_label("Remove");
+        cx.emit(SidebarEvent::OpenConfirmDialog {
+            spec,
+            action: ConfirmAction::RemoveSessionFromHistory { session_id },
+        });
+    }
+
+    /// Dispatch a confirmed [`ConfirmAction`] to the matching sidebar
+    /// mutation path. Called by AppShell when the themed
+    /// [`crate::confirm_dialog::ConfirmDialog`] resolves to `true`.
+    /// Variants that need AppShell state (the session-history one)
+    /// are handled on the AppShell side and never reach this match.
+    pub fn execute_confirm_action(
+        &mut self,
+        action: ConfirmAction,
+        cx: &mut Context<Self>,
+    ) {
+        match action {
+            ConfirmAction::RemoveProject { project_id } => {
+                self.remove_project_by_id(&project_id, cx);
+            }
+            ConfirmAction::DiscardWorktreeChanges { project_id, worktree_id } => {
+                self.perform_discard_worktree_changes(&project_id, &worktree_id, cx);
+            }
+            ConfirmAction::RemoveWorktree { project_id, worktree_id } => {
+                self.perform_remove_worktree_initial(&project_id, &worktree_id, cx);
+            }
+            ConfirmAction::RemoveWorktreeForce { project_id, worktree_id } => {
+                self.perform_remove_worktree_force(&project_id, &worktree_id, cx);
+            }
+            ConfirmAction::RemoveSessionFromHistory { .. } => {
+                // Handled by AppShell — the session store lives there.
+                // Hitting this branch would mean a routing bug; the
+                // log line keeps the failure visible without crashing.
+                eprintln!(
+                    "warning: RemoveSessionFromHistory routed to Sidebar; AppShell should handle this action"
+                );
+            }
+        }
+    }
+
+    /// Open the themed confirm dialog for "Remove project". On confirm
+    /// the AppShell-side handler dispatches
+    /// [`ConfirmAction::RemoveProject`] back to
+    /// [`Self::execute_confirm_action`], which calls
+    /// [`Self::remove_project_by_id`]. We snapshot the project's id
+    /// (not the index) so a `projects.json` reorder between
+    /// emit-and-confirm can't pin the wrong row.
+    fn request_remove_project(&mut self, idx: usize, cx: &mut Context<Self>) {
+        let Some(project) = self.projects.projects.get(idx) else {
+            self.close_menu(cx);
+            return;
+        };
+        let project_id = project.id.clone();
+        let project_name = project.name.clone();
+        let project_path = project.path.clone();
+        self.close_menu(cx);
+        let spec = ConfirmSpec::destructive(
+            format!("Remove project '{project_name}' from CodeScope?"),
+            "The folder on disk stays untouched; only this app's record is removed.",
+        )
+        .with_detail(SharedString::from(project_path))
+        .with_confirm_label("Remove");
+        cx.emit(SidebarEvent::OpenConfirmDialog {
+            spec,
+            action: ConfirmAction::RemoveProject { project_id },
+        });
+    }
+
     /// Drop a project from the sidebar list and persist `projects.json`.
     /// Does **not** touch anything on disk — the working tree stays
     /// where it is; the user just removes it from CodeScope's view.
     /// Save-then-commit ordering matches `add_project` so a write
     /// failure leaves both disk and UI in their previous state.
+    ///
+    /// Stable-id variant of [`Self::remove_project`] — resolves the
+    /// row by `project_id` so the action survives a reorder between
+    /// dialog-open and dialog-confirm.
+    fn remove_project_by_id(&mut self, project_id: &str, cx: &mut Context<Self>) {
+        let Some(idx) = self.projects.projects.iter().position(|p| p.id == project_id)
+        else {
+            return;
+        };
+        self.remove_project(idx, cx);
+    }
+
     fn remove_project(&mut self, idx: usize, cx: &mut Context<Self>) {
         if idx >= self.projects.projects.len() {
             return;
@@ -3349,7 +3546,7 @@ impl Sidebar {
                 "menu-remove",
                 "Remove project",
                 true,
-                Box::new(move |this, _window, cx| this.remove_project(idx, cx)),
+                Box::new(move |this, _window, cx| this.request_remove_project(idx, cx)),
             ))
             // Click on the menu itself shouldn't bubble out and trigger
             // the dismiss handler we install below.
@@ -3705,11 +3902,10 @@ impl Sidebar {
                             "wt-menu-discard",
                             "Discard changes…",
                             true,
-                            Box::new(move |this, window, cx| {
-                                this.discard_worktree_changes(
+                            Box::new(move |this, _window, cx| {
+                                this.request_discard_worktree_changes(
                                     project_idx,
                                     &id_for_discard,
-                                    window,
                                     cx,
                                 );
                             }),
@@ -3762,8 +3958,8 @@ impl Sidebar {
                     "wt-menu-remove",
                     "Remove worktree…",
                     true,
-                    Box::new(move |this, window, cx| {
-                        this.remove_worktree(project_idx, &id_for_remove, window, cx);
+                    Box::new(move |this, _window, cx| {
+                        this.request_remove_worktree(project_idx, &id_for_remove, cx);
                     }),
                 ))
             }))
@@ -3833,6 +4029,8 @@ impl Sidebar {
         let reopen_session_id = session_id.clone();
         let rename_session_id = session_id.clone();
         let rename_current = label.clone();
+        let remove_session_id = session_id.clone();
+        let remove_label = label.clone();
 
         let menu_body = div()
             .flex()
@@ -3885,6 +4083,18 @@ impl Sidebar {
                     this.close_menu(cx);
                 }),
             ))
+            .child(div().h_px().bg(divider).my_1())
+            .child(item(
+                "hist-menu-remove",
+                "Remove from history…",
+                Box::new(move |this, _window, cx| {
+                    this.request_remove_session_from_history(
+                        remove_session_id.clone(),
+                        remove_label.clone(),
+                        cx,
+                    );
+                }),
+            ))
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(|_, _, _, cx| cx.stop_propagation()),
@@ -3915,14 +4125,17 @@ struct WorktreeRemoveContext {
     display_label: String,
 }
 
-/// Run the post-confirm `git worktree remove` flow. Lives outside the
-/// `Sidebar` impl because `cx.spawn_in` hands us an `AsyncApp` and a
-/// `WeakEntity<Sidebar>`, not a `&mut Sidebar` — wrapping the whole
-/// thing in a free async function keeps the borrow shape obvious.
+/// Run the post-confirm initial `git worktree remove` (force=false).
+/// On success, rewrites `projects.json`. On failure, fires a follow-
+/// up [`SidebarEvent::OpenConfirmDialog`] with
+/// [`ConfirmAction::RemoveWorktreeForce`] so the user can opt in
+/// to `--force`. Lives outside the `Sidebar` impl because the
+/// `cx.spawn` task gets a `WeakEntity<Sidebar>`, not `&mut Sidebar`
+/// — keeping the borrow shape explicit.
 async fn run_remove_worktree_flow(
     this: gpui::WeakEntity<Sidebar>,
     ctx: WorktreeRemoveContext,
-    cx: &mut gpui::AsyncWindowContext,
+    cx: &mut gpui::AsyncApp,
 ) {
     use codescope_core::git;
 
@@ -3938,56 +4151,78 @@ async fn run_remove_worktree_flow(
             .await
     };
 
-    let needs_force = match first_attempt {
-        Ok(()) => false,
+    match first_attempt {
+        Ok(()) => {
+            commit_worktree_removal(this, &ctx, cx).await;
+        }
         Err(err) => {
-            // Retry-with-force prompt. Same wording shape as the C#
-            // dialog: show the underlying git error so the user sees
-            // *why* the normal remove failed before deciding to force.
-            let prompt_msg = "Couldn't remove worktree — force?".to_string();
+            // Raise the themed force-retry confirm. Same wording
+            // shape as the C# dialog: show the underlying git error
+            // so the user sees *why* the normal remove failed before
+            // deciding to force.
+            let project_id = ctx.project_id.clone();
+            let worktree_id = ctx.worktree_id.clone();
             let detail = format!(
                 "{}\n\nForce remove will discard uncommitted changes and untracked files in the worktree.",
                 err
             );
-            let receiver = match this.update_in(cx, |_this, window, cx| {
-                window.prompt(
-                    gpui::PromptLevel::Warning,
-                    &prompt_msg,
-                    Some(&detail),
-                    &["Force remove", "Cancel"],
-                    cx,
+            let _ = this.update(cx, |_, cx| {
+                let spec = crate::confirm_dialog::ConfirmSpec::destructive(
+                    "Couldn't remove worktree — force?",
+                    "",
                 )
-            }) {
-                Ok(rx) => rx,
-                Err(_) => return,
-            };
-            match receiver.await {
-                Ok(0) => true,
-                _ => return,
-            }
-        }
-    };
-
-    if needs_force {
-        let repo = repo.clone();
-        let wt_path = wt_path.clone();
-        let forced = cx
-            .background_spawn(async move { git::remove_worktree(&repo, &wt_path, true) })
-            .await;
-        if let Err(err) = forced {
-            eprintln!(
-                "warning: force-remove of worktree '{}' failed: {err:#}",
-                ctx.display_label
-            );
-            return;
+                .with_detail(SharedString::from(detail))
+                .with_confirm_label("Force remove");
+                cx.emit(SidebarEvent::OpenConfirmDialog {
+                    spec,
+                    action: ConfirmAction::RemoveWorktreeForce {
+                        project_id,
+                        worktree_id,
+                    },
+                });
+            });
         }
     }
+}
 
-    // Git is happy; rewrite `projects.json` to drop the row. Match by
-    // (project id, worktree id) so a concurrent edit that reordered
-    // the list still hits the right row. If the project / worktree is
-    // already gone (e.g. another window beat us to it), the rewrite
-    // is a no-op and we still return success.
+/// Run `git worktree remove --force`, fired after the user confirms
+/// the retry dialog. Same finish-up as the non-force path.
+async fn run_remove_worktree_force_flow(
+    this: gpui::WeakEntity<Sidebar>,
+    ctx: WorktreeRemoveContext,
+    cx: &mut gpui::AsyncApp,
+) {
+    use codescope_core::git;
+
+    let repo = std::path::PathBuf::from(&ctx.project_path);
+    let wt_path = std::path::PathBuf::from(&ctx.worktree_path);
+
+    let forced = {
+        let repo = repo.clone();
+        let wt_path = wt_path.clone();
+        cx.background_spawn(async move { git::remove_worktree(&repo, &wt_path, true) })
+            .await
+    };
+    if let Err(err) = forced {
+        eprintln!(
+            "warning: force-remove of worktree '{}' failed: {err:#}",
+            ctx.display_label
+        );
+        return;
+    }
+    commit_worktree_removal(this, &ctx, cx).await;
+}
+
+/// Rewrite `projects.json` to drop the just-removed worktree. Shared
+/// by the non-force and force flows. Matches by (project id,
+/// worktree id) so a concurrent edit that reordered the list still
+/// hits the right row. If the project / worktree is already gone
+/// (e.g. another window beat us to it), the rewrite is a no-op.
+async fn commit_worktree_removal(
+    this: gpui::WeakEntity<Sidebar>,
+    ctx: &WorktreeRemoveContext,
+    cx: &mut gpui::AsyncApp,
+) {
     let _ = this.update(cx, |this, cx| {
         let mut next = this.projects.clone();
         let Some(project) = next.projects.iter_mut().find(|p| p.id == ctx.project_id) else {

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -13,6 +13,7 @@
 
 mod app;
 mod command_palette;
+mod confirm_dialog;
 mod new_project_dialog;
 mod new_worktree_dialog;
 mod notifications;


### PR DESCRIPTION
## Summary

Themed in-app `ConfirmDialog` (Rust port of `src/CodeScope.Ui/Dialogs/ConfirmDialog.xaml(.cs)`) that replaces the OS-native `window.prompt(...)` used by destructive sidebar actions. The new dialog mirrors the visual idiom of the other in-app modals (`new_project_dialog`, `rename_dialog`, `settings_dialog`) — elevated card on a dim backdrop, divider border, accent-or-danger primary button, 440 px wide.

Two flavors mirror the C# `Flavor.Confirm` / `Flavor.Destructive`:
- **Confirm** — accent primary, Enter auto-commits.
- **Destructive** — danger (red) primary, Enter does NOT auto-commit (the user has to click the button — same friction the C# build adds for irreversible actions).

API: `app.open_confirm_dialog(spec, window, cx) -> oneshot::Receiver<bool>`. The caller awaits inside a `cx.spawn` task, matching the call-shape of the `window.prompt(...)` it replaces. Sidebar emits `SidebarEvent::OpenConfirmDialog { spec, action: ConfirmAction }` so the dialog itself lives on `AppShell` (matching every other dialog) while the typed `ConfirmAction` enum dispatches the post-confirm mutation back to the sidebar.

## Migrated destructive sites

- `remove_project` — previously had **no confirm** (HANDOFF rough edge). Now opens a Destructive dialog with the message *"Remove project '{name}' from CodeScope?"* + detail *"The folder on disk stays untouched; only this app's record is removed."*
- `discard_worktree_changes` — was `window.prompt(Critical)`. Now Destructive flavor.
- `remove_worktree` — was `window.prompt(Warning)`. Now Destructive flavor.
- `remove_worktree` force-retry — was a second `window.prompt`. Now Destructive flavor (raised by `run_remove_worktree_flow` on first-attempt failure).
- `"Remove from history…"` — **new menu row** on the closed-session history context menu (the row didn't exist on the Rust side at all yet). Routes through new `AppShell::remove_session_from_history`, which calls `SessionManager::hard_remove` + persists — mirrors C# `RemoveSessionFromHistoryAsync`.

## Tests

- 4 new unit tests in `confirm_dialog.rs` for `ConfirmSpec` label normalisation + detail-slot wiring (purely about pure helpers — no view rendering tests, matching the rename_dialog test discipline).
- Full workspace suite (`cargo test --workspace`) stays green: **417 + 76 + 19 + 1 = 513 tests passing**.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` green (513 tests)
- [x] No native `window.prompt` calls remain in the destructive sidebar flows
- [ ] Smoke check: launch the dev build (`CODESCOPE_DEV=1`), right-click a project → Remove project — themed dialog appears.
- [ ] Smoke check: discard changes / remove worktree / force-retry all use themed dialog.
- [ ] Smoke check: right-click a closed-history row → Remove from history… appears and works.