### PR TITLE
fix(rs): refresh sidebar agent-registry on settings save

### DIFF
--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -2314,10 +2314,18 @@ impl AppShell {
     /// edit fully takes over only after the next Ctrl+Shift+T.
     pub(crate) fn apply_settings(&mut self, settings: Settings, cx: &mut Context<Self>) {
         let theme = Arc::new(codescope_core::theme::builtin::by_name(&settings.theme));
+        // Rebuild the AgentRegistry from the new settings so the
+        // sidebar's "New session ▸" default-row reflects the freshly
+        // chosen `default_agent` and any `agents` overrides. Without
+        // this the sidebar keeps its construction-time registry and
+        // the Settings dialog appears to do nothing for agent choice.
+        let agent_registry =
+            codescope_core::AgentRegistry::from_settings(&settings);
         self.settings = Arc::new(settings);
         self.theme = theme.clone();
         self.sidebar.update(cx, |sidebar, cx| {
             sidebar.apply_theme(theme, cx);
+            sidebar.apply_agent_registry(agent_registry, cx);
         });
         cx.notify();
     }

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -1290,6 +1290,21 @@ impl Sidebar {
         cx.notify();
     }
 
+    /// Replace the cached `AgentRegistry`. AppShell calls this from
+    /// `apply_settings` after the user saves a new `default_agent` so
+    /// the worktree menu's "New session ▸" default-row, the project
+    /// menu, and any other registry consumer here render the freshly-
+    /// chosen default instead of the stale one captured at
+    /// construction time.
+    pub fn apply_agent_registry(
+        &mut self,
+        agent_registry: AgentRegistry,
+        cx: &mut Context<Self>,
+    ) {
+        self.agent_registry = agent_registry;
+        cx.notify();
+    }
+
     /// Open the project context menu at `position` (window coords)
     /// for the project at `idx`. No-op if the index is out of range.
     fn open_project_menu(


### PR DESCRIPTION
User-reported: changing the default agent in Settings doesn't take effect.

`apply_settings` was updating `self.settings` and the theme but the sidebar's `agent_registry` was set once at construction and never refreshed. So the worktree's "New session ▸" submenu kept marking and spawning the old default.

Fix: rebuild `AgentRegistry::from_settings(&new_settings)` and push it into the sidebar via new `Sidebar::apply_agent_registry`. Ctrl+Shift+T already read fresh settings; this closes the sidebar-side regression.