### PR TITLE
feat(rs): multiplatform release pipeline - Windows + macOS x64/ARM + Linux x64

### DIFF
--- a/codescope-rs/dist-workspace.toml
+++ b/codescope-rs/dist-workspace.toml
@@ -5,20 +5,27 @@ members = ["cargo:."]
 #
 # Scope notes for the CodeScope Rust port:
 #
-# - We deliberately ship Windows-only artifacts in this iteration. The
-#   gpui 0.2.x stack technically supports macOS and Linux (target-gated
-#   deps in its Cargo.toml), but the Rust port hasn't been compiled or
-#   tested on those platforms yet, the Windows dev box used for
-#   day-to-day work has no cross-toolchain installed (cc / clang / zig
-#   missing — ring's build.rs fails on first run), and the visual chrome
-#   relies on a Win32-only custom titlebar plus an ITaskbarList3 badge.
-#   Until somebody validates a real macOS / Linux build end-to-end, the
-#   pipeline only emits Windows binaries and an MSI installer — same
-#   scope as the C# build's `release.yml`. See `docs/HANDOFF.md`
-#   "Cross-platform status" section for the path forward.
-# - The MSI installer is built via WiX (cargo-dist's `msi` installer).
-#   On a stock GitHub-hosted `windows-latest` runner cargo-dist
-#   downloads the WiX toolset itself; no manual install required.
+# - The pipeline runs natively on GitHub-hosted runners for each
+#   target — `windows-2022` (MSVC), `macos-14` (Apple Silicon),
+#   `macos-15-intel` (Intel x86_64), and `ubuntu-22.04` (glibc).
+#   cargo-dist 0.31 picks these runner labels itself from the target
+#   triple. Cross-compiling from the Windows dev box is *not*
+#   supported (ring's build.rs needs `cc` / `clang` / `zig` that
+#   aren't installed), but that's irrelevant on the native matrix.
+#   The visual chrome's Win32-only bits (custom titlebar,
+#   ITaskbarList3 badge) are `#[cfg(windows)]` gated with no-op
+#   stubs on macOS / Linux so the same crate compiles on every
+#   target.
+# - The MSI installer (Windows only) is built via WiX (cargo-dist's
+#   `msi` installer). On a stock GitHub-hosted `windows-latest`
+#   runner cargo-dist downloads the WiX toolset itself; no manual
+#   install required. macOS ships a `.tar.xz` of the binary +
+#   resources (cargo-dist's default for that platform); Linux ships
+#   a `.tar.xz` archive.
+# - Linux runtime deps (gpui needs wayland + x11 + xkbcommon +
+#   fontconfig + freetype) are installed in the GH Actions Linux
+#   job via apt before `dist build` runs. See
+#   `.github/workflows/rs--release.yml`.
 # - `install-path = "CARGO_HOME"` is the cargo-dist default for CLI
 #   tools, but CodeScope is a GUI app users launch from the Start menu,
 #   so we leave that field at its default and let the MSI installer
@@ -39,10 +46,19 @@ members = ["cargo:."]
 cargo-dist-version = "0.31.0"
 # CI backend.
 ci = "github"
-# Installers to generate per target platform.
+# Installers to generate per target platform. `msi` only applies on
+# Windows targets; cargo-dist silently skips it for macOS / Linux and
+# emits the default per-platform archive (`.tar.xz` on Linux / macOS,
+# `.zip` on Windows) alongside the installer.
 installers = ["msi"]
-# Target platforms. Windows-only intentionally — see scope note above.
-targets = ["x86_64-pc-windows-msvc"]
+# Target platforms. Native runners on the GH Actions matrix build each
+# triple — see the workflow for the runner / OS mapping.
+targets = [
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+]
 # Where to host releases.
 hosting = "github"
 # Don't bundle axoupdater; Velopack handles self-update.
@@ -64,3 +80,23 @@ allow-dirty = ["ci"]
 # "only trigger on tag pushes". This empties cargo-dist's PR mode so
 # the workflow's pull_request gate (when present) is a no-op.
 pr-run-mode = "skip"
