### PR TITLE
chore(rs): bump version to 0.3.0-rc.5

### DIFF
--- a/codescope-rs/Cargo.lock
+++ b/codescope-rs/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/codescope-rs/Cargo.toml
+++ b/codescope-rs/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["vendor/gpui-terminal"]
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 edition = "2024"
 publish = false
 description = "CodeScope (Rust port): gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
## Summary
First release that exercises the cross-platform Velopack pipeline shipped by PRs #201 + #202:
- Per-platform channels in \`velopack_bridge::channel_for\`
- Per-platform \`vpk pack\` jobs + \`packId\`s in \`rs--release.yml\`

## What the rs-v0.3.0-rc.5 tag will publish
Four Velopack feeds in one GitHub release:

| Channel | Installer / bundle |
|---|---|
| \`releases.win.json\` | \`*-win-Setup.exe\` + nupkgs |
| \`releases.osx-arm64.json\` | \`.app.zip\` + nupkgs |
| \`releases.osx-x64.json\` | \`.app.zip\` + nupkgs |
| \`releases.linux-x64.json\` | \`.AppImage\` + nupkgs |

## Test plan
- [x] \`cargo build\` clean at 0.3.0-rc.5
- [ ] Merge → tag \`rs-v0.3.0-rc.5\` → watch workflow → verify each platform's release assets exist + Velopack-installed clients on each OS pick up the feed on next poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)