### PR TITLE
fix(rs): insert space when "space" key fires in dialog inputs

### DIFF
--- a/codescope-rs/src/command_palette.rs
+++ b/codescope-rs/src/command_palette.rs
@@ -662,6 +662,14 @@ fn handle_key_down(
             }
             return;
         }
+        "space" => {
+            if let Some(state) = shell.command_palette_mut() {
+                state.insert_char(' ');
+                shell.wake_text_blink(cx);
+                cx.notify();
+            }
+            return;
+        }
         _ => {}
     }
 

--- a/codescope-rs/src/new_project_dialog.rs
+++ b/codescope-rs/src/new_project_dialog.rs
@@ -1119,6 +1119,17 @@ fn handle_key_down(
             }
             return;
         }
+        "space" => {
+            let changed = sidebar
+                .new_project_dialog_mut()
+                .map(|s| s.insert_char(' '))
+                .unwrap_or(false);
+            if changed {
+                sidebar.wake_text_blink(cx);
+                cx.notify();
+            }
+            return;
+        }
         _ => {}
     }
 

--- a/codescope-rs/src/new_worktree_dialog.rs
+++ b/codescope-rs/src/new_worktree_dialog.rs
@@ -1486,6 +1486,15 @@ fn handle_key_down(
             }
             return;
         }
+        "space" => {
+            let changed =
+                sidebar.dialog_mut().map(|s| s.insert_char(' ')).unwrap_or(false);
+            if changed {
+                sidebar.wake_text_blink(cx);
+                cx.notify();
+            }
+            return;
+        }
         _ => {}
     }
 

--- a/codescope-rs/src/rename_dialog.rs
+++ b/codescope-rs/src/rename_dialog.rs
@@ -536,6 +536,15 @@ fn handle_key_down(
             }
             return;
         }
+        "space" => {
+            if let Some(state) = shell.rename_dialog.as_mut() {
+                state.name.insert_char(' ');
+                state.error = None;
+                shell.wake_text_blink(cx);
+                cx.notify();
+            }
+            return;
+        }
         _ => {}
     }
 

--- a/codescope-rs/src/settings_dialog.rs
+++ b/codescope-rs/src/settings_dialog.rs
@@ -943,6 +943,14 @@ fn handle_key_down(
             }
             return;
         }
+        "space" => {
+            if let Some(state) = shell.settings_dialog.as_mut() {
+                state.insert_char(' ');
+                shell.wake_text_blink(cx);
+                cx.notify();
+            }
+            return;
+        }
         _ => {}
     }
 


### PR DESCRIPTION
## Summary

gpui emits the space bar as `KeyDownEvent { keystroke: { key: "space", key_char: None, .. } }`. The dialog key handlers introduced in #189 match the named-key arms ("escape", "enter", "backspace", "left", …) and then fall through to insert printables via `keystroke.key_char` — which is `None` for the space key, so spaces were dropped silently.

Add an explicit `"space"` arm in each handler that calls `insert_char(' ')` and runs the standard wake_text_blink + notify path.

Affected dialogs: rename, new-project, new-worktree, settings, command palette.

## Test plan
- [x] cargo check clean
- [ ] Manual: open each dialog, type a string containing spaces, confirm they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)