### PR TITLE
chore(rs): bump version to 0.3.0-rc.4

### DIFF
--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["vendor/gpui-terminal"]
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 edition = "2024"
 publish = false
 description = "CodeScope (Rust port): gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
## Summary

Cuts the next release candidate on top of rc.3 with the conhost-flicker fix:

- #193 suppress transient conhost windows on git/gh spawns
  (CREATE_NO_WINDOW for every machine-readable subprocess; fixes the
  runaway empty-console-window flicker the user hit on rc.3 after
  PR #184 made the release binary GUI subsystem)

Tag `rs-v0.3.0-rc.4` after merge to trigger the release pipeline.

## Test plan

- [x] cargo check clean
- [ ] CI tag pipeline produces multi-platform artefacts
- [ ] User installs MSI, leaves idle: no conhost flicker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)