### PR TITLE
fix(rs): restore-under-cursor when dragging a maximized titlebar

### DIFF
--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -86,6 +86,7 @@ notify-rust = "4"
 # VS Code, and Windows Terminal use for their custom title bars.
 windows = { version = "0.61", features = [
     "Win32_Foundation",
+    "Win32_UI_HiDpi",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",

--- a/codescope-rs/src/win32_titlebar.rs
+++ b/codescope-rs/src/win32_titlebar.rs
@@ -22,13 +22,14 @@
 
 use gpui::Window;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
+use windows::Win32::Foundation::{HWND, LPARAM, POINT, RECT, WPARAM};
 use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx, CoUninitialize};
 use windows::Win32::UI::Input::KeyboardAndMouse::ReleaseCapture;
 use windows::Win32::UI::Shell::ShellExecuteW;
 use windows::Win32::UI::WindowsAndMessaging::{
-    HTCAPTION, IsZoomed, PostMessageW, SC_CLOSE, SC_MAXIMIZE, SC_MINIMIZE, SC_RESTORE,
-    SW_SHOWNORMAL, WM_NCLBUTTONDOWN, WM_SYSCOMMAND,
+    GetCursorPos, GetWindowPlacement, GetWindowRect, HTCAPTION, IsZoomed, PostMessageW,
+    SC_CLOSE, SC_MAXIMIZE, SC_MINIMIZE, SC_RESTORE, SW_SHOWNORMAL, SetWindowPlacement,
+    WINDOWPLACEMENT, WM_NCLBUTTONDOWN, WM_SYSCOMMAND,
 };
 use windows::core::HSTRING;
 
@@ -70,12 +71,99 @@ pub fn start_drag(window: &Window) {
         // Releasing capture is fine to call synchronously — it's a
         // simple state flip with no nested message pumping.
         let _ = ReleaseCapture();
+
+        // Maximized → restore-then-drag dance.
+        //
+        // Default Windows behaviour: drag the title bar of a
+        // maximized window and the OS auto-restores it under the
+        // cursor so you can keep dragging. That hand-off lives in
+        // `DefWindowProc`'s `WM_NCLBUTTONDOWN(HTCAPTION)` handler and
+        // only fires when the message is delivered SYNCHRONOUSLY via
+        // `SendMessage`. We have to `PostMessage` (see the doc on
+        // this fn for the re-entrance reason), so the modal move
+        // loop starts on a maximized window that never restores —
+        // the user sees their cursor "stuck" and no drag happens.
+        //
+        // Fix: when we detect the window is maximized, repoint the
+        // restore rect under the cursor (preserving horizontal ratio)
+        // and post `SC_RESTORE` before the `NCLBUTTONDOWN`. Both posts
+        // are queued ahead of the modal loop entry, so by the time
+        // the loop starts, the window is the right size and the
+        // cursor is on the title bar.
+        if IsZoomed(hwnd).as_bool() {
+            reposition_for_restore_under_cursor(hwnd);
+            let _ = PostMessageW(
+                Some(hwnd),
+                WM_SYSCOMMAND,
+                WPARAM(SC_RESTORE as usize),
+                LPARAM(0),
+            );
+        }
+
         let _ = PostMessageW(
             Some(hwnd),
             WM_NCLBUTTONDOWN,
             WPARAM(HTCAPTION as usize),
             LPARAM(0),
         );
+    }
+}
+
+/// Helper for `start_drag`: when the user grabs the title bar of a
+/// maximized window, update `WINDOWPLACEMENT.rcNormalPosition` so the
+/// restored window lands under the cursor instead of at its
+/// previously-saved windowed position. Preserves the cursor's
+/// horizontal ratio across the maximize → restore transition the
+/// way native Windows does, so a drag from the right edge of a
+/// maximized window keeps the cursor near the right edge of the
+/// restored window (not at the centre and not off the title bar).
+///
+/// SAFETY: caller holds the HWND for the lifetime of this call.
+/// All Win32 calls take pointers to locals we own. Errors are
+/// best-effort — a failure leaves the placement struct untouched and
+/// the subsequent `SC_RESTORE` falls back to the OS's saved
+/// rcNormalPosition, which is the previous (slightly worse) behaviour
+/// but still leaves the window draggable.
+unsafe fn reposition_for_restore_under_cursor(hwnd: HWND) {
+    unsafe {
+        let mut cursor = POINT::default();
+        if GetCursorPos(&mut cursor).is_err() {
+            return;
+        }
+
+        let mut current = RECT::default();
+        if GetWindowRect(hwnd, &mut current).is_err() {
+            return;
+        }
+        let maximized_width = (current.right - current.left).max(1);
+        let cursor_ratio_x =
+            ((cursor.x - current.left) as f64 / maximized_width as f64).clamp(0.0, 1.0);
+
+        let mut placement = WINDOWPLACEMENT {
+            length: std::mem::size_of::<WINDOWPLACEMENT>() as u32,
+            ..Default::default()
+        };
+        if GetWindowPlacement(hwnd, &mut placement).is_err() {
+            return;
+        }
+
+        let normal = placement.rcNormalPosition;
+        let restored_width = (normal.right - normal.left).max(1);
+        let restored_height = (normal.bottom - normal.top).max(1);
+
+        // Centre the cursor horizontally at the same ratio of the
+        // restored width; place the title bar so the cursor is a
+        // few px into it (matches the native hand-off offset).
+        let title_offset = 15_i32;
+        let new_left = cursor.x - (cursor_ratio_x * restored_width as f64) as i32;
+        let new_top = cursor.y - title_offset;
+        placement.rcNormalPosition = RECT {
+            left: new_left,
+            top: new_top,
+            right: new_left + restored_width,
+            bottom: new_top + restored_height,
+        };
+        let _ = SetWindowPlacement(hwnd, &placement);
     }
 }
 

