### PR TITLE
feat(rs): Open remote / Open PR in browser everywhere

### DIFF
--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -3369,6 +3369,34 @@ impl AppShell {
         let copy_session_id = tab_session_id.clone();
         let rename_session_id = tab_session_id.clone();
         let rename_current = tab_title.to_string();
+        // "Open remote" / "Open PR" gating mirrors the sidebar's
+        // worktree-row menu — same `Sidebar` accessors so the two
+        // surfaces agree row-for-row. We only emit the rows when the
+        // tab's working directory matches a tracked worktree (Open
+        // remote) and the PR cache has a `Resolved { info: Some(_) }`
+        // entry whose branch still matches the live branch (Open PR).
+        // Each path is captured into its own `Option<String>` so the
+        // closure for each row only takes ownership of the path it
+        // needs.
+        let (open_remote_path, open_pr_path) = {
+            let sidebar = self.sidebar.read(cx);
+            match tab_working_dir_str.as_ref() {
+                Some(path) => {
+                    let tracked = sidebar.path_is_tracked_worktree(path);
+                    let has_pr = sidebar.pr_url_for_path(path).is_some();
+                    (
+                        tracked.then(|| path.clone()),
+                        has_pr.then(|| path.clone()),
+                    )
+                }
+                None => (None, None),
+            }
+        };
+        // Snapshot for the divider gate — the row builders below
+        // consume the `Option<String>`s by `.map(|path| …)` and we
+        // need the boolean answer to "should we paint a divider
+        // above the section" regardless of which row is enabled.
+        let has_open_in_browser_rows = open_remote_path.is_some() || open_pr_path.is_some();
 
         let mut menu_body = div()
             .flex()
@@ -3483,6 +3511,52 @@ impl AppShell {
                     this.move_tab_to_new_group(group_id, tab_id, window, cx);
                 }),
             ))
+            // ── Open in browser section ──
+            //
+            // Both rows are gated against `Sidebar` state at menu-build
+            // time so the menu height collapses cleanly when neither
+            // surface applies (e.g. a plain shell tab with no project
+            // context, or a worktree whose PR cache hasn't landed).
+            // We don't render a greyed-out unclickable affordance —
+            // the row disappears entirely instead. Mirrors the C#
+            // tab menu's `HasOriginRemote` / `HasPullRequest` gates
+            // in `GroupStripView.PopulateTabContextMenu`.
+            .children(
+                has_open_in_browser_rows
+                    .then(|| div().h_px().bg(divider).my_1().into_any_element()),
+            )
+            .children(open_remote_path.map(|path| {
+                item(
+                    "tab-menu-open-remote",
+                    "Open remote in browser",
+                    true,
+                    false,
+                    Box::new(move |this, _window, cx| {
+                        let path = path.clone();
+                        this.close_tab_menu(cx);
+                        this.sidebar.update(cx, |sidebar, cx| {
+                            sidebar.open_remote_in_browser_for_path(path, cx);
+                        });
+                    }),
+                )
+                .into_any_element()
+            }))
+            .children(open_pr_path.map(|path| {
+                item(
+                    "tab-menu-open-pr",
+                    "Open PR in browser",
+                    true,
+                    false,
+                    Box::new(move |this, _window, cx| {
+                        let path = path.clone();
+                        this.close_tab_menu(cx);
+                        this.sidebar.update(cx, |sidebar, cx| {
+                            sidebar.open_pr_in_browser_for_path(path, cx);
+                        });
+                    }),
+                )
+                .into_any_element()
+            }))
             .child(div().h_px().bg(divider).my_1())
             // ── Close section ──
             .child(item(
@@ -4577,6 +4651,8 @@ impl AppShell {
         //   Ctrl+Shift+P            command palette (toggle)
         //   Ctrl+Shift+O            overview pane (toggle)
         //   Ctrl+Shift+\            split right
+        //   Ctrl+Shift+G            open active tab's remote in browser
+        //   Ctrl+Shift+R            open active tab's PR in browser
         //   Alt+Left / Alt+Right    cycle focus group
         //   Alt+1..9                focus group N
         //
@@ -4647,6 +4723,22 @@ impl AppShell {
                 cx.stop_propagation();
                 let next = !self.show_overview;
                 self.set_show_overview(next, cx);
+            }
+            // Ctrl+Shift+G — open the active tab's worktree origin
+            // remote in the browser. Plain Ctrl+G is "abort" /
+            // history-cancel in many shells, so we keep it on the
+            // shifted form to stay out of the terminal.
+            "g" if mods.shift => {
+                cx.stop_propagation();
+                self.open_active_tab_remote_in_browser(cx);
+            }
+            // Ctrl+Shift+R — open the active tab's cached PR URL in
+            // the browser. Plain Ctrl+R is readline reverse-history-
+            // search and is heavily used inside coding agents, so
+            // this chord stays on Ctrl+Shift.
+            "r" if mods.shift => {
+                cx.stop_propagation();
+                self.open_active_tab_pr_in_browser(cx);
             }
             // Ctrl+Tab / Ctrl+Shift+Tab — cycle tabs forwards /
             // backwards. Shift is intrinsic to the prev-tab chord
@@ -5584,6 +5676,12 @@ impl AppShell {
                         cx,
                     );
                 }
+                BuiltInCommand::OpenRemoteInBrowser => {
+                    self.open_active_tab_remote_in_browser(cx);
+                }
+                BuiltInCommand::OpenPullRequestInBrowser => {
+                    self.open_active_tab_pr_in_browser(cx);
+                }
             },
         }
     }
