### PR TITLE
fix(rs): flume async feature for macOS build

### DIFF
--- a/codescope-rs/terminal/Cargo.toml
+++ b/codescope-rs/terminal/Cargo.toml
@@ -9,7 +9,7 @@ description = "Terminal emulator component for CodeScope-rs."
 alacritty_terminal = "0.25"
 anyhow = "1"
 codescope-core = { path = "../core" }
-flume = { version = "0.11", default-features = false }
+flume = { version = "0.11", default-features = false, features = ["async"] }
 gpui = "0.2.2"
 linkify = "0.10"
 open = "5"


### PR DESCRIPTION
macOS build failed because `flume` was loaded with `default-features = false` and no `async` feature; `recv_async().await` only compiles with `async`. Windows/Linux were getting it indirectly via feature unification with another dep. Add it explicitly.