### PR TITLE
fix(rs): persist agent_session_id from discovery so Rust-spawned sessions can resume by id

### DIFF
--- a/codescope-rs/core/src/session.rs
+++ b/codescope-rs/core/src/session.rs
@@ -410,6 +410,68 @@ impl SessionManager {
         Err(anyhow!("session '{session_id}' not found"))
     }
 
+    /// Stamp `agent_session_id` on the session whose CodeScope id is
+    /// `session_id`. Strict variant: errors when the session can't be
+    /// found in any project.
+    ///
+    /// This is the discovery-callback entry point used by the Rust app
+    /// shell once an agent (Claude / Pi / OpenCode / Copilot) reports
+    /// its own session UUID via a transcript / state file. Mirrors C#
+    /// `SessionStore.UpdateAgentSessionIdAsync` but with the
+    /// non-optional `&str` signature `MainViewModel.ApplyAdoption`
+    /// actually uses at the callsite — see PR #178 for the resume-by-id
+    /// machinery that consumes the persisted value.
+    ///
+    /// Idempotent: a no-op when the persisted value already matches
+    /// `agent_session_id`, so callers can hit this on every discovery
+    /// tick without producing redundant writes. Returns `Ok(true)` when
+    /// the value actually changed (callers should persist),
+    /// `Ok(false)` for a no-op (callers can skip the write).
+    pub fn set_agent_session_id(
+        cfg: &mut ProjectsConfig,
+        session_id: &str,
+        agent_session_id: &str,
+    ) -> Result<bool> {
+        for project in cfg.projects.iter_mut() {
+            if let Some(s) = project.sessions.iter_mut().find(|s| s.id == session_id) {
+                if s.agent_session_id.as_deref() == Some(agent_session_id) {
+                    return Ok(false);
+                }
+                s.agent_session_id = Some(agent_session_id.to_string());
+                return Ok(true);
+            }
+        }
+        Err(anyhow!("session '{session_id}' not found"))
+    }
+
+    /// Lenient cousin of [`Self::set_agent_session_id`]. Returns
+    /// `Ok(false)` instead of erroring when the session id isn't found
+    /// — used by the agent-discovery callback path to swallow the
+    /// cold-start race where a freshly-spawned tab's first discovery
+    /// tick fires before [`Self::open`] has written the new row to
+    /// `projects.json`. The next tick (250–350 ms later) will land
+    /// after the row exists and the stamp succeeds normally.
+    ///
+    /// Same return contract as the strict variant otherwise:
+    /// `Ok(true)` on actual mutation, `Ok(false)` on no-op (either the
+    /// value already matched, or the session id is unknown).
+    pub fn set_agent_session_id_lenient(
+        cfg: &mut ProjectsConfig,
+        session_id: &str,
+        agent_session_id: &str,
+    ) -> bool {
+        for project in cfg.projects.iter_mut() {
+            if let Some(s) = project.sessions.iter_mut().find(|s| s.id == session_id) {
+                if s.agent_session_id.as_deref() == Some(agent_session_id) {
+                    return false;
+                }
+                s.agent_session_id = Some(agent_session_id.to_string());
+                return true;
+            }
+        }
+        false
+    }
+
     // ---- queries ---------------------------------------------------
 
     /// All sessions across all projects with `closed_at = None`.
