### PR TITLE
fix(rs): resume sessions by explicit agent_session_id

### DIFF
--- a/codescope-rs/core/src/agent_registry.rs
+++ b/codescope-rs/core/src/agent_registry.rs
@@ -272,6 +272,71 @@ pub fn built_in_defaults() -> Vec<AgentProfile> {
     ]
 }
 
+/// Build the auto-type command string used to (re)attach a terminal
+/// session to a previously-running agent conversation. Mirrors C#
+/// `SessionManager.CreateAgentSession` resume branch + `JoinResumeByIdArgs`
+/// (see `src/CodeScope.Core/Services/SessionManager.cs`).
+///
+/// Resolution table:
+///
+/// 1. `agent_session_id = Some(id)` AND `resume_by_id_args` non-empty
+///    → `[command, resume_by_id_args[0..n-1]..,
+///        resume_by_id_args[last] + id_suffix]`
+///    where the last token is concat'd with the id without a space
+///    when it ends with `=` (Copilot's `--resume=<id>` shape) and
+///    appended as a separate argv element otherwise (Claude's
+///    `--resume <id>`, OpenCode's `--session <id>`, Pi's
+///    `--session <id>`).
+/// 2. Otherwise (no known id, or the profile has no resume-by-id
+///    flow) → `[command, resume_args...]`. Empty `resume_args` yields
+///    just the bare `command` — matches C# `CreateAgentSession` with
+///    `resume = true` and an empty `ResumeArgs`.
+///
+/// Tokens are joined with single spaces. The result is intended for
+/// `auto_type` in a PowerShell prompt, exactly like the C# build.
+pub fn build_resume_auto_type(
+    profile: &AgentProfile,
+    agent_session_id: Option<&str>,
+) -> Option<String> {
+    if profile.command.is_empty() {
+        return None;
+    }
+
+    let id_for_resume = agent_session_id
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    if let Some(id) = id_for_resume {
+        if !profile.resume_by_id_args.is_empty() {
+            let mut argv: Vec<String> =
+                Vec::with_capacity(1 + profile.resume_by_id_args.len());
+            argv.push(profile.command.clone());
+            let last_idx = profile.resume_by_id_args.len() - 1;
+            for (i, token) in profile.resume_by_id_args.iter().enumerate() {
+                if i == last_idx && token.ends_with('=') {
+                    // Copilot's optional-value flag — `--resume=<id>`
+                    // requires no space between flag and value.
+                    argv.push(format!("{token}{id}"));
+                } else if i == last_idx {
+                    argv.push(token.clone());
+                    argv.push(id.to_string());
+                } else {
+                    argv.push(token.clone());
+                }
+            }
+            return Some(argv.join(" "));
+        }
+        // Fall through to resume_args — the profile has no per-id
+        // resume verb (Codex), so the best we can do is "continue
+        // most recent" or just re-launch.
+    }
+
+    let mut argv: Vec<String> = Vec::with_capacity(1 + profile.resume_args.len());
+    argv.push(profile.command.clone());
+    argv.extend(profile.resume_args.iter().cloned());
+    Some(argv.join(" "))
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -461,5 +526,184 @@ mod tests {
         assert!(json.contains("\"resumeByIdArgs\""));
         assert!(json.contains("\"isDefault\""));
         assert!(json.contains("\"contextWindowTokens\""));
+    }
+
+    // ─── build_resume_auto_type ────────────────────────────────────
+    //
+    // Covers the resume-by-explicit-id flow for every built-in
+    // agent. Each test pairs a "with id" assertion against the
+    // "without id" fallback so a regression in either branch is
+    // caught. Mirrors the C# `SessionManager.CreateAgentSession`
+    // resume branch + `JoinResumeByIdArgs`.
+
+    fn registry_profile(id: &str) -> AgentProfile {
+        AgentRegistry::with_built_ins()
+            .get_by_id(id)
+            .cloned()
+            .expect("built-in profile present")
+    }
+
+    #[test]
+    fn build_resume_auto_type_claude_with_id() {
+        let profile = registry_profile("claude");
+        assert_eq!(
+            build_resume_auto_type(&profile, Some("abc-123")),
+            Some("claude --resume abc-123".into()),
+        );
+    }
+
+    #[test]
+    fn build_resume_auto_type_claude_without_id_yields_bare_command() {
+        // Claude's `resume_args` is empty — the bare `claude` is the
+        // fallback when no specific session id is known.
+        let profile = registry_profile("claude");
+        assert_eq!(
+            build_resume_auto_type(&profile, None),
+            Some("claude".into()),
+        );
+    }
+
+    #[test]
+    fn build_resume_auto_type_codex_ignores_id_when_resume_by_id_args_empty() {
+        // Codex has `resume_args = ["resume"]` but no
+        // `resume_by_id_args` — passing an id must not change the
+        // shape, the helper falls through to `resume_args`.
+        let profile = registry_profile("codex");
+        assert_eq!(
+            build_resume_auto_type(&profile, Some("ignored-id")),
+            Some("codex resume".into()),
+        );
+        assert_eq!(
+            build_resume_auto_type(&profile, None),
+            Some("codex resume".into()),
+        );
+    }
+
+    #[test]
+    fn build_resume_auto_type_copilot_with_id_concats_with_equals() {
+        // Copilot's last `resume_by_id_args` entry is `"--resume="`
+        // (trailing `=`). The helper must concat the id without
+        // emitting an intermediate space.
+        let profile = registry_profile("copilot");
+        assert_eq!(
+            build_resume_auto_type(&profile, Some("abc-123")),
+            Some("copilot --resume=abc-123".into()),
+        );
+    }
+
+    #[test]
+    fn build_resume_auto_type_copilot_without_id_uses_continue() {
+        let profile = registry_profile("copilot");
+        assert_eq!(
+            build_resume_auto_type(&profile, None),
+            Some("copilot --continue".into()),
+        );
+    }
+
+    #[test]
+    fn build_resume_auto_type_opencode_with_id() {
+        // OpenCode resumes by `--session <id>` (space-separated, no
+        // trailing `=` on the flag). The built-in command is
+        // `opencode-cli` on Windows.
+        let profile = registry_profile("opencode");
+        let cmd = profile.command.clone();
+        assert_eq!(
+            build_resume_auto_type(&profile, Some("abc-123")),
+            Some(format!("{cmd} --session abc-123")),
+        );
+    }
+
+    #[test]
+    fn build_resume_auto_type_opencode_without_id_uses_continue() {
+        let profile = registry_profile("opencode");
+        let cmd = profile.command.clone();
+        assert_eq!(
+            build_resume_auto_type(&profile, None),
+            Some(format!("{cmd} --continue")),
+        );
+    }
+
+    #[test]
+    fn build_resume_auto_type_pi_with_id_uses_session_flag() {
+        // The user-visible bug: `pi -c` was resuming "most recent"
+        // instead of `pi --session <id>` — this test pins the
+        // correct shape.
+        let profile = registry_profile("pi");
+        assert_eq!(
+            build_resume_auto_type(&profile, Some("abc-123")),
+            Some("pi --session abc-123".into()),
+        );
+    }
+
+    #[test]
+    fn build_resume_auto_type_pi_without_id_falls_back_to_continue() {
+        let profile = registry_profile("pi");
+        assert_eq!(
+            build_resume_auto_type(&profile, None),
+            Some("pi -c".into()),
+        );
+    }
+
+    #[test]
+    fn build_resume_auto_type_empty_id_treated_as_no_id() {
+        // Defensive: a persisted `agent_session_id = Some("")` (or
+        // whitespace) must not produce `claude --resume ` with a
+        // trailing space — fall back to the no-id path instead.
+        let profile = registry_profile("claude");
+        assert_eq!(
+            build_resume_auto_type(&profile, Some("")),
+            Some("claude".into()),
+        );
+        assert_eq!(
+            build_resume_auto_type(&profile, Some("   ")),
+            Some("claude".into()),
+        );
+    }
+
+    #[test]
+    fn build_resume_auto_type_returns_none_when_command_empty() {
+        // Defensive: a hand-edited `settings.json` with a blank
+        // `command` (or a registry override that forgot to set
+        // one) must not emit a leading-space argv. Returning
+        // `None` lets the caller fall through to a plain shell.
+        let profile = AgentProfile {
+            id: "broken".into(),
+            display_name: "Broken".into(),
+            command: String::new(),
+            resume_args: vec!["--continue".into()],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec!["--resume".into()],
+            is_default: false,
+            icon: None,
+            context_window_tokens: 0,
+        };
+        assert!(build_resume_auto_type(&profile, Some("abc")).is_none());
+        assert!(build_resume_auto_type(&profile, None).is_none());
+    }
+
+    #[test]
+    fn build_resume_auto_type_multi_token_resume_by_id_args_appends_id_to_last() {
+        // Future-proofing for a hypothetical profile whose
+        // `resume_by_id_args` is e.g. `["--resume", "--id"]` —
+        // tokens are emitted in order and the id rides the last
+        // one (still space-separated because the last token
+        // doesn't end with `=`).
+        let profile = AgentProfile {
+            id: "multi".into(),
+            display_name: "Multi".into(),
+            command: "multi".into(),
+            resume_args: vec!["--continue".into()],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec!["--resume".into(), "--id".into()],
+            is_default: false,
+            icon: None,
+            context_window_tokens: 0,
+        };
+        assert_eq!(
+            build_resume_auto_type(&profile, Some("xyz")),
+            Some("multi --resume --id xyz".into()),
+        );
     }
 }

