### PR TITLE
fix(rs): rehydrate open sessions from projects.json, not layout.json

### DIFF
--- a/codescope-rs/core/src/layout.rs
+++ b/codescope-rs/core/src/layout.rs
@@ -37,16 +37,31 @@ pub struct LayoutState {
     /// group count matches; out-of-range falls back to 0. Mirrors
     /// `WorkspaceLayout.FocusedGroupIndex`.
     pub focused_group_index: usize,
-    /// Open tabs to rehydrate at next launch. Each entry binds a
-    /// terminal session to a group + active flag. We don't try to
-    /// restore the *running process* (the pty was killed at app
-    /// shutdown) — `auto_type` re-runs whatever command was used to
-    /// spawn the original tab so "New Claude session" comes back as
-    /// claude and plain shells come back as plain shells. Tabs
-    /// whose `working_directory` no longer exists are silently
-    /// dropped on rehydrate. Empty → no tabs at last save (fresh
-    /// install / migration from older layout.json), AppShell falls
-    /// back to a single cold-start tab.
+    /// Placement metadata for the live sessions persisted in
+    /// `projects.json`. Each entry binds a `Session.id` to the group
+    /// it should rehydrate into. The authoritative list of *which*
+    /// sessions are open lives in `projects.json` (rows with
+    /// `closed_at = None`); this field only decides where each one
+    /// lands. Mirrors C# `LayoutStore.Layout.SessionToGroup` plus an
+    /// extra `active_in_group` flag because Rust has no per-group
+    /// "active tab" map elsewhere.
+    ///
+    /// Missing entries fall back to group 0 + non-active on
+    /// rehydrate. Stale entries (no matching live session) are
+    /// silently ignored. Empty → fresh install / pre-migration
+    /// layout.json; the legacy `open_tabs` field below feeds the
+    /// one-shot upgrade in [`LayoutState::migrate`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub session_placements: Vec<SessionPlacement>,
+    /// Legacy "open tabs" snapshot — Rust port's pre-parity bag of
+    /// (working_directory, title, auto_type, session_id, …) per
+    /// tab. New writes leave this empty (it's never serialised when
+    /// `session_placements` is the source); old writes are read
+    /// once and converted to [`session_placements`] via
+    /// [`LayoutState::migrate`] so users upgrading don't see their
+    /// tab layout shuffle. Deserialise-only after the migration
+    /// step runs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub open_tabs: Vec<RestoreTab>,
     /// Project ids the user has collapsed in the sidebar tree.
     /// Restored on launch so chevron state survives a restart;
@@ -57,6 +72,26 @@ pub struct LayoutState {
     /// longer match a known project before saving so the file
     /// can't grow stale entries across many sessions.
     pub collapsed_projects: Vec<String>,
+}
+
+/// Where a single live session rehydrates on next launch. The
+/// session row itself lives in `projects.json`; this just tells the
+/// AppShell which group the matching tab should land in and whether
+/// it was the active tab in its group at save time. Mirrors C#
+/// `LayoutStore.Layout.SessionToGroup` plus an active-tab marker.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionPlacement {
+    /// `Session.id` from `projects.json`. Stale ids (no matching live
+    /// session at rehydrate time) are silently ignored.
+    pub session_id: String,
+    /// Group index this tab belongs to in `group_weights`'s
+    /// numbering. Restore clamps out-of-range values to 0.
+    pub group_index: usize,
+    /// Was this tab the active one in its group at save time?
+    /// Restore picks the first `true` per group; if none, the first
+    /// spawned tab in the group wins.
+    #[serde(default)]
+    pub active_in_group: bool,
 }
 
 /// One tab worth of restore metadata. Light enough to round-trip
@@ -105,6 +140,7 @@ impl Default for LayoutState {
             selected_project_id: None,
             group_weights: Vec::new(),
             focused_group_index: 0,
+            session_placements: Vec::new(),
             open_tabs: Vec::new(),
             collapsed_projects: Vec::new(),
         }