@@ -951,6 +1013,94 @@ mod tests {
             .unwrap();
         assert!(changed);
         assert!(cfg.projects[0].sessions[0].agent_session_id.is_none());
+    }
+
+    #[test]
+    fn set_agent_session_id_stamps_a_fresh_value() {
+        let mut cfg = ProjectsConfig::default();
+        let mut p = make_project("p1");
+        p.sessions.push(make_session("s1", None));
+        cfg.projects.push(p);
+
+        let changed = SessionManager::set_agent_session_id(&mut cfg, "s1", "uuid-abc")
+            .unwrap();
+        assert!(changed);
+        assert_eq!(
+            cfg.projects[0].sessions[0].agent_session_id.as_deref(),
+            Some("uuid-abc"),
+        );
+    }
+
+    #[test]
+    fn set_agent_session_id_is_idempotent_for_same_value() {
+        let mut cfg = ProjectsConfig::default();
+        let mut p = make_project("p1");
+        let mut s = make_session("s1", None);
+        s.agent_session_id = Some("uuid-abc".into());
+        p.sessions.push(s);
+        cfg.projects.push(p);
+
+        let changed = SessionManager::set_agent_session_id(&mut cfg, "s1", "uuid-abc")
+            .unwrap();
+        assert!(!changed);
+        assert_eq!(
+            cfg.projects[0].sessions[0].agent_session_id.as_deref(),
+            Some("uuid-abc"),
+        );
+    }
+
+    #[test]
+    fn set_agent_session_id_errors_on_unknown_session() {
+        let mut cfg = ProjectsConfig::default();
+        cfg.projects.push(make_project("p1"));
+        let err = SessionManager::set_agent_session_id(&mut cfg, "ghost", "uuid-abc")
+            .unwrap_err();
+        assert!(err.to_string().contains("ghost"));
+    }
+
+    #[test]
+    fn set_agent_session_id_lenient_swallows_unknown_session() {
+        let mut cfg = ProjectsConfig::default();
+        let mut p = make_project("p1");
+        p.sessions.push(make_session("s1", None));
+        cfg.projects.push(p);
+
+        // Unknown session — no error, no mutation. Mirrors the
+        // cold-start race the discovery callback path swallows.
+        let changed = SessionManager::set_agent_session_id_lenient(
+            &mut cfg, "ghost", "uuid-abc",
+        );
+        assert!(!changed);
+        assert!(cfg.projects[0].sessions[0].agent_session_id.is_none());
+
+        // Known session still works.
+        let changed = SessionManager::set_agent_session_id_lenient(
+            &mut cfg, "s1", "uuid-abc",
+        );
+        assert!(changed);
+        assert_eq!(
+            cfg.projects[0].sessions[0].agent_session_id.as_deref(),
+            Some("uuid-abc"),
+        );
+    }
+
+    #[test]
+    fn set_agent_session_id_round_trips_through_save_and_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("projects.json");
+
+        let mut cfg = ProjectsConfig::default();
+        let mut p = make_project("p1");
+        p.sessions.push(make_session("s1", None));
+        cfg.projects.push(p);
+
+        SessionManager::set_agent_session_id(&mut cfg, "s1", "uuid-abc").unwrap();
+        cfg.save_to(&path).unwrap();
+
+        let loaded = SessionManager::load_from_with_sweep(&path, fixed_now()).unwrap();
+        let stamped = &loaded.projects[0].sessions[0];
+        assert_eq!(stamped.id, "s1");
+        assert_eq!(stamped.agent_session_id.as_deref(), Some("uuid-abc"));
     }
 
     // ---- queries ----------------------------------------------