--- a/codescope-rs/core/src/layout.rs
+++ b/codescope-rs/core/src/layout.rs
@@ -84,6 +84,17 @@ pub struct RestoreTab {
     /// tab wins.
     #[serde(default)]
     pub active_in_group: bool,
+    /// Persisted [`crate::projects::Session`] id this tab was bound
+    /// to at save time. `Some` lets the rehydrate path look up the
+    /// stored `agent_session_id` and reattach to the *specific*
+    /// conversation via `resume_by_id_args` instead of the agent's
+    /// "most recent" fallback. `None` for older layout.json files
+    /// (pre-resume-by-id) and for tabs that never made it into the
+    /// session store (no project context at spawn time) — those
+    /// rehydrate as a fresh agent launch, matching the previous
+    /// behaviour.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
 }
 
 impl Default for LayoutState {
@@ -163,6 +174,7 @@ mod tests {
                 auto_type: Some("claude".into()),
                 group_index: 0,
                 active_in_group: true,
+                session_id: Some("sess-1".into()),
             }],
             collapsed_projects: vec!["proj-2".into(), "proj-3".into()],
         };
@@ -175,6 +187,7 @@ mod tests {
         assert_eq!(loaded.open_tabs.len(), 1);
         assert_eq!(loaded.open_tabs[0].auto_type.as_deref(), Some("claude"));
         assert!(loaded.open_tabs[0].active_in_group);
+        assert_eq!(loaded.open_tabs[0].session_id.as_deref(), Some("sess-1"));
         assert_eq!(loaded.collapsed_projects, vec!["proj-2", "proj-3"]);
     }
 