@@ -117,13 +153,51 @@ impl LayoutState {
     }
 
     pub fn load_from(path: &Path) -> Result<Self> {
-        match std::fs::read(path) {
-            Ok(bytes) if bytes.is_empty() => Ok(Self::default()),
+        let mut state: Self = match std::fs::read(path) {
+            Ok(bytes) if bytes.is_empty() => Self::default(),
             Ok(bytes) => serde_json::from_slice(&bytes)
-                .with_context(|| format!("parse {}", path.display())),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
-            Err(err) => Err(err).with_context(|| format!("read {}", path.display())),
+                .with_context(|| format!("parse {}", path.display()))?,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Self::default(),
+            Err(err) => return Err(err).with_context(|| format!("read {}", path.display())),
+        };
+        state.migrate();
+        Ok(state)
+    }
+
+    /// Convert a legacy `open_tabs` snapshot into the slim
+    /// `session_placements` form. Idempotent: a no-op once
+    /// `session_placements` is populated (post-migration writes never
+    /// emit `open_tabs` again). Legacy entries without `session_id`
+    /// are dropped — they have no `projects.json` row to bind to and
+    /// the new rehydrate path drives off live sessions, not free-
+    /// floating descriptors.
+    ///
+    /// Runs unconditionally on load so old layout.json files upgrade
+    /// in place. The migration explicitly does NOT touch
+    /// `session_placements` when it's already non-empty so a manually
+    /// edited file with both fields stays under user control.
+    fn migrate(&mut self) {
+        if !self.session_placements.is_empty() {
+            // New shape already on disk; drop any legacy carry-over
+            // so the next save doesn't keep emitting it.
+            self.open_tabs.clear();
+            return;
         }
+        if self.open_tabs.is_empty() {
+            return;
+        }
+        let migrated: Vec<SessionPlacement> = std::mem::take(&mut self.open_tabs)
+            .into_iter()
+            .filter_map(|tab| {
+                let session_id = tab.session_id?;
+                Some(SessionPlacement {
+                    session_id,
+                    group_index: tab.group_index,
+                    active_in_group: tab.active_in_group,
+                })
+            })
+            .collect();
+        self.session_placements = migrated;
     }
 
     pub fn save(&self, paths: &AppPaths) -> Result<()> {
@@ -168,14 +242,12 @@ mod tests {
             selected_project_id: Some("proj-1".into()),
             group_weights: vec![1.5, 1.0],
             focused_group_index: 1,
-            open_tabs: vec![RestoreTab {
-                working_directory: "C:\\repos\\foo".into(),
-                title: "foo · main · claude".into(),
-                auto_type: Some("claude".into()),
+            session_placements: vec![SessionPlacement {
+                session_id: "sess-1".into(),
                 group_index: 0,
                 active_in_group: true,
-                session_id: Some("sess-1".into()),
             }],
+            open_tabs: Vec::new(),
             collapsed_projects: vec!["proj-2".into(), "proj-3".into()],
         };
         state.save_to(&path).unwrap();
@@ -184,11 +256,143 @@ mod tests {
         assert_eq!(loaded.selected_project_id.as_deref(), Some("proj-1"));
         assert_eq!(loaded.group_weights, vec![1.5, 1.0]);
         assert_eq!(loaded.focused_group_index, 1);
-        assert_eq!(loaded.open_tabs.len(), 1);
-        assert_eq!(loaded.open_tabs[0].auto_type.as_deref(), Some("claude"));
-        assert!(loaded.open_tabs[0].active_in_group);
-        assert_eq!(loaded.open_tabs[0].session_id.as_deref(), Some("sess-1"));
+        assert_eq!(loaded.session_placements.len(), 1);
+        assert_eq!(loaded.session_placements[0].session_id, "sess-1");
+        assert!(loaded.session_placements[0].active_in_group);
+        assert!(loaded.open_tabs.is_empty());
         assert_eq!(loaded.collapsed_projects, vec!["proj-2", "proj-3"]);
+    }
+
+    #[test]
+    fn save_omits_empty_legacy_open_tabs() {
+        // A migrated `LayoutState` has `open_tabs = []`. Serialising it
+        // must not emit an `"open_tabs": []` key; otherwise every save
+        // would write a redundant empty array and a second `cargo run`
+        // would still load (harmlessly) the legacy migration code path.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("layout.json");
+        let state = LayoutState {
+            session_placements: vec![SessionPlacement {
+                session_id: "sess-1".into(),
+                group_index: 0,
+                active_in_group: false,
+            }],
+            ..LayoutState::default()
+        };
+        state.save_to(&path).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains("open_tabs"), "expected open_tabs key to be omitted: {raw}");
+        assert!(raw.contains("session_placements"), "{raw}");
+    }
+
+    #[test]
+    fn migrate_legacy_open_tabs_to_session_placements() {
+        // A layout.json written by a pre-stap-2 Rust build carries the
+        // wide `open_tabs` shape with `session_id` already present (the
+        // resume-by-id work). On load we drop everything except the
+        // (session_id, group_index, active_in_group) triple — the rest
+        // can be derived from the projects.json Session row at
+        // rehydrate time.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("layout.json");
+        std::fs::write(
+            &path,
+            r#"{
+              "sidebar_visible": true,
+              "sidebar_width": 240,
+              "open_tabs": [
+                {
+                  "working_directory": "C:\\repos\\foo",
+                  "title": "foo · main · claude",
+                  "auto_type": "claude",
+                  "group_index": 1,
+                  "active_in_group": true,
+                  "session_id": "sess-1"
+                },
+                {
+                  "working_directory": "C:\\repos\\bar",
+                  "title": "bar",
+                  "group_index": 0,
+                  "active_in_group": false,
+                  "session_id": "sess-2"
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+        let loaded = LayoutState::load_from(&path).unwrap();
+        assert_eq!(loaded.session_placements.len(), 2);
+        assert_eq!(loaded.session_placements[0].session_id, "sess-1");
+        assert_eq!(loaded.session_placements[0].group_index, 1);
+        assert!(loaded.session_placements[0].active_in_group);
+        assert_eq!(loaded.session_placements[1].session_id, "sess-2");
+        assert!(!loaded.session_placements[1].active_in_group);
+        // open_tabs cleared so the next save doesn't keep round-tripping
+        // the legacy shape.
+        assert!(loaded.open_tabs.is_empty());
+    }
+
+    #[test]
+    fn migrate_drops_legacy_entries_without_session_id() {
+        // Pre-resume-by-id Rust builds wrote `RestoreTab` entries
+        // without a `session_id`. Those have no projects.json row to
+        // bind to and the new rehydrate path drives off live sessions,
+        // so they're silently dropped on migration. The user gets a
+        // slightly smaller tab strip on first launch after upgrade,
+        // not stale ghost tabs.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("layout.json");
+        std::fs::write(
+            &path,
+            r#"{
+              "open_tabs": [
+                {
+                  "working_directory": "C:\\repos\\foo",
+                  "title": "foo",
+                  "group_index": 0,
+                  "active_in_group": true
+                },
+                {
+                  "working_directory": "C:\\repos\\bar",
+                  "title": "bar",
+                  "group_index": 0,
+                  "active_in_group": false,
+                  "session_id": "sess-keeper"
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+        let loaded = LayoutState::load_from(&path).unwrap();
+        assert_eq!(loaded.session_placements.len(), 1);
+        assert_eq!(loaded.session_placements[0].session_id, "sess-keeper");
+    }
+
+    #[test]
+    fn migrate_is_noop_when_session_placements_already_present() {
+        // A layout.json that already carries `session_placements` is
+        // already on the new shape. `open_tabs`, if somehow present
+        // (manual edit, partial revert), is dropped without
+        // overwriting the authoritative `session_placements`.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("layout.json");
+        std::fs::write(
+            &path,
+            r#"{
+              "session_placements": [
+                { "session_id": "sess-real", "group_index": 0, "active_in_group": true }
+              ],
+              "open_tabs": [
+                { "working_directory": "C:\\stale", "title": "stale", "group_index": 0,
+                  "active_in_group": false, "session_id": "sess-stale" }
+              ]
+            }"#,
+        )
+        .unwrap();
+        let loaded = LayoutState::load_from(&path).unwrap();
+        assert_eq!(loaded.session_placements.len(), 1);
+        assert_eq!(loaded.session_placements[0].session_id, "sess-real");
+        assert!(loaded.open_tabs.is_empty());
     }
 
     #[test]
@@ -208,24 +412,6 @@ mod tests {
         let loaded = LayoutState::load_from(&path).unwrap();
         assert_eq!(loaded.selected_project_id.as_deref(), Some("proj-x"));
         assert!(loaded.collapsed_projects.is_empty());
-    }
-
-    #[test]
-    fn legacy_restore_tab_without_session_id_loads() {
-        // layout.json files written before resume-by-explicit-id
-        // landed don't carry `session_id` on each tab. They must
-        // still load (with `session_id = None`) so a one-shot
-        // upgrade doesn't drop the user's restored tab strip.
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("layout.json");
-        std::fs::write(
-            &path,
-            r#"{"sidebar_visible":true,"sidebar_width":240,"open_tabs":[{"working_directory":"C:\\repos\\foo","title":"foo","auto_type":"claude","group_index":0,"active_in_group":true}]}"#,
-        )
-        .unwrap();
-        let loaded = LayoutState::load_from(&path).unwrap();
-        assert_eq!(loaded.open_tabs.len(), 1);
-        assert!(loaded.open_tabs[0].session_id.is_none());
     }
 
     #[test]

--- a/codescope-rs/core/src/lib.rs
+++ b/codescope-rs/core/src/lib.rs
@@ -66,7 +66,7 @@ pub use overview::{
 };
 pub use pi_discovery::POLL_INTERVAL_MS as PI_DISCOVERY_POLL_MS;
 pub use pi_telemetry::PiTranscriptTail;
-pub use layout::{LayoutState, RestoreTab};
+pub use layout::{LayoutState, RestoreTab, SessionPlacement};
 pub use paths::AppPaths;
 pub use projects::{Project, ProjectsConfig, Session, Worktree};
 pub use session::{RetentionPolicy, SessionDescriptor, SessionManager, build_agent_shell_args, now_iso8601};

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -751,6 +751,18 @@ pub struct AppShell {
     /// agent-rollup state with no extra polling cost. Cleared when
     /// the shell drops.
     taskbar_badge: crate::taskbar_badge::TaskbarBadge,
+    /// Set to `true` while [`AppShell::rehydrate_or_cold_start`] is
+    /// walking live sessions and calling [`AppShell::spawn_tab_in`] for
+    /// each one. All `save_layout` calls (direct and indirect, via
+    /// `activate_tab`'s focused-group hook) short-circuit while this is
+    /// set; the rehydrate driver does a single `save_layout` at the
+    /// end. Without this, N live sessions produced N read-modify-write
+    /// cycles on `layout.json` per cold start AND each intermediate
+    /// write persisted a *partial* `session_placements` snapshot — a
+    /// crash mid-rehydrate would leave already-spawned placements but
+    /// drop the rest (they would still come back via `projects.json`,
+    /// but in group 0 instead of their saved group).
+    suppress_layout_save: bool,
 }
 
 impl AppShell {
@@ -1194,6 +1206,7 @@ impl AppShell {
             rename_dialog: None,
             confirm_dialog: None,
             taskbar_badge: crate::taskbar_badge::TaskbarBadge::new(window),
+            suppress_layout_save: false,
         };
         shell.start_telemetry_poll(cx);
         shell.start_agent_discovery_poll(cx);
@@ -1269,6 +1282,16 @@ impl AppShell {
     /// last reload, so we re-read on every save to avoid the
     /// last-writer-wins data loss the reviewer flagged in #73.
     fn save_layout(&mut self) {
+        // Short-circuit while rehydrate is walking live sessions.
+        // Otherwise the N spawn_tab_in calls become N read-modify-write
+        // cycles on layout.json *and* each intermediate write persists
+        // a partial session_placements list (only the tabs spawned so
+        // far). The rehydrate driver flushes once at the end via
+        // `flush_layout_after_rehydrate`. Outside rehydrate this is
+        // always false so user-driven mutations save normally.
+        if self.suppress_layout_save {
+            return;
+        }
         let mut on_disk = match LayoutState::load(self.paths.as_ref()) {
             Ok(state) => state,
             Err(err) => {
@@ -2039,7 +2062,6 @@ impl AppShell {
             agent_session_id: Option<String>,
             project_name: String,
             branch: Option<String>,
-            display_name: Option<String>,
         }
         let entries: Vec<RehydrateEntry> = self
             .projects
@@ -2064,7 +2086,6 @@ impl AppShell {
                         agent_session_id: s.agent_session_id.clone(),
                         project_name: project_name.clone(),
                         branch,
-                        display_name: s.display_name.clone(),
                     })
                 })
             })
@@ -2095,6 +2116,14 @@ impl AppShell {
         let mut active_by_group: Vec<Option<usize>> = vec![None; group_count];
         let mut spawned_any = false;
 
+        // Suppress per-spawn `save_layout` writes while the loop runs;
+        // we flush a single complete snapshot at the end. Without this,
+        // each `spawn_tab_in` would read+write `layout.json` (and a
+        // crash mid-loop would persist a partial `session_placements`
+        // list — sessions not yet spawned would still rehydrate via
+        // `projects.json` on the next boot, just demoted to group 0).
+        self.suppress_layout_save = true;
+
         for entry in entries {
             let path = std::path::PathBuf::from(&entry.worktree_path);
             if !path.exists() {
@@ -2123,10 +2152,11 @@ impl AppShell {
             // the agent profile. Falls back to the agent's "most recent"
             // resume args when the persisted `agent_session_id` is
             // missing, and to `None` for plain shells.
-            let auto: Option<SharedString> = entry
+            let agent_profile = entry
                 .agent_id
                 .as_deref()
-                .and_then(|aid| self.agent_registry.get_by_id(aid))
+                .and_then(|aid| self.agent_registry.get_by_id(aid));
+            let auto: Option<SharedString> = agent_profile
                 .and_then(|profile| {
                     codescope_core::build_resume_auto_type(
                         profile,
@@ -2135,18 +2165,31 @@ impl AppShell {
                 })
                 .map(SharedString::from);
 
-            // Title mirrors C# `MainViewModel.HydrateFromLoaded`:
-            // `{project} · {branch}` when we have a branch, else the
-            // user-set display name, else the project name. Display
-            // name wins last because the C# tab title binding pulls
-            // from descriptor.Title (project · branch); rename lives
-            // in a separate SessionTabViewModel projection.
+            // Title mirrors C# `MainViewModel.HydrateFromLoaded`
+            // (`src/CodeScope.Ui/ViewModels/MainViewModel.cs:1126-1133`):
+            // when the worktree has a branch we override the
+            // descriptor title with `{project} · {branch}`, otherwise
+            // we fall back to the descriptor's own title — which
+            // `CreateAgentSession` builds as `{agent.DisplayName} ·
+            // {folderName}` and `CreateShellSession` builds as just
+            // `Path.GetFileName(workingDirectory)`. `displayNameOverride`
+            // is explicitly `null` at hydrate time in C#, so the
+            // user-set `Session.DisplayName` does NOT participate in
+            // the tab title here — it only flows into the sidebar
+            // row title (a separate projection). Mirroring that
+            // exactly avoids the asymmetry where a renamed session
+            // with a branch would lose its rename on restart while
+            // the same rename without a branch would survive.
+            let folder_name = std::path::Path::new(&entry.worktree_path)
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| entry.worktree_path.clone());
             let title: SharedString = if let Some(branch) = entry.branch.as_deref() {
                 SharedString::from(format!("{} · {}", entry.project_name, branch))
-            } else if let Some(name) = entry.display_name.as_deref() {
-                SharedString::from(name.to_string())
+            } else if let Some(profile) = agent_profile {
+                SharedString::from(format!("{} · {}", profile.display_name, folder_name))
             } else {
-                SharedString::from(entry.project_name.clone())
+                SharedString::from(folder_name)
             };
 
             self.spawn_tab_in(
@@ -2163,6 +2206,12 @@ impl AppShell {
                 active_by_group[group_idx] = Some(new_idx);
             }
         }
+
+        // Re-enable layout persistence so the final flush below
+        // actually hits disk. Even on the all-paths-missing branch we
+        // need to clear this — otherwise a later user action would
+        // silently no-op every save_layout.
+        self.suppress_layout_save = false;
 
         if !spawned_any {
             // Every live session's worktree was missing — leave the
@@ -2192,6 +2241,11 @@ impl AppShell {
             let active = self.groups[focused].active_tab;
             self.activate_tab(focused, active, window, cx);
         }
+
+        // Single flush of the complete `session_placements` snapshot.
+        // All the per-spawn saves above were suppressed; this is the
+        // one disk write that captures the final rehydrated layout.
+        self.save_layout();
     }
 
     // -----------------------------------------------------------------------

--- a/codescope-rs/src/app.rs
+++ b/codescope-rs/src/app.rs
@@ -114,10 +114,6 @@ struct Tab {
     /// folder without going through the sidebar's active-project
     /// fallback (which may have shifted since save).
     working_directory: Option<std::path::PathBuf>,
-    /// Auto-typed command at spawn (None for plain shells, Some for
-    /// agent-launch tabs). Persisted so "New Claude session" comes
-    /// back as claude on restore.
-    auto_type: Option<SharedString>,
     /// Wall-clock spawn time, captured at `spawn_tab_in`. Used as the
     /// `since` filter for Claude session adoption — only `.jsonl`
     /// transcripts created/modified at or after this point qualify
@@ -1287,7 +1283,14 @@ impl AppShell {
         on_disk.focused_group_index = self.focused_group;
         on_disk.sidebar_visible = self.sidebar_visible;
         on_disk.sidebar_width = self.sidebar_width;
-        on_disk.open_tabs = self.snapshot_open_tabs();
+        on_disk.session_placements = self.snapshot_session_placements();
+        // Drop the legacy `open_tabs` array — `session_placements` is
+        // authoritative now, and `projects.json` carries the open-vs-
+        // closed answer. Belt-and-braces: `LayoutState::load` already
+        // clears `open_tabs` after migration, but a save kicked off
+        // before the next load (e.g. an upgrade installer that swaps
+        // binaries mid-session) would otherwise re-emit it.
+        on_disk.open_tabs.clear();
         if let Err(err) = on_disk.save(self.paths.as_ref()) {
             eprintln!("warning: failed to save layout.json: {err:#}");
             return;
@@ -1978,151 +1981,199 @@ impl AppShell {
     // Layout persistence
     // -----------------------------------------------------------------------
 
-    /// Build a `RestoreTab` for every currently-open tab. Tabs
-    /// without a known working directory are skipped — we'd have
-    /// nothing useful to spawn them with on rehydrate.
-    fn snapshot_open_tabs(&self) -> Vec<codescope_core::RestoreTab> {
+    /// Capture the on-disk placement of every currently-open tab whose
+    /// session id resolves to a row in `projects.json`. Mirrors C#
+    /// `MainViewModel.CaptureLayout` (`LayoutStore.Layout.SessionToGroup`):
+    /// the authoritative "is this session open?" answer lives in
+    /// `projects.json`'s `closed_at` field; this snapshot only records
+    /// the layout decisions (which group + which tab was active).
+    ///
+    /// Free-floating tabs (no project context at spawn time → no row
+    /// in `projects.json`) are skipped: they don't survive a restart
+    /// in the new model because the rehydrate path drives off live
+    /// sessions from `projects.json`. Matches C# where every tab
+    /// belongs to a project (the "unsorted" bucket is the catch-all).
+    fn snapshot_session_placements(&self) -> Vec<codescope_core::SessionPlacement> {
         let mut out = Vec::new();
         for (g_idx, group) in self.groups.iter().enumerate() {
             for (t_idx, tab) in group.tabs.iter().enumerate() {
-                let Some(ref wd) = tab.working_directory else { continue };
-                // Persist `session_id` only when this tab's id actually
-                // resolves to a row in `projects.json` — free-floating
-                // tabs (no project context at spawn time) mint an id
-                // that's never appended via `SessionManager::open`, so
-                // writing it here would (a) be unresolvable on next
-                // launch and (b) trick the rehydrate path into
-                // adopting a non-existent row (`allocate_session_id`
-                // skips the `open` append when `restore_session_id`
-                // is `Some`). Leave it `None` for those tabs so the
-                // rehydrate falls back to the legacy fresh-spawn
-                // path and still produces a working terminal.
-                let persisted_session_id = self
-                    .lookup_session_by_id(&tab.session_id)
-                    .map(|_| tab.session_id.clone());
-                out.push(codescope_core::RestoreTab {
-                    working_directory: wd.to_string_lossy().into_owned(),
-                    title: tab.title.to_string(),
-                    auto_type: tab.auto_type.as_ref().map(|s| s.to_string()),
+                if self.lookup_session_by_id(&tab.session_id).is_none() {
+                    continue;
+                }
+                out.push(codescope_core::SessionPlacement {
+                    session_id: tab.session_id.clone(),
                     group_index: g_idx,
                     active_in_group: t_idx == group.active_tab,
-                    // Persist the session id so the rehydrate path on
-                    // next launch can look up `agent_session_id` and
-                    // resume the *specific* conversation, not just
-                    // "most recent". Matches the C# build's behaviour
-                    // where layout-rehydrate goes through
-                    // `CreateAgentSession(resume: true, agentSessionId:
-                    // stored.AgentSessionId)`.
-                    session_id: persisted_session_id,
                 });
             }
         }
         out
     }
 
-    /// Restore tabs from `LayoutState::open_tabs`, or fall back to
-    /// the cold-start spawn when nothing's saved. Builds on PR #74's
-    /// group-shape rehydration: by the time this runs the AppShell
-    /// already has N empty groups; we just put a tab back into each.
-    /// Tabs whose working directory no longer exists are silently
-    /// dropped; if everything is dropped (rare) we cold-start so the
-    /// user isn't left staring at empty groups.
+    /// Rehydrate the tab strip from `projects.json` live sessions
+    /// (rows where `closed_at = None`). Mirrors C#
+    /// `MainViewModel.HydrateFromLoaded`: the authoritative source of
+    /// "what should be open" is the project store, and `layout.json`
+    /// only decides which group each session lands in (via
+    /// [`SessionPlacement`]) plus widths / focus. This guarantees that
+    /// a tab opened minutes before a crash — even with no intervening
+    /// `save_layout` — comes back on next launch, because the
+    /// `SessionManager::open` call that spawned the tab also persisted
+    /// the row to `projects.json`.
+    ///
+    /// Sessions whose `worktree_path` no longer exists are skipped
+    /// (matches C# `Directory.Exists` guard). When no live session
+    /// survives, we leave the window empty so the user lands on the
+    /// neutral cold-start state instead of an auto-spawned default
+    /// shell pinned to an arbitrary project.
     fn rehydrate_or_cold_start(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let saved: Vec<codescope_core::RestoreTab> = self.layout.open_tabs.clone();
-        if saved.is_empty() {
-            // Cold launch — leave the window empty. The user opens
-            // sessions explicitly via the sidebar (double-click on a
-            // worktree row), Ctrl+Shift+T, or the "+ new tab" button.
-            // The previous behaviour auto-spawned a default-shell tab
-            // pinned to the first project, which surprised users who
-            // had multiple projects and didn't expect one of them to
-            // be selected on every fresh boot. Mirrors C#'s empty
-            // workspace state ("CodeScope — add a project to begin.").
-            //
-            // Focus the AppShell root so app-level chords (Ctrl+Shift+T
-            // to open a new tab, Ctrl+Shift+P for the palette, etc.)
-            // fire from a fresh boot — without explicit focus there's
-            // no focused element at all and the key handler never
-            // triggers (Copilot caught this on PR #184).
+        // Snapshot the live sessions up front so the spawn loop can
+        // mutate `self` (focused_group, groups) without colliding with
+        // a long-lived borrow on `self.projects`. Project iteration
+        // order is the on-disk order, matching C#'s
+        // `foreach (var p in loaded.Projects) foreach (var s in p.Sessions)`.
+        struct RehydrateEntry {
+            session_id: String,
+            worktree_path: String,
+            agent_id: Option<String>,
+            agent_session_id: Option<String>,
+            project_name: String,
+            branch: Option<String>,
+            display_name: Option<String>,
+        }
+        let entries: Vec<RehydrateEntry> = self
+            .projects
+            .projects
+            .iter()
+            .flat_map(|p| {
+                let project_name = p.name.clone();
+                p.sessions.iter().filter_map(move |s| {
+                    if s.closed_at.is_some() {
+                        return None;
+                    }
+                    let branch = s.branch.clone().or_else(|| {
+                        p.worktrees
+                            .iter()
+                            .find(|w| Some(&w.id) == s.worktree_id.as_ref())
+                            .and_then(|w| w.branch.clone())
+                    });
+                    Some(RehydrateEntry {
+                        session_id: s.id.clone(),
+                        worktree_path: s.worktree_path.clone(),
+                        agent_id: s.agent_id.clone(),
+                        agent_session_id: s.agent_session_id.clone(),
+                        project_name: project_name.clone(),
+                        branch,
+                        display_name: s.display_name.clone(),
+                    })
+                })
+            })
+            .collect();
+
+        if entries.is_empty() {
+            // Cold launch — leave the window empty. Focus the AppShell
+            // root so app-level chords (Ctrl+Shift+T to open a new tab,
+            // Ctrl+Shift+P for the palette, etc.) fire from a fresh
+            // boot — without explicit focus there's no focused element
+            // at all and the key handler never triggers.
             self.focus_handle.focus(window);
             cx.notify();
             return;
         }
+
+        // Build a placement lookup keyed by session id. Stale entries
+        // (no matching live session) are skipped implicitly; missing
+        // entries fall back to group 0, non-active.
+        let placements: std::collections::HashMap<String, codescope_core::SessionPlacement> = self
+            .layout
+            .session_placements
+            .iter()
+            .map(|p| (p.session_id.clone(), p.clone()))
+            .collect();
+
         let group_count = self.groups.len();
         let mut active_by_group: Vec<Option<usize>> = vec![None; group_count];
         let mut spawned_any = false;
-        for tab in saved.into_iter() {
-            let path = std::path::PathBuf::from(&tab.working_directory);
+
+        for entry in entries {
+            let path = std::path::PathBuf::from(&entry.worktree_path);
             if !path.exists() {
                 eprintln!(
-                    "info: skipping restored tab — path no longer exists: {}",
-                    tab.working_directory
+                    "info: skipping live session — worktree path no longer exists: {} ({})",
+                    entry.worktree_path, entry.session_id
                 );
                 continue;
             }
-            let group_idx = tab.group_index.min(group_count.saturating_sub(1));
-            // `spawn_tab_in` always lands in the focused group, so
-            // we move focus first then restore the saved focus
-            // index after the loop.
-            self.focused_group = group_idx;
-            let title = SharedString::from(tab.title);
 
-            // Reattach to the persisted session row when the layout
-            // entry carries a `session_id` (post-resume-by-id
-            // builds). We re-resolve `auto_type` from the stored
-            // `Session.agent_id` + `Session.agent_session_id` so the
-            // rehydrated tab runs `claude --resume <id>` / `pi
-            // --session <id>` / `copilot --resume=<id>` instead of
-            // the original spawn command (which was just "claude").
-            // Falls back to the layout's recorded `auto_type` when
-            // the session row can't be found (project removed,
-            // layout.json from a pre-session-id build) so legacy
-            // entries still rehydrate as a fresh agent launch.
-            let stored_session = tab
-                .session_id
+            let placement = placements.get(&entry.session_id);
+            let group_idx = placement
+                .map(|p| p.group_index)
+                .unwrap_or(0)
+                .min(group_count.saturating_sub(1));
+            let active_in_group = placement.map(|p| p.active_in_group).unwrap_or(false);
+
+            // `spawn_tab_in` always lands in the focused group, so
+            // we move focus first then restore the saved focus index
+            // after the loop.
+            self.focused_group = group_idx;
+
+            // Resume-by-id when we have an agent + its session UUID.
+            // `build_resume_auto_type` returns `claude --resume <id>` /
+            // `pi --session <id>` / `copilot --resume=<id>` depending on
+            // the agent profile. Falls back to the agent's "most recent"
+            // resume args when the persisted `agent_session_id` is
+            // missing, and to `None` for plain shells.
+            let auto: Option<SharedString> = entry
+                .agent_id
                 .as_deref()
-                .and_then(|sid| self.lookup_session_by_id(sid));
-            let auto: Option<SharedString> = match stored_session.as_ref() {
-                Some(stored) => stored
-                    .agent_id
-                    .as_deref()
-                    .and_then(|aid| self.agent_registry.get_by_id(aid))
-                    .and_then(|profile| {
-                        codescope_core::build_resume_auto_type(
-                            profile,
-                            stored.agent_session_id.as_deref(),
-                        )
-                    })
-                    .map(SharedString::from)
-                    .or_else(|| tab.auto_type.clone().map(SharedString::from)),
-                None => tab.auto_type.clone().map(SharedString::from),
+                .and_then(|aid| self.agent_registry.get_by_id(aid))
+                .and_then(|profile| {
+                    codescope_core::build_resume_auto_type(
+                        profile,
+                        entry.agent_session_id.as_deref(),
+                    )
+                })
+                .map(SharedString::from);
+
+            // Title mirrors C# `MainViewModel.HydrateFromLoaded`:
+            // `{project} · {branch}` when we have a branch, else the
+            // user-set display name, else the project name. Display
+            // name wins last because the C# tab title binding pulls
+            // from descriptor.Title (project · branch); rename lives
+            // in a separate SessionTabViewModel projection.
+            let title: SharedString = if let Some(branch) = entry.branch.as_deref() {
+                SharedString::from(format!("{} · {}", entry.project_name, branch))
+            } else if let Some(name) = entry.display_name.as_deref() {
+                SharedString::from(name.to_string())
+            } else {
+                SharedString::from(entry.project_name.clone())
             };
-            // Re-bind to the stored session row only when the row
-            // actually exists in `projects.json` right now. Passing
-            // `Some(id)` makes `allocate_session_id` skip the
-            // `SessionManager::open` append (it assumes the row is
-            // already on disk), so handing it a ghost id would leave
-            // the tab bound to a session that history / close
-            // bookkeeping can't touch. When the row is gone (project
-            // removed, hard-remove from history, race with a sidebar
-            // write) we fall back to `None` and let
-            // `allocate_session_id` mint a fresh id + append a new
-            // row — matches the pre-resume-by-id rehydrate
-            // behaviour for legacy layout.json files.
-            let restore_session_id = stored_session.as_ref().map(|s| s.id.clone());
-            self.spawn_tab_in(Some(path), Some(title), auto, restore_session_id, window, cx);
+
+            self.spawn_tab_in(
+                Some(path),
+                Some(title),
+                auto,
+                Some(entry.session_id.clone()),
+                window,
+                cx,
+            );
             spawned_any = true;
-            if tab.active_in_group {
+            if active_in_group {
                 let new_idx = self.groups[group_idx].tabs.len() - 1;
                 active_by_group[group_idx] = Some(new_idx);
             }
         }
+
         if !spawned_any {
-            // Every saved path was missing — fall back to cold-start
-            // so the user gets *something*.
-            self.spawn_tab(window, cx);
+            // Every live session's worktree was missing — leave the
+            // window empty instead of fabricating a default-shell tab
+            // on a path the user already lost. Matches C#'s
+            // "everything skipped → empty workspace" behaviour.
+            self.focus_handle.focus(window);
+            cx.notify();
             return;
         }
+
         // Apply per-group active-tab selections.
         for (g_idx, active) in active_by_group.iter().enumerate() {
             if let Some(t_idx) = active
@@ -3011,7 +3062,6 @@ impl AppShell {
             title,
             terminal,
             working_directory: working_directory_for_tab,
-            auto_type: auto_type.clone(),
             spawned_at: SystemTime::now(),
             adopted_session_id: None,
             fired_session_ids: std::collections::HashSet::new(),
@@ -3019,6 +3069,15 @@ impl AppShell {
         });
         let new_idx = group.tabs.len() - 1;
         self.activate_tab(group_idx, new_idx, window, cx);
+        // Persist the placement now so a crash before the next state
+        // change (close / split / drag) still leaves a `layout.json`
+        // that mentions this session's group. `activate_tab` only
+        // saves when focused_group actually changes — for a spawn
+        // into the already-focused group it wouldn't fire, so the
+        // tab would come back in group 0 next launch even though
+        // `projects.json` carries the live row. The `projects.json`
+        // write already happened inside `allocate_session_id`.
+        self.save_layout();
 
         // Fallback: auto-type the agent command into the shell when we
         // *couldn't* build the agent into the shell argv up-front

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -507,3 +507,55 @@ sidebar's "+ New Project → Clone from URL" tab uses today.
 - If/when the C# build wires its clone flow, both ports converge
   on the same affordance.
 
+## ADR-0021 — Rust rehydrate is driven by `projects.json`, not `layout.json`
+
+**Date:** 2026-05-14
+**Status:** Accepted
+
+Until this ADR the Rust port had two sources of truth for "which
+sessions are open across a restart": `projects.json` carried the live
+`Session` rows (with `closed_at = None`), and `layout.json` carried a
+parallel `open_tabs: Vec<RestoreTab>` that the cold-start path
+(`AppShell::rehydrate_or_cold_start`) actually read. Any divergence
+between the two — a crash before `save_layout` fired after a spawn, a
+manual file edit, a partially-restored backup — left "live" rows in
+`projects.json` that were invisible to the user because they weren't
+in `layout.json`.
+
+The C# build doesn't have this problem: `LayoutStore.Layout` carries
+only `GroupCount`, `FocusedGroupIndex`, `Dictionary<string, int>
+SessionToGroup` and `GroupWidths`. `MainViewModel.HydrateFromLoaded`
+iterates every `Session` with `ClosedAt is null` and uses
+`SessionToGroup[s.Id]` purely to decide *where* the tab lands, not
+whether it lands at all.
+
+**Decision:** mirror the C# split. `LayoutState.session_placements:
+Vec<SessionPlacement>` replaces `open_tabs` as the placement record;
+each entry binds a `Session.id` to its group index and an
+`active_in_group` flag. The legacy `open_tabs` field stays
+deserialise-only and is migrated in place on first load, then dropped
+on next save. `rehydrate_or_cold_start` walks `self.projects.projects[].sessions`
+where `closed_at.is_none()` and falls back to group 0 / non-active for
+sessions without a placement.
+
+**Consequences:**
+
+- A session opened via `Ctrl+T` is durable from the moment
+  `SessionManager::open` writes `projects.json` — even a process kill
+  before the next `save_layout` keeps the tab on next launch (it just
+  comes back in group 0 if the placement wasn't captured yet).
+- `Tab.auto_type` is no longer persisted as separate state; the
+  resume command line is rebuilt at rehydrate time from
+  `Session.agent_id` + `Session.agent_session_id` via
+  `build_resume_auto_type`, matching the C# hydrate path.
+- Free-floating tabs (no project context at spawn time → no row in
+  `projects.json`) no longer survive a restart. This matches C#'s
+  invariant that every session belongs to a project (the "unsorted"
+  bucket is the catch-all; `AppShell` already routes there via the
+  Add Project flow).
+- One-shot migration: pre-ADR `layout.json` files keep their tab
+  groups via the `open_tabs → session_placements` conversion in
+  `LayoutState::migrate`; entries without `session_id` are dropped
+  (those predate resume-by-id and had no `projects.json` link
+  anyway).
+


### PR DESCRIPTION
## Summary

- Rust port had two sources of truth for "which sessions are open at restart": `projects.json` (live `Session` rows with `closed_at = None`) and `layout.json` (`open_tabs: Vec<RestoreTab>`). The cold-start path read the latter; any divergence between them lost open sessions on restart.
- Mirror the C# build (new ADR-0021): `LayoutState.session_placements` carries only group index + active flag per session id, and `rehydrate_or_cold_start` walks `projects.json` live sessions to decide which tabs to spawn. Matches `MainViewModel.HydrateFromLoaded`.
- Call `save_layout` at the tail of `spawn_tab_in` so a fresh Ctrl+T persists its group placement immediately — `activate_tab` only saves on focused-group changes and would otherwise skip same-group spawns.

## Test plan

- [x] `cargo test --workspace` (630 tests) green
- [x] New `core::layout::tests::*` covering: round-trip new shape, save-omits-empty-legacy-open-tabs, legacy `open_tabs → session_placements` migration, drop-entries-without-session-id, no-op when both fields present
- [ ] Manual: dev-build CodeScope (`$env:CODESCOPE_DEV=1`); open several agent sessions across two groups; kill the process via Task Manager (no graceful shutdown); relaunch — sessions return in their groups
- [ ] Manual: same as above, but soft-close one session before kill — it stays in the worktree history surface and does NOT respawn as a tab
- [ ] Manual: load a pre-PR `layout.json` (with `open_tabs`) into the dev profile; verify tabs come back in the right groups and the file is rewritten with `session_placements` only after the next save