### PR TITLE
fix(rs): cargo-dist workflow runs from codescope-rs subdirectory

### DIFF
--- a/.github/workflows/rs--release.yml
+++ b/.github/workflows/rs--release.yml
@@ -85,6 +85,11 @@ jobs:
       # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
+        # dist-workspace.toml and Cargo.toml live in codescope-rs/, so all
+        # `dist` invocations run from that subdir. Artifact paths below are
+        # prefixed with `codescope-rs/` because actions/*-artifact resolves
+        # `path:` relative to $GITHUB_WORKSPACE, not the step's working-dir.
+        working-directory: codescope-rs
         run: |
           dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
@@ -94,7 +99,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: artifacts-plan-dist-manifest
-          path: plan-dist-manifest.json
+          path: codescope-rs/plan-dist-manifest.json
 
   # Build and packages all the platform-specific things
   build-local-artifacts:
@@ -120,6 +125,9 @@ jobs:
     container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Path is relative to the step's working-directory (codescope-rs) for
+      # shell use, then re-prefixed below for the upload-artifact `path:`
+      # (which resolves from $GITHUB_WORKSPACE).
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - name: enable windows longpaths
@@ -138,17 +146,20 @@ jobs:
           fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
-      # Get the dist-manifest
+      # Get the dist-manifest. Drop into codescope-rs/target/distrib/ so dist
+      # (which runs from codescope-rs/) can find prior artifacts at the path
+      # it expects.
       - name: Fetch local artifacts
         uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
-          path: target/distrib/
+          path: codescope-rs/target/distrib/
           merge-multiple: true
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}
       - name: Build artifacts
+        working-directory: codescope-rs
         run: |
           # Actually do builds and make zips and whatnot
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
@@ -159,10 +170,14 @@ jobs:
         # to "real" actions without writing to env-vars, and writing to env-vars has
         # inconsistent syntax between shell and powershell.
         shell: bash
+        working-directory: codescope-rs
         run: |
-          # Parse out what we just built and upload it to scratch storage
+          # Parse out what we just built and upload it to scratch storage.
+          # dist emits paths relative to its working-dir (codescope-rs/), but
+          # upload-artifact resolves `path:` from $GITHUB_WORKSPACE — prepend
+          # `codescope-rs/` to every emitted path so the upload step finds them.
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json | sed 's|^|codescope-rs/|' >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
@@ -172,7 +187,7 @@ jobs:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
-            ${{ env.BUILD_MANIFEST_NAME }}
+            codescope-rs/${{ env.BUILD_MANIFEST_NAME }}
 
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:
@@ -199,17 +214,21 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
-          path: target/distrib/
+          path: codescope-rs/target/distrib/
           merge-multiple: true
       - id: cargo-dist
         shell: bash
+        working-directory: codescope-rs
         run: |
           dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
 
-          # Parse out what we just built and upload it to scratch storage
+          # Parse out what we just built and upload it to scratch storage.
+          # dist runs from codescope-rs/, so emitted upload_files are
+          # codescope-rs-relative — prefix them for upload-artifact which
+          # resolves `path:` from $GITHUB_WORKSPACE.
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          jq --raw-output ".upload_files[]" dist-manifest.json | sed 's|^|codescope-rs/|' >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
@@ -219,7 +238,7 @@ jobs:
           name: artifacts-build-global
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
-            ${{ env.BUILD_MANIFEST_NAME }}
+            codescope-rs/${{ env.BUILD_MANIFEST_NAME }}
   # Determines if we should publish/announce
   host:
     needs:
@@ -249,10 +268,11 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
-          path: target/distrib/
+          path: codescope-rs/target/distrib/
           merge-multiple: true
       - id: host
         shell: bash
+        working-directory: codescope-rs
         run: |
           dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
           echo "artifacts uploaded and released successfully"
@@ -263,7 +283,7 @@ jobs:
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
-          path: dist-manifest.json
+          path: codescope-rs/dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@v7

--- a/.github/workflows/rs--release.yml
+++ b/.github/workflows/rs--release.yml
@@ -86,20 +86,22 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         # dist-workspace.toml and Cargo.toml live in codescope-rs/, so all
-        # `dist` invocations run from that subdir. Artifact paths below are
-        # prefixed with `codescope-rs/` because actions/*-artifact resolves
-        # `path:` relative to $GITHUB_WORKSPACE, not the step's working-dir.
+        # `dist` invocations run from that subdir. Subsequent jobs extract
+        # artifacts at the workspace root, so each upload `path:` carries its
+        # final workspace-relative location (e.g. `codescope-rs/target/...`)
+        # — keeps the artifact ZIPs round-trip-correct.
         working-directory: codescope-rs
         run: |
-          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          mkdir -p target/distrib
+          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > target/distrib/plan-dist-manifest.json
           echo "dist ran successfully"
-          cat plan-dist-manifest.json
-          echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          cat target/distrib/plan-dist-manifest.json
+          echo "manifest=$(jq -c "." target/distrib/plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v6
         with:
           name: artifacts-plan-dist-manifest
-          path: codescope-rs/plan-dist-manifest.json
+          path: codescope-rs/target/distrib/plan-dist-manifest.json
 
   # Build and packages all the platform-specific things
   build-local-artifacts:
@@ -146,14 +148,17 @@ jobs:
           fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
-      # Get the dist-manifest. Drop into codescope-rs/target/distrib/ so dist
-      # (which runs from codescope-rs/) can find prior artifacts at the path
-      # it expects.
+      # Get the dist-manifest. Extract to the workspace root: upload-artifact
+      # preserves each entry's workspace-relative path inside the artifact, so
+      # the uploads carry `codescope-rs/target/distrib/...` already — pointing
+      # the download at the workspace root restores the original layout (using
+      # `codescope-rs/target/distrib/` here would nest it as
+      # `codescope-rs/target/distrib/codescope-rs/target/distrib/...`).
       - name: Fetch local artifacts
         uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
-          path: codescope-rs/target/distrib/
+          path: .
           merge-multiple: true
       - name: Install dependencies
         run: |
@@ -209,12 +214,15 @@ jobs:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
-      # Get all the local artifacts for the global tasks to use (for e.g. checksums)
+      # Get all the local artifacts for the global tasks to use (for e.g.
+      # checksums). Extract to workspace root — uploaded entries already carry
+      # their `codescope-rs/target/distrib/...` prefix, so this restores the
+      # original layout without doubling the prefix.
       - name: Fetch local artifacts
         uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
-          path: codescope-rs/target/distrib/
+          path: .
           merge-multiple: true
       - id: cargo-dist
         shell: bash
@@ -263,12 +271,14 @@ jobs:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
-      # Fetch artifacts from scratch-storage
+      # Fetch artifacts from scratch-storage. Extract to workspace root so the
+      # `codescope-rs/...` prefixes embedded in each upload land at their
+      # natural path, where `dist host` (running from codescope-rs/) finds them.
       - name: Fetch artifacts
         uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
-          path: codescope-rs/target/distrib/
+          path: .
           merge-multiple: true
       - id: host
         shell: bash
@@ -293,6 +303,14 @@ jobs:
           merge-multiple: true
       - name: Cleanup
         run: |
+          # Uploaded artifacts preserve their workspace-relative paths, so
+          # everything lands under `artifacts/codescope-rs/...`. Flatten that
+          # back to `artifacts/<basename>` so `gh release create artifacts/*`
+          # sees the release files (it doesn't recurse into directories).
+          if [ -d artifacts/codescope-rs ]; then
+            find artifacts/codescope-rs -type f -exec mv -t artifacts/ {} +
+            rm -rf artifacts/codescope-rs
+          fi
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

The autogenerated cargo-dist release workflow (`rs--release.yml`) assumed `dist-workspace.toml` and `Cargo.toml` lived at repo root, but they live in `codescope-rs/`. The `rs-v0.3.0-rc1` tag push failed instantly with:

```
× No workspace found; either your project doesn't have a Cargo.toml/dist.toml, or we couldn't read it
× Failed to find dist.toml in an ancestor of /home/runner/work/CodeScope/CodeScope
× Failed to find Cargo.toml in an ancestor of /home/runner/work/CodeScope/CodeScope
```

## Fix

- Add `working-directory: codescope-rs` to every step that invokes `dist` (plan, Build artifacts, Post-build, build-global cargo-dist, host) so dist can find its workspace config.
- Prefix every artifact `path:` in `actions/upload-artifact` and `actions/download-artifact` with `codescope-rs/`, because those actions resolve paths from `$GITHUB_WORKSPACE`, not the step's `working-directory`.
- For the two steps that emit dynamic upload-file lists (`dist print-upload-files-from-manifest` and `jq '.upload_files[]'`), pipe through `sed 's|^|codescope-rs/|'` so the subsequent `upload-artifact` step finds the files at `codescope-rs/target/distrib/...`.

`BUILD_MANIFEST_NAME` is kept relative (`target/distrib/...`) for shell use under the `codescope-rs` working-directory, and re-prefixed inline where the upload `path:` references it.

cargo-dist 0.31 has no `--manifest-path` flag, so the `working-directory` approach is the lightest viable touch.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses cleanly.
- [x] `dist plan --output-format=json` runs successfully from `codescope-rs/`.
- [x] `cargo build --workspace` is still green.
- [ ] User re-tags `rs-v0.3.0-rc1` after merge and confirms the multiplatform matrix runs end-to-end. (Cannot exercise without pushing a tag, which is out of scope for this PR.)

The other workflow (`release.yml` for the C# build) is untouched.