### PR TITLE
feat(rs): overview live-only + settings dialog sizing + darker terminal bg

### DIFF
--- a/codescope-rs/core/src/overview.rs
+++ b/codescope-rs/core/src/overview.rs
@@ -1,30 +1,35 @@
 //! Pure-data helpers for the Overview panel.
 //!
-//! The Rust Overview view (see `codescope-rs/src/overview.rs`) shows
-//! every open + recently-closed session across every project in one
-//! grid. The on-screen sort + filter belong on the gpui side, but the
-//! row-building + sort key derivation are pure-data so they live here
-//! and ship with unit tests.
+//! The Rust Overview view (see `codescope-rs/src/overview.rs`) is an
+//! "active sessions" dashboard — one row per currently open session
+//! across every project. The on-screen sort + filter belong on the
+//! gpui side, but the row-building + sort key derivation are pure-data
+//! so they live here and ship with unit tests.
 //!
 //! Mirrors the C# `OverviewViewModel.Rebuild` flow: walk every project,
-//! enumerate live tabs (`closed_at = None`) plus closed rows
-//! (`closed_at = Some`), and surface them ordered "live first, closed
-//! sorted newest-first by `closed_at`". The C# view only renders live
-//! sessions; the Rust port surfaces closed history too because the
-//! brief explicitly asks for "open + recently-closed sessions" in one
-//! panel.
+//! enumerate live tabs (`closed_at = None`), and surface them sorted
+//! newest-first by `last_opened`. Closed (soft-deleted) sessions are
+//! deliberately *not* surfaced here — earlier revisions of the Rust
+//! port appended a closed-history block to this grid, but it was just
+//! noise next to live work. The reopen flow still exists via the
+//! sidebar's history menu; Overview is for what's open right now.
 
 use crate::projects::{Project, ProjectsConfig, Session};
 use crate::time::parse_iso8601_secs;
 
-/// Live vs. closed discriminator for an Overview row.
+/// Lifecycle discriminator for an Overview row. Today only `Live`
+/// rows are surfaced by [`build_rows`] — the panel is an active-
+/// sessions dashboard. The enum is kept (rather than collapsed away)
+/// so the gpui-side render path can stay shape-stable if a future
+/// "show recently closed" toggle reintroduces closed rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OverviewLifecycle {
     /// `closed_at == None` — the session row is live on disk; the
     /// runtime may or may not have a matching tab open.
     Live,
     /// `closed_at == Some(_)` — soft-closed session row, eligible for
-    /// reopen via [`crate::SessionManager::reopen`].
+    /// reopen via [`crate::SessionManager::reopen`]. Not currently
+    /// emitted by [`build_rows`]; reserved for a future toggle.
     Closed,
 }
 
@@ -84,106 +89,41 @@ impl OverviewRow {
     }
 }
 
