### PR TITLE
fix(rs): address Copilot review on PR #175 (per-user MSI followups)

### DIFF
--- a/codescope-rs/dist-workspace.toml
+++ b/codescope-rs/dist-workspace.toml
@@ -81,9 +81,12 @@ source-tarball = false
 # trigger (we only want tag pushes to spin up the release pipeline).
 # We also ship a custom WiX template at `codescope-rs/wix/main.wxs`
 # (per-user install to `%LOCALAPPDATA%\Programs\codescope-rs\`,
-# per-user Start Menu shortcut, `ALLUSERS=""` / `MSIINSTALLPERUSER=1`
-# for no-UAC installs and upgrades). `allow-dirty` tells cargo-dist
-# not to fight the manual edits on either path on every `dist plan`
+# per-user Start Menu shortcut, `InstallScope="perUser"` plus
+# `MSIINSTALLPERUSER=1` for no-UAC installs and upgrades — we do
+# *not* set `ALLUSERS` explicitly because WiX 3.14 rejects
+# `Property@Value=""` and the perUser InstallScope already handles
+# the ALLUSERS bookkeeping). `allow-dirty` tells cargo-dist not to
+# fight the manual edits on either path on every `dist plan`
 # invocation.
 allow-dirty = ["ci", "msi"]
 # Don't fan out a PR-validation build matrix — the task brief says

--- a/codescope-rs/wix/main.wxs
+++ b/codescope-rs/wix/main.wxs
@@ -107,7 +107,16 @@
               of LocalAppData.
             -->
             <Directory Id='LocalAppDataFolder'>
-                <Directory Id='ProgramsFolder' Name='Programs'>
+                <!--
+                  `LocalAppDataProgramsFolder` is our id for the
+                  `%LOCALAPPDATA%\Programs` subdir. We deliberately do
+                  *not* name it `ProgramsFolder` to avoid confusion with
+                  the WiX `ProgramMenuFolder` (per-user Start Menu) and
+                  the Windows shell's "Programs" concept — both are
+                  authored a few lines below and live in a different
+                  directory tree entirely.
+                -->
+                <Directory Id='LocalAppDataProgramsFolder' Name='Programs'>
                     <Directory Id='APPLICATIONFOLDER' Name='codescope-rs'>
                         <Directory Id='Bin' Name='bin'>
                             <!--
@@ -116,9 +125,14 @@
                               HKCU registry KeyPath (not a file) and every
                               per-user directory in the tree needs a
                               RemoveFolder so uninstall leaves no trace.
-                              We pin both `RemoveFolder` cleanups for the
-                              non-leaf dirs to this component since it's
-                              the one that always runs.
+                              The `RemoveFolder` cleanups for `Bin`,
+                              `APPLICATIONFOLDER`, and
+                              `LocalAppDataProgramsFolder` are authored
+                              under the `binary0` component below — that
+                              component is always installed (the PATH
+                              component is optional via the Environment
+                              sub-feature), so it's the right anchor for
+                              directory cleanup.
                             -->
                             <Component Id='Path' Guid='3326208D-A1EE-453F-ACB6-EDBEE0D923C5'>
                                 <!--
@@ -166,7 +180,7 @@
                                               Directory='APPLICATIONFOLDER'
                                               On='uninstall'/>
                                 <RemoveFolder Id='RemoveProgramsDir'
-                                              Directory='ProgramsFolder'
+                                              Directory='LocalAppDataProgramsFolder'
                                               On='uninstall'/>
                             </Component>
                         </Directory>


### PR DESCRIPTION
## Summary

PR #175 (per-user MSI install) merged before its Copilot review comments could be folded into the same PR. This is the followup with the three review nits applied:

- Rename the WiX directory id `ProgramsFolder` → `LocalAppDataProgramsFolder` so it can't be confused with `ProgramMenuFolder` / the Start Menu "Programs" concept that lives in the same file (Copilot review comment).
- Rewrite the comment near the `Path` component that incorrectly claimed it owned the `RemoveFolder` cleanups — those actually live under `binary0`. The new comment explains why `binary0` is the right anchor (always installed; PATH is an optional sub-feature).
- Drop the `ALLUSERS=""` mention from the `dist-workspace.toml` comment block — `wix/main.wxs` deliberately does **not** set `ALLUSERS` (WiX 3.14 rejects `Property@Value=""` and `InstallScope="perUser"` already handles the bookkeeping).

No behavior change.

## Test plan

- [x] `candle.exe` + `light.exe` process the updated `wix/main.wxs` cleanly (ICE38 / ICE64 / ICE91 pass) after the rename.
- [ ] Tag-driven release (`rs-v0.3.0-rc2`) reproduces the MSI on CI — user-controlled, no action here.