@@ -195,6 +208,24 @@ mod tests {
         let loaded = LayoutState::load_from(&path).unwrap();
         assert_eq!(loaded.selected_project_id.as_deref(), Some("proj-x"));
         assert!(loaded.collapsed_projects.is_empty());
+    }
+
+    #[test]
+    fn legacy_restore_tab_without_session_id_loads() {
+        // layout.json files written before resume-by-explicit-id
+        // landed don't carry `session_id` on each tab. They must
+        // still load (with `session_id = None`) so a one-shot
+        // upgrade doesn't drop the user's restored tab strip.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("layout.json");
+        std::fs::write(
+            &path,
+            r#"{"sidebar_visible":true,"sidebar_width":240,"open_tabs":[{"working_directory":"C:\\repos\\foo","title":"foo","auto_type":"claude","group_index":0,"active_in_group":true}]}"#,
+        )
+        .unwrap();
+        let loaded = LayoutState::load_from(&path).unwrap();
+        assert_eq!(loaded.open_tabs.len(), 1);
+        assert!(loaded.open_tabs[0].session_id.is_none());
     }
 
     #[test]

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -43,7 +43,7 @@ pub mod update_check;
 pub mod window_state;
 
 pub use agent::{AgentId, agent_id_from_auto_type};
-pub use agent_registry::{AgentProfile, AgentRegistry, built_in_defaults};
+pub use agent_registry::{AgentProfile, AgentRegistry, build_resume_auto_type, built_in_defaults};
 pub use claude_discovery::{AdoptionCandidate, POLL_INTERVAL_MS as CLAUDE_DISCOVERY_POLL_MS};
 pub use claude_telemetry::{
     SessionState, TelemetrySnapshot, TranscriptTail, context_window_for_model, encode_cwd,

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1759,6 +1759,14 @@ impl AppShell {
                     auto_type: tab.auto_type.as_ref().map(|s| s.to_string()),
                     group_index: g_idx,
                     active_in_group: t_idx == group.active_tab,
+                    // Persist the session id so the rehydrate path on
+                    // next launch can look up `agent_session_id` and
+                    // resume the *specific* conversation, not just
+                    // "most recent". Matches the C# build's behaviour
+                    // where layout-rehydrate goes through
+                    // `CreateAgentSession(resume: true, agentSessionId:
+                    // stored.AgentSessionId)`.
+                    session_id: Some(tab.session_id.clone()),
                 });
             }
         }
