### PR TITLE
feat(rs): per-user MSI install to %LOCALAPPDATA%\Programs (VS Code / Zed style)

### DIFF
--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["vendor/gpui-terminal"]
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2024"
 publish = false
 description = "CodeScope (Rust port): gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."

--- a/codescope-rs/dist-workspace.toml
+++ b/codescope-rs/dist-workspace.toml
@@ -26,16 +26,22 @@ members = ["cargo:."]
 #   fontconfig + freetype) are installed in the GH Actions Linux
 #   job via apt before `dist build` runs. See
 #   `.github/workflows/rs--release.yml`.
-# - `install-path = "CARGO_HOME"` is the cargo-dist default for CLI
-#   tools, but CodeScope is a GUI app users launch from the Start menu,
-#   so we leave that field at its default and let the MSI installer
-#   put the binary under `%ProgramFiles%\codescope-rs\` (the WiX
-#   template derives the directory name from the Cargo `package.name`).
-#   The C# build installs to `%ProgramFiles%\CodeScope\` instead, so
-#   the two MSIs coexist on the same machine while we work the Rust
-#   port toward feature parity. The directory name can be rebranded
-#   to `CodeScope` once the Rust build is the only build shipping —
-#   that's a `[package.metadata.wix]` edit, not a rename.
+# - The MSI installs **per-user** to
+#   `%LOCALAPPDATA%\Programs\codescope-rs\bin\` and lays a Start Menu
+#   shortcut under the user's `%APPDATA%\Microsoft\Windows\Start
+#   Menu\Programs\` tree. No admin / UAC prompt at install or upgrade
+#   time. This matches VS Code Stable, Zed, Discord, Slack, and GitHub
+#   Desktop's modern default, and it deliberately diverges from the
+#   C# CodeScope build (still `%ProgramFiles%\CodeScope\`, per-machine)
+#   so Velopack-style auto-updates can rewrite the install dir without
+#   needing to escalate every time. The C# and Rust MSIs now live in
+#   different scopes entirely, so they coexist cleanly on the same
+#   machine while we work the Rust port toward feature parity.
+#
+#   The directory chain + `InstallScope="perUser"` + `MSIINSTALLPERUSER=1`
+#   are authored in `codescope-rs/wix/main.wxs` (a hand-edited
+#   cargo-wix template). `allow-dirty = ["msi"]` below tells cargo-dist
+#   to leave the template alone — see the comment near it.
 # - `install-updater = false` for now — Velopack handles the
 #   self-update path in-process (see `codescope-rs/core/src/update_check.rs`
 #   and the velopack integration on the AppShell). The axoupdater
@@ -73,9 +79,13 @@ tag-namespace = "rs-"
 source-tarball = false
 # We hand-edit the generated workflow to drop the `pull_request:`
 # trigger (we only want tag pushes to spin up the release pipeline).
-# `allow-dirty` tells cargo-dist not to fight the manual edit on every
-# `dist plan` invocation.
-allow-dirty = ["ci"]
+# We also ship a custom WiX template at `codescope-rs/wix/main.wxs`
+# (per-user install to `%LOCALAPPDATA%\Programs\codescope-rs\`,
+# per-user Start Menu shortcut, `ALLUSERS=""` / `MSIINSTALLPERUSER=1`
+# for no-UAC installs and upgrades). `allow-dirty` tells cargo-dist
+# not to fight the manual edits on either path on every `dist plan`
+# invocation.
+allow-dirty = ["ci", "msi"]
 # Don't fan out a PR-validation build matrix — the task brief says
 # "only trigger on tag pushes". This empties cargo-dist's PR mode so
 # the workflow's pull_request gate (when present) is a no-op.

--- a/codescope-rs/wix/main.wxs
+++ b/codescope-rs/wix/main.wxs
@@ -45,16 +45,19 @@
 -->
 
 <!--
