### PR TITLE
chore(rs): bump version to 0.3.0-rc.3

### DIFF
--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["vendor/gpui-terminal"]
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2024"
 publish = false
 description = "CodeScope (Rust port): gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
## Summary

Cuts the next release candidate on top of rc.2. Shipped since rc.2:

- #189 proper caret in dialog inputs (blink + keyboard movement + mouse-click positioning)
- #190 light theme
- #191 space-bar fix in dialog inputs
- #188 normalise group weights on layout load
- #186 PTY arg quoting fix (Set-Location drive-name error)
- #184 GUI subsystem + survive-last-tab-close + no-spawn-on-cold-start
- #185 focus AppShell root in empty-workspace states

Tag `rs-v0.3.0-rc.3` after merge to trigger the release pipeline.

## Test plan

- [x] cargo check clean
- [ ] CI tag pipeline produces multi-platform artefacts (Windows MSI, macOS x64/ARM tar.xz, Linux x64 tar.xz, Velopack RELEASES/nupkg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)