@@ -5618,6 +5716,8 @@ impl AppShell {
             BuiltInCommand::NewProject,
             BuiltInCommand::OpenSettings,
             BuiltInCommand::ReloadTheme,
+            BuiltInCommand::OpenRemoteInBrowser,
+            BuiltInCommand::OpenPullRequestInBrowser,
         ] {
             out.push(PaletteAction {
                 kind: PaletteActionKind::Command(cmd),
@@ -5758,6 +5858,50 @@ impl AppShell {
             .read(cx)
             .active_project()
             .map(|p| p.path.clone())
+    }
+
+    /// Active tab's working directory as a `String`. Used by the
+    /// "Open remote / PR in browser" surfaces (tab menu, palette,
+    /// Ctrl+Shift+G / +R) to look the path up in the sidebar's
+    /// `git_status` / `pr_urls` caches. Returns `None` when the
+    /// active tab is a plain shell with no project context.
+    fn active_tab_working_dir(&self) -> Option<String> {
+        let g = self.groups.get(self.focused_group)?;
+        let t = g.tabs.get(g.active_tab)?;
+        t.working_directory
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned())
+    }
+
+    /// Open the active tab's worktree origin remote in the user's
+    /// default browser. Mirrors the sidebar worktree menu's
+    /// "Open remote in browser" row — and shares the same helper, so
+    /// the URL resolution / shell-execute path is exactly one code
+    /// path. No-ops when the active tab has no working directory the
+    /// sidebar tracks as a worktree.
+    fn open_active_tab_remote_in_browser(&mut self, cx: &mut Context<Self>) {
+        let Some(path) = self.active_tab_working_dir() else {
+            return;
+        };
+        self.sidebar.update(cx, |sidebar, cx| {
+            if !sidebar.path_is_tracked_worktree(&path) {
+                return;
+            }
+            sidebar.open_remote_in_browser_for_path(path, cx);
+        });
+    }
+
+    /// Open the active tab's cached PR URL in the user's default
+    /// browser. Same gating as the sidebar worktree menu's
+    /// "Open PR in browser" row — a missing / stale-branch / no-open-PR
+    /// cache entry no-ops.
+    fn open_active_tab_pr_in_browser(&mut self, cx: &mut Context<Self>) {
+        let Some(path) = self.active_tab_working_dir() else {
+            return;
+        };
+        self.sidebar.update(cx, |sidebar, cx| {
+            sidebar.open_pr_in_browser_for_path(path, cx);
+        });
     }
 }
 

--- a/codescope-rs/src/command_palette.rs
+++ b/codescope-rs/src/command_palette.rs
@@ -96,6 +96,19 @@ pub enum BuiltInCommand {
     /// the user has hand-edited `settings.json` and wants to see the
     /// change without restarting. Keymap hint: none.
     ReloadTheme,
+    /// Open the active tab's worktree origin remote in the user's
+    /// default browser. Mirrors the sidebar worktree menu's
+    /// "Open remote in browser" row. Hint: Ctrl+Shift+G (G for
+    /// "git remote"). No-ops when the active tab has no working
+    /// directory the sidebar tracks as a worktree, or when the
+    /// underlying repo has no `origin` configured.
+    OpenRemoteInBrowser,
+    /// Open the active tab's worktree pull-request URL in the user's
+    /// default browser. Mirrors the sidebar worktree menu's
+    /// "Open PR in browser" row — same gating: only fires when the
+    /// cached `gh pr list` lookup resolved to an open PR for the
+    /// worktree's *current* branch. Hint: Ctrl+Shift+R (R for "PR").
+    OpenPullRequestInBrowser,
 }
 
 impl BuiltInCommand {
@@ -110,6 +123,8 @@ impl BuiltInCommand {
             BuiltInCommand::NewSession => "New session",
             BuiltInCommand::OpenSettings => "Open settings",
             BuiltInCommand::ReloadTheme => "Reload theme",
+            BuiltInCommand::OpenRemoteInBrowser => "Open remote in browser",
+            BuiltInCommand::OpenPullRequestInBrowser => "Open PR in browser",
         }
     }
 
@@ -123,6 +138,8 @@ impl BuiltInCommand {
             BuiltInCommand::NewSession => "Ctrl+Shift+T",
             BuiltInCommand::OpenSettings => "Ctrl+Shift+,",
             BuiltInCommand::ReloadTheme => "menu",
+            BuiltInCommand::OpenRemoteInBrowser => "Ctrl+Shift+G",
+            BuiltInCommand::OpenPullRequestInBrowser => "Ctrl+Shift+R",
         }
     }
 }