--- a/codescope-rs/core/src/session.rs
+++ b/codescope-rs/core/src/session.rs
@@ -427,49 +427,40 @@ impl SessionManager {
     /// tick without producing redundant writes. Returns `Ok(true)` when
     /// the value actually changed (callers should persist),
     /// `Ok(false)` for a no-op (callers can skip the write).
+    ///
+    /// Implemented as a thin wrapper over
+    /// [`Self::update_agent_session_id`] so the session-walk/mutation
+    /// logic only lives in one place.
     pub fn set_agent_session_id(
         cfg: &mut ProjectsConfig,
         session_id: &str,
         agent_session_id: &str,
     ) -> Result<bool> {
-        for project in cfg.projects.iter_mut() {
-            if let Some(s) = project.sessions.iter_mut().find(|s| s.id == session_id) {
-                if s.agent_session_id.as_deref() == Some(agent_session_id) {
-                    return Ok(false);
-                }
-                s.agent_session_id = Some(agent_session_id.to_string());
-                return Ok(true);
-            }
-        }
-        Err(anyhow!("session '{session_id}' not found"))
+        Self::update_agent_session_id(cfg, session_id, Some(agent_session_id))
     }
 
     /// Lenient cousin of [`Self::set_agent_session_id`]. Returns
-    /// `Ok(false)` instead of erroring when the session id isn't found
-    /// — used by the agent-discovery callback path to swallow the
+    /// `false` instead of erroring when the session id isn't found —
+    /// used by the agent-discovery callback path to swallow the
     /// cold-start race where a freshly-spawned tab's first discovery
     /// tick fires before [`Self::open`] has written the new row to
     /// `projects.json`. The next tick (250–350 ms later) will land
     /// after the row exists and the stamp succeeds normally.
     ///
-    /// Same return contract as the strict variant otherwise:
-    /// `Ok(true)` on actual mutation, `Ok(false)` on no-op (either the
-    /// value already matched, or the session id is unknown).
+    /// Returns `true` when the value actually changed, `false` for a
+    /// no-op (either the value already matched, or the session id is
+    /// unknown). Mirrors the strict variant's `Result<bool>` contract
+    /// minus the error arm.
+    ///
+    /// Implemented on top of [`Self::set_agent_session_id`] so the
+    /// session-walk/mutation logic is shared — the lenient policy is
+    /// just "treat the strict variant's error as a no-op".
     pub fn set_agent_session_id_lenient(
         cfg: &mut ProjectsConfig,
         session_id: &str,
         agent_session_id: &str,
     ) -> bool {
-        for project in cfg.projects.iter_mut() {
-            if let Some(s) = project.sessions.iter_mut().find(|s| s.id == session_id) {
-                if s.agent_session_id.as_deref() == Some(agent_session_id) {
-                    return false;
-                }
-                s.agent_session_id = Some(agent_session_id.to_string());
-                return true;
-            }
-        }
-        false
+        Self::set_agent_session_id(cfg, session_id, agent_session_id).unwrap_or(false)
     }
 
     // ---- queries ---------------------------------------------------

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1205,6 +1205,40 @@ impl AppShell {
     // Claude telemetry
     // -----------------------------------------------------------------------
 
+    /// Stamp `Session.agent_session_id` for the CodeScope session
+    /// identified by `session_id` (the stable id from `projects.json`,
+    /// **not** the agent-minted UUID) and persist `projects.json` so
+    /// `build_resume_auto_type` (PR #178) can resume the session by id
+    /// after a restart.
+    ///
+    /// Called from the agent-discovery loop the moment any of the four
+    /// agents (Claude, Copilot, OpenCode, Pi) mints a session id we
+    /// can recognise. Mirrors C# `MainViewModel.ApplyAdoption` →
+    /// `SessionStore.UpdateAgentSessionIdAsync` round-trip.
+    ///
+    /// Lenient on missing sessions: a freshly-spawned tab's first
+    /// discovery tick can race [`SessionManager::open`]'s write to
+    /// `projects.json`. We swallow that — the next tick (~350 ms
+    /// later) will land after the row exists and the stamp will
+    /// succeed. Persist failures are logged and otherwise ignored to
+    /// match the rest of the persist callsites in this file
+    /// (`spawn_tab_in`, `close_tab`, etc).
+    fn persist_agent_session_id(&mut self, session_id: &str, agent_session_id: &str) {
+        let changed = codescope_core::SessionManager::set_agent_session_id_lenient(
+            &mut self.projects,
+            session_id,
+            agent_session_id,
+        );
+        if !changed {
+            return;
+        }
+        if let Err(err) = codescope_core::session::save(&self.projects, &self.paths) {
+            eprintln!(
+                "warning: failed to persist agent_session_id for {session_id}: {err:#}"
+            );
+        }
+    }
+
     /// Register a transcript tail for `session_id` under
     /// `working_directory`, dispatching by `agent_id`. Safe to call
     /// multiple times with the same id — the old tail is replaced
@@ -1451,6 +1485,13 @@ impl AppShell {
                         previous_session_id: Option<String>,
                         new_session_id: String,
                         working_directory: String,
+                        /// CodeScope session id (from `projects.json`),
+                        /// the stable handle we stamp
+                        /// `agent_session_id` against. Captured here
+                        /// so the second pass can persist the
+                        /// agent-minted id without re-borrowing the
+                        /// tab.
+                        codescope_session_id: String,
                     }
                     let mut found = Vec::new();
                     let mut any_active = false;
@@ -1564,6 +1605,7 @@ impl AppShell {
                                     previous_session_id: tab.adopted_session_id.clone(),
                                     new_session_id: sid,
                                     working_directory: wd_str,
+                                    codescope_session_id: tab.session_id.clone(),
                                 });
                             }
                         }