-/// Default cap on the number of closed-session rows surfaced in the
-/// Overview. Mirrors the "show the last 20 closed sessions" heuristic
-/// the brief calls out — the on-disk `RetentionPolicy` keeps a much
-/// larger window (60 days / 200 entries per project) so the user can
-/// reopen old work, but dumping every retained closed row into a
-/// single grid drowns the panel. Live rows are never capped.
-pub const DEFAULT_MAX_CLOSED_ROWS: usize = 20;
-
-/// Closed-row dedup window. Two closed sessions for the same
-/// `(project_name, agent_id)` whose `closed_at` stamps fall within
-/// this window are treated as the same logical tab restarted and
-/// only the newest row is kept. The 5-minute span was picked to
-/// match the brief — long enough to swallow a quick crash + respawn
-/// loop, short enough that two genuinely separate working sessions
-/// from the same agent on the same project don't get folded into
-/// one row.
-pub const CLOSED_DEDUP_WINDOW_SECS: f64 = 5.0 * 60.0;
-
-/// Build the flat row list from a [`ProjectsConfig`] snapshot,
-/// already sorted via [`sort_rows`] and capped at
-/// [`DEFAULT_MAX_CLOSED_ROWS`] closed rows. Mirrors C#
-/// `OverviewViewModel.Rebuild` minus the per-card preview lines (the
-/// Rust port builds those in the gpui layer so it can fold in live
-/// telemetry without re-running this pass).
+/// Build the flat row list from a [`ProjectsConfig`] snapshot —
+/// **live sessions only**, sorted newest-first by `last_opened`.
+/// Mirrors C# `OverviewViewModel.Rebuild` minus the per-card preview
+/// lines (the Rust port builds those in the gpui layer so it can fold
+/// in live telemetry without re-running this pass).
+///
+/// Closed sessions are filtered out here — the Overview panel is an
+/// "active sessions" dashboard and closed-history noise was hurting
+/// the signal-to-noise ratio. The reopen flow still exists via the
+/// sidebar's per-project history menu.
 pub fn build_rows(cfg: &ProjectsConfig) -> Vec<OverviewRow> {
-    build_rows_capped(cfg, DEFAULT_MAX_CLOSED_ROWS)
-}
-
-/// Build the flat row list with an explicit cap on the number of
-/// closed-session rows. Live rows are never capped; closed rows are
-/// sorted newest-first, deduped by `(project_name, agent_id)` within
-/// a [`CLOSED_DEDUP_WINDOW_SECS`] window (so a quick respawn loop
-/// only surfaces the most recent row), and then truncated to
-/// `max_closed` entries.
-pub fn build_rows_capped(cfg: &ProjectsConfig, max_closed: usize) -> Vec<OverviewRow> {
     let mut rows: Vec<OverviewRow> = cfg
         .projects
         .iter()
-        .flat_map(|p| p.sessions.iter().map(move |s| OverviewRow::from_session(p, s)))
+        .flat_map(|p| {
+            p.sessions
+                .iter()
+                .filter(|s| s.closed_at.is_none())
+                .map(move |s| OverviewRow::from_session(p, s))
+        })
         .collect();
     sort_rows(&mut rows);
-
-    // Split into live (no cap) + closed (sorted newest-first by
-    // virtue of `sort_rows`). The live partition keeps its sort order
-    // because `sort_rows` already puts live before closed.
-    let split = rows
-        .iter()
-        .position(|r| r.lifecycle == OverviewLifecycle::Closed)
-        .unwrap_or(rows.len());
-    let closed_tail = rows.split_off(split);
-    let mut live = rows;
-
-    // Dedup near-identical closed rows. For each kept row we record
-    // the (project_name, agent_id, closed_at_secs) key. A candidate
-    // row is suppressed when an earlier (newer) row shares the same
-    // (project, agent) and its `closed_at` is within the dedup
-    // window. We keep the newest row of each cluster which falls out
-    // naturally because `closed_tail` is already newest-first.
-    let mut deduped: Vec<OverviewRow> = Vec::with_capacity(closed_tail.len().min(max_closed));
-    let mut kept_keys: Vec<(String, Option<String>, Option<f64>)> = Vec::new();
-    for row in closed_tail {
-        let key_proj = row.project_name.clone();
-        let key_agent = row.agent_id.clone();
-        let row_secs = row.closed_at.as_deref().and_then(parse_iso8601_secs);
-        let is_dup = kept_keys.iter().any(|(p, a, t)| {
-            p == &key_proj
-                && a == &key_agent
-                && match (row_secs, *t) {
-                    (Some(a_secs), Some(b_secs)) => {
-                        (a_secs - b_secs).abs() <= CLOSED_DEDUP_WINDOW_SECS
-                    }
-                    // Without a parseable timestamp on either side we
-                    // can't bound the cluster, so we don't dedup.
-                    _ => false,
-                }
-        });
-        if is_dup {
-            continue;
-        }
-        kept_keys.push((key_proj, key_agent, row_secs));
-        deduped.push(row);
-        if deduped.len() >= max_closed {
-            break;
-        }
-    }
-
-    live.extend(deduped);
-    live
+    rows
 }
 
 /// Sort an Overview row list in display order:
 ///
 /// 1. Live rows first (live before closed),
 /// 2. within live: newest `last_opened` first (missing values sort last),