@@ -604,6 +621,28 @@ mod tests {
         assert_eq!(BuiltInCommand::NewProject.title(), "New project");
         assert_eq!(BuiltInCommand::OpenSettings.title(), "Open settings");
         assert_eq!(BuiltInCommand::ReloadTheme.title(), "Reload theme");
+        assert_eq!(
+            BuiltInCommand::OpenRemoteInBrowser.title(),
+            "Open remote in browser"
+        );
+        assert_eq!(
+            BuiltInCommand::OpenPullRequestInBrowser.title(),
+            "Open PR in browser"
+        );
+    }
+
+    #[test]
+    fn open_remote_and_pr_commands_advertise_chords() {
+        // The palette right-hand hint is the only place users see the
+        // chord without opening the docs — assert it stays in lockstep
+        // with the chord wired in `app.rs::on_key_down` /
+        // `terminal/src/view.rs::is_app_level_shortcut`. A drift here
+        // means the palette would lie about the keymap.
+        assert_eq!(BuiltInCommand::OpenRemoteInBrowser.hint(), "Ctrl+Shift+G");
+        assert_eq!(
+            BuiltInCommand::OpenPullRequestInBrowser.hint(),
+            "Ctrl+Shift+R"
+        );
     }
 
     #[test]

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -1043,6 +1043,98 @@ impl Sidebar {
         self.git_status.get(path)
     }
 