@@ -1796,19 +1804,48 @@ impl AppShell {
             // index after the loop.
             self.focused_group = group_idx;
             let title = SharedString::from(tab.title);
-            let auto = tab.auto_type.map(SharedString::from);
-            // Rehydrate path lets `spawn_tab_in` mint a fresh session
-            // id and append a new row through `SessionManager::open`,
-            // even though the tab is logically "the same" tab the
-            // user closed in the previous launch. This is a known
-            // limitation: `LayoutState::open_tabs` does not yet carry
-            // the persisted `Session.id`, so we can't map back to the
-            // stored row. The follow-up that unifies the rehydrate
-            // path with `SessionManager::live` will tighten this up;
-            // until then, accept the duplicate row as the cost of
-            // landing the lifecycle plumbing without a coordinated
-            // schema change.
-            self.spawn_tab_in(Some(path), Some(title), auto, None, window, cx);
+
+            // Reattach to the persisted session row when the layout
+            // entry carries a `session_id` (post-resume-by-id
+            // builds). We re-resolve `auto_type` from the stored
+            // `Session.agent_id` + `Session.agent_session_id` so the
+            // rehydrated tab runs `claude --resume <id>` / `pi
+            // --session <id>` / `copilot --resume=<id>` instead of
+            // the original spawn command (which was just "claude").
+            // Falls back to the layout's recorded `auto_type` when
+            // the session row can't be found (project removed,
+            // layout.json from a pre-session-id build) so legacy
+            // entries still rehydrate as a fresh agent launch.
+            let stored_session = tab
+                .session_id
+                .as_deref()
+                .and_then(|sid| self.lookup_session_by_id(sid));
+            let auto: Option<SharedString> = match stored_session.as_ref() {
+                Some(stored) => stored
+                    .agent_id
+                    .as_deref()
+                    .and_then(|aid| self.agent_registry.get_by_id(aid))
+                    .and_then(|profile| {
+                        codescope_core::build_resume_auto_type(
+                            profile,
+                            stored.agent_session_id.as_deref(),
+                        )
+                    })
+                    .map(SharedString::from)
+                    .or_else(|| tab.auto_type.clone().map(SharedString::from)),
+                None => tab.auto_type.clone().map(SharedString::from),
+            };
+            // Re-bind to the stored session row when the layout
+            // entry carries an id and the row still exists in
+            // `projects.json`. Otherwise we fall back to a fresh
+            // session id (`spawn_tab_in` mints one via
+            // `allocate_session_id`) — the legacy behaviour for
+            // pre-resume-by-id layouts.
+            let restore_session_id =
+                stored_session.as_ref().map(|s| s.id.clone()).or_else(
+                    || tab.session_id.clone(),
+                );
+            self.spawn_tab_in(Some(path), Some(title), auto, restore_session_id, window, cx);
             spawned_any = true;
             if tab.active_in_group {
                 let new_idx = self.groups[group_idx].tabs.len() - 1;
@@ -2025,6 +2062,22 @@ impl AppShell {
             }
         }
         new_id
+    }
+
+    /// Find a persisted [`codescope_core::Session`] by id in the
+    /// current `self.projects` snapshot. Returns a clone so callers
+    /// can drop the borrow on `self` immediately — the layout
+    /// rehydrate path needs that to call `spawn_tab_in` afterwards.
+    /// `None` when the id no longer exists (project removed,
+    /// hard-remove from history, race with a concurrent sidebar
+    /// write).
+    fn lookup_session_by_id(&self, session_id: &str) -> Option<codescope_core::Session> {
+        for project in self.projects.projects.iter() {
+            if let Some(s) = project.sessions.iter().find(|s| s.id == session_id) {
+                return Some(s.clone());
+            }
+        }
+        None
     }
 
     /// Mark `session_id` as soft-closed and persist. Called from