-/// 3. within closed: newest `closed_at` first (matches
+/// 3. within closed (only reachable if a future caller surfaces them):
+///    newest `closed_at` first (matches
 ///    [`crate::SessionManager::closed`]).
 ///
 /// Mirrors the visual reading order of the C# Overview's
-/// `FilteredCards` — active sessions read top-to-bottom, closed
-/// history trails below.
+/// `FilteredCards` — active sessions read top-to-bottom.
 pub fn sort_rows(rows: &mut [OverviewRow]) {
     rows.sort_by(|a, b| {
         match (a.lifecycle, b.lifecycle) {
@@ -276,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn live_rows_sort_before_closed_rows() {
+    fn closed_rows_are_filtered_out() {
         let cfg = ProjectsConfig {
             version: 1,
             agents: vec![],
@@ -284,23 +224,22 @@ mod tests {
                 "p1",
                 "alpha",
                 vec![
-                    // closed but recent
+                    // closed but recent — must NOT appear
                     mk_session("closed_recent", None, Some("2026-05-11T12:30:00Z")),
-                    // live but stale
+                    // live but stale — must appear
                     mk_session("live_old", Some("2026-05-01T08:00:00Z"), None),
                 ],
             )],
         };
 
         let rows = build_rows(&cfg);
-        assert_eq!(rows[0].session_id, "live_old"); // live always before closed
+        assert_eq!(rows.len(), 1, "Overview surfaces live sessions only");
+        assert_eq!(rows[0].session_id, "live_old");
         assert_eq!(rows[0].lifecycle, OverviewLifecycle::Live);
-        assert_eq!(rows[1].session_id, "closed_recent");
-        assert_eq!(rows[1].lifecycle, OverviewLifecycle::Closed);
     }
 
     #[test]
-    fn closed_rows_sort_newest_first() {
+    fn build_rows_excludes_every_closed_session() {
         let cfg = ProjectsConfig {
             version: 1,
             agents: vec![],
@@ -308,17 +247,15 @@ mod tests {
                 "p1",
                 "alpha",
                 vec![
-                    mk_session("oldest", None, Some("2026-05-09T09:00:00Z")),
-                    mk_session("newest", None, Some("2026-05-11T09:00:00Z")),
-                    mk_session("middle", None, Some("2026-05-10T09:00:00Z")),
+                    mk_session("c1", None, Some("2026-05-09T09:00:00Z")),
+                    mk_session("c2", None, Some("2026-05-11T09:00:00Z")),
+                    mk_session("c3", None, Some("2026-05-10T09:00:00Z")),
                 ],
             )],
         };
 
         let rows = build_rows(&cfg);
-        assert_eq!(rows[0].session_id, "newest");
-        assert_eq!(rows[1].session_id, "middle");
-        assert_eq!(rows[2].session_id, "oldest");
+        assert!(rows.is_empty(), "no closed rows must leak into Overview");
     }
 
     #[test]
@@ -370,147 +307,4 @@ mod tests {
         assert_eq!(closed.lifecycle, OverviewLifecycle::Closed);
     }
 
-    #[test]
-    fn build_rows_caps_closed_at_default_limit() {
-        // 25 closed sessions, one project — only the newest 20 survive
-        // and the live row is always retained even though it'd sort
-        // below all the recent closed rows by raw timestamp (live
-        // rows have a separate sort domain).
-        let mut sessions = Vec::new();
-        sessions.push(mk_session("live", Some("2026-01-01T00:00:00Z"), None));
-        for i in 0..25 {
-            // Stagger closed_at stamps an hour apart so the dedup
-            // window can't fold them together, and vary the agent
-            // slightly per row so the (project, agent) dedup key is
-            // unique.
-            let stamp = format!("2026-05-11T{:02}:00:00Z", i);
-            let mut s = mk_session(&format!("c{i}"), None, Some(&stamp));
-            s.agent_id = Some(format!("agent-{i}"));
-            sessions.push(s);
-        }
-        let cfg = ProjectsConfig {
-            version: 1,
-            agents: vec![],
-            projects: vec![mk_project("p1", "alpha", sessions)],
-        };
-
-        let rows = build_rows(&cfg);
-        let live_count = rows
-            .iter()
-            .filter(|r| r.lifecycle == OverviewLifecycle::Live)
-            .count();
-        let closed_count = rows
-            .iter()
-            .filter(|r| r.lifecycle == OverviewLifecycle::Closed)
-            .count();
-        assert_eq!(live_count, 1, "live row must always be retained");
-        assert_eq!(
-            closed_count, DEFAULT_MAX_CLOSED_ROWS,
-            "closed cap honoured"
-        );
-    }
-
-    #[test]
-    fn build_rows_under_cap_returns_everything() {
-        let mut sessions = Vec::new();
-        for i in 0..5 {
-            let stamp = format!("2026-05-11T{:02}:00:00Z", i);
-            let mut s = mk_session(&format!("c{i}"), None, Some(&stamp));
-            s.agent_id = Some(format!("agent-{i}"));
-            sessions.push(s);
-        }
-        let cfg = ProjectsConfig {
-            version: 1,
-            agents: vec![],
-            projects: vec![mk_project("p1", "alpha", sessions)],
-        };
-
-        let rows = build_rows(&cfg);
-        assert_eq!(rows.len(), 5);
-    }
-
-    #[test]
-    fn build_rows_capped_keeps_newest_first_when_over_cap() {
-        // 5 closed rows, cap to 2 — must keep the two newest by
-        // closed_at, in newest-first order.
-        let sessions = vec![
-            {
-                let mut s = mk_session("oldest", None, Some("2026-05-01T00:00:00Z"));
-                s.agent_id = Some("a".into());
-                s
-            },
-            {
-                let mut s = mk_session("mid1", None, Some("2026-05-02T00:00:00Z"));
-                s.agent_id = Some("b".into());
-                s
-            },
-            {
-                let mut s = mk_session("mid2", None, Some("2026-05-03T00:00:00Z"));
-                s.agent_id = Some("c".into());
-                s
-            },
-            {
-                let mut s = mk_session("newer", None, Some("2026-05-04T00:00:00Z"));
-                s.agent_id = Some("d".into());
-                s
-            },
-            {
-                let mut s = mk_session("newest", None, Some("2026-05-05T00:00:00Z"));
-                s.agent_id = Some("e".into());
-                s
-            },
-        ];
-        let cfg = ProjectsConfig {
-            version: 1,
-            agents: vec![],
-            projects: vec![mk_project("p1", "alpha", sessions)],
-        };
-
-        let rows = build_rows_capped(&cfg, 2);
-        assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].session_id, "newest");
-        assert_eq!(rows[1].session_id, "newer");
-    }
-
-    #[test]
-    fn build_rows_dedups_near_duplicate_closed_rows() {
-        // Three closed rows for the same (project, agent) clustered
-        // within ~4 minutes of each other plus one fully separate row
-        // an hour later. Dedup must collapse the cluster to the
-        // newest entry; the separated row stays.
-        let sessions = vec![
-            mk_session("crash1", None, Some("2026-05-11T10:00:00Z")),
-            mk_session("crash2", None, Some("2026-05-11T10:02:00Z")),
-            mk_session("crash3", None, Some("2026-05-11T10:04:00Z")),
-            mk_session("separate", None, Some("2026-05-11T11:00:00Z")),
-        ];
-        let cfg = ProjectsConfig {
-            version: 1,
-            agents: vec![],
-            projects: vec![mk_project("p1", "alpha", sessions)],
-        };
-
-        let rows = build_rows(&cfg);
-        assert_eq!(rows.len(), 2, "near-duplicate cluster collapsed to newest");
-        assert_eq!(rows[0].session_id, "separate");
-        assert_eq!(rows[1].session_id, "crash3");
-    }
-
-    #[test]
-    fn build_rows_dedup_does_not_collapse_different_agents() {
-        // Same project + same closed_at, different agents → not a
-        // duplicate, both rows survive.
-        let mut s1 = mk_session("a_row", None, Some("2026-05-11T10:00:00Z"));
-        s1.agent_id = Some("claude".into());
-        let mut s2 = mk_session("b_row", None, Some("2026-05-11T10:00:00Z"));
-        s2.agent_id = Some("codex".into());
-        let cfg = ProjectsConfig {
-            version: 1,
-            agents: vec![],
-            projects: vec![mk_project("p1", "alpha", vec![s1, s2])],
-        };
-
-        let rows = build_rows(&cfg);
-        assert_eq!(rows.len(), 2);
-    }
 }

--- a/codescope-rs/core/src/theme/builtin_impl.rs
+++ b/codescope-rs/core/src/theme/builtin_impl.rs
@@ -64,7 +64,19 @@ pub fn codescope_default() -> Theme {
                 Rgb::from_hex(0x666666), Rgb::from_hex(0xf14c4c), Rgb::from_hex(0x23d18b), Rgb::from_hex(0xf5f543),
                 Rgb::from_hex(0x3b8eea), Rgb::from_hex(0xd670d6), Rgb::from_hex(0x29b8db), Rgb::from_hex(0xffffff),
             ],
-            Rgb::from_hex(0xcccccc), Rgb::from_hex(0x1e1e1e), Rgb::from_hex(0xffffff),
+            // Foreground / **terminal background** / cursor.
+            //
+            // `#0a0a0c` is the canonical terminal canvas for the
+            // default theme — a near-black with a faint cool tint, so
+            // the canvas reads as dark without going full `#000000`
+            // (which can crush against IPS panel uniformity issues).
+            // Reference points considered:
+            //   * Windows Terminal default `#0c0c0c`,
+            //   * Alacritty default      `#1d1f21`,
+            //   * VS Code Dark+          `#1e1e1e` (too light for us).
+            // The chrome `canvas` field stays `#000000` — only the
+            // *terminal* canvas changed here.
+            Rgb::from_hex(0xcccccc), Rgb::from_hex(0x0a0a0c), Rgb::from_hex(0xffffff),
         ),
     }
 }