+    /// Resolve the cached "open PR URL" for the worktree rooted at
+    /// `path`. Returns `Some(url)` only when the cached `gh pr list`
+    /// lookup landed on a `Resolved { info: Some(_) }` whose branch
+    /// still matches the live branch (live `git_status` first, with
+    /// the persisted worktree branch as a fallback). Mirrors the same
+    /// gate the sidebar's "Open PR in browser" row uses — so a
+    /// branch-switch-since-fetch hides the row rather than opening a
+    /// stale URL.
+    ///
+    /// Returns `None` for paths we don't track, paths with no PR
+    /// cache entry yet (poller hasn't landed), `Pending` entries, and
+    /// `Resolved` entries with `info: None` (gh said "no open PR for
+    /// this branch") or a mismatched cached branch.
+    pub(crate) fn pr_url_for_path(&self, path: &str) -> Option<String> {
+        let live = self
+            .git_status
+            .get(path)
+            .map(|s| s.branch.clone())
+            .or_else(|| {
+                self.projects
+                    .projects
+                    .iter()
+                    .flat_map(|p| p.worktrees.iter())
+                    .find(|wt| wt.path == path)
+                    .and_then(|wt| wt.branch.clone())
+            })?;
+        match self.pr_urls.get(path)? {
+            PrLookup::Resolved { branch, info: Some(info) } if *branch == live => {
+                Some(info.url.clone())
+            }
+            _ => None,
+        }
+    }
+
+    /// Whether `path` matches a tracked worktree (primary or
+    /// secondary) on any project. Used by the tab right-click menu
+    /// to decide whether the "Open remote in browser" row makes
+    /// sense — tabs spawned in a plain shell with no project context
+    /// hide the row entirely. The actual "is there a git remote"
+    /// check still runs lazily inside `spawn_open_remote_in_browser`
+    /// (no `origin` → log + no-op), same gating the sidebar row
+    /// uses.
+    pub(crate) fn path_is_tracked_worktree(&self, path: &str) -> bool {
+        self.projects
+            .projects
+            .iter()
+            .flat_map(|p| p.worktrees.iter())
+            .any(|wt| wt.path == path)
+    }
+
+    /// Open the remote (`origin`) for the worktree rooted at `path`
+    /// in the user's default browser. Looks up which project owns the
+    /// path and dispatches to the same async helper the sidebar
+    /// worktree-menu row uses. No-ops + logs when the path doesn't
+    /// match a tracked worktree, when `origin` isn't set, or when
+    /// the URL shape isn't recognised. Used by the tab right-click
+    /// menu and the command palette.
+    pub(crate) fn open_remote_in_browser_for_path(
+        &mut self,
+        path: String,
+        cx: &mut Context<Self>,
+    ) {
+        let project_path = self
+            .projects
+            .projects
+            .iter()
+            .find(|p| p.worktrees.iter().any(|wt| wt.path == path))
+            .map(|p| std::path::PathBuf::from(&p.path));
+        let Some(project_path) = project_path else {
+            return;
+        };
+        cx.spawn(async move |_, cx| {
+            spawn_open_remote_in_browser(project_path, cx).await;
+        })
+        .detach();
+    }
+
+    /// Open the cached PR URL for the worktree rooted at `path` in
+    /// the user's default browser. No-ops when [`Self::pr_url_for_path`]
+    /// returns `None` (no cache entry, mismatched branch, or no open
+    /// PR). Used by the tab right-click menu and the command palette
+    /// — mirrors the gating the sidebar worktree menu uses.
+    pub(crate) fn open_pr_in_browser_for_path(
+        &mut self,
+        path: String,
+        _cx: &mut Context<Self>,
+    ) {
+        if let Some(url) = self.pr_url_for_path(&path) {
+            open_url_in_browser(&url);
+        }
+    }
+
     /// Read-only handle to the in-memory project list. Exposed so the
     /// dialog module can read project metadata without re-borrowing
     /// every private field individually.

--- a/codescope-rs/terminal/src/view.rs
+++ b/codescope-rs/terminal/src/view.rs
@@ -832,6 +832,17 @@ pub(crate) fn is_app_level_shortcut(key: &str, mods: &gpui::Modifiers) -> bool {
     if key == "," && mods.shift {
         return true;
     }
+    // Ctrl+Shift+G — open active tab's worktree remote in browser.
+    // Plain Ctrl+G stays with the terminal (readline abort).
+    if key == "g" && mods.shift {
+        return true;
+    }
+    // Ctrl+Shift+R — open active tab's PR in browser. Plain Ctrl+R
+    // is readline reverse-history-search and stays with the
+    // terminal.
+    if key == "r" && mods.shift {
+        return true;
+    }
     false
 }
 
