### PR TITLE
fix(rs): write plan manifest outside dist_dir to avoid empty-file JSON parse

### DIFF
--- a/.github/workflows/rs--release.yml
+++ b/.github/workflows/rs--release.yml
@@ -126,10 +126,19 @@ jobs:
         # artifacts at the workspace root, so each upload `path:` carries its
         # final workspace-relative location (e.g. `codescope-rs/target/...`)
         # — keeps the artifact ZIPs round-trip-correct.
+        #
+        # Write the plan manifest into the working directory (codescope-rs/),
+        # NOT into `target/distrib/`. Bash creates the redirect target as an
+        # empty file BEFORE `dist` runs; `dist` calls `load_manifests` over
+        # its `dist_dir` (= `target/distrib/`) and tries to parse every
+        # `*dist-manifest.json` file it finds there. An empty file makes
+        # axoasset bail with `failed to parse JSON / EOF while parsing a
+        # value at line 1 column 0`. Matches the upstream cargo-dist 0.31
+        # template, which also keeps `plan-dist-manifest.json` at the
+        # workspace root for the same reason.
         working-directory: codescope-rs
         shell: bash
         run: |
-          mkdir -p target/distrib
           if [ -z "${{ github.event.pull_request }}" ]; then
             # `dist host --steps=create` needs the *stripped* tag (see
             # tag-flag rationale on the job outputs above).
@@ -137,15 +146,15 @@ jobs:
           else
             DIST_SUBCOMMAND="plan"
           fi
-          dist $DIST_SUBCOMMAND --output-format=json > target/distrib/plan-dist-manifest.json
+          dist $DIST_SUBCOMMAND --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
-          cat target/distrib/plan-dist-manifest.json
-          echo "manifest=$(jq -c "." target/distrib/plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          cat plan-dist-manifest.json
+          echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v6
         with:
           name: artifacts-plan-dist-manifest
-          path: codescope-rs/target/distrib/plan-dist-manifest.json
+          path: codescope-rs/plan-dist-manifest.json
 
   # Build and packages all the platform-specific things
   build-local-artifacts:


### PR DESCRIPTION
## Summary

- The release pipeline plan step failed with `× failed to parse JSON / ╰─▶ EOF while parsing a value at line 1 column 0` from `dist` itself (not `jq`).
- Root cause: the workflow redirected stdout to `target/distrib/plan-dist-manifest.json`. Bash creates the redirect target as an empty file **before** `dist` runs. `dist host --steps=create` then calls `load_manifests` over its `dist_dir` (`target/distrib/`), scans every `*dist-manifest.json` file in there, and chokes on the empty placeholder via `axoasset::SourceFile::deserialize_json`.
- Fix: write `plan-dist-manifest.json` at the working-directory root (`codescope-rs/`) so it sits outside `dist`'s manifest scan. Matches the upstream cargo-dist 0.31 template, which keeps the plan manifest at the workspace root for the exact same reason.
- The prefix-strip logic from PR #166 and the `working-directory: codescope-rs` adjustment from PR #165 are preserved; only the redirect target and the artifact upload path change.

## Verification

Reproduced the failure locally and confirmed the fix in `codescope-rs/`:

```bash
# Reproduction (mirrors the failed CI behaviour)
mkdir -p target/distrib
touch target/distrib/plan-dist-manifest.json
dist host --steps=create --tag=v0.3.0-rc.1 --output-format=json \
    > target/distrib/plan-dist-manifest.json
# -> exit 127, "EOF while parsing a value at line 1 column 0"

# After fix
rm -rf target/distrib
dist host --steps=create --tag=v0.3.0-rc.1 --output-format=json \
    > plan-dist-manifest.json
# -> exit 0, ~10 KB valid JSON manifest
```

The C# `release.yml` is untouched; this change only affects `.github/workflows/rs--release.yml`. cargo-dist stays on 0.31.0.

## Test plan

- [x] Reproduce the failure locally (empty `target/distrib/plan-dist-manifest.json` triggers the JSON parse error)
- [x] Verify the fix locally (manifest written at workspace root, dist exits 0 with valid JSON)
- [ ] After merge: retag with `git tag rs-v0.3.0-rc.1 origin/main && git push origin rs-v0.3.0-rc.1` and confirm the plan job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)