--- a/codescope-rs/src/win32_titlebar.rs
+++ b/codescope-rs/src/win32_titlebar.rs
@@ -26,6 +26,7 @@ use windows::Win32::Foundation::{HWND, LPARAM, POINT, RECT, WPARAM};
 use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx, CoUninitialize};
 use windows::Win32::UI::Input::KeyboardAndMouse::ReleaseCapture;
 use windows::Win32::UI::Shell::ShellExecuteW;
+use windows::Win32::UI::HiDpi::GetDpiForWindow;
 use windows::Win32::UI::WindowsAndMessaging::{
     GetCursorPos, GetWindowPlacement, GetWindowRect, HTCAPTION, IsZoomed, PostMessageW,
     SC_CLOSE, SC_MAXIMIZE, SC_MINIMIZE, SC_RESTORE, SW_SHOWNORMAL, SetWindowPlacement,
@@ -154,7 +155,18 @@ unsafe fn reposition_for_restore_under_cursor(hwnd: HWND) {
         // Centre the cursor horizontally at the same ratio of the
         // restored width; place the title bar so the cursor is a
         // few px into it (matches the native hand-off offset).
-        let title_offset = 15_i32;
+        //
+        // DPI-scale the offset: the app manifest is PerMonitorV2, so
+        // window coordinates are physical pixels at the monitor's DPI.
+        // A hard-coded 15 lands ~7.5 logical px on a 200 % display,
+        // which puts the cursor in/above the chrome border instead of
+        // on the title bar. `GetDpiForWindow` reports 96 at 100 %,
+        // 192 at 200 %, etc.; we scale the 15 px design value by
+        // `dpi/96` so the offset stays roughly 15 logical px on every
+        // monitor. Falls back to 96 (1.0 scale) on the rare 0 return.
+        let dpi = GetDpiForWindow(hwnd);
+        let dpi_scale = if dpi == 0 { 1.0 } else { dpi as f64 / 96.0 };
+        let title_offset = (15.0 * dpi_scale) as i32;
         let new_left = cursor.x - (cursor_ratio_x * restored_width as f64) as i32;
         let new_top = cursor.y - title_offset;
         placement.rcNormalPosition = RECT {


### PR DESCRIPTION
## Summary
- Restores native Windows behaviour: dragging the title bar of a maximized window now auto-restores it under the cursor so the user can keep dragging.
- Pure Win32 fix in `win32_titlebar::start_drag` — no other modules touched.

## Root cause
\`DefWindowProc\`'s \`WM_NCLBUTTONDOWN(HTCAPTION)\` handles the maximize → restore hand-off, but only when the message is delivered *synchronously* via \`SendMessage\`. Our path has to \`PostMessage\` to avoid the re-entrance bug documented on \`start_drag\` (\`SendMessage\` reaches our \`WndProc\` while the App is already borrowed → \`RefCell already borrowed\` panic). So the modal move loop entered a maximized window that never restored, and the cursor appeared "stuck".

## Fix
When \`IsZoomed(hwnd)\` is true at drag start:
1. \`GetCursorPos\` + \`GetWindowRect\` to compute the cursor's horizontal ratio inside the maximized bounds.
2. \`GetWindowPlacement\` → patch \`rcNormalPosition\` so the restored window lands under the cursor (same horizontal ratio, title bar a few px below the cursor — matches the native offset).
3. Post \`SC_RESTORE\`, then post the \`NCLBUTTONDOWN\` as before. Both queue ahead of the modal loop entry, so by the time the loop starts the window is the right size and the cursor is on the title bar.

## Test plan
- [x] \`cargo build\` clean
- [x] Manual on Windows: maximize CodeScope, grab the title bar and drag — window restores under cursor and follows the drag (parity with native).
- [x] Manual: drag from edge of a maximized window → restored window stays under the cursor (no centre-snap).
- [x] Drag from a windowed (non-maximized) state → unchanged behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)