### PR TITLE
fix(rs): version slug right-aligned + rs-v* describe + workflow env

### DIFF
--- a/.github/workflows/rs--release.yml
+++ b/.github/workflows/rs--release.yml
@@ -218,7 +218,21 @@ jobs:
           ${{ matrix.packages_install }}
       - name: Build artifacts
         working-directory: codescope-rs
+        shell: bash
         run: |
+          # Pin the version slug to the stripped tag (e.g.
+          # `0.3.0-rc.1`) so the title-bar chrome reads the actual
+          # release version instead of `git describe --always`'s
+          # commit-hash fallback — Actions checkouts are shallow and
+          # often can't see any `rs-v*` tag, even though the workflow
+          # itself was triggered by one. `build.rs` consumes
+          # `CODESCOPE_VERSION` as an override; strip the leading
+          # `rs-v` so the slug renders as `V0.3.0-rc.1` (build.rs adds
+          # the `V` prefix at render time).
+          FULL_TAG="${GITHUB_REF_NAME}"
+          STRIPPED_VERSION="${FULL_TAG#rs-v}"
+          export CODESCOPE_VERSION="${STRIPPED_VERSION}"
+          echo "Building with CODESCOPE_VERSION=${CODESCOPE_VERSION}"
           # Actually do builds and make zips and whatnot
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"

--- a/codescope-rs/build.rs
+++ b/codescope-rs/build.rs
@@ -112,16 +112,23 @@ fn git_path(relative: &str) -> Option<PathBuf> {
 }
 
 fn git_describe() -> Option<String> {
-    // `--match v*` restricts to product-version tags (`v0.2.5`,
-    // `v0.3.0-rc1`). The Rust-side release pipeline cuts its own
-    // `rs-vX.Y.Z` tags in the same repo (`rs--release.yml`,
-    // ADR-0019); without the filter `git describe` would pick the
-    // most recent reachable tag of either flavour and stamp the
-    // running Rust build with `rs-v…`, which `update_check::evaluate`
-    // would then try to parse as a semver triple (and fail to a
-    // false `UpToDate` via `is_unknown_fallback`'s catch-all). The
-    // C# `Directory.Build.targets` carries the same filter for the
-    // same reason.
-    let raw = run_git(&["describe", "--tags", "--always", "--dirty", "--match", "v*"])?;
-    Some(strip_v_prefix(&raw))
+    // The Rust port cuts its release tags as `rs-vX.Y.Z`
+    // (`rs--release.yml`, ADR-0019). Match only those — `--match v*`
+    // would catch the C# build's tags instead and stamp this binary
+    // with a version that doesn't correspond to anything the Rust
+    // release pipeline ever shipped. Strip the `rs-v` prefix so the
+    // chrome can render `V0.3.0-rc.1` consistently.
+    let raw = run_git(&["describe", "--tags", "--always", "--dirty", "--match", "rs-v*"])?;
+    Some(strip_rs_v_prefix(&raw))
+}
+
+/// Strip a leading `rs-v` / `rs-V` from a `git describe` output so
+/// the chrome version slug reads `0.3.0-rc.1` instead of
+/// `rs-v0.3.0-rc.1`. Falls through to [`strip_v_prefix`] when the
+/// describe didn't match any `rs-v*` tag (commit-hash-only fallback).
+fn strip_rs_v_prefix(s: &str) -> String {
+    if let Some(rest) = s.strip_prefix("rs-v").or_else(|| s.strip_prefix("rs-V")) {
+        return rest.to_owned();
+    }
+    strip_v_prefix(s)
 }

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -5399,14 +5399,18 @@ impl Render for AppShell {
                     .text_color(theme::ink(&theme))
                     .child("CodeScope"),
             )
+            // Flex filler so the version slug pushes to the right edge
+            // of the sidebar column (mirrors `Grid.Column="3"` in
+            // `MainWindow.xaml`'s brand grid).
+            .child(div().flex_grow())
             .child(
                 // Version slug — `Fig.Font.Mono` @ `FontSize="10"` in
-                // `MainWindow.xaml` (Text.Faint foreground; the closest
-                // themable analogue here is `ink_ghost`).
+                // `MainWindow.xaml`, right-aligned (`Grid.Column="3"`),
+                // `Text.Faint` foreground.
                 div()
                     .font(theme::font_mono())
                     .text_size(px(10.0))
-                    .text_color(theme::ink_ghost(&theme))
+                    .text_color(theme::text_faint())
                     .truncate()
                     .child(VERSION_DISPLAY),
             )


### PR DESCRIPTION
Three coupled fixes around the title-bar version slug.

- build.rs matches `rs-v*` tags instead of C#'s `v*`
- Title-bar brand cluster gets `flex_grow` filler so slug sticks to right edge of sidebar column (`Grid.Column=3` parity with MainWindow.xaml)
- Release workflow exports `CODESCOPE_VERSION=${tag#rs-v}` so the MSI binary has the real version, not the commit-hash fallback (user reported `V0fc57af`)