-  Please do not remove these pre-processor If-Else blocks. These are used with
-  the `cargo wix` subcommand to automatically determine the installation
-  destination for 32-bit versus 64-bit installers. Removal of these lines will
-  cause installation errors.
+  Per-user install layout. CodeScope (Rust port) ships as a per-user MSI that
+  drops the binary under `%LOCALAPPDATA%\Programs\codescope-rs\bin\` and the
+  Start Menu shortcut under the per-user `%APPDATA%\Microsoft\Windows\Start
+  Menu\Programs\` tree. No admin/UAC prompt at install or upgrade time, which
+  is what modern Velopack-style auto-update needs (the updater must be able to
+  rewrite the install dir without escalating).
+
+  This matches VS Code Stable, Zed, Discord, Slack, and GitHub Desktop's
+  default installer scope, and it deliberately diverges from the C# CodeScope
+  build (which still installs to `%ProgramFiles%\CodeScope\` per-machine) —
+  the two MSIs now live in different scopes entirely so they coexist
+  cleanly while we work the Rust port toward feature parity.
 -->
-<?if $(sys.BUILDARCH) = x64 or $(sys.BUILDARCH) = arm64 ?>
-    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
-<?else ?>
-    <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
-<?endif ?>
 
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
 
@@ -71,12 +74,22 @@
             Keywords='Installer'
             Description='CodeScope (Rust port): gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation.'
             Manufacturer='maui1911'
-            InstallerVersion='450'
+            InstallerVersion='500'
             Languages='1033'
             Compressed='yes'
-            InstallScope='perMachine'
+            InstallScope='perUser'
             SummaryCodepage='1252'
             />
+
+        <!--
+          `InstallScope='perUser'` on the `Package` element above is the
+          WiX shorthand that emits the right `ALLUSERS` / `MSIINSTALLPERUSER`
+          summary-info combo for a single-package per-user install: no UAC
+          elevation, ARP entry under HKCU, files go to HKCU-rooted paths.
+          We deliberately do not redeclare `ALLUSERS` here — WiX 3.14 errors
+          on `Property@Value=""` and the perUser scope already handles it.
+        -->
+        <Property Id='MSIINSTALLPERUSER' Value='1' />
 
         <MajorUpgrade
             Schedule='afterInstallInitialize'
@@ -86,49 +99,107 @@
         <Property Id='DiskPrompt' Value='codescope-rs Installation'/>
 
         <Directory Id='TARGETDIR' Name='SourceDir'>
-            <Directory Id='$(var.PlatformProgramFilesFolder)' Name='PFiles'>
-                <Directory Id='APPLICATIONFOLDER' Name='codescope-rs'>
-                    
-                    <!--
-                      Enabling the license sidecar file in the installer is a four step process:
-
-                      1. Uncomment the `Component` tag and its contents.
-                      2. Change the value for the `Source` attribute in the `File` tag to a path
-                         to the file that should be included as the license sidecar file. The path
-                         can, and probably should be, relative to this file.
-                      3. Change the value for the `Name` attribute in the `File` tag to the
-                         desired name for the file when it is installed alongside the `bin` folder
-                         in the installation directory. This can be omitted if the desired name is
-                         the same as the file name.
-                      4. Uncomment the `ComponentRef` tag with the Id attribute value of "License"
-                         further down in this file.
-                    -->
-                    <!--
-                    <Component Id='License' Guid='*'>
-                        <File Id='LicenseFile' Name='ChangeMe' DiskId='1' Source='C:\Path\To\File' KeyPath='yes'/>
-                    </Component>
-                    -->
-
-                    <Directory Id='Bin' Name='bin'>
-                        <Component Id='Path' Guid='3326208D-A1EE-453F-ACB6-EDBEE0D923C5' KeyPath='yes'>
-                            <Environment
-                                Id='PATH'
-                                Name='PATH'
-                                Value='[Bin]'
-                                Permanent='no'
-                                Part='last'
-                                Action='set'
-                                System='yes'/>
-                        </Component>
-                        <Component Id='binary0' Guid='*'>
-                            <File
-                                Id='exe0'
-                                Name='codescope-rs.exe'
-                                DiskId='1'
-                                Source='$(var.CargoTargetBinDir)\codescope-rs.exe'
-                                KeyPath='yes'/>
-                        </Component>
+            <!--
+              `LocalAppDataFolder` resolves to `%LOCALAPPDATA%` (i.e.
+              `C:\Users\<user>\AppData\Local`). We mirror VS Code / Zed's
+              convention of nesting under a `Programs` subdirectory so the
+              install location reads naturally and doesn't pollute the root
+              of LocalAppData.
+            -->
+            <Directory Id='LocalAppDataFolder'>
+                <Directory Id='ProgramsFolder' Name='Programs'>
+                    <Directory Id='APPLICATIONFOLDER' Name='codescope-rs'>
+                        <Directory Id='Bin' Name='bin'>
+                            <!--
+                              Per-user MSI rules (ICE38 / ICE64): components
+                              that land under the user profile must have an
+                              HKCU registry KeyPath (not a file) and every
+                              per-user directory in the tree needs a
+                              RemoveFolder so uninstall leaves no trace.
+                              We pin both `RemoveFolder` cleanups for the
+                              non-leaf dirs to this component since it's
+                              the one that always runs.
+                            -->
+                            <Component Id='Path' Guid='3326208D-A1EE-453F-ACB6-EDBEE0D923C5'>
+                                <!--
+                                  Per-user PATH lives in HKCU. `System='no'`
+                                  is the per-user mode of the WiX Environment
+                                  element; pairs with the perUser InstallScope.
+                                -->
+                                <Environment
+                                    Id='PATH'
+                                    Name='PATH'
+                                    Value='[Bin]'
+                                    Permanent='no'
+                                    Part='last'
+                                    Action='set'
+                                    System='no'/>
+                                <RegistryValue Root='HKCU'
+                                               Key='Software\maui1911\codescope-rs'
+                                               Name='PathFeatureInstalled'
+                                               Type='integer'
+                                               Value='1'
+                                               KeyPath='yes'/>
+                            </Component>
+                            <!--
+                              Explicit Guid (not `*`) because this component
+                              mixes a `File` with a `RegistryValue KeyPath` —
+                              auto-GUID is only legal for single-resource
+                              components per WiX's CNDL0230 rule.
+                            -->
+                            <Component Id='binary0' Guid='BFABF36E-C1F5-46AA-8418-2FE35E434FBB'>
+                                <File
+                                    Id='exe0'
+                                    Name='codescope-rs.exe'
+                                    DiskId='1'
+                                    Source='$(var.CargoTargetBinDir)\codescope-rs.exe'/>
+                                <RegistryValue Root='HKCU'
+                                               Key='Software\maui1911\codescope-rs'
+                                               Name='BinaryInstalled'
+                                               Type='integer'
+                                               Value='1'
+                                               KeyPath='yes'/>
+                                <RemoveFolder Id='RemoveBinDir'
+                                              Directory='Bin'
+                                              On='uninstall'/>
+                                <RemoveFolder Id='RemoveAppDir'
+                                              Directory='APPLICATIONFOLDER'
+                                              On='uninstall'/>
+                                <RemoveFolder Id='RemoveProgramsDir'
+                                              Directory='ProgramsFolder'
+                                              On='uninstall'/>
+                            </Component>
+                        </Directory>
                     </Directory>
+                </Directory>
+            </Directory>
+
+            <!--
+              Per-user Start Menu. `ProgramMenuFolder` is the standard WiX
+              directory that points at the user's
+              `%APPDATA%\Microsoft\Windows\Start Menu\Programs` tree when the
+              package is per-user. The shortcut is the primary launch path
+              for a GUI app; we keep the PATH entry as a convenience for
+              power users who want to invoke `codescope-rs` from a shell.
+            -->
+            <Directory Id='ProgramMenuFolder'>
+                <Directory Id='AppShortcutFolder' Name='CodeScope (Rust)'>
+                    <Component Id='ApplicationShortcut' Guid='5B7B5B47-7F2A-4E1A-9F3F-2C4B82C7F1A0'>
+                        <Shortcut Id='ApplicationStartMenuShortcut'
+                                  Name='CodeScope (Rust)'
+                                  Description='CodeScope (Rust port)'
+                                  Target='[Bin]codescope-rs.exe'
+                                  WorkingDirectory='Bin' />
+                        <RemoveFolder Id='RemoveAppShortcutFolder'
+                                      Directory='AppShortcutFolder'
+                                      On='uninstall' />
+                        <RegistryValue Root='HKCU'
+                                       Key='Software\maui1911\codescope-rs'
+                                       Name='installed'
+                                       Type='integer'
+                                       Value='1'
+                                       KeyPath='yes' />
+                    </Component>
                 </Directory>
             </Directory>
         </Directory>
@@ -136,25 +207,20 @@
         <Feature
             Id='Binaries'
             Title='Application'
-            Description='Installs all binaries and the license.'
+            Description='Installs the codescope-rs binary and Start Menu shortcut.'
             Level='1'
             ConfigurableDirectory='APPLICATIONFOLDER'
             AllowAdvertise='no'
             Display='expand'
             Absent='disallow'>
-            
-            <!--
-              Uncomment the following `ComponentRef` tag to add the license
-              sidecar file to the installer.
-            -->
-            <!--<ComponentRef Id='License'/>-->
 
             <ComponentRef Id='binary0'/>
+            <ComponentRef Id='ApplicationShortcut'/>
 
             <Feature
                 Id='Environment'
                 Title='PATH Environment Variable'
-                Description='Add the install location of the [ProductName] executable to the PATH system environment variable. This allows the [ProductName] executable to be called from any location.'
+                Description='Add the install location of the [ProductName] executable to the per-user PATH environment variable. This allows the [ProductName] executable to be called from any location.'
                 Level='1'
                 Absent='allow'>
                 <ComponentRef Id='Path'/>
@@ -163,7 +229,7 @@
 
         <SetProperty Id='ARPINSTALLLOCATION' Value='[APPLICATIONFOLDER]' After='CostFinalize'/>
 
-        
+
         <!--
           Uncomment the following `Icon` and `Property` tags to change the product icon.
 
@@ -174,10 +240,10 @@
         <!--<Property Id='ARPPRODUCTICON' Value='ProductICO' />-->
 
         <Property Id='ARPHELPLINK' Value='https://github.com/maui1911/CodeScope'/>
-        
+
         <UI>
             <UIRef Id='WixUI_FeatureTree'/>
-            
+
             <!--
               Enabling the EULA dialog in the installer is a three step process:
 
@@ -193,7 +259,7 @@
 
         </UI>
 
-        
+
         <!--
           Enabling the EULA dialog in the installer requires uncommenting
           the following `WixUILicenseRTF` tag and changing the `Value`
@@ -201,7 +267,7 @@
         -->
         <!-- <WixVariable Id='WixUILicenseRtf' Value='Relative\Path\to\Eula.rtf'/> -->
 
-        
+
         <!--
           Uncomment the next `WixVariable` tag to customize the installer's
           Graphical User Interface (GUI) and add a custom banner image across
@@ -212,7 +278,7 @@
         -->
         <!--<WixVariable Id='WixUIBannerBmp' Value='wix\Banner.bmp'/>-->
 
-        
+
         <!--
           Uncomment the next `WixVariable` tag to customize the installer's
           Graphical User Interface (GUI) and add a custom image to the first


### PR DESCRIPTION
## Summary

- Switch the Rust port's MSI installer from per-machine `%ProgramFiles%\codescope-rs\` to **per-user** `%LOCALAPPDATA%\Programs\codescope-rs\bin\`. No admin / UAC prompt at install or upgrade time.
- Add a per-user Start Menu shortcut (`%APPDATA%\Microsoft\Windows\Start Menu\Programs\CodeScope (Rust)\`).
- Bump `codescope-rs` to `0.3.0-rc.2` so the next tag picks up the new installer.

## Why

Velopack-style auto-updates need write access to the install dir; per-machine installs would require admin every update. VS Code Stable, Zed, Discord, Slack, and GitHub Desktop all default to per-user for exactly this reason. The C# CodeScope build still installs to `%ProgramFiles%\CodeScope\` per-machine — the two MSIs now live in different scopes entirely, which keeps coexistence clean while the Rust port works toward feature parity.

## Implementation

Hand-edited `codescope-rs/wix/main.wxs` (the cargo-wix template that cargo-dist 0.31 invokes for MSI generation):

- `<Package InstallScope="perUser">` — emits `InstallPrivileges="limited"` so the MSI never elevates.
- Directory chain rooted at `LocalAppDataFolder → Programs → codescope-rs → bin`.
- `<Property Id='MSIINSTALLPERUSER' Value='1'/>` — explicit single-package per-user authoring.
- `ProgramMenuFolder` shortcut component for the per-user Start Menu entry.
- HKCU registry `KeyPath` on every component (ICE38: per-user components need an HKCU keypath, not a file).
- `RemoveFolder` entries for every per-user directory (ICE64: per-user dirs must be cleaned up on uninstall).
- PATH `Environment` switched to `System="no"` (per-user PATH lives in HKCU).
- `allow-dirty = ["ci", "msi"]` in `dist-workspace.toml` so cargo-dist leaves the template alone.

The big comment block at the top of `dist-workspace.toml` is rewritten to document the new policy.

## Test plan

- [x] `dist plan` reports the planned MSI cleanly.
- [x] `dist build --artifacts=local --target=x86_64-pc-windows-msvc` produces `codescope-rs-x86_64-pc-windows-msvc.msi` (~5.4 MB) on the Windows dev box.
- [x] WiX 3.14 ICE checks pass (ICE38 / ICE64 / ICE91 — caught and fixed during iteration).
- [x] `dark.exe` decompile of the produced MSI confirms `InstallPrivileges="limited"`, `LocalAppDataFolder` directory chain, `MSIINSTALLPERUSER=1` property, per-user Start Menu shortcut, and `RemoveFolder` entries.
- [ ] Smoke install on the Windows dev box: confirm no UAC prompt and files land under `%LOCALAPPDATA%\Programs\codescope-rs\` (manual step after merge — destructive on the dev box's installed builds).
- [ ] Tag-driven release pipeline (`rs-v0.3.0-rc2`) reproduces the build on CI (manual — user controls when the next tag ships).

## Notes

- An existing per-machine 0.3.0-rc.1 install does **not** auto-uninstall when the per-user 0.3.0-rc.2 MSI runs — Windows Installer can't upgrade across scopes. RC users (if any) will need to uninstall the previous build manually. This only affects RC adopters; v0.3.0 stable will be the first per-user release proper.
- Velopack integration is unchanged. The cargo-dist MSI continues to install without a Velopack manifest; the in-process Velopack `UpdateManager` path activates only for builds that were Velopack-bootstrapped, same as before.
- C# CodeScope build is untouched.