### PR TITLE
fix(rs): suppress transient conhost windows on git/gh spawns

### DIFF
--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -20,9 +20,11 @@
 //! sentence is worse UX than a slightly long line.
 
 use std::path::Path;
-use std::process::{Command, Output, Stdio};
+use std::process::{Output, Stdio};
 
 use anyhow::{Context, Result, anyhow};
+
+use crate::process::no_window_command;
 
 /// One row from `git for-each-ref refs/heads refs/remotes`. Surfaced
 /// to the "New worktree" dialog so the user can pick a base branch.
@@ -248,7 +250,7 @@ pub fn rebase_onto(repo: &Path, base_ref: &str) -> Result<String> {
 /// Exit-code conventions: `git config --get` returns 1 specifically
 /// for "key not found"; anything else is a real error.
 pub fn remote_origin_url(repo: &Path) -> Result<Option<String>> {
-    let output = Command::new("git")
+    let output = no_window_command("git")
         .args(["config", "--get", "remote.origin.url"])
         .current_dir(repo)
         .stdin(Stdio::null())
@@ -517,7 +519,7 @@ pub(crate) fn parse_numstat(stdout: &str) -> (u32, u32) {
 /// returns `false` for `has_upstream` so the UI hides the segment
 /// rather than showing stale / wrong data.
 fn ahead_behind(repo: &Path) -> (u32, u32, bool) {
-    let output = Command::new("git")
+    let output = no_window_command("git")
         .args(["rev-list", "--left-right", "--count", "HEAD...@{u}"])
         .current_dir(repo)
         .stdin(Stdio::null())
@@ -558,7 +560,7 @@ pub(crate) fn parse_ahead_behind(line: &str) -> (u32, u32) {
 /// Run `git <args...>` in `cwd`. Returns the captured `Output` on
 /// success; bubbles up stderr (trimmed) on non-zero exit.
 fn run_git(cwd: &Path, args: &[&str]) -> Result<Output> {
-    let output = Command::new("git")
+    let output = no_window_command("git")
         .args(args)
         .current_dir(cwd)
         .stdin(Stdio::null())
@@ -777,7 +779,7 @@ some-future-field foo bar\n";
     /// path, and the absolute worktrees-root path (already created so
     /// `git worktree add` doesn't have to).
     fn init_repo() -> Option<(TempDir, std::path::PathBuf, std::path::PathBuf)> {
-        if Command::new("git").arg("--version").output().is_err() {
+        if no_window_command("git").arg("--version").output().is_err() {
             eprintln!("skipping: `git` not on PATH");
             return None;
         }
@@ -795,7 +797,7 @@ some-future-field foo bar\n";
     }
 
     fn run(repo: &Path, args: &[&str]) {
-        let output = Command::new("git")
+        let output = no_window_command("git")
             .args(args)
             .current_dir(repo)
             .output()
@@ -828,7 +830,7 @@ some-future-field foo bar\n";
         // After the rebase `feat/x` should descend from the new main
         // tip — confirm by checking `git log main..feat/x` lists the
         // single feat commit.
-        let output = Command::new("git")
+        let output = no_window_command("git")
             .args(["log", "--oneline", "main..feat/x"])
             .current_dir(&repo)
             .output()

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod paths;
 pub mod pi_discovery;
 pub mod pi_telemetry;
 pub mod pr;
+pub mod process;
 pub mod projects;
 pub mod session;
 pub mod settings;

--- a/codescope-rs/core/src/pr.rs
+++ b/codescope-rs/core/src/pr.rs
@@ -14,7 +14,9 @@
 //! warm the cache on first interaction.
 
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
+
+use crate::process::no_window_command;
 
 #[cfg(test)]
 use serde::Deserialize;
@@ -87,7 +89,7 @@ pub fn fetch_for_branch(working_dir: &Path, branch: &str) -> Option<PullRequestI
     if branch.is_empty() || branch.starts_with('-') {
         return None;
     }
-    let output = Command::new("gh")
+    let output = no_window_command("gh")
         .args([
             "pr",
             "list",

--- a/codescope-rs/core/src/process.rs
+++ b/codescope-rs/core/src/process.rs
@@ -1,0 +1,76 @@
+//! Subprocess-spawning helpers shared by every background poller and
+//! one-shot CLI invocation we make (`git`, `gh`, …).
+//!
+//! ## Why this exists
+//!
+//! Once we set `windows_subsystem = "windows"` on the release binary
+//! (PR #184), every `Command::new("git").output()` we run popped a
+//! fresh `conhost.exe` console window because the parent (now GUI
+//! subsystem) no longer owns a console for the child to inherit.
+//! Cargo-debug builds were unaffected — the dev binary is console
+//! subsystem and the child borrows the parent's console.
+//!
+//! The five-second git status / dirty-state pollers plus the 60-second
+//! `gh pr list` poll were spawning a flicker of empty conhost windows
+//! every tick, sometimes piling up faster than the OS could dismiss
+//! them. The fix is to set `CREATE_NO_WINDOW` on every CreateProcess
+//! call we make to a console-subsystem child.
+//!
+//! See:
+//!   - <https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags>
+//!   - <https://doc.rust-lang.org/std/os/windows/process/trait.CommandExt.html#tymethod.creation_flags>
+//!
+//! ## Usage
+//!
+//! Replace `Command::new("git")` with [`no_window_command("git")`]
+//! everywhere we spawn a console binary for our own machine-readable
+//! consumption (`.output()` / `.status()`). For user-launched GUI
+//! apps (Explorer, `wt`, `open`, `xdg-open`) the flag is unnecessary —
+//! those binaries are already GUI subsystem on Windows or don't
+//! exist on Windows at all.
+
+use std::ffi::OsStr;
+use std::process::Command;
+
+/// Windows `CREATE_NO_WINDOW` process-creation flag. Suppresses the
+/// transient `conhost.exe` window a GUI-subsystem parent would
+/// otherwise allocate when spawning a console-subsystem child.
+///
+/// Value mirrors the constant in `winbase.h` (0x0800_0000). We pull
+/// the literal directly to avoid taking a dependency on the `windows`
+/// or `winapi` crates just for one symbol.
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Build a `Command` for a console-subsystem child binary with the
+/// transient-console window suppressed on Windows. No-op on every
+/// other host so callers can use the same helper unconditionally.
+///
+/// Call this for `git`, `gh`, or any other tool we shell out to for
+/// machine-readable output — i.e. anything where the user must never
+/// see a flashing console window.
+pub fn no_window_command(program: impl AsRef<OsStr>) -> Command {
+    let mut cmd = Command::new(program);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The helper must not change behaviour on non-Windows hosts —
+    /// the returned `Command` should be byte-equivalent to a plain
+    /// `Command::new`. We can only assert the program name; the
+    /// `creation_flags` value is Windows-private state we can't read
+    /// back through the public API.
+    #[test]
+    fn returns_command_for_program() {
+        let cmd = no_window_command("git");
+        assert_eq!(cmd.get_program(), "git");
+    }
+}


### PR DESCRIPTION
## Summary

User reported the rc-installed binary kept spawning empty console windows fast while the app was idle. \"Never happened in debug mode\" pointed straight at the cause:

- PR #184 set `windows_subsystem = \"windows\"` on the release binary so the installer build no longer ships with a console.
- With a GUI-subsystem parent, every `CreateProcess` of a console-subsystem child (`git`, `gh`) allocates a fresh `conhost.exe` window — Windows can't attach the child to a nonexistent parent console.
- Our git status / dirty-state / `gh pr list` pollers run every 5–60 s, so the flicker piles up faster than the user can dismiss the windows.
- Debug builds are console subsystem and the child inherits the parent's console — no new conhost, no flicker.

## Fix

- New shared helper `codescope_core::process::no_window_command(...)` builds a `Command` with `CREATE_NO_WINDOW` set on Windows (no-op on other hosts).
- Every `Command::new(\"git\")` (`core/src/git.rs`, 6 call sites) and `Command::new(\"gh\")` (`core/src/pr.rs`, 1 call site) now goes through the helper.
- User-launched GUI apps (Explorer, `wt`, macOS `open`, Linux `xdg-open`) keep plain `Command::new` — they're GUI subsystem, no transient console.
- PTY spawning is untouched (the terminal is supposed to show, obviously).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace` — 602 passed (+1 new test for the helper)
- [ ] Cut rc.4 once merged, install MSI, leave idle: no flicker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)