### PR TITLE
feat(rs): cross-platform OS toast on agent turn complete

### DIFF
--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -987,6 +987,7 @@ dependencies = [
  "futures-channel",
  "gpui",
  "gpui-terminal",
+ "notify-rust",
  "parking_lot",
  "portable-pty",
  "raw-window-handle",
@@ -1375,6 +1376,15 @@ name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derivative"
@@ -3232,6 +3242,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3487,6 +3509,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite 2.6.1",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3544,6 +3580,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -3688,6 +3730,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4100,6 +4144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4213,6 +4263,15 @@ name = "quick-xml"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
@@ -5593,6 +5652,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5678,6 +5749,25 @@ dependencies = [
  "weezl",
  "zune-jpeg",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tiny-keccak"
@@ -7082,6 +7172,15 @@ name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -66,6 +66,14 @@ velopack = "0.0.1589-ga2c5a97"
 # return type; we depend on it explicitly so the confirm dialog reads
 # from the same well-known crate without going through gpui internals.
 futures-channel = "0.3"
+# Cross-platform OS notification for the agent "turn complete" toast.
+# Mirrors C# `WindowsIdleToastNotifier` / `IIdleToastNotifier`; the
+# Rust port uses notify-rust so the same code path lights up
+# WinRT toast on Windows, FreeDesktop dbus on Linux, and
+# NSUserNotification on macOS. Click activation isn't supported on
+# Windows by this crate — the in-app bell handles tab routing already,
+# so the OS toast is intentionally show-only for v1.
+notify-rust = "4"
 
 [target.'cfg(windows)'.dependencies]
 # Direct Win32 access for the custom titlebar: gpui's

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -646,6 +646,23 @@ pub struct AppShell {
     /// after each telemetry tick to match `telemetry_tails`, so a
     /// rotated/closed session doesn't leak.
     last_session_state: HashMap<String, codescope_core::SessionState>,
+    /// Cross-platform OS-toast notifier for the "turn complete"
+    /// signal. Port of C# `WindowsIdleToastNotifier`. Owns its own
+    /// 2 s per-session de-dupe so the FS-watcher and poll-fallback
+    /// re-fires don't stack two toasts. Actual `Notification::show()`
+    /// runs on the background executor in [`Self::apply_activity_notifications`]
+    /// so the gpui main loop stays snappy.
+    idle_notifier: crate::idle_notifier::IdleNotifier,
+    /// `Window::is_window_active()` value captured at the most recent
+    /// render. The telemetry poll task can't query gpui's `Window`
+    /// directly (it runs without a `&Window` borrow), so we cache the
+    /// flag here every frame and read it from
+    /// [`Self::apply_activity_notifications`] as the gate for OS
+    /// toasts. Up to one frame stale; on a 250 ms telemetry cadence
+    /// that's well below the threshold the user would notice.
+    /// Defaults to `true` so a transition fired during start-up (rare)
+    /// is treated as "user can see the app".
+    window_active_cached: bool,
     /// Live telemetry tails, keyed by adopted-agent session id.
     /// Entries are registered via `register_telemetry` (per-agent
     /// dispatch) and polled by the background task spawned in
@@ -1168,6 +1185,8 @@ impl AppShell {
             text_blink_phase: true,
             notifications: crate::notifications::Notifications::new(),
             last_session_state: HashMap::new(),
+            idle_notifier: crate::idle_notifier::IdleNotifier::new(),
+            window_active_cached: true,
             telemetry_tails: HashMap::new(),
             bell_bounds: None,
             last_announced_update: None,
@@ -4975,6 +4994,13 @@ impl AppShell {
             detail: SharedString,
             session_title: SharedString,
         }
+        // (session_id, tab_title, detail) — fired on the background
+        // executor below as OS toasts. Separate from `pending` because
+        // the OS toast intentionally does *not* honour the
+        // focused-tab suppression (the gate is "is the user looking
+        // at the app", not "which tab is in front"), matching the C#
+        // build's split.
+        let mut pending_toasts: Vec<(String, String, String)> = Vec::new();
         let mut pending: Vec<Pending> = Vec::new();
         // Only records *changed* (sid, state) pairs so the steady-state
         // tick — every tab same as last time — stays allocation-free.
@@ -4999,6 +5025,38 @@ impl AppShell {
                 // (can't write to it inside this loop without giving up
                 // the immutable `&self.groups` borrow).
                 state_updates.push((sid.to_string(), snap.state));
+
+                // OS-level "turn complete" toast: fires on
+                // `(Busy | PendingToolUse) → Idle` regardless of which
+                // tab is currently focused. The gate is "user is not
+                // looking at the app window" — there's no point
+                // pinging the OS if the user is already staring at
+                // CodeScope. Matches the C# `IdleNotifier` placement
+                // *before* the SelectedTab suppression check.
+                if !self.window_active_cached
+                    && matches!(
+                        (prev, snap.state),
+                        (
+                            codescope_core::SessionState::Busy
+                                | codescope_core::SessionState::PendingToolUse,
+                            codescope_core::SessionState::Idle
+                        )
+                    )
+                {
+                    let detail = match snap.last_turn_duration {
+                        Some(d) => format!(
+                            "Turn complete · {}",
+                            codescope_core::TranscriptTail::format_duration(d)
+                        ),
+                        None => "Turn complete.".to_string(),
+                    };
+                    pending_toasts.push((
+                        sid.to_string(),
+                        tab.title.to_string(),
+                        detail,
+                    ));
+                }
+
                 let is_focused = focused_tab_key
                     .map(|(g, t)| g == group.id && t == tab.id)
                     .unwrap_or(false);
@@ -5016,6 +5074,23 @@ impl AppShell {
                     });
                 }
             }
+        }
+
+        // De-dupe + spawn the OS-toast show() calls on the background
+        // executor. notify-rust's `show()` can block for tens of ms on
+        // Windows (COM marshalling) and macOS (NSUserNotification
+        // round-trip) — keep it off the gpui main loop. Errors are
+        // swallowed inside `fire_os_notification` since the toast is
+        // a best-effort surface.
+        for (sid, title, detail) in pending_toasts {
+            if !self.idle_notifier.should_fire(&sid) {
+                continue;
+            }
+            cx.background_executor()
+                .spawn(async move {
+                    crate::idle_notifier::fire_os_notification(&title, &detail);
+                })
+                .detach();
         }
 
         for (sid, state) in state_updates {
@@ -5558,6 +5633,11 @@ impl Render for AppShell {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
+        // Snapshot the OS-level "is the user looking at us" flag so
+        // the background telemetry poll task can read it without a
+        // `&Window` borrow. Updated every frame — at the 250 ms
+        // telemetry cadence, one frame of staleness is invisible.
+        self.window_active_cached = window.is_window_active();
         let theme = self.theme.clone();
         // Tab-drag rect cache: swap the just-built map into
         // `prev_tab_rects` so the in-flight render can still answer

--- a/codescope-rs/src/idle_notifier.rs
+++ b/codescope-rs/src/idle_notifier.rs
@@ -157,8 +157,10 @@ mod tests {
     fn stale_entries_are_pruned_on_every_call() {
         let mut n = IdleNotifier::new();
         let t0 = Instant::now();
-        // Seed a stale-from-the-future entry; pruning happens before
-        // the contains_key check so it should not block sid-a.
+        // Seed an entry at `t0` and then advance the clock so the
+        // entry is well past the dedupe window. Pruning happens before
+        // the contains_key check, so the next call for *any* session
+        // is enough to evict it.
         n.should_fire_at("sid-stale", t0);
         let t_far = t0 + DEDUPE_WINDOW + Duration::from_secs(60);
         // The stale "sid-stale" entry is now well outside the window;
@@ -169,9 +171,10 @@ mod tests {
 
     #[test]
     fn re_fire_at_exact_window_boundary_is_blocked() {
-        // The check is `< DEDUPE_WINDOW`, so a fire at exactly
-        // `t0 + DEDUPE_WINDOW` is still inside the window and should
-        // be dropped. One nanosecond later it's allowed (covered by
+        // Retain predicate is `<= DEDUPE_WINDOW`, so an entry whose
+        // age equals exactly `DEDUPE_WINDOW` is still kept (matching
+        // the C# build's `kv.Value < cutoff` boundary). One nanosecond
+        // later it's allowed (covered by
         // `second_fire_after_window_returns_true_again`).
         let mut n = IdleNotifier::new();
         let t0 = Instant::now();

--- a/codescope-rs/src/idle_notifier.rs
+++ b/codescope-rs/src/idle_notifier.rs
@@ -1,0 +1,181 @@
+//! Cross-platform OS notification for the "turn complete" toast.
+//!
+//! Port of the C# `WindowsIdleToastNotifier` / `IIdleToastNotifier`
+//! pair (`src/CodeScope.App/Notifications/`, `src/CodeScope.Ui/Services/`).
+//! The Rust port uses [`notify_rust`] so the same code path lights up
+//! a WinRT toast on Windows, a FreeDesktop dbus notification on Linux,
+//! and an `NSUserNotification` on macOS — no per-platform fork required.
+//!
+//! # Surface vs the C# build
+//!
+//! - **Show-only**: `notify_rust` does not support click-activation on
+//!   Windows (it's a Linux/BSD/macOS-only API), and the in-app bell
+//!   already handles tab routing on click. So the toast is purely a
+//!   "look at the app" signal — same role the C# build's toast served
+//!   in practice once the bell shipped.
+//! - **Window-active gate, not minimised**: gpui exposes
+//!   `Window::is_window_active()` cross-platform but no minimised
+//!   getter. We gate on "window is not the active OS window" instead,
+//!   which is broader than the C# minimised-only check (toast fires
+//!   when CodeScope is behind another window too) but matches user
+//!   intent — if you're staring at the app, you don't need an OS
+//!   toast.
+//!
+//! # De-dupe
+//!
+//! The telemetry layer fires the same transition from the FS watcher
+//! *and* the poll fallback (~100–500 ms apart) — two toasts for one
+//! turn-complete would be noise. We track the last-fired wall-clock
+//! per session id and drop a fire that lands inside a 2 s window after
+//! the previous one, matching the C# `DedupeWindow`. Stale entries are
+//! pruned in-place on every call so the map stays bounded to "sessions
+//! seen in the last 2 s" (a handful of entries at most).
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Window the de-dupe filter keeps a session quiet after the previous
+/// fire. Matches `WindowsIdleToastNotifier.DedupeWindow` in the C#
+/// build (2 s).
+pub const DEDUPE_WINDOW: Duration = Duration::from_secs(2);
+
+/// Per-session de-dupe state for "turn complete" OS toasts.
+///
+/// Tested in isolation via [`Self::should_fire`]; the actual toast
+/// `show()` call is intentionally separate so unit tests don't need
+/// to spawn a real notification surface.
+pub struct IdleNotifier {
+    last_fired: HashMap<String, Instant>,
+}
+
+impl IdleNotifier {
+    pub fn new() -> Self {
+        Self { last_fired: HashMap::new() }
+    }
+
+    /// Returns `true` when a toast for `session_id` should be shown,
+    /// `false` when the dedupe window is still active for that id.
+    ///
+    /// Updates internal state on every call: on a `true` return we
+    /// stamp `now` so the next call inside the window is dropped; on
+    /// a `false` return we leave the existing stamp in place.
+    /// Always prunes stale entries before checking so a long-running
+    /// session can't pin the map.
+    pub fn should_fire(&mut self, session_id: &str) -> bool {
+        self.should_fire_at(session_id, Instant::now())
+    }
+
+    /// Test seam for [`Self::should_fire`] — accepts the wall-clock so
+    /// tests don't have to sleep through the dedupe window.
+    pub fn should_fire_at(&mut self, session_id: &str, now: Instant) -> bool {
+        // Prune entries strictly older than the window. `<=` keeps an
+        // entry at the exact boundary, matching the C# build's
+        // `kv.Value < cutoff` predicate (which retains values that
+        // *equal* the cutoff). One-nanosecond edge but worth pinning
+        // for parity with the test fixture.
+        self.last_fired
+            .retain(|_, t| now.saturating_duration_since(*t) <= DEDUPE_WINDOW);
+        if self.last_fired.contains_key(session_id) {
+            return false;
+        }
+        self.last_fired.insert(session_id.to_string(), now);
+        true
+    }
+
+    /// Dropped to keep tests independent — fresh notifier per case.
+    #[cfg(test)]
+    fn entry_count(&self) -> usize {
+        self.last_fired.len()
+    }
+}
+
+impl Default for IdleNotifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Fire-and-forget OS notification. Intended to be spawned on
+/// `cx.background_executor()` — the underlying `notify-rust` call can
+/// block for tens of milliseconds on Windows (COM marshalling) and
+/// macOS (NSUserNotification round-trip), and we don't want to stall
+/// the gpui main loop on a non-essential surface.
+///
+/// Errors are swallowed: the toast is a best-effort enhancement and
+/// shouldn't be able to take the app down. Common failures are
+/// sandbox / missing Start-menu shortcut on a first-run unpackaged
+/// exe.
+pub fn fire_os_notification(title: &str, detail: &str) {
+    let _ = notify_rust::Notification::new()
+        .summary(title)
+        .body(detail)
+        .appname("CodeScope")
+        .show();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_fire_returns_true_and_records_session() {
+        let mut n = IdleNotifier::new();
+        let t0 = Instant::now();
+        assert!(n.should_fire_at("sid-a", t0));
+        assert_eq!(n.entry_count(), 1);
+    }
+
+    #[test]
+    fn second_fire_within_window_returns_false() {
+        let mut n = IdleNotifier::new();
+        let t0 = Instant::now();
+        assert!(n.should_fire_at("sid-a", t0));
+        let t1 = t0 + Duration::from_millis(500);
+        assert!(!n.should_fire_at("sid-a", t1));
+    }
+
+    #[test]
+    fn second_fire_after_window_returns_true_again() {
+        let mut n = IdleNotifier::new();
+        let t0 = Instant::now();
+        assert!(n.should_fire_at("sid-a", t0));
+        let t1 = t0 + DEDUPE_WINDOW + Duration::from_millis(1);
+        assert!(n.should_fire_at("sid-a", t1));
+    }
+
+    #[test]
+    fn distinct_sessions_do_not_block_each_other() {
+        let mut n = IdleNotifier::new();
+        let t0 = Instant::now();
+        assert!(n.should_fire_at("sid-a", t0));
+        // Inside the window for sid-a, but sid-b is fresh.
+        assert!(n.should_fire_at("sid-b", t0 + Duration::from_millis(100)));
+        assert_eq!(n.entry_count(), 2);
+    }
+
+    #[test]
+    fn stale_entries_are_pruned_on_every_call() {
+        let mut n = IdleNotifier::new();
+        let t0 = Instant::now();
+        // Seed a stale-from-the-future entry; pruning happens before
+        // the contains_key check so it should not block sid-a.
+        n.should_fire_at("sid-stale", t0);
+        let t_far = t0 + DEDUPE_WINDOW + Duration::from_secs(60);
+        // The stale "sid-stale" entry is now well outside the window;
+        // calling for a *different* session should prune it.
+        assert!(n.should_fire_at("sid-fresh", t_far));
+        assert_eq!(n.entry_count(), 1, "stale entry should have been pruned");
+    }
+
+    #[test]
+    fn re_fire_at_exact_window_boundary_is_blocked() {
+        // The check is `< DEDUPE_WINDOW`, so a fire at exactly
+        // `t0 + DEDUPE_WINDOW` is still inside the window and should
+        // be dropped. One nanosecond later it's allowed (covered by
+        // `second_fire_after_window_returns_true_again`).
+        let mut n = IdleNotifier::new();
+        let t0 = Instant::now();
+        assert!(n.should_fire_at("sid-a", t0));
+        assert!(!n.should_fire_at("sid-a", t0 + DEDUPE_WINDOW));
+    }
+}

--- a/codescope-rs/src/window.rs
+++ b/codescope-rs/src/window.rs
@@ -24,6 +24,7 @@ mod app;
 mod assets;
 mod command_palette;
 mod confirm_dialog;
+mod idle_notifier;
 mod new_project_dialog;
 mod new_worktree_dialog;
 mod notifications;


### PR DESCRIPTION
## Summary
- Ports C# `IIdleToastNotifier` / `WindowsIdleToastNotifier` to the Rust shell.
- Fires a system notification when any tab transitions `Busy | PendingToolUse → Idle` and CodeScope isn't the active window.
- Cross-platform via `notify-rust`: WinRT toast on Windows, FreeDesktop dbus on Linux, NSUserNotification on macOS — same code path, no per-platform fork.

## Design choices worth flagging
- **Window-active gate, not minimised.** gpui has no cross-platform `is_minimized()` getter — it does have `is_window_active()`. Broader than the C# build's strict minimised-only gate, but arguably more useful: the toast also fires when CodeScope is behind another window, not just iconified.
- **`window_active_cached` snapshot.** The telemetry poll task runs without a `&Window` borrow, so we cache `is_window_active()` from `Render::render` every frame and read it from `apply_activity_notifications`. One frame stale at the 250 ms telemetry cadence — invisible.
- **Show-only click handling.** `notify-rust`'s `wait_for_action()` does not compile on Windows. The in-app bell already routes clicks to the right tab, so the OS toast is intentionally a "look at the app" signal only.
- **2 s per-session de-dupe**, mirroring `WindowsIdleToastNotifier.DedupeWindow`, absorbs the FS-watcher + poll-fallback re-fires (~100–500 ms apart).
- **`Notification::show()` runs on `cx.background_executor()`** because the underlying call can block for tens of ms on Windows (COM marshalling) and macOS — keep it off the gpui main loop.

## Test plan
- [x] `cargo test --workspace` — 623 tests pass, including 6 new `idle_notifier` cases (dedupe inside/outside window, distinct sessions, stale-entry pruning, exact-boundary parity with C#).
- [ ] Manual on Windows: minimise CodeScope, finish a Claude turn → WinRT toast appears in Action Center with the tab title + "Turn complete · <duration>". Trigger again within 2 s → only one toast.
- [ ] Manual on Linux (later): same flow, dbus notification surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)