### PR TITLE
fix(rs): address Copilot review on PR #176 (build_new_session_auto_type + doc fix)

### DIFF
--- a/codescope-rs/core/src/agent_registry.rs
+++ b/codescope-rs/core/src/agent_registry.rs
@@ -348,8 +348,10 @@ pub fn build_resume_auto_type(
 ///
 /// Shared helper called from every new-session entry point (the
 /// sidebar's double-click handler, `AppShell::default_agent_auto_type`,
-/// and the per-agent rows in `render_new_session_submenu`) so they
-/// can't drift out of sync.
+/// the worktree menu's `New session ▸` parent row in
+/// `Sidebar::build_new_session_parent_row`, and the per-agent rows in
+/// `Sidebar::render_new_session_submenu`) so they can't drift out of
+/// sync.
 pub fn build_new_session_auto_type(profile: &AgentProfile) -> Option<String> {
     if profile.command.is_empty() {
         return None;
@@ -735,10 +737,10 @@ mod tests {
     // Pins the contract every new-session entry point (sidebar
     // double-click, Ctrl+Shift+T, per-agent submenu rows) relies on:
     // `<command> [<new_session_args>...]` joined by single spaces,
-    // with `None` only when `command` is empty. Built-in profiles
-    // ship empty `new_session_args` for every agent except Codex's
-    // (also empty today), so the bare-command shape covers them all.
-    // The custom-profile test below pins the multi-arg joining shape.
+    // with `None` only when `command` is empty. All five built-in
+    // profiles ship empty `new_session_args` today, so the bare-
+    // command shape covers each one — the custom-profile test below
+    // pins the multi-arg joining shape for user-defined profiles.
 
     #[test]
     fn build_new_session_auto_type_claude_yields_bare_command() {

--- a/codescope-rs/core/src/agent_registry.rs
+++ b/codescope-rs/core/src/agent_registry.rs
@@ -337,6 +337,29 @@ pub fn build_resume_auto_type(
     Some(argv.join(" "))
 }
 
+/// Build the auto-type command string used to launch a brand-new
+/// session for `profile`. Mirrors C#
+/// `SessionManager.CreateAgentSession` with `resume = false`:
+/// `[command, new_session_args...]` joined by single spaces.
+///
+/// Returns `None` when `profile.command` is empty — defensive against
+/// a hand-edited `settings.json` so callers can fall back to a plain
+/// shell instead of emitting a leading-space argv.
+///
+/// Shared helper called from every new-session entry point (the
+/// sidebar's double-click handler, `AppShell::default_agent_auto_type`,
+/// and the per-agent rows in `render_new_session_submenu`) so they
+/// can't drift out of sync.
+pub fn build_new_session_auto_type(profile: &AgentProfile) -> Option<String> {
+    if profile.command.is_empty() {
+        return None;
+    }
+    let mut argv: Vec<String> = Vec::with_capacity(1 + profile.new_session_args.len());
+    argv.push(profile.command.clone());
+    argv.extend(profile.new_session_args.iter().cloned());
+    Some(argv.join(" "))
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -705,5 +728,88 @@ mod tests {
             build_resume_auto_type(&profile, Some("xyz")),
             Some("multi --resume --id xyz".into()),
         );
+    }
+
+    // ─── build_new_session_auto_type ───────────────────────────────
+    //
+    // Pins the contract every new-session entry point (sidebar
+    // double-click, Ctrl+Shift+T, per-agent submenu rows) relies on:
+    // `<command> [<new_session_args>...]` joined by single spaces,
+    // with `None` only when `command` is empty. Built-in profiles
+    // ship empty `new_session_args` for every agent except Codex's
+    // (also empty today), so the bare-command shape covers them all.
+    // The custom-profile test below pins the multi-arg joining shape.
+
+    #[test]
+    fn build_new_session_auto_type_claude_yields_bare_command() {
+        let profile = registry_profile("claude");
+        assert_eq!(
+            build_new_session_auto_type(&profile),
+            Some("claude".into()),
+        );
+    }
+
+    #[test]
+    fn build_new_session_auto_type_codex_yields_bare_command() {
+        // Codex's `new_session_args` is empty — the bare `codex` is
+        // the expected new-session launch (`resume_args = ["resume"]`
+        // is the resume shape, not the new-session shape).
+        let profile = registry_profile("codex");
+        assert_eq!(
+            build_new_session_auto_type(&profile),
+            Some("codex".into()),
+        );
+    }
+
+    #[test]
+    fn build_new_session_auto_type_copilot_yields_bare_command() {
+        let profile = registry_profile("copilot");
+        assert_eq!(
+            build_new_session_auto_type(&profile),
+            Some("copilot".into()),
+        );
+    }
+
+    #[test]
+    fn build_new_session_auto_type_joins_custom_new_session_args() {
+        // A user-defined profile with new-session args must serialise
+        // as `<command> <arg1> <arg2>...` so the terminal gets a
+        // single ready-to-run line.
+        let profile = AgentProfile {
+            id: "custom".into(),
+            display_name: "Custom".into(),
+            command: "my-cli".into(),
+            resume_args: vec![],
+            new_session_args: vec!["--init".into(), "fresh".into()],
+            session_id_flag: None,
+            resume_by_id_args: vec![],
+            is_default: true,
+            icon: None,
+            context_window_tokens: 0,
+        };
+        assert_eq!(
+            build_new_session_auto_type(&profile),
+            Some("my-cli --init fresh".into()),
+        );
+    }
+
+    #[test]
+    fn build_new_session_auto_type_returns_none_when_command_empty() {
+        // Defensive: a hand-edited `settings.json` with a blank
+        // `command` must not emit a leading-space argv. Returning
+        // `None` lets the caller fall through to a plain shell.
+        let profile = AgentProfile {
+            id: "broken".into(),
+            display_name: "Broken".into(),
+            command: String::new(),
+            resume_args: vec![],
+            new_session_args: vec!["--init".into()],
+            session_id_flag: None,
+            resume_by_id_args: vec![],
+            is_default: false,
+            icon: None,
+            context_window_tokens: 0,
+        };
+        assert!(build_new_session_auto_type(&profile).is_none());
     }
 }

--- a/codescope-rs/core/src/agent_registry.rs
+++ b/codescope-rs/core/src/agent_registry.rs
@@ -353,11 +353,17 @@ pub fn build_resume_auto_type(
 /// `Sidebar::render_new_session_submenu`) so they can't drift out of
 /// sync.
 pub fn build_new_session_auto_type(profile: &AgentProfile) -> Option<String> {
-    if profile.command.is_empty() {
+    // Trim before the emptiness check so a whitespace-only `command`
+    // (e.g. `"   "` from a hand-edited `settings.json`) also returns
+    // `None` instead of auto-typing junk like `"   --init"`. Accidental
+    // leading/trailing spaces around the command don't get typed
+    // either — we emit the trimmed token, not the raw field.
+    let command = profile.command.trim();
+    if command.is_empty() {
         return None;
     }
     let mut argv: Vec<String> = Vec::with_capacity(1 + profile.new_session_args.len());
-    argv.push(profile.command.clone());
+    argv.push(command.to_string());
     argv.extend(profile.new_session_args.iter().cloned());
     Some(argv.join(" "))
 }
@@ -813,5 +819,51 @@ mod tests {
             context_window_tokens: 0,
         };
         assert!(build_new_session_auto_type(&profile).is_none());
+    }
+
+    #[test]
+    fn build_new_session_auto_type_treats_whitespace_only_command_as_empty() {
+        // A whitespace-only `command` from a hand-edited
+        // `settings.json` (e.g. `"   "`) is just as broken as a
+        // truly empty one — auto-typing `"    --init"` would emit
+        // junk. The helper trims before the emptiness check.
+        let profile = AgentProfile {
+            id: "broken".into(),
+            display_name: "Broken".into(),
+            command: "   ".into(),
+            resume_args: vec![],
+            new_session_args: vec!["--init".into()],
+            session_id_flag: None,
+            resume_by_id_args: vec![],
+            is_default: false,
+            icon: None,
+            context_window_tokens: 0,
+        };
+        assert!(build_new_session_auto_type(&profile).is_none());
+    }
+
+    #[test]
+    fn build_new_session_auto_type_trims_padded_command() {
+        // Accidental leading/trailing spaces around a real command
+        // (e.g. `" claude "` from a hand-edited `settings.json`) get
+        // trimmed before joining — otherwise the auto-typed line
+        // would be `" claude "` and PowerShell would fail to find
+        // the executable.
+        let profile = AgentProfile {
+            id: "padded".into(),
+            display_name: "Padded".into(),
+            command: " claude ".into(),
+            resume_args: vec![],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec![],
+            is_default: true,
+            icon: None,
+            context_window_tokens: 0,
+        };
+        assert_eq!(
+            build_new_session_auto_type(&profile),
+            Some("claude".into()),
+        );
     }
 }

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -43,7 +43,10 @@ pub mod update_check;
 pub mod window_state;
 
 pub use agent::{AgentId, agent_id_from_auto_type};
-pub use agent_registry::{AgentProfile, AgentRegistry, build_resume_auto_type, built_in_defaults};
+pub use agent_registry::{
+    AgentProfile, AgentRegistry, build_new_session_auto_type, build_resume_auto_type,
+    built_in_defaults,
+};
 pub use claude_discovery::{AdoptionCandidate, POLL_INTERVAL_MS as CLAUDE_DISCOVERY_POLL_MS};
 pub use claude_telemetry::{
     SessionState, TelemetrySnapshot, TranscriptTail, context_window_for_model, encode_cwd,

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -6962,14 +6962,22 @@ fn push_non_empty_font_candidate(candidates: &mut Vec<String>, family: &str) {
 /// as a free function so it can be unit-tested without a gpui context.
 /// Returns `<command> [<new_session_args>...]` joined by spaces.
 ///
-/// `None` only when `AgentRegistry::from_settings` yields an empty
-/// list — which today can only happen if `settings.agents` was passed
-/// in non-empty but every entry was filtered out somewhere upstream.
-/// `from_settings` re-seeds the built-in profiles when
-/// `settings.agents` is empty, and `get_default()` falls back to the
-/// first profile when no `is_default` flag is set, so a typo'd /
-/// missing `default_agent` still resolves to *some* agent (just not
-/// the user's preferred one).
+/// `None` in two cases:
+///
+/// 1. `AgentRegistry::from_settings` yields an empty list and
+///    `get_default()` returns `None`. Today this only happens if
+///    `settings.agents` was passed in non-empty but every entry was
+///    filtered out somewhere upstream — `from_settings` re-seeds the
+///    built-in profiles when `settings.agents` is empty, and
+///    `get_default()` falls back to the first profile when no
+///    `is_default` flag is set, so a typo'd / missing `default_agent`
+///    still resolves to *some* agent (just not the user's preferred
+///    one).
+/// 2. The resolved profile has an empty `command`. This is a
+///    defensive fallback in `build_new_session_auto_type` — a
+///    hand-edited `settings.json` with a blank `command` would
+///    otherwise emit a leading-space argv. Returning `None` lets the
+///    caller fall back to a plain shell instead of auto-typing junk.
 fn default_agent_auto_type_for(settings: &Settings) -> Option<SharedString> {
     let registry = codescope_core::AgentRegistry::from_settings(settings);
     let profile = registry.get_default()?;

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -6973,10 +6973,7 @@ fn push_non_empty_font_candidate(candidates: &mut Vec<String>, family: &str) {
 fn default_agent_auto_type_for(settings: &Settings) -> Option<SharedString> {
     let registry = codescope_core::AgentRegistry::from_settings(settings);
     let profile = registry.get_default()?;
-    let mut argv: Vec<String> = Vec::with_capacity(1 + profile.new_session_args.len());
-    argv.push(profile.command.clone());
-    argv.extend(profile.new_session_args.iter().cloned());
-    Some(SharedString::from(argv.join(" ")))
+    codescope_core::build_new_session_auto_type(profile).map(SharedString::from)
 }
 
 #[cfg(test)]

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -3642,13 +3642,13 @@ impl Sidebar {
         // the submenu's "Default" entry highlights). Uses the shared
         // core helper so the parent-row click matches the submenu's
         // "Default" entry, `Sidebar::default_agent_auto_type`, and
-        // `default_agent_auto_type_for` byte-for-byte.
-        let default_id = self.agent_registry.get_default().map(|a| a.id.clone());
-        let default_cmd = default_id.as_deref().and_then(|id| {
-            self.agent_registry
-                .get_by_id(id)
-                .and_then(codescope_core::build_new_session_auto_type)
-        });
+        // `default_agent_auto_type_for` byte-for-byte. Resolves the
+        // profile via `get_default()` directly — no second `get_by_id`
+        // lookup, no intermediate `default_id` clone.
+        let default_cmd = self
+            .agent_registry
+            .get_default()
+            .and_then(codescope_core::build_new_session_auto_type);
 
         let path = PathBuf::from(worktree_path);
         let title = title_prefix.clone();

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -1351,19 +1351,20 @@ impl Sidebar {
     }
 
     /// Build the auto-type command string for the registry's default
-    /// agent (e.g. `"claude"`, `"codex --resume"`). Used by the
+    /// agent (e.g. `"claude"` with the built-in Claude profile, or
+    /// `"my-cli --init fresh"` for a custom profile whose
+    /// `new_session_args` is `["--init", "fresh"]`). Used by the
     /// double-click handler on a worktree row so opening a tab from
     /// the sidebar lands in the user's configured default agent
     /// instead of a plain shell. Mirrors AppShell::default_agent_auto_type
     /// but reads from the sidebar's own cached registry — the two are
-    /// kept in lockstep via `apply_agent_registry`.
+    /// kept in lockstep via `apply_agent_registry`. The argv→string
+    /// joining lives in `codescope_core::build_new_session_auto_type`
+    /// so this path can't drift from `default_agent_auto_type_for` /
+    /// `render_new_session_submenu`.
     fn default_agent_auto_type(&self) -> Option<SharedString> {
         let profile = self.agent_registry.get_default()?;
-        let mut argv: Vec<String> =
-            Vec::with_capacity(1 + profile.new_session_args.len());
-        argv.push(profile.command.clone());
-        argv.extend(profile.new_session_args.iter().cloned());
-        Some(SharedString::from(argv.join(" ")))
+        codescope_core::build_new_session_auto_type(profile).map(SharedString::from)
     }
 
     /// Open the project context menu at `position` (window coords)
@@ -3793,11 +3794,16 @@ impl Sidebar {
                 title_prefix.as_ref(),
                 profile.id,
             ));
-            let mut argv: Vec<String> =
-                Vec::with_capacity(1 + profile.new_session_args.len());
-            argv.push(profile.command.clone());
-            argv.extend(profile.new_session_args.iter().cloned());
-            let cmd = argv.join(" ");
+            // Shared helper keeps the new-session command shape in
+            // sync with the double-click handler and Ctrl+Shift+T.
+            // A profile with an empty `command` falls back to bare
+            // `command` (= empty string) only when the helper returns
+            // `None`; we filter that case to a blank string so the
+            // row still renders — clicking it would auto-type
+            // nothing, matching how the helper returning `None` is
+            // handled elsewhere.
+            let cmd =
+                codescope_core::build_new_session_auto_type(profile).unwrap_or_default();
             let frost_hover = frost;
             let base_color = if is_default { ink } else { ink_dim };
             let hover_color = ink;

--- a/codescope-rs/src/sidebar.rs
+++ b/codescope-rs/src/sidebar.rs
@@ -3639,16 +3639,15 @@ impl Sidebar {
         let frost = theme::frost_10(&theme);
 
         // Default agent — the row's primary click target (and the row
-        // the submenu's "Default" entry highlights).
+        // the submenu's "Default" entry highlights). Uses the shared
+        // core helper so the parent-row click matches the submenu's
+        // "Default" entry, `Sidebar::default_agent_auto_type`, and
+        // `default_agent_auto_type_for` byte-for-byte.
         let default_id = self.agent_registry.get_default().map(|a| a.id.clone());
         let default_cmd = default_id.as_deref().and_then(|id| {
-            self.agent_registry.get_by_id(id).map(|p| {
-                let mut argv: Vec<String> =
-                    Vec::with_capacity(1 + p.new_session_args.len());
-                argv.push(p.command.clone());
-                argv.extend(p.new_session_args.iter().cloned());
-                argv.join(" ")
-            })
+            self.agent_registry
+                .get_by_id(id)
+                .and_then(codescope_core::build_new_session_auto_type)
         });
 
         let path = PathBuf::from(worktree_path);
@@ -3796,14 +3795,13 @@ impl Sidebar {
             ));
             // Shared helper keeps the new-session command shape in
             // sync with the double-click handler and Ctrl+Shift+T.
-            // A profile with an empty `command` falls back to bare
-            // `command` (= empty string) only when the helper returns
-            // `None`; we filter that case to a blank string so the
-            // row still renders — clicking it would auto-type
-            // nothing, matching how the helper returning `None` is
-            // handled elsewhere.
-            let cmd =
-                codescope_core::build_new_session_auto_type(profile).unwrap_or_default();
+            // Preserves the `Option` semantics: a profile with an
+            // empty `command` flows through as `auto_type: None` so
+            // the session manager falls back to a plain shell prompt
+            // (matching the parent-row's no-default-agent path) —
+            // emitting `Some("")` would auto-type a `-Command "& {  }"`
+            // scriptblock on Windows pwsh, which is *not* "no command".
+            let cmd = codescope_core::build_new_session_auto_type(profile);
             let frost_hover = frost;
             let base_color = if is_default { ink } else { ink_dim };
             let hover_color = ink;
@@ -3826,7 +3824,7 @@ impl Sidebar {
                         cx.emit(SidebarEvent::OpenSession {
                             working_directory: path.clone(),
                             title: title.clone(),
-                            auto_type: Some(cmd.clone().into()),
+                            auto_type: cmd.clone().map(SharedString::from),
                             force_new: true,
                         });
                         this.close_menu(cx);


### PR DESCRIPTION
## Summary

Two follow-ups for the two Copilot review comments left unresolved when PR #176 merged.

- Extract `codescope_core::build_new_session_auto_type(profile)` (mirrors `build_resume_auto_type` from PR #178) and migrate the three argv-join callsites — `Sidebar::default_agent_auto_type`, `app.rs::default_agent_auto_type_for`, and `sidebar.rs::render_new_session_submenu` — onto it so they can't drift out of sync.
- Fix the misleading example in `Sidebar::default_agent_auto_type`'s doc comment. The previous `"codex --resume"` did not match the helper's output (Codex's `new_session_args` is empty, so the helper actually yields bare `"codex"`). The doc now uses a real built-in example plus a custom-profile multi-arg shape.

The new core helper is a pure function with unit tests covering built-in profiles (Claude / Codex / Copilot), custom multi-arg new-session args, and the empty-command defensive `None` path.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` clean (587 tests pass)
- [x] No C# touched
- [ ] Wait for Copilot review and address any comments before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)