@@ -251,6 +263,19 @@ mod tests {
         assert_eq!(t.chrome.ink_muted,    Rgb::from_hex(0xa6a6a6));
         assert_eq!(t.chrome.divider,      Rgb::from_hex(0x222222));
         assert_eq!(t.chrome.accent,       Rgb::from_hex(0x0099ff));
+    }
+
+    #[test]
+    fn default_terminal_canvas_is_near_black() {
+        // Lock the terminal background (`palette.background`) for the
+        // default theme. `#0a0a0c` is intentionally darker than VS
+        // Code Dark+ (`#1e1e1e`) and Alacritty default (`#1d1f21`),
+        // closer to Windows Terminal (`#0c0c0c`) with a faint cool
+        // tint. Any drift away from this value should be deliberate
+        // and considered alongside the chrome canvas (#000000) — the
+        // two reads together set the "depth" of the panel.
+        let t = codescope_default();
+        assert_eq!(t.palette.background, Rgb::from_hex(0x0a0a0c));
     }
 
     #[test]

--- a/codescope-rs/src/overview.rs
+++ b/codescope-rs/src/overview.rs
@@ -1,27 +1,25 @@
-//! Overview panel — one card per open + recently-closed session
-//! across every project. Toggled on/off via the sidebar footer
-//! "Overview" button or `Ctrl+Shift+O`; while visible, replaces the
-//! workspace area (per-group tab strip + terminal grid) inside the
-//! main row so the sidebar + status bar stay anchored.
+//! Overview panel — one card per currently-open session across every
+//! project. Toggled on/off via the sidebar footer "Overview" button or
+//! `Ctrl+Shift+O`; while visible, replaces the workspace area
+//! (per-group tab strip + terminal grid) inside the main row so the
+//! sidebar + status bar stay anchored.
 //!
 //! Mirrors `src/CodeScope.Ui/Views/OverviewView.xaml` /
