### PR TITLE
feat(rs): paste clipboard images as attachment paths

### DIFF
--- a/codescope-rs/core/src/attachments.rs
+++ b/codescope-rs/core/src/attachments.rs
@@ -20,7 +20,11 @@ use crate::process::no_window_command;
 use crate::time::unix_secs_to_civil;
 
 const ATTACHMENT_DIR: &str = ".codescope/attachments";
-const GIT_EXCLUDE_PATTERN: &str = "/.codescope/attachments/";
+// Unanchored on purpose: the tab's working directory can be a
+// subdirectory of the worktree, so attachments live at
+// `<working_dir>/.codescope/attachments/`, not at the worktree root.
+// A leading `/` would only match at the root and miss those.
+const GIT_EXCLUDE_PATTERN: &str = ".codescope/attachments/";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SavedAttachment {
@@ -129,9 +133,36 @@ fn slash_path(path: &Path) -> String {
 }
 
 fn ensure_git_exclude(root: &Path) -> Result<()> {
+    // Resolve the worktree root first so subsequent git invocations
+    // produce paths relative to a stable base. `git rev-parse --git-path`
+    // returns paths relative to its current working directory, so calling
+    // it from a subdirectory of a worktree would otherwise give us a
+    // relative path that only resolves correctly via filesystem `..`
+    // traversal — fragile, and on some hosts would silently create a
+    // stray `.git/info/exclude` under the subdirectory.
+    let top_level_output = no_window_command("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()?;
+
+    if !top_level_output.status.success() {
+        return Ok(());
+    }
+
+    let top_level_str = String::from_utf8_lossy(&top_level_output.stdout)
+        .trim()
+        .to_string();
+    if top_level_str.is_empty() {
+        return Ok(());
+    }
+    let top_level = PathBuf::from(top_level_str);
+
     let output = no_window_command("git")
         .args(["rev-parse", "--git-path", "info/exclude"])
-        .current_dir(root)
+        .current_dir(&top_level)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -151,7 +182,7 @@ fn ensure_git_exclude(root: &Path) -> Result<()> {
         if path.is_absolute() {
             path
         } else {
-            root.join(path)
+            top_level.join(path)
         }
     };
 
@@ -223,6 +254,49 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let err = save_attachment_bytes_at(dir.path(), "png", b"", UNIX_EPOCH).unwrap_err();
         assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn writes_git_exclude_at_worktree_root_when_saving_from_subdir() {
+        if no_window_command("git").arg("--version").output().is_err() {
+            return;
+        }
+
+        let dir = TempDir::new().unwrap();
+        let init = no_window_command("git")
+            .arg("init")
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(init.status.success());
+
+        let subdir = dir.path().join("nested").join("workdir");
+        fs::create_dir_all(&subdir).unwrap();
+
+        save_attachment_bytes_at(&subdir, "png", b"sub", UNIX_EPOCH).unwrap();
+
+        // The exclude file must live at the worktree root, not under the
+        // subdirectory we saved from.
+        let root_exclude = dir.path().join(".git/info/exclude");
+        assert!(root_exclude.exists(), "exclude file should be at worktree root");
+        assert!(
+            !subdir.join(".git").exists(),
+            "must not have created a stray .git under the subdirectory"
+        );
+
+        let exclude = fs::read_to_string(&root_exclude).unwrap();
+        // Pattern must be unanchored so it matches attachments saved from
+        // any subdirectory of the worktree.
+        assert!(
+            exclude
+                .lines()
+                .any(|line| line.trim() == GIT_EXCLUDE_PATTERN),
+            "exclude file should contain the unanchored attachments pattern"
+        );
+        assert!(
+            !GIT_EXCLUDE_PATTERN.starts_with('/'),
+            "pattern must not be anchored to the worktree root"
+        );
     }
 
     #[test]

--- a/codescope-rs/core/src/attachments.rs
+++ b/codescope-rs/core/src/attachments.rs
@@ -1,0 +1,254 @@
+//! Local attachment storage for terminal-agent prompts.
+//!
+//! Terminal CLIs can only receive text through the PTY. CodeScope's
+//! screenshot-paste flow stores clipboard image bytes under the active
+//! worktree and then pastes the relative path into the agent prompt.
+//! This module owns the filesystem contract so the gpui terminal layer
+//! only has to supply bytes + an image extension.
+
+use std::collections::hash_map::DefaultHasher;
+use std::fs::{self, OpenOptions};
+use std::hash::{Hash, Hasher};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, anyhow};
+
+use crate::process::no_window_command;
+use crate::time::unix_secs_to_civil;
+
+const ATTACHMENT_DIR: &str = ".codescope/attachments";
+const GIT_EXCLUDE_PATTERN: &str = "/.codescope/attachments/";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SavedAttachment {
+    /// Absolute path to the file CodeScope wrote.
+    pub absolute_path: PathBuf,
+    /// Text that should be inserted into the terminal prompt.
+    /// Always relative to the storage root and slash-normalized so it
+    /// works in PowerShell, bash, and agent prompt parsers.
+    pub paste_path: String,
+}
+
+/// Store attachment bytes under `<working-directory>/.codescope/attachments/`
+/// and return the prompt-friendly relative path.
+///
+/// Best-effort updates the repo-local `.git/info/exclude` when the
+/// working directory is inside a git worktree. A failure to find git or
+/// write the exclude file does **not** fail the paste — the screenshot
+/// is already local and the user asked for a path, not a git operation.
+pub fn save_attachment_bytes(
+    working_directory: Option<&Path>,
+    extension: &str,
+    bytes: &[u8],
+) -> Result<SavedAttachment> {
+    let root = match working_directory {
+        Some(path) => path.to_path_buf(),
+        None => {
+            std::env::current_dir().context("resolve current directory for attachment paste")?
+        }
+    };
+    save_attachment_bytes_at(&root, extension, bytes, SystemTime::now())
+}
+
+fn save_attachment_bytes_at(
+    root: &Path,
+    extension: &str,
+    bytes: &[u8],
+    now: SystemTime,
+) -> Result<SavedAttachment> {
+    if bytes.is_empty() {
+        return Err(anyhow!("clipboard image was empty"));
+    }
+
+    fs::create_dir_all(root.join(ATTACHMENT_DIR))?;
+
+    let extension = sanitize_extension(extension);
+    let filename = attachment_filename(bytes, &extension, now);
+    let mut relative_path = PathBuf::from(ATTACHMENT_DIR).join(&filename);
+    let mut absolute_path = root.join(&relative_path);
+
+    let mut suffix = 2usize;
+    while absolute_path.exists() {
+        let suffix_to_strip = format!(".{extension}");
+        let stem = filename.strip_suffix(&suffix_to_strip).unwrap_or(&filename);
+        let candidate = format!("{stem}-{suffix}.{extension}");
+        relative_path = PathBuf::from(ATTACHMENT_DIR).join(&candidate);
+        absolute_path = root.join(&relative_path);
+        suffix += 1;
+    }
+
+    fs::write(&absolute_path, bytes)?;
+    let _ = ensure_git_exclude(root);
+
+    Ok(SavedAttachment {
+        absolute_path,
+        paste_path: slash_path(&relative_path),
+    })
+}
+
+fn attachment_filename(bytes: &[u8], extension: &str, now: SystemTime) -> String {
+    let duration = now.duration_since(UNIX_EPOCH).unwrap_or_default();
+    let secs = duration.as_secs() as i64;
+    let (year, month, day, hour, minute, second) = unix_secs_to_civil(secs);
+
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    duration.as_nanos().hash(&mut hasher);
+    let fingerprint = hasher.finish() & 0x00ff_ffff;
+
+    format!(
+        "screenshot-{year:04}{month:02}{day:02}-{hour:02}{minute:02}{second:02}-{fingerprint:06x}.{extension}"
+    )
+}
+
+fn sanitize_extension(extension: &str) -> String {
+    let cleaned: String = extension
+        .trim()
+        .trim_start_matches('.')
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .flat_map(|c| c.to_lowercase())
+        .take(8)
+        .collect();
+
+    match cleaned.as_str() {
+        "" => "png".to_string(),
+        "jpeg" => "jpg".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn slash_path(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn ensure_git_exclude(root: &Path) -> Result<()> {
+    let output = no_window_command("git")
+        .args(["rev-parse", "--git-path", "info/exclude"])
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()?;
+
+    if !output.status.success() {
+        return Ok(());
+    }
+
+    let raw_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw_path.is_empty() {
+        return Ok(());
+    }
+
+    let exclude_path = {
+        let path = PathBuf::from(raw_path);
+        if path.is_absolute() {
+            path
+        } else {
+            root.join(path)
+        }
+    };
+
+    if let Some(parent) = exclude_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut existing = String::new();
+    if exclude_path.exists() {
+        fs::File::open(&exclude_path)?.read_to_string(&mut existing)?;
+    }
+
+    if existing
+        .lines()
+        .any(|line| line.trim() == GIT_EXCLUDE_PATTERN)
+    {
+        return Ok(());
+    }
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&exclude_path)?;
+    if !existing.is_empty() && !existing.ends_with('\n') {
+        writeln!(file)?;
+    }
+    writeln!(file, "{GIT_EXCLUDE_PATTERN}")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn saves_attachment_under_codescope_folder_and_returns_slash_relative_path() {
+        let dir = TempDir::new().unwrap();
+        let bytes = b"not really png, but saved verbatim";
+        let saved = save_attachment_bytes_at(
+            dir.path(),
+            "png",
+            bytes,
+            UNIX_EPOCH + std::time::Duration::from_secs(1_779_811_330),
+        )
+        .unwrap();
+
+        assert_eq!(fs::read(&saved.absolute_path).unwrap(), bytes);
+        assert!(saved.absolute_path.starts_with(dir.path()));
+        assert!(
+            saved
+                .paste_path
+                .starts_with(".codescope/attachments/screenshot-")
+        );
+        assert!(saved.paste_path.ends_with(".png"));
+        assert!(!saved.paste_path.contains('\\'));
+    }
+
+    #[test]
+    fn sanitizes_extensions_for_filenames() {
+        assert_eq!(sanitize_extension(".PNG"), "png");
+        assert_eq!(sanitize_extension("jpeg"), "jpg");
+        assert_eq!(sanitize_extension(" ../bad!! "), "bad");
+        assert_eq!(sanitize_extension(""), "png");
+    }
+
+    #[test]
+    fn rejects_empty_attachment_bytes() {
+        let dir = TempDir::new().unwrap();
+        let err = save_attachment_bytes_at(dir.path(), "png", b"", UNIX_EPOCH).unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn appends_git_exclude_once_when_inside_git_worktree() {
+        if no_window_command("git").arg("--version").output().is_err() {
+            return;
+        }
+
+        let dir = TempDir::new().unwrap();
+        let init = no_window_command("git")
+            .arg("init")
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(init.status.success());
+
+        save_attachment_bytes_at(dir.path(), "png", b"one", UNIX_EPOCH).unwrap();
+        save_attachment_bytes_at(dir.path(), "png", b"two", UNIX_EPOCH).unwrap();
+
+        let exclude = fs::read_to_string(dir.path().join(".git/info/exclude")).unwrap();
+        assert_eq!(
+            exclude
+                .lines()
+                .filter(|line| line.trim() == GIT_EXCLUDE_PATTERN)
+                .count(),
+            1
+        );
+    }
+}

--- a/codescope-rs/core/src/git.rs
+++ b/codescope-rs/core/src/git.rs
@@ -763,7 +763,6 @@ some-future-field foo bar\n";
     // so these run on every local invocation.
 
     use std::path::Path;
-    use std::process::Command;
     use tempfile::TempDir;
 
     /// Initialise a fresh repo *inside a per-test tempdir* and produce

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod agent;
 pub mod agent_registry;
+pub mod attachments;
 pub mod claude_discovery;
 pub mod claude_telemetry;
 pub mod command_palette;
@@ -48,6 +49,7 @@ pub use agent_registry::{
     AgentProfile, AgentRegistry, build_new_session_auto_type, build_resume_auto_type,
     built_in_defaults,
 };
+pub use attachments::{SavedAttachment, save_attachment_bytes};
 pub use claude_discovery::{AdoptionCandidate, POLL_INTERVAL_MS as CLAUDE_DISCOVERY_POLL_MS};
 pub use claude_telemetry::{
     SessionState, TelemetrySnapshot, TranscriptTail, context_window_for_model, encode_cwd,

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -2898,7 +2898,15 @@ impl AppShell {
             }
         };
 
-        let terminal = cx.new(|cx| TerminalView::new_full(backend, palette, font, cx));
+        let terminal = cx.new(|cx| {
+            TerminalView::new_full_with_working_directory(
+                backend,
+                palette,
+                font,
+                working_directory_for_tab.clone(),
+                cx,
+            )
+        });
         let id = self.next_tab_id;
         self.next_tab_id += 1;
         let title: SharedString = title_override

--- a/codescope-rs/terminal/src/view.rs
+++ b/codescope-rs/terminal/src/view.rs
@@ -17,6 +17,7 @@
 //! * The canvas measure phase reports its laid-out bounds back so the
 //!   grid resize logic and mouse-coordinate translation can use them.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -28,10 +29,11 @@ use crate::input::keystroke_to_bytes;
 use crate::mouse::{self, MouseEventKind};
 use crate::paint::paint_snapshot;
 use gpui::{
-    App, Bounds, ClipboardItem, Context, FocusHandle, Focusable, Font, FontFallbacks,
-    FontFeatures, FontStyle, FontWeight, InteractiveElement, IntoElement, KeyDownEvent,
-    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Point,
-    Render, ScrollDelta, ScrollWheelEvent, SharedString, Styled, TextRun, Window, canvas, div, px,
+    App, Bounds, ClipboardEntry, ClipboardItem, Context, FocusHandle, Focusable, Font, FontFallbacks,
+    FontFeatures, FontStyle, FontWeight, Image, ImageFormat, InteractiveElement, IntoElement,
+    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels,
+    Point, Render, ScrollDelta, ScrollWheelEvent, SharedString, Styled, TextRun, Window, canvas,
+    div, px,
 };
 
 /// User-overridable font + size knobs. The defaults target oh-my-posh
@@ -101,6 +103,10 @@ pub struct TerminalView {
     snapshot: TerminalSnapshot,
     palette: ColorPalette,
     font: FontConfig,
+    /// Directory the PTY was spawned in. Screenshot paste stores
+    /// clipboard images under this root and inserts a relative path
+    /// into the prompt.
+    working_directory: Option<PathBuf>,
     focus_handle: FocusHandle,
     /// Last grid size we sent to the Backend, so we don't trigger a
     /// resize on every render.
@@ -157,6 +163,19 @@ impl TerminalView {
         backend: Backend,
         palette: ColorPalette,
         font: FontConfig,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::new_full_with_working_directory(backend, palette, font, None, cx)
+    }
+
+    /// Full constructor with the tab's resolved working directory.
+    /// The app shell uses this so image paste can save screenshots in
+    /// the active project / worktree instead of a global temp folder.
+    pub fn new_full_with_working_directory(
+        backend: Backend,
+        palette: ColorPalette,
+        font: FontConfig,
+        working_directory: Option<PathBuf>,
         cx: &mut Context<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
@@ -235,6 +254,7 @@ impl TerminalView {
             snapshot,
             palette,
             font,
+            working_directory,
             focus_handle,
             last_size: Arc::new(Mutex::new((0, 0))),
             pending_size,
@@ -542,14 +562,39 @@ impl TerminalView {
                 .backend
                 .mode()
                 .contains(alacritty_terminal::term::TermMode::BRACKETED_PASTE);
-        if always_paste || smart_ctrl_v {
-            if let Some(item) = cx.read_from_clipboard()
-                && let Some(text) = item.text()
-            {
-                self.paste(&text);
-                self.show_cursor_now();
+        let any_clipboard_paste_chord = key == "v"
+            && !mods.alt
+            && ((mods.control && !mods.platform) || (mods.platform && !mods.control));
+        if any_clipboard_paste_chord {
+            if let Some(item) = cx.read_from_clipboard() {
+                // Image paste is CodeScope-specific: terminal PTYs can
+                // only receive text, so store the clipboard image in
+                // the tab's worktree and paste the relative path. Do
+                // this even for plain Ctrl+V when bracketed paste is
+                // off; otherwise the shell would only receive ^V.
+                if let Some(image) = clipboard_image(&item) {
+                    match self.save_clipboard_image(image) {
+                        Ok(path) => {
+                            self.paste(&path);
+                            self.show_cursor_now();
+                        }
+                        Err(err) => {
+                            eprintln!("failed to save clipboard image attachment: {err:#}");
+                        }
+                    }
+                    return;
+                }
+
+                if always_paste || smart_ctrl_v {
+                    if let Some(text) = item.text() {
+                        self.paste(&text);
+                        self.show_cursor_now();
+                    }
+                    return;
+                }
+            } else if always_paste || smart_ctrl_v {
+                return;
             }
-            return;
         }
 
         // PageUp/PageDown without modifiers scroll the view's history
@@ -629,6 +674,15 @@ impl TerminalView {
         // gpui reports +y for wheel-up, alacritty's Scroll::Delta
         // is +n for "scroll up into history" — same direction.
         self.backend.scroll(lines);
+    }
+
+    fn save_clipboard_image(&self, image: &Image) -> anyhow::Result<String> {
+        let saved = codescope_core::save_attachment_bytes(
+            self.working_directory.as_deref(),
+            image_extension(image.format()),
+            image.bytes(),
+        )?;
+        Ok(saved.paste_path)
     }
 
     /// Write clipboard text into the PTY. Honours bracketed-paste mode
@@ -723,6 +777,25 @@ struct PendingResize {
     cols: u16,
     rows: u16,
     set_at: Instant,
+}
+
+fn clipboard_image(item: &ClipboardItem) -> Option<&Image> {
+    item.entries().iter().find_map(|entry| match entry {
+        ClipboardEntry::Image(image) => Some(image),
+        ClipboardEntry::String(_) => None,
+    })
+}
+
+fn image_extension(format: ImageFormat) -> &'static str {
+    match format {
+        ImageFormat::Png => "png",
+        ImageFormat::Jpeg => "jpg",
+        ImageFormat::Webp => "webp",
+        ImageFormat::Gif => "gif",
+        ImageFormat::Svg => "svg",
+        ImageFormat::Bmp => "bmp",
+        ImageFormat::Tiff => "tiff",
+    }
 }
 
 /// Map gpui's `MouseButton` enum to the wire-encoded button this
@@ -977,8 +1050,8 @@ impl Render for TerminalView {
 
 #[cfg(test)]
 mod tests {
-    use super::is_app_level_shortcut;
-    use gpui::Modifiers;
+    use super::{clipboard_image, image_extension, is_app_level_shortcut};
+    use gpui::{ClipboardItem, Image, ImageFormat, Modifiers};
 
     fn ctrl() -> Modifiers {
         Modifiers {
@@ -1001,6 +1074,22 @@ mod tests {
             alt: true,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn clipboard_image_detects_image_entries() {
+        let image = Image::from_bytes(ImageFormat::Png, b"png".to_vec());
+        let item = ClipboardItem::new_image(&image);
+
+        assert_eq!(clipboard_image(&item).map(Image::bytes), Some(b"png".as_slice()));
+        assert!(clipboard_image(&ClipboardItem::new_string("text".to_string())).is_none());
+    }
+
+    #[test]
+    fn image_extension_maps_agent_friendly_extensions() {
+        assert_eq!(image_extension(ImageFormat::Png), "png");
+        assert_eq!(image_extension(ImageFormat::Jpeg), "jpg");
+        assert_eq!(image_extension(ImageFormat::Webp), "webp");
     }
 
     #[test]

--- a/codescope-rs/terminal/src/view.rs
+++ b/codescope-rs/terminal/src/view.rs
@@ -577,12 +577,15 @@ impl TerminalView {
                         Ok(path) => {
                             self.paste(&path);
                             self.show_cursor_now();
+                            return;
                         }
                         Err(err) => {
+                            // Image save failed — fall through to the
+                            // legacy text / \x16 paste path so the key
+                            // press is never silently swallowed.
                             eprintln!("failed to save clipboard image attachment: {err:#}");
                         }
                     }
-                    return;
                 }
 
                 if always_paste || smart_ctrl_v {

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -9,15 +9,44 @@
 >
 > **The Rust port (`codescope-rs/`) is a 1:1 functional port of the C# CodeScope build (`src/CodeScope.App/`, `src/CodeScope.Core/`, `src/CodeScope.AgentCli/`).** Before implementing any feature on the Rust side, **read the equivalent C# code first** and mirror its behavior, button labels, dialogs, data shapes, and persistence layout. Functional parity is the goal — we are not redesigning. If a `HANDOFF.md` entry, README line, or "next entry point" disagrees with what the C# code actually does, the C# code wins; update the doc. Genuine platform-forced deviations (gpui vs WPF idiom) get a one-line comment and an entry in `docs/DECISIONS.md`. "Cleaner" or "more elegant" is not a reason on its own. (Reinforced in session 33 after PR #56 invented a non-existent UX.)
 
-**Last updated:** 2026-05-12 (session 39 — Rust release pipeline + Velopack apply path)
+**Last updated:** 2026-05-13 (session 40 — Rust screenshot paste MVP)
 **Branch:** `main`
-**Head:** `6346668` (themed ConfirmDialog + destructive-site migration, #150)
+**Head:** `442e03c` (fix(rs): suppress transient conhost windows on git/gh spawns, #193)
 **Release:** `v0.2.5` shipped in session 36 — no new release this run
 **Build status:** ✅ C# untouched. Rust workspace builds clean.
-Tests: `codescope-core` (418) + `codescope-rs` bin (100) +
-`codescope-terminal` (24) + 1 doctest — **543 total**, all passing.
-**Uncommitted work:** none on `main`.
-**Open issues:** none on GitHub.
+Tests: `codescope-core` (462) + `codescope-rs` bin (117) +
+`codescope-terminal` (28) + doctests (1 core + 0 terminal) — **608 total**, all passing
+when `TMP` / `TEMP` point outside the repo (used `../codescope-rs-test-tmp`; repo-local
+`target/tmp` makes `git_status_non_repo_returns_none` invalid because temp dirs are inside the worktree).
+**Uncommitted work:** Rust screenshot paste MVP in progress:
+`codescope-rs/core/src/attachments.rs`, `core/src/lib.rs`, `core/src/git.rs`,
+`terminal/src/view.rs`, `src/app.rs`, plus this handoff update.
+**Open issues:** none checked this run.
+
+### Session 40 — Rust screenshot paste MVP
+
+Pulled `main` first (`f63107e..442e03c`, PR #193) per user request, then implemented the minimal
+Rust-only screenshot paste flow:
+
+- `codescope-rs/core/src/attachments.rs` stores image bytes under
+  `<tab-working-directory>/.codescope/attachments/screenshot-YYYYMMDD-HHMMSS-xxxxxx.<ext>` and returns a
+  slash-normalized relative prompt path like `.codescope/attachments/screenshot-...png`.
+- Best-effort appends `/.codescope/attachments/` to the repo-local `.git/info/exclude` using
+  `git rev-parse --git-path info/exclude`; failure to find/write git exclude does not fail paste.
+- `codescope-rs/terminal/src/view.rs` now treats clipboard images specially on paste chords. Plain
+  `Ctrl+V` saves the image + pastes only the relative path, even when bracketed paste is off; text paste keeps
+  the old semantics (`Ctrl+Shift+V` always, plain `Ctrl+V` only with bracketed paste).
+- `codescope-rs/src/app.rs` passes each tab's resolved working directory into `TerminalView` so attachments land
+  in the active project/worktree instead of a global temp folder.
+
+Validation commands:
+
+```bash
+cargo test --manifest-path codescope-rs/Cargo.toml -p codescope-core attachments
+cargo test --manifest-path codescope-rs/Cargo.toml -p codescope-terminal
+cargo build --manifest-path codescope-rs/Cargo.toml --bin codescope-rs
+TMP=$(pwd)/../codescope-rs-test-tmp TEMP=$(pwd)/../codescope-rs-test-tmp cargo test --manifest-path codescope-rs/Cargo.toml --workspace
+```
 
 ### Cross-platform status (Rust port)
 


### PR DESCRIPTION
## Summary
- add a Rust attachment store that writes clipboard images to `.codescope/attachments` under the active tab working directory
- make terminal paste chords save clipboard images and paste the relative path into the PTY
- pass each tab's resolved working directory into `TerminalView` so attachments land in the active project/worktree
- locally exclude `.codescope/attachments` via `.git/info/exclude` when inside a git worktree

## Validation
- `cargo test --manifest-path codescope-rs/Cargo.toml -p codescope-core attachments`
- `cargo test --manifest-path codescope-rs/Cargo.toml -p codescope-terminal`
- `cargo build --manifest-path codescope-rs/Cargo.toml --bin codescope-rs`
- `TMP=/d/Dev/private/CodeScope/../codescope-rs-test-tmp TEMP=/d/Dev/private/CodeScope/../codescope-rs-test-tmp cargo test --manifest-path codescope-rs/Cargo.toml --workspace`