### PR TITLE
fix(rs): normalise group weights on load too

### DIFF
--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1093,10 +1093,10 @@ impl AppShell {
         // post-drag weights (a single drag against a peer can leave a
         // survivor at 0.5), and taffy treats `flex_grow = 0.5` as
         // "claim half of free space" even on a lone item — the rest of
-        // the work area stays blank. close/split/move already call
-        // this on mutation; the load path was the missing site, so a
-        // fresh boot showed the half-width regression even before the
-        // user touched anything.
+        // the work area stays blank. close/move removal paths already
+        // call this after dropping or transferring columns; the load
+        // path was the missing site, so a fresh boot showed the half-
+        // width regression even before the user touched anything.
         normalise_group_weights(&mut sanitized_weights);
         let group_count = sanitized_weights.len();
         let groups: Vec<Group> = (0..group_count)

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -1089,6 +1089,15 @@ impl AppShell {
         if sanitized_weights.is_empty() {
             sanitized_weights.push(1.0);
         }
+        // Renormalise on load too. layout.json round-trips the raw
+        // post-drag weights (a single drag against a peer can leave a
+        // survivor at 0.5), and taffy treats `flex_grow = 0.5` as
+        // "claim half of free space" even on a lone item — the rest of
+        // the work area stays blank. close/split/move already call
+        // this on mutation; the load path was the missing site, so a
+        // fresh boot showed the half-width regression even before the
+        // user touched anything.
+        normalise_group_weights(&mut sanitized_weights);
         let group_count = sanitized_weights.len();
         let groups: Vec<Group> = (0..group_count)
             .map(|idx| Group {


### PR DESCRIPTION
PR #187 only called `normalise_group_weights` on close/split/move — but `AppShell::new` reads weights from layout.json without normalising. A previous splitter drag persists `group_weights = [0.5]`, and taffy treats `flex_grow = 0.5` on a lone item as 'claim 50% of free space' rather than fill — so a fresh boot showed a half-width pane even with one tab and no group ever closed. Add the call after the load-time sanitisation pass.