@@ -1120,6 +1131,25 @@ mod tests {
         // be bound inside the terminal by user tooling.
         assert!(is_app_level_shortcut(",", &ctrl_shift()));
         assert!(!is_app_level_shortcut(",", &ctrl()));
+    }
+
+    #[test]
+    fn ctrl_shift_g_bubbles_for_open_remote() {
+        // Ctrl+Shift+G opens the active tab's worktree remote in the
+        // browser. Plain Ctrl+G is readline abort and stays with the
+        // terminal so coding agents inside the PTY keep working.
+        assert!(is_app_level_shortcut("g", &ctrl_shift()));
+        assert!(!is_app_level_shortcut("g", &ctrl()));
+    }
+
+    #[test]
+    fn ctrl_shift_r_bubbles_for_open_pr() {
+        // Ctrl+Shift+R opens the active tab's PR URL in the browser.
+        // Plain Ctrl+R is readline reverse-history-search and is
+        // heavily used inside agent CLIs — must stay with the
+        // terminal.
+        assert!(is_app_level_shortcut("r", &ctrl_shift()));
+        assert!(!is_app_level_shortcut("r", &ctrl()));
     }
 }
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -38,6 +38,8 @@ chord therefore lives on **Ctrl+Shift** so it can't conflict.
 | Command palette      | Ctrl+Shift+P         |
 | Overview             | Ctrl+Shift+O         |
 | Split right          | Ctrl+Shift+\         |
+| Open remote          | Ctrl+Shift+G         |
+| Open PR              | Ctrl+Shift+R         |
 | Focus group L/R      | Alt+Left / Alt+Right |
 | Focus group N        | Alt+1..9             |
 


### PR DESCRIPTION
## Summary

Adds three surfaces for the existing sidebar "Open remote in browser" / "Open PR in browser" helpers so the user doesn't have to right-click a worktree row to reach them.

- **Tab right-click menu**: new "Open in browser" section above the Close block. Both rows hide entirely when their data isn't available (tab without a worktree path, or PR cache miss / stale branch).
- **Command palette**: two new built-in commands (`OpenRemoteInBrowser`, `OpenPullRequestInBrowser`) targeting the active tab's worktree.
- **Keyboard chords**: `Ctrl+Shift+G` (remote) and `Ctrl+Shift+R` (PR), whitelisted in the terminal whitelist so the PTY doesn't eat them. Plain `Ctrl+G` / `Ctrl+R` stay with the terminal (readline abort / reverse-history-search).

All three paths route through new `Sidebar::open_remote_in_browser_for_path` / `open_pr_in_browser_for_path` helpers that reuse the existing `spawn_open_remote_in_browser` and `open_url_in_browser` plumbing — no URL-resolution or PR-cache logic is duplicated.

## Test plan

- [x] `cargo build --workspace` clean, no new warnings
- [x] `cargo test --workspace` — 26 terminal tests, 97 codescope-rs tests, all green
- [x] New unit tests: `ctrl_shift_g_bubbles_for_open_remote`, `ctrl_shift_r_bubbles_for_open_pr` (terminal whitelist), `open_remote_and_pr_commands_advertise_chords`, extended `built_in_command_titles_are_stable`
- [ ] Manual: right-click a tab whose working directory is a tracked worktree with an open PR → both rows appear above Close; clicking "Open PR in browser" opens the cached URL
- [ ] Manual: right-click a plain-shell tab with no working directory → no "Open in browser" section at all
- [ ] Manual: `Ctrl+Shift+G` on the active tab opens the project remote
- [ ] Manual: `Ctrl+Shift+R` on the active tab opens the cached PR URL (no-op when no PR cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)