+
+# System packages required at build time for the Linux target.
+# gpui's Linux backend links against wayland-client, xkbcommon, X11,
+# fontconfig, and freetype; the matching `-dev` packages plus pkg-config
+# are needed for the build to succeed on a stock `ubuntu-22.04` runner.
+# cargo-dist injects this as the `packages_install` shell step in the
+# generated workflow, gated to the Linux job via the matrix entry's
+# `packages_install` field.
+[dist.dependencies.apt]
+libwayland-dev = "*"
+libxkbcommon-dev = "*"
+libxkbcommon-x11-dev = "*"
+libfontconfig1-dev = "*"
+libfreetype6-dev = "*"
+libxcb1-dev = "*"
+libxcb-render0-dev = "*"
+libxcb-shape0-dev = "*"
+libxcb-xfixes0-dev = "*"
+libssl-dev = "*"
+pkg-config = "*"

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -452,9 +452,17 @@ brand — the split is purely build-system.
 - Two parallel release flows for the user:
   - `git tag v0.2.6 && git push --tags` → C# release (existing).
   - `git tag rs-v0.0.2 && git push --tags` → Rust release (new).
-- The Rust pipeline currently ships **Windows-only** artifacts
-  (`x86_64-pc-windows-msvc`). See `docs/HANDOFF.md` "Cross-platform
-  status" for the path forward to macOS / Linux.
+- The Rust pipeline ships **multiplatform** artifacts as of the
+  multiplatform-release-pipeline PR: `x86_64-pc-windows-msvc` (MSI +
+  zip), `aarch64-apple-darwin` + `x86_64-apple-darwin` (`.tar.xz`),
+  and `x86_64-unknown-linux-gnu` (`.tar.xz`). The original
+  cross-compile-from-Windows blocker (ring's build.rs needing
+  `cc` / `clang` / `zig`) is sidestepped by running native builds
+  on the GH Actions matrix (`windows-2022`, `macos-14`,
+  `macos-15-intel`, `ubuntu-22.04`). See `docs/HANDOFF.md`
+  "Cross-platform status" for the runtime test matrix and known
+  per-platform gaps (code signing / SmartScreen / Gatekeeper
+  remain follow-ups).
 - `velopack` crate replaces a hand-rolled apply path. The
   `codescope_core::update_check` module (which polls the GitHub
   releases endpoint and emits an `UpdateStatus::Available`) keeps

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -21,24 +21,30 @@ Tests: `codescope-core` (418) + `codescope-rs` bin (100) +
 
 ### Cross-platform status (Rust port)
 
-The Rust port currently ships Windows-only artifacts. The state of
-each tier-1 target as of session 39:
+The Rust port builds natively on the GH Actions matrix
+(`windows-2022`, `macos-14`, `macos-15-intel`, `ubuntu-22.04`) as of
+the multiplatform-release-pipeline PR. Cross-compiling from the
+Windows dev box is still impractical (`ring`'s build.rs hard-fails
+without `cc` / `clang` / `zig`), but that's no longer the only path —
+the release pipeline runs the right toolchain on each platform.
 
-| Target                          | Compiles on Windows-host check? | Why |
-|---------------------------------|---------------------------------|-----|
-| `x86_64-pc-windows-msvc`        | ✅ (workspace clean, 543 tests) | Day-to-day dev target. |
-| `x86_64-apple-darwin`           | ❓ untested                     | `ring` (TLS for ureq) needs `cc`; the Windows dev box has no Apple SDK / cross-toolchain. gpui 0.2.x *declares* macOS deps (`cocoa`, `objc2-app-kit`, `metal`) so a native macOS runner should at least get past dep-resolution. |
-| `aarch64-apple-darwin`          | ❓ untested                     | Same as above. |
-| `x86_64-unknown-linux-gnu`      | ❓ untested                     | `ring` + gpui's wayland/x11 deps need a real cc + system packages (xkbcommon, fontconfig, libxcb). Likely buildable on a stock ubuntu-22.04 runner with `apt install` for the system libs; nobody has tried yet. |
+| Target                          | Build on native runner? | Notes |
+|---------------------------------|-------------------------|-------|
+| `x86_64-pc-windows-msvc`        | ✅                      | Day-to-day dev target. Workspace clean, 543 tests passing on Windows host. Ships MSI + zip. |
+| `aarch64-apple-darwin`          | ✅ via `macos-14`       | Native Apple Silicon runner. Ships `.tar.xz`. `taskbar_badge.rs` macOS branch is a no-op stub. |
+| `x86_64-apple-darwin`           | ✅ via `macos-15-intel` | Native Intel macOS runner. Same artifact shape as ARM. |
+| `x86_64-unknown-linux-gnu`      | ✅ via `ubuntu-22.04`   | apt installs `libwayland-dev`, `libxkbcommon-dev`/`-x11-dev`, `libfontconfig1-dev`, `libfreetype6-dev`, `libxcb*-dev`, `libssl-dev`, `pkg-config` for gpui's Linux backend. |
 