-//! `ViewModels/OverviewViewModel.cs` from the C# build, with two
-//! deliberate extensions called out in the brief:
+//! `ViewModels/OverviewViewModel.cs` from the C# build. Like the C#
+//! Overview, this view shows live sessions only — closed history is
+//! filtered out at the core layer ([`codescope_core::build_overview_rows`])
+//! and the reopen flow lives in the sidebar's per-project history
+//! menu, not here.
 //!
-//! * the Rust port surfaces *closed* session rows alongside live ones
-//!   (C# Overview hides them — it shows live tabs only), with a
-//!   "Reopen" action that wires through the existing
-//!   [`crate::app::AppShell::reopen_session`] path,
-//! * each card surfaces telemetry-aware decoration (model name, tokens
-//!   used, last-turn duration, state dot) when the runtime is tailing
-//!   the agent — same data the status-bar cluster already reads from
-//!   [`crate::app::AppShell::telemetry_for`].
+//! Each card surfaces telemetry-aware decoration (model name, tokens
+//! used, last-turn duration, state dot) when the runtime is tailing
+//! the agent — same data the status-bar cluster already reads from
+//! [`crate::app::AppShell::telemetry_for`].
 //!
 //! Row data comes from [`codescope_core::build_overview_rows`] which
-//! flattens the on-disk `ProjectsConfig` and applies the same sort
-//! the C# `Rebuild` pass uses (live first, then closed newest-first).
-//! Live-row decoration is folded in here by joining on `session_id`
-//! against `self.groups`.
+//! flattens the on-disk `ProjectsConfig` and sorts live sessions
+//! newest-first by `last_opened`. Live-row decoration is folded in
+//! here by joining on `session_id` against `self.groups`.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -91,18 +89,15 @@ impl AppShell {
         // 56 px tall, divider bottom border. Mirrors C# OverviewView's
         // header: OVERVIEW eyebrow chip + "N sessions across N
         // projects" subtitle + "← Back to workspace" link on the