@@ -1578,6 +1620,16 @@ impl AppShell {
                             f.agent_id,
                             f.new_session_id.clone(),
                             &f.working_directory,
+                        );
+                        // Persist the agent-minted id back to
+                        // `projects.json` so `build_resume_auto_type`
+                        // (PR #178) can resume the session by id after
+                        // a restart. Lenient on missing sessions —
+                        // see `persist_agent_session_id` for the
+                        // cold-start race rationale.
+                        this.persist_agent_session_id(
+                            &f.codescope_session_id,
+                            &f.new_session_id,
                         );
                         if let Some(group) = this.groups.get_mut(f.group_idx) {
                             if let Some(tab) = group.tabs.get_mut(f.tab_idx) {

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1220,11 +1220,33 @@ impl AppShell {
     /// discovery tick can race [`SessionManager::open`]'s write to
     /// `projects.json`. We swallow that — the next tick (~350 ms
     /// later) will land after the row exists and the stamp will
-    /// succeed. Persist failures are logged and otherwise ignored to
-    /// match the rest of the persist callsites in this file
-    /// (`spawn_tab_in`, `close_tab`, etc).
+    /// succeed.
+    ///
+    /// Reload-before-mutate: the sidebar persists `projects.json`
+    /// independently (add / remove project, soft-close session, …), so
+    /// stamping a stale in-memory `self.projects` would clobber any
+    /// changes the sidebar wrote between two AppShell mutations.
+    /// Mirrors the discipline used in `allocate_session_id`,
+    /// `soft_close_session`, `reopen_session`, and `open_rename_dialog`.
+    /// On reload failure we leave `self.projects` untouched and bail
+    /// out without writing — same rule the other persist sites use, so
+    /// a transient I/O hiccup doesn't end with a stale snapshot landing
+    /// on top of newer disk state. Persist failures themselves are
+    /// logged and otherwise ignored to match the rest of the persist
+    /// callsites in this file (`spawn_tab_in`, `close_tab`, etc).
     fn persist_agent_session_id(&mut self, session_id: &str, agent_session_id: &str) {
-        let changed = codescope_core::SessionManager::set_agent_session_id_lenient(
+        match ProjectsConfig::load(&self.paths) {
+            Ok(cfg) => {
+                self.projects = cfg;
+            }
+            Err(err) => {
+                eprintln!(
+                    "warning: failed to reload projects.json before persist of agent_session_id for {session_id}: {err:#}"
+                );
+                return;
+            }
+        }
+        let changed = SessionManager::set_agent_session_id_lenient(
             &mut self.projects,
             session_id,
             agent_session_id,
@@ -1482,15 +1504,24 @@ impl AppShell {
                         group_idx: usize,
                         tab_idx: usize,
                         agent_id: codescope_core::AgentId,
-                        previous_session_id: Option<String>,
-                        new_session_id: String,
+                        /// Agent-minted UUID we'd previously adopted
+                        /// for this tab, if any — used to unregister
+                        /// the old telemetry tail on rotation
+                        /// (Claude `/clear`, Pi re-invocation).
+                        previous_agent_session_id: Option<String>,
+                        /// Agent-minted UUID this tick is adopting.
+                        new_agent_session_id: String,
                         working_directory: String,
                         /// CodeScope session id (from `projects.json`),
                         /// the stable handle we stamp
                         /// `agent_session_id` against. Captured here
                         /// so the second pass can persist the
                         /// agent-minted id without re-borrowing the
-                        /// tab.
+                        /// tab. Distinct from
+                        /// `new_agent_session_id` above — that's the
+                        /// UUID the agent CLI minted, this is the
+                        /// CodeScope-allocated id from
+                        /// `projects.json::Session.id`.
                         codescope_session_id: String,
                     }
                     let mut found = Vec::new();
@@ -1602,8 +1633,8 @@ impl AppShell {
                                     group_idx: g_idx,
                                     tab_idx: t_idx,
                                     agent_id,
-                                    previous_session_id: tab.adopted_session_id.clone(),
-                                    new_session_id: sid,
+                                    previous_agent_session_id: tab.adopted_session_id.clone(),
+                                    new_agent_session_id: sid,
                                     working_directory: wd_str,
                                     codescope_session_id: tab.session_id.clone(),
                                 });
@@ -1611,14 +1642,14 @@ impl AppShell {
                         }
                     }
                     for f in found {
-                        if let Some(prev) = f.previous_session_id.as_deref() {
-                            if prev != f.new_session_id {
+                        if let Some(prev) = f.previous_agent_session_id.as_deref() {
+                            if prev != f.new_agent_session_id {
                                 this.unregister_telemetry(prev);
                             }
                         }
                         this.register_telemetry(
                             f.agent_id,
-                            f.new_session_id.clone(),
+                            f.new_agent_session_id.clone(),
                             &f.working_directory,
                         );
                         // Persist the agent-minted id back to
@@ -1629,12 +1660,13 @@ impl AppShell {
                         // cold-start race rationale.
                         this.persist_agent_session_id(
                             &f.codescope_session_id,
-                            &f.new_session_id,
+                            &f.new_agent_session_id,
                         );
                         if let Some(group) = this.groups.get_mut(f.group_idx) {
                             if let Some(tab) = group.tabs.get_mut(f.tab_idx) {
-                                tab.adopted_session_id = Some(f.new_session_id.clone());
-                                tab.fired_session_ids.insert(f.new_session_id);
+                                tab.adopted_session_id =
+                                    Some(f.new_agent_session_id.clone());
+                                tab.fired_session_ids.insert(f.new_agent_session_id);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

The Rust discovery layer (Claude / Pi / OpenCode / Copilot) was stamping `Tab.adopted_session_id` in memory whenever an agent minted its own session UUID, but it never wrote that UUID back to `Session.agent_session_id` in `projects.json`. As a result, PR #178's `build_resume_auto_type` only fired for sessions whose id was originally minted by the C# build — brand-new Rust-spawned sessions could not be resumed by id after a restart.

User flagged this as kritieke functionaliteit.

## Root cause

`AppShell::start_agent_discovery_poll` (codescope-rs/src/app.rs) calls `register_telemetry` and updates `Tab.adopted_session_id` on every successful discovery hit, but the corresponding `Session.agent_session_id` mutation+save was missing. The C# build does this via `SessionStore.UpdateAgentSessionIdAsync` invoked from `MainViewModel.ApplyAdoption`.

## Fix

- **Core:** add `SessionManager::set_agent_session_id` (strict — errors on unknown id) and `set_agent_session_id_lenient` (returns false without error on unknown — covers the cold-start race where a freshly spawned tab's first discovery tick can fire before `SessionManager::open` has written the new row).
- **AppShell:** new `persist_agent_session_id(session_id, agent_session_id)` helper that calls the lenient variant and persists via the existing `codescope_core::session::save` atomic-write path. Logs `eprintln!` on persist failure (matches the existing persist sites — `spawn_tab_in`, `close_tab`, etc.). No panics.
- The unified `start_agent_discovery_poll` loop now captures the CodeScope `session_id` alongside the agent-minted UUID in its `Found` struct and calls `persist_agent_session_id` for every adoption — covering all four agents through one codepath.

## Tests

Five new core unit tests in `core/src/session.rs`:

- `set_agent_session_id_stamps_a_fresh_value` — base case.
- `set_agent_session_id_is_idempotent_for_same_value` — no-op return on unchanged.
- `set_agent_session_id_errors_on_unknown_session` — strict variant errors.
- `set_agent_session_id_lenient_swallows_unknown_session` — lenient variant returns `false` without mutating, then succeeds when the row appears.
- `set_agent_session_id_round_trips_through_save_and_load` — verifies the persisted value survives `save_to` + `load_from_with_sweep`.

Full workspace `cargo test --workspace` passes (582 tests, 0 failed).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` clean
- [ ] Manual smoke: spawn a fresh Claude tab in the dev build, send a prompt, observe `agent_session_id` appearing in `projects.json` within ~350 ms — then restart and confirm the tab resumes the same conversation via PR #178's resume-by-id flow.