-Cross-compilation from the Windows dev box is **not** the path forward
-— `ring`'s build.rs hard-fails without `cc` / `clang` / `zig`. The
-realistic move is a native CI matrix on the GitHub Actions side, but
-that's deferred until a real user asks for a non-Windows build.
+`codescope-rs/dist-workspace.toml` now lists all four targets and
+declares the Linux apt deps under `[dist.dependencies.apt]`; cargo-dist
+expands that into the matrix's `packages_install` step in
+`.github/workflows/rs--release.yml`.
 
-Until then `codescope-rs/dist-workspace.toml` ships `targets =
-["x86_64-pc-windows-msvc"]` only, matching the C# build's scope. See
-the file's leading comment for the rationale.
+Code signing remains a follow-up on every platform — unsigned MSIs
+trigger Windows SmartScreen, unsigned `.app`/`.dmg` payloads trigger
+macOS Gatekeeper, and Linux has no equivalent gate. Document the
+per-OS friction in the README install section when first user-facing
+builds ship.
 
 ### Rust release pipeline (cargo-dist + Velopack)
 


### PR DESCRIPTION
## Summary

Extends the cargo-dist Rust release pipeline (set up in #162) from a single Windows target to four native targets built on the GitHub Actions matrix:

| Target | Runner | Artifacts |
|---|---|---|
| `x86_64-pc-windows-msvc` | `windows-2022` | MSI + zip + sha256 |
| `aarch64-apple-darwin` | `macos-14` (Apple Silicon) | `.tar.xz` + sha256 |
| `x86_64-apple-darwin` | `macos-15-intel` | `.tar.xz` + sha256 |
| `x86_64-unknown-linux-gnu` | `ubuntu-22.04` | `.tar.xz` + sha256 |

`.github/workflows/rs--release.yml` computes its job matrix dynamically from `dist plan` at runtime (the `${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}` expression), so no YAML hand-edit was needed — extending the `targets` list in `dist-workspace.toml` expands the matrix automatically.

Linux gpui deps (wayland/x11/xkbcommon/fontconfig/freetype/xcb) are declared in `[dist.dependencies.apt]`; cargo-dist injects them as the matrix entry's `packages_install` shell step, gated to the Linux job only.

## Why this works now

ADR-0019 (#154) and `HANDOFF.md` "Cross-platform status" documented the cross-compile-from-Windows blocker (ring's `build.rs` needs `cc` / `clang` / `zig` that aren't installed on the dev box). That's irrelevant on the native CI matrix — each platform builds with its own toolchain. Updated both docs to reflect the new state.

Windows-only `#[cfg]` paths in `theme.rs`, `win32_titlebar.rs`, `taskbar_badge.rs`, `notifications.rs`, `sidebar.rs`, `app.rs` already have non-Windows stubs from earlier work, so the same crate compiles on every target.

## Test plan

The release workflow only fires on tag pushes (`rs-v[0-9]*.[0-9]*.[0-9]*`), so PR CI doesn't validate it. To actually exercise the multiplatform build, after merging push a draft tag:

- [ ] `git tag rs-v0.3.0-rc1 && git push origin rs-v0.3.0-rc1`
- [ ] Watch the `Release` workflow build all four target matrix entries
- [ ] Verify the GitHub release has the seven expected artifacts (3x `.tar.xz` + `.zip` + `.msi` + 5 sha256 + `sha256.sum`)
- [ ] Smoke-test the MSI on a fresh Windows machine (no behaviour change expected vs #162)
- [ ] Smoke-test the macOS / Linux tarballs once a real user wants them — code signing / Gatekeeper / SmartScreen friction remains a follow-up

**Don't push a real tag yet** — leave that to @maui1911. This PR is just the pipeline extension.

## Local verification

- `dist plan` lists all four artifact bundles cleanly.
- `dist generate --mode=ci --allow-dirty` is a no-op on the workflow YAML (matrix is dynamic).
- `cargo check --workspace` still passes on the Windows dev box.

## Constraints respected

- No Windows behaviour change — same MSI shape as #162.
- C# build untouched.
- No tag pushes, no force-pushes, no `main` commits.