-        // right.
-        let live_count = rows
-            .iter()
-            .filter(|r| r.lifecycle == OverviewLifecycle::Live)
-            .count();
-        let closed_count = rows.len() - live_count;
+        // right. Closed rows are filtered upstream so `rows.len()`
+        // is the live-session count.
+        let live_count = rows.len();
         let project_count = projects
             .projects
             .iter()
             .filter(|p| p.sessions.iter().any(|s| s.closed_at.is_none()))
             .count();
-        let subtitle = subtitle_line(live_count, closed_count, project_count);
+        let subtitle = subtitle_line(live_count, project_count);
 
         let eyebrow = div()
             .px(px(7.0))
@@ -565,30 +560,20 @@ impl AppShell {
     }
 }
 
-/// "5 live + 2 closed across 3 projects" — drives the header
-/// subtitle. Mirrors C# `OverviewViewModel.SubtitleBody` shape, with
-/// an extra closed-count term because the Rust port renders history
-/// in the same grid.
-fn subtitle_line(live: usize, closed: usize, project_count: usize) -> String {
-    if live == 0 && closed == 0 {
+/// "5 live across 3 projects" — drives the header subtitle. Mirrors
+/// C# `OverviewViewModel.SubtitleBody`. The Rust port used to carry
+/// an extra "N closed" term when Overview surfaced closed history;
+/// that's been removed along with the closed-row branch — the panel
+/// is now active-sessions-only.
+fn subtitle_line(live: usize, project_count: usize) -> String {
+    if live == 0 {
         return "no sessions yet".to_string();
     }
-    let mut parts: Vec<String> = Vec::new();
-    if live > 0 {
-        parts.push(if live == 1 {
-            "1 live".to_string()
-        } else {
-            format!("{live} live")
-        });
-    }
-    if closed > 0 {
-        parts.push(if closed == 1 {
-            "1 closed".to_string()
-        } else {
-            format!("{closed} closed")
-        });
-    }
-    let count_part = parts.join(" + ");
+    let count_part = if live == 1 {
+        "1 live".to_string()
+    } else {
+        format!("{live} live")
+    };
     let project_part = if project_count == 1 {
         "1 project".to_string()
     } else {
@@ -649,15 +634,10 @@ mod tests {
 
     #[test]
     fn subtitle_line_handles_pluralization_and_zero_cases() {
-        assert_eq!(subtitle_line(0, 0, 0), "no sessions yet");
-        assert_eq!(subtitle_line(1, 0, 1), "1 live across 1 project");
-        assert_eq!(subtitle_line(3, 0, 2), "3 live across 2 projects");
-        assert_eq!(subtitle_line(1, 1, 1), "1 live + 1 closed across 1 project");
-        assert_eq!(
-            subtitle_line(2, 5, 3),
-            "2 live + 5 closed across 3 projects"
-        );
-        assert_eq!(subtitle_line(0, 4, 2), "4 closed across 2 projects");
+        assert_eq!(subtitle_line(0, 0), "no sessions yet");
+        assert_eq!(subtitle_line(1, 1), "1 live across 1 project");
+        assert_eq!(subtitle_line(3, 2), "3 live across 2 projects");
+        assert_eq!(subtitle_line(2, 3), "2 live across 3 projects");
     }
 
     #[test]

--- a/codescope-rs/src/settings_dialog.rs
+++ b/codescope-rs/src/settings_dialog.rs
@@ -192,6 +192,24 @@ fn id_hash(id: &str) -> u64 {
     hasher.finish()
 }
 
+/// Render the font-fallback chain as a one-line read-only hint.
+/// Truncates to the first 3 names + `…` when the chain is longer so
+/// the line never overflows the dialog width regardless of how many
+/// fallbacks the user has configured. The full list is applied at
+/// runtime — this is purely a UI truncation.
+const FALLBACKS_HINT_VISIBLE: usize = 3;
+fn format_fallbacks_hint(fallbacks: &[String]) -> String {
+    if fallbacks.is_empty() {
+        return "fallbacks: (none)".to_string();
+    }
+    if fallbacks.len() <= FALLBACKS_HINT_VISIBLE {
+        return format!("fallbacks: {}", fallbacks.join(", "));
+    }
+    let visible = fallbacks[..FALLBACKS_HINT_VISIBLE].join(", ");
+    let hidden = fallbacks.len() - FALLBACKS_HINT_VISIBLE;
+    format!("fallbacks: {visible}, … (+{hidden} more)")
+}
+
 /// Format an `f32` for the text buffer: trim trailing zeros so `13.0`
 /// renders as `13` (less noisy in the input), `1.25` stays `1.25`.
 fn format_f32(value: f32) -> String {
@@ -385,7 +403,12 @@ impl AppShell {
             div().text_size(px(11.0)).text_color(ink_ghost).child(text)
         };
         let hint = |text: SharedString| {
-            div().text_size(px(11.0)).text_color(ink_ghost).child(text)
+            div()
+                .w_full()
+                .text_size(px(11.0))
+                .text_color(ink_ghost)
+                .truncate()
+                .child(text)
         };
 
         // ─── Theme picker ──────────────────────────────────────────
@@ -518,8 +541,10 @@ impl AppShell {
             SettingsField::Scrollback,
         );
 
-        let fallbacks_hint: SharedString =
-            format!("fallbacks: {}", draft.font.fallbacks.join(", ")).into();
+        // Cap the visible fallback chain so a 10-deep Nerd-Font list
+        // doesn't blow past the dialog width. The full chain is still
+        // applied at runtime — this is purely a display truncation.
+        let fallbacks_hint: SharedString = format_fallbacks_hint(&draft.font.fallbacks).into();
 
         // ─── Cursor shape radios ───────────────────────────────────
         let cursor_radio = |id: &'static str, label: &'static str, value: &'static str| {
@@ -602,9 +627,10 @@ impl AppShell {
         //
         // Two-column scroll-friendly stack: left column = theme +
         // agent pickers; right column = font + cursor + scrollback.
-        // Both share the dialog's 520 px width minus the 20 px gutter
-        // — keeps each column roughly the same width as the
-        // new-project dialog's body.
+        // Both share the dialog's 640 px width minus the 40 px side
+        // padding + 16 px gutter — leaves ~290 px per column which
+        // is enough for the font-family input plus the truncated
+        // fallback hint without wrapping.
 
         let restart_hint = div()
             .text_size(px(10.0))
@@ -725,8 +751,8 @@ impl AppShell {
             .flex()
             .flex_col()
             .gap_3()
-            .w(px(560.0))
-            .max_h(px(640.0))
+            .w(px(640.0))
+            .max_h(px(720.0))
             .bg(elevated)
             .border_1()
             .border_color(divider)
@@ -909,6 +935,28 @@ mod tests {
         // the same process — gpui ties element identity to it across
         // frames.
         assert_eq!(id_hash("codescope-default"), id_hash("codescope-default"));
+    }
+
+    #[test]
+    fn format_fallbacks_hint_truncates_long_chains() {
+        // Empty list reads as "(none)" rather than a dangling colon.
+        assert_eq!(format_fallbacks_hint(&[]), "fallbacks: (none)");
+        // Short chains render in full.
+        let three = vec!["A".to_string(), "B".to_string(), "C".to_string()];
+        assert_eq!(format_fallbacks_hint(&three), "fallbacks: A, B, C");
+        // Long chains keep the first three and indicate the rest.
+        let ten: Vec<String> = (0..10).map(|i| format!("F{i}")).collect();
+        let hint = format_fallbacks_hint(&ten);
+        assert!(hint.starts_with("fallbacks: F0, F1, F2"), "{hint}");
+        assert!(hint.contains("(+7 more)"), "{hint}");
+    }
+
+    #[test]
+    fn format_fallbacks_hint_keeps_exactly_three_inline() {
+        // Exactly the visible cap — no "+N more" suffix.
+        let three = vec!["A".to_string(), "B".to_string(), "C".to_string()];
+        let hint = format_fallbacks_hint(&three);
+        assert!(!hint.contains("more"), "{hint}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three small UI fixes bundled into one PR:

- **Overview is live-only.** `build_overview_rows` filters out
  closed sessions; closed history was drowning the active-sessions
  signal. The cap + dedup machinery that existed solely for the
  closed tail is gone too. The `OverviewLifecycle` enum stays for
  shape stability if a future toggle reintroduces closed rows; the
  reopen flow still lives in the sidebar's per-project history menu.
- **Settings dialog fits its content.** Width 560 → 640 px, max-h
  600 → 720 px. Font-fallback hint truncates to the first 3 names +
  `(+N more)` so a 10-deep Nerd Font chain no longer wraps; the
  full chain still applies at runtime. The hint row gets
  `truncate()` + `w_full()` as a belt-and-braces guard.
- **Default theme's terminal canvas darkens** from `#1e1e1e`
  (VS Code Dark+) to `#0a0a0c` — a near-black with a faint cool
  tint, bracketing Windows Terminal's `#0c0c0c` and avoiding the
  panel-uniformity issues a hard `#000000` can show. The chrome
  canvas (sidebar / status bar / dialogs) is unchanged at `#000000`.
  A new lock test pins the hex so future drift fails fast.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (418 core + 84 bin + 23 terminal, all
      passing)
- [x] New tests: `build_rows_excludes_every_closed_session`,
      `format_fallbacks_hint_truncates_long_chains`,
      `default_terminal_canvas_is_near_black`

🤖 Generated with [Claude Code](https://claude.com/claude-code)