@@ -2274,27 +2327,26 @@ impl AppShell {
         // in `agent_registry` so non-Claude reopens
         // (Codex / OpenCode / Copilot / Pi, plus any
         // `settings.agents` overrides) come back with the right
-        // command instead of dropping to a plain shell. Resume args
-        // are preferred when present (`claude --resume <id>`,
-        // `pi -c`, `copilot --continue`, …) so the agent reattaches
-        // to the previous conversation; falls back to `new_session_args`
-        // when the profile has no resume verb. Plain shell sessions
-        // (no `agent_id`) come back as plain shells.
+        // command instead of dropping to a plain shell.
+        //
+        // When `Session.agent_session_id` is known we resume the
+        // specific conversation via `resume_by_id_args` (`claude
+        // --resume <id>`, `pi --session <id>`, `opencode --session
+        // <id>`, `copilot --resume=<id>`). Without a stored id we
+        // fall back to `resume_args` (`pi -c`, `copilot --continue`,
+        // bare `claude`). Mirrors C# `SessionManager.CreateAgentSession`
+        // resume branch + `JoinResumeByIdArgs`.
         let auto_type: Option<SharedString> = restored
             .agent_id
             .as_deref()
             .and_then(|id| self.agent_registry.get_by_id(id))
-            .map(|profile| {
-                let resume_args = if profile.resume_args.is_empty() {
-                    profile.new_session_args.as_slice()
-                } else {
-                    profile.resume_args.as_slice()
-                };
-                let mut argv: Vec<&str> = Vec::with_capacity(1 + resume_args.len());
-                argv.push(profile.command.as_str());
-                argv.extend(resume_args.iter().map(|s| s.as_str()));
-                SharedString::from(argv.join(" "))
-            });
+            .and_then(|profile| {
+                codescope_core::build_resume_auto_type(
+                    profile,
+                    restored.agent_session_id.as_deref(),
+                )
+            })
+            .map(SharedString::from);
 
         self.spawn_tab_in(
             Some(working_directory),

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1753,6 +1753,20 @@ impl AppShell {
         for (g_idx, group) in self.groups.iter().enumerate() {
             for (t_idx, tab) in group.tabs.iter().enumerate() {
                 let Some(ref wd) = tab.working_directory else { continue };
+                // Persist `session_id` only when this tab's id actually
+                // resolves to a row in `projects.json` — free-floating
+                // tabs (no project context at spawn time) mint an id
+                // that's never appended via `SessionManager::open`, so
+                // writing it here would (a) be unresolvable on next
+                // launch and (b) trick the rehydrate path into
+                // adopting a non-existent row (`allocate_session_id`
+                // skips the `open` append when `restore_session_id`
+                // is `Some`). Leave it `None` for those tabs so the
+                // rehydrate falls back to the legacy fresh-spawn
+                // path and still produces a working terminal.
+                let persisted_session_id = self
+                    .lookup_session_by_id(&tab.session_id)
+                    .map(|_| tab.session_id.clone());
                 out.push(codescope_core::RestoreTab {
                     working_directory: wd.to_string_lossy().into_owned(),
                     title: tab.title.to_string(),
@@ -1766,7 +1780,7 @@ impl AppShell {
                     // where layout-rehydrate goes through
                     // `CreateAgentSession(resume: true, agentSessionId:
                     // stored.AgentSessionId)`.
-                    session_id: Some(tab.session_id.clone()),
+                    session_id: persisted_session_id,
                 });
             }
         }
@@ -1835,16 +1849,19 @@ impl AppShell {
                     .or_else(|| tab.auto_type.clone().map(SharedString::from)),
                 None => tab.auto_type.clone().map(SharedString::from),
             };
-            // Re-bind to the stored session row when the layout
-            // entry carries an id and the row still exists in
-            // `projects.json`. Otherwise we fall back to a fresh
-            // session id (`spawn_tab_in` mints one via
-            // `allocate_session_id`) — the legacy behaviour for
-            // pre-resume-by-id layouts.
-            let restore_session_id =
-                stored_session.as_ref().map(|s| s.id.clone()).or_else(
-                    || tab.session_id.clone(),
-                );
+            // Re-bind to the stored session row only when the row
+            // actually exists in `projects.json` right now. Passing
+            // `Some(id)` makes `allocate_session_id` skip the
+            // `SessionManager::open` append (it assumes the row is
+            // already on disk), so handing it a ghost id would leave
+            // the tab bound to a session that history / close
+            // bookkeeping can't touch. When the row is gone (project
+            // removed, hard-remove from history, race with a sidebar
+            // write) we fall back to `None` and let
+            // `allocate_session_id` mint a fresh id + append a new
+            // row — matches the pre-resume-by-id rehydrate
+            // behaviour for legacy layout.json files.
+            let restore_session_id = stored_session.as_ref().map(|s| s.id.clone());
             self.spawn_tab_in(Some(path), Some(title), auto, restore_session_id, window, cx);
             spawned_any = true;
             if tab.active_in_group {


### PR DESCRIPTION
## Summary

Fixes the session-resume path so each session reattaches to the SPECIFIC conversation instead of the agent's most-recent fallback. Mirrors C# `SessionManager.CreateAgentSession` resume branch + `JoinResumeByIdArgs`.

User report: reopening sessions in CodeScope rs was issuing `pi -c` instead of `pi --session <id>`, with equivalent regressions across Claude / Copilot / OpenCode.

## Changes

- New pure helper `codescope_core::build_resume_auto_type(profile, agent_session_id)` selects:
  - `[command, resume_by_id_args[0..n-1].., resume_by_id_args[last] + id_suffix]` when both id and `resume_by_id_args` are present. Last token concat'd without a space when it ends with `=` (Copilot's `--resume=<id>`), space-separated otherwise (Claude `--resume <id>`, OpenCode `--session <id>`, Pi `--session <id>`).
  - `[command, resume_args...]` otherwise (Pi `-c`, Copilot `--continue`, bare `claude`, Codex `resume`).
- `AppShell::reopen_session` (sidebar history reopen) now passes `restored.agent_session_id` through the helper.
- `LayoutState::RestoreTab` carries the persisted session id; the cold-start rehydrate path in `rehydrate_or_cold_start` looks up the session row in `projects.json` and re-derives the resume auto-type from `Session.agent_id + agent_session_id`. Falls back to the legacy `auto_type` (and a fresh-spawn path) when the layout entry has no session id or the row was removed.
- Cross-group tab drag (`move_tab_to_group`) reparents the existing pty in-process — no auto-type re-evaluation needed.

## Tests

- 12 new unit tests in `codescope_core::agent_registry` covering every built-in agent (Claude / Codex / OpenCode / Copilot / Pi) in both with-id and without-id shapes, plus edge cases (empty id treated as no-id, empty `command` returns `None`, multi-token `resume_by_id_args` appends id to the last token).
- New layout test for legacy `RestoreTab` rows without a `session_id` field.
- `cargo test --workspace` clean (571 tests pass).
- `cargo build --workspace` clean.

## Follow-up (out of scope)

The discovery layer (claude/copilot/opencode/pi) currently updates `Tab::adopted_session_id` in memory but does NOT persist it back to `Session.agent_session_id` in `projects.json`. As a result, resume-by-id only fires today for sessions whose id was stamped through the C# build's `agentSessionId` flow (which the Rust port hasn't ported yet). Filing as a separate issue per the user's instructions.

## Test plan

- [ ] Open Claude session, close tab, reopen from history → `claude --resume <id>` is typed at the prompt.
- [ ] Open Pi session, close tab, reopen from history → `pi --session <id>` (not `pi -c`).
- [ ] Open Copilot session, close tab, reopen from history → `copilot --resume=<id>` (no space).
- [ ] Open OpenCode session, close tab, reopen from history → `opencode-cli --session <id>`.
- [ ] Close + reopen the app with a tab strip → tabs rehydrate using `resume_by_id_args + id` when the persisted session row carries `agent_session_id`.
- [ ] Sessions without a stored `agent_session_id` still rehydrate via `resume_args` (existing behaviour) — no regression for legacy projects.json rows.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>