### PR TITLE
fix(rs): strip rs- prefix before cargo-dist tag parse

### DIFF
--- a/.github/workflows/rs--release.yml
+++ b/.github/workflows/rs--release.yml
@@ -59,8 +59,21 @@ jobs:
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
+      # `tag` is the *original* git tag (e.g. `rs-v0.3.0-rc1`) — used as the
+      # GitHub release tag downstream so the two release pipelines on this
+      # repo (C# `v*` and Rust `rs-v*`) don't collide.
+      # `tag-flag` is the *stripped* tag (e.g. `v0.3.0-rc1`) passed to every
+      # `dist` invocation via `--tag=`. cargo-dist 0.31's `tag-namespace`
+      # config only controls the workflow filename and the trigger glob; it
+      # does NOT strip the namespace before the underlying `axotag` parser
+      # sees the value. `axotag` then tries to parse `rs-v0.3.0-rc1` as
+      # `<package-name>-v<version>` (no package called `rs` exists) or as a
+      # bare semver (fails on the `r`). Stripping `rs-` here side-steps the
+      # bug — cargo-dist sees a clean `v0.3.0-rc1` and the GitHub release
+      # below is still tagged `rs-v0.3.0-rc1` because `gh release create`
+      # uses `needs.plan.outputs.tag` (the un-stripped value).
+      tag: ${{ steps.tags.outputs.tag }}
+      tag-flag: ${{ steps.tags.outputs.tag-flag }}
       publishing: ${{ !github.event.pull_request }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,6 +82,29 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - id: tags
+        # Compute the namespaced + stripped tag values once and reuse them
+        # across every downstream `dist` call. See the comment on the
+        # `tag` / `tag-flag` job outputs above for why both are needed.
+        # On a pull_request event (currently unreachable — the workflow's
+        # `on:` block only lists `push.tags` — but kept defensive in case
+        # we re-enable PR validation later) we emit empty strings, mirroring
+        # cargo-dist's original generator behaviour.
+        shell: bash
+        run: |
+          if [ -z "${{ github.event.pull_request }}" ]; then
+            FULL_TAG="${{ github.ref_name }}"
+            # Strip the `rs-` namespace prefix (matches `tag-namespace` in
+            # `codescope-rs/dist-workspace.toml`). `${var#prefix}` is a
+            # POSIX shell parameter expansion that removes the shortest
+            # leading match — exactly what we want.
+            STRIPPED_TAG="${FULL_TAG#rs-}"
+            echo "tag=${FULL_TAG}" >> "$GITHUB_OUTPUT"
+            echo "tag-flag=--tag=${STRIPPED_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "tag-flag=" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
@@ -91,9 +127,17 @@ jobs:
         # final workspace-relative location (e.g. `codescope-rs/target/...`)
         # — keeps the artifact ZIPs round-trip-correct.
         working-directory: codescope-rs
+        shell: bash
         run: |
           mkdir -p target/distrib
-          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > target/distrib/plan-dist-manifest.json
+          if [ -z "${{ github.event.pull_request }}" ]; then
+            # `dist host --steps=create` needs the *stripped* tag (see
+            # tag-flag rationale on the job outputs above).
+            DIST_SUBCOMMAND="host --steps=create ${{ steps.tags.outputs.tag-flag }}"
+          else
+            DIST_SUBCOMMAND="plan"
+          fi
+          dist $DIST_SUBCOMMAND --output-format=json > target/distrib/plan-dist-manifest.json
           echo "dist ran successfully"
           cat target/distrib/plan-dist-manifest.json
           echo "manifest=$(jq -c "." target/distrib/plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes the second of the two release-pipeline bugs surfaced by the failed `rs-v0.3.0-rc1` tag push. The Windows-only `targets` bug was already addressed by #164 — the four targets are present in `codescope-rs/dist-workspace.toml`. This PR only tackles the second one.

cargo-dist 0.31's `tag-namespace = "rs-"` config does **not** strip the namespace before parsing. It only:
1. Renames the generated workflow to `rs--release.yml`.
2. Filters the `push.tags` trigger glob to require the prefix.

The actual tag is then passed unchanged to `axotag::parse_tag`, which tries `<package-name>-v<version>` (no package called `rs` exists in this workspace) and then bare semver (fails on the leading `r`). Result:

```
× Couldn't parse the version from the provided announcement tag (rs-v0.3.0-rc1)
╰─▶ unexpected character 'r' while parsing major version number
```

This PR works around it (option **A** from the bug report) by computing the stripped tag once in a new `tags` step on the `plan` job and threading both flavours through as job outputs:

- `tag` = original (`rs-v0.3.0-rc1`) → fed to `gh release create` so the GitHub release stays namespace-tagged and doesn't collide with the C# `release.yml` (which fires on `v*`).
- `tag-flag` = `--tag=v0.3.0-rc1` → fed to every downstream `dist plan / build / host` call so axotag sees a clean version.

## Verification

- `dist plan --tag=rs-v0.3.0-rc1` from `codescope-rs/` reproduces the exact failure cited in the bug report.
- `dist plan --tag=v0.3.0-rc1` parses cleanly (the residual "version mismatch" is expected — `Cargo.toml` is at 0.0.1; the real release commit will bump it).
- `dist plan` (no `--tag`) lists all 4 targets so the targets-fix from #164 still holds.
- YAML parses with `python -c "yaml.safe_load(...)"`.
- C# `release.yml` is untouched and its `v[0-9]+.[0-9]+.[0-9]+` tag filter doesn't match `rs-v*`, so the two pipelines remain non-overlapping.

## Test plan

- [ ] User re-tags after merge: `git fetch origin && git tag rs-v0.3.0-rc1 origin/main && git push origin rs-v0.3.0-rc1`
- [ ] `rs--release.yml` triggers, plan job completes (was failing here before)
- [ ] All 4 build matrix entries (Windows/macOS arm64/macOS x64/Linux x64) succeed
- [ ] GitHub release `rs-v0.3.0-rc1` is created with all artifacts attached