### PR TITLE
docs: declare Rust port canonical, retire C# build (cutover-1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@ intentional deviations in `docs/DECISIONS.md`.
 
 ## Style
 
-- Idiomatic Rust 2021. Run `cargo fmt` before committing
+- Idiomatic Rust 2024 (workspace pins `edition = "2024"` — needs
+  Rust 1.85+). Run `cargo fmt` before committing
 - `cargo clippy --workspace --all-targets` clean on changed files
 - Prefer `?` over `match`/`unwrap` for error propagation; reserve
   `unwrap` for proven invariants with a one-line `// SAFETY:` style
@@ -52,17 +53,32 @@ need to coexist with the installed app.
 Start the dev build with the `CODESCOPE_DEV` env var set:
 
 ```pwsh
+# Windows (PowerShell)
 $env:CODESCOPE_DEV = "1"
 cargo run --manifest-path codescope-rs/Cargo.toml --bin codescope-rs
 ```
 
-`codescope_core::paths` resolves the env var once at process start
-and redirects:
+```bash
+# macOS / Linux
+CODESCOPE_DEV=1 cargo run --manifest-path codescope-rs/Cargo.toml --bin codescope-rs
+```
+
+`codescope_core::paths::AppPaths::detect()` resolves the env var once
+at process start and redirects (paths come from `AppPaths` accessor
+methods — `projects_file()`, `layout_file()`, `window_file()`,
+`settings_file()`):
 
 - single-instance mutex → `Global\CodeScope.SingleInstance.Dev`
-- `%APPDATA%\CodeScope\` → `%APPDATA%\CodeScope.Dev\` (`projects.json`)
-- `%LOCALAPPDATA%\CodeScope\` → `%LOCALAPPDATA%\CodeScope.Dev\`
+  (Windows only)
+- Windows: `%APPDATA%\CodeScope\` → `%APPDATA%\CodeScope.Dev\`
+  (`projects.json`, `settings.json`);
+  `%LOCALAPPDATA%\CodeScope\` → `%LOCALAPPDATA%\CodeScope.Dev\`
   (`layout.json`, `window.json`, `console.log`, `crash.log`)
+- Linux: `~/.config/CodeScope/` → `~/.config/CodeScope.Dev/` (config);
+  `~/.local/state/CodeScope/` → `~/.local/state/CodeScope.Dev/` (state)
+- macOS: `~/Library/Application Support/CodeScope/` →
+  `~/Library/Application Support/CodeScope.Dev/` (both config and
+  state — Apple's HIG keeps them together)
 - window title → `CodeScope [dev] — …`
 
 The Dev store is independent — projects opened in the dev build are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,68 +2,94 @@
 
 ## Project
 
-Native Windows app (.NET 10, WPF) for orchestrating parallel AI coding agent CLI sessions with Git worktree isolation.
+Cross-platform native app (Rust + [GPUI](https://www.gpui.rs/)) for
+orchestrating parallel AI coding agent CLI sessions with Git worktree
+isolation. Ships on Windows, macOS (arm64 + x64), and Linux x64.
+
+> The original .NET 10 / WPF implementation was retired on 2026-05-14;
+> see [ADR-0022](docs/DECISIONS.md) and
+> [docs/MIGRATION-csharp-to-rust.md](docs/MIGRATION-csharp-to-rust.md).
+> The last buildable C# tree is tagged `legacy/v0.2.6-final`. If you
+> are reading historical PRs, expect `src/CodeScope.*/` references that
+> no longer exist on `main`.
 
 ## Technology decisions (non-negotiable)
 
-- `.NET 10` / `C# 14` — do not downgrade
-- WPF — do not suggest WinUI 3, MAUI, or Avalonia
-- `EasyWindowsTerminalControl` — do not suggest xterm.js + WebView2
-- Shell out to `git` — do not suggest LibGit2Sharp
-- `System.Text.Json` — do not suggest Newtonsoft.Json
-- `CommunityToolkit.Mvvm` — do not suggest Prism, Caliburn.Micro, ReactiveUI
+- Rust (stable toolchain) — workspace at `codescope-rs/Cargo.toml`
+- [GPUI](https://www.gpui.rs/) for the application shell — do not
+  suggest egui, iced, or web frontends
+- `codescope-terminal` (GPUI-native ConPTY/PTY) for terminal hosting —
+  do not suggest xterm.js + WebView2 or wrapping VS Code's terminal
+- Shell out to `git` — do not suggest `git2`/libgit2 bindings
+- `serde_json` for on-disk state — do not introduce other JSON crates
+- `velopack-rs` for auto-update — do not suggest Sparkle, Squirrel, or
+  custom updaters
 
 ## Design reference
 
-UI/UX decisions are documented in `docs/DESIGN.md` and `docs/DECISIONS.md`. Mirror established patterns in the existing Views/ViewModels when adding features; document intentional deviations in `docs/DECISIONS.md`.
+UI/UX decisions live in `docs/DESIGN.md` and `docs/DECISIONS.md`.
+Mirror established patterns in the existing GPUI views and the
+`AppShell` / `MainViewModel` parallel when adding features; document
+intentional deviations in `docs/DECISIONS.md`.
 
 ## Style
 
-- Nullable reference types enabled; respect annotations
-- File-scoped namespaces
-- Primary constructors where they clean up code
-- Target-typed `new()` where obvious
-- `var` always unless the type isn't obvious from the right-hand side
-- 4-space indent, 120 char line length guideline
+- Idiomatic Rust 2021. Run `cargo fmt` before committing
+- `cargo clippy --workspace --all-targets` clean on changed files
+- Prefer `?` over `match`/`unwrap` for error propagation; reserve
+  `unwrap` for proven invariants with a one-line `// SAFETY:` style
+  comment explaining why
+- Module names `snake_case`, types `CamelCase`
+- 4-space indent, 100 char line length guideline (Rust default)
 
 ## Running side-by-side with an installed build
 
-The user develops CodeScope *inside* CodeScope — the installed v0.1.0+ build
-hosts the sessions that work on this repo, so closing it to test a dev build
-would kill every other project's session. Dev runs therefore need to coexist
-with the installed app.
+The user develops CodeScope *inside* CodeScope — the installed build
+hosts the sessions that work on this repo, so closing it to test a dev
+build would kill every other project's session. Dev runs therefore
+need to coexist with the installed app.
 
 Start the dev build with the `CODESCOPE_DEV` env var set:
 
 ```pwsh
 $env:CODESCOPE_DEV = "1"
-dotnet run --project src/CodeScope.App
+cargo run --manifest-path codescope-rs/Cargo.toml --bin codescope-rs
 ```
 
-`NoScope.CodeScope.Core.AppPaths` resolves the env var once at process start
+`codescope_core::paths` resolves the env var once at process start
 and redirects:
 
 - single-instance mutex → `Global\CodeScope.SingleInstance.Dev`
-- `%APPDATA%\CodeScope\` → `%APPDATA%\CodeScope.Dev\` (projects.json)
-- `%LOCALAPPDATA%\CodeScope\` → `%LOCALAPPDATA%\CodeScope.Dev\` (layout.json,
-  window.json, console.log, crash.log)
+- `%APPDATA%\CodeScope\` → `%APPDATA%\CodeScope.Dev\` (`projects.json`)
+- `%LOCALAPPDATA%\CodeScope\` → `%LOCALAPPDATA%\CodeScope.Dev\`
+  (`layout.json`, `window.json`, `console.log`, `crash.log`)
 - window title → `CodeScope [dev] — …`
 
-The Dev store is independent — projects opened in the dev build are separate
-from the installed build's projects. Typical loop: keep v0.1.0 running with
-real work, launch dev with a subset of projects (or different ones) to
-exercise changes. Claude telemetry tails at `~/.claude/projects/…` are shared
-by design — two FSWatchers, no state conflict.
+The Dev store is independent — projects opened in the dev build are
+separate from the installed build's projects. Typical loop: keep the
+installed build running with real work, launch dev with a subset of
+projects (or different ones) to exercise changes. Claude telemetry
+tails at `~/.claude/projects/…` are shared by design — two
+FSWatchers, no state conflict.
 
-When adding new on-disk state, thread it through `AppPaths.AppFolderName` so
+When adding new on-disk state, thread it through the `paths` module so
 dev-mode separation keeps working.
 
 ## Workflow
 
-- **First, on any fresh session, read `docs/HANDOFF.md`** — it holds the cursor (what we were doing), current build/test status, roadmap state, open rough edges, and suggested next entry points. It is updated at the end of each session.
+- **First, on any fresh session, read `docs/HANDOFF.md`** — it holds
+  the cursor (what we were doing), current build/test status, roadmap
+  state, open rough edges, and suggested next entry points. It is
+  updated at the end of each session.
 - Read `docs/DECISIONS.md` before proposing architecture changes
-- Write the test first for `Core` services (TDD for logic, not UI)
+- Write the test first for `codescope-core` services (TDD for logic,
+  not UI). Tests live next to the code they cover, behind
+  `#[cfg(test)]`
 - Keep commits focused; one concern per commit
-- Never commit new work directly to `main` — always create a feature branch and open a PR (even for small changes). `main` is protected; pushing to it bypasses review
-- At the **end** of every working session, update `docs/HANDOFF.md` with the new cursor, commit SHAs, and anything a fresh session would need
+- Never commit new work directly to `main` — always create a feature
+  branch and open a PR (even for small changes). `main` is protected;
+  pushing to it bypasses review
+- At the **end** of every working session, update `docs/HANDOFF.md`
+  with the new cursor, commit SHAs, and anything a fresh session would
+  need
 - Never leave `TODO` / `FIXME` without a linked issue number

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Grab the latest release from the [**Releases page**](https://github.com/maui1911
 Only needed if you want to contribute or hack on CodeScope itself.
 
 ```pwsh
-# Prerequisites: stable Rust toolchain (1.80+), git
+# Prerequisites: stable Rust toolchain (1.85+, edition 2024), git
 cargo build --manifest-path codescope-rs/Cargo.toml
 cargo run --manifest-path codescope-rs/Cargo.toml --bin codescope-rs
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CodeScope
 
-**A native Windows command center for AI coding agents.**
+**A native command center for AI coding agents.**
 
-CodeScope runs Claude Code, Codex, Copilot, OpenCode, Pi and any other CLI agent as parallel, worktree-isolated sessions inside a single WPF window — with tabbed terminals, split editor groups, a live git overview, and a keyboard-first command palette.
+CodeScope runs Claude Code, Codex, Copilot, OpenCode, Pi and any other CLI agent as parallel, worktree-isolated sessions inside a single window — with tabbed terminals, split editor groups, a live git overview, and a keyboard-first command palette. Ships on Windows, macOS (Apple Silicon + Intel), and Linux x64.
 
 ![CodeScope main window](docs/screenshots/hero.png)
 
@@ -10,11 +10,11 @@ CodeScope runs Claude Code, Codex, Copilot, OpenCode, Pi and any other CLI agent
 
 ## Why
 
-Agents are fast enough that one at a time is now the bottleneck. Running five parallel `claude` sessions from Windows Terminal means juggling five shells, five branches, and five mental stacks. CodeScope gives each agent its own git worktree, its own tab, its own notification status, and surfaces the state of every session at a glance:
+Agents are fast enough that one at a time is now the bottleneck. Running five parallel `claude` sessions from a plain terminal means juggling five shells, five branches, and five mental stacks. CodeScope gives each agent its own git worktree, its own tab, its own notification status, and surfaces the state of every session at a glance:
 
 - **Worktree isolation** — every session starts with `git worktree add -b` under the hood, so agents never step on each other's branches.
-- **Native Windows** — WPF + Wpf.Ui chrome, ConPTY-backed terminals via `EasyWindowsTerminalControl`. No Electron, no WebView2.
-- **Bring your own agent** — anything on `PATH` works: `claude`, `codex`, `opencode`, raw `pwsh`. Zero translation layer.
+- **Native** — Rust + [GPUI](https://www.gpui.rs/) chrome, ConPTY/PTY-backed terminals via the in-tree `codescope-terminal` crate. No Electron, no WebView2.
+- **Bring your own agent** — anything on `PATH` works: `claude`, `codex`, `opencode`, raw `pwsh` / `bash`. Zero translation layer.
 
 ## Features
 
@@ -46,44 +46,47 @@ Snap a worktree into its own workspace with `Ctrl+\`. Two agents, side by side, 
 
 ## Install
 
-Grab the latest release from the [**Releases page**](https://github.com/maui1911/CodeScope/releases/latest):
+Grab the latest release from the [**Releases page**](https://github.com/maui1911/CodeScope/releases/latest). Each release ships a per-platform Velopack feed; pick the asset that matches your machine:
 
-| Asset | What |
+| Asset | Platform |
 |---|---|
-| **`CodeScope-win-Setup.exe`** | One-click installer (recommended). Installs to `%LocalAppData%\CodeScope`, auto-updates via Velopack. |
-| **`CodeScope-win-Portable.zip`** | Standalone zip — extract and run `CodeScope.exe`. No install, no auto-update. |
+| **`codescope-rs-win-Setup.exe`** | Windows 10 22H2+ / Windows 11 (x64) — installs to `%LocalAppData%\codescope-rs`, auto-updates. |
+| **`codescope-rs-osx-arm64.app.zip`** | macOS 13+ on Apple Silicon — unzip and drag to `/Applications`. |
+| **`codescope-rs-osx-x64.app.zip`** | macOS 13+ on Intel — unzip and drag to `/Applications`. |
+| **`codescope-rs-linux-x64.AppImage`** | Linux x64 — `chmod +x` and run. |
+
+> Pack id `codescope-rs` is in effect through the `0.3.0-rc.X` line. It is renamed to `codescope` in cutover-3 of the C# retirement; users on `codescope-rs` will need to uninstall and reinstall once when that release ships. `%APPDATA%\CodeScope\projects.json` carries over unchanged.
 
 ### Requirements
 
-- Windows 10 22H2+ or Windows 11
 - `git` on `PATH`
 - At least one agent CLI on `PATH` (`claude`, `codex`, `copilot`, `opencode`, `pi`, etc.)
 
-> **No .NET SDK needed** — the release is self-contained.
+> **No Rust toolchain needed** — the release is self-contained.
 
 ## Build from source
 
 Only needed if you want to contribute or hack on CodeScope itself.
 
 ```pwsh
-# Prerequisites: .NET 10 SDK (10.0.100+), git
-dotnet restore
-dotnet build
-dotnet run --project src/CodeScope.App
+# Prerequisites: stable Rust toolchain (1.80+), git
+cargo build --manifest-path codescope-rs/Cargo.toml
+cargo run --manifest-path codescope-rs/Cargo.toml --bin codescope-rs
 ```
 
 Run the tests:
 
 ```pwsh
-dotnet test
+cargo test --manifest-path codescope-rs/Cargo.toml --workspace
 ```
 
-Publish a release binary:
+Build a release binary:
 
 ```pwsh
-dotnet publish src/CodeScope.App -c Release -r win-x64 `
-    -p:PublishSingleFile=true -p:PublishReadyToRun=true
+cargo build --manifest-path codescope-rs/Cargo.toml --release
 ```
+
+For installer / Velopack packaging see `.github/workflows/rs--release.yml`.
 
 ## Keyboard shortcuts
 
@@ -105,24 +108,32 @@ dotnet publish src/CodeScope.App -c Release -r win-x64 `
 ## Repository layout
 
 ```
-src/
-  CodeScope.App/     WPF host — App.xaml, MainWindow, DI composition root
-  CodeScope.Core/    Pure logic — services, models, no UI references
-  CodeScope.Ui/      ViewModels, Views, Dialogs, Converters
-tests/
-  CodeScope.Core.Tests/
+codescope-rs/
+  src/               GPUI application shell — AppShell, MainViewModel, dialogs, views
+  core/              Pure logic — services, models, no UI references
+  terminal/          GPUI-native ConPTY/PTY terminal view (codescope-terminal crate)
+  examples/          Standalone GPUI demos
+  assets/            Icons, fonts, packaged resources
+  wix/               Windows installer chrome
+  scripts/           Release / packaging helpers
+  vendor/            Vendored upstream crates (see ADR-0017-style notes)
 docs/
   DESIGN.md          Design tokens
   DECISIONS.md       ADRs
   HANDOFF.md         Rolling cursor between working sessions
+  MIGRATION-csharp-to-rust.md   Historical note on the 2026-05-14 cutover
   screenshots/       README imagery
 ```
 
-The `NoScope.CodeScope.*` CLR namespace pairs with the `CodeScope` binary name.
+> Historical note: through `v0.2.6` the canonical tree was a .NET 10 / WPF
+> build at `src/CodeScope.{App,Core,Ui}/`. That tree is preserved at tag
+> `legacy/v0.2.6-final`; see [docs/MIGRATION-csharp-to-rust.md](docs/MIGRATION-csharp-to-rust.md)
+> for the why and how of the cutover. Cutover-3 flattens `codescope-rs/*`
+> to repo root.
 
 ## Status
 
-Pre-1.0. The core session / worktree / PR workflows are stable and used daily; the design system is in its final pass and the release story (Velopack, auto-update) is the current milestone.
+Pre-1.0. The core session / worktree / PR workflows are stable and used daily; per-platform Velopack feeds ship from `rs-v0.3.0-rc.5` onward, and the C# implementation is being retired in three sequential PRs (see `docs/superpowers/specs/2026-05-14-csharp-build-retirement-design.md`).
 
 See `docs/HANDOFF.md` for the live status cursor and `docs/DECISIONS.md` for the architectural record.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,9 +85,11 @@ Both paths live in `codescope-terminal`.
 
 ## Config schema
 
-`%APPDATA%\CodeScope\projects.json` (path is `paths::projects_json()`
-on every platform — `%APPDATA%` resolves to platform-appropriate
-directories on macOS / Linux):
+`%APPDATA%\CodeScope\projects.json` on Windows (resolved by
+`AppPaths::projects_file()`; the config root is
+`~/.config/CodeScope/` on Linux and
+`~/Library/Application Support/CodeScope/` on macOS — see
+`codescope-rs/core/src/paths.rs`):
 
 ```json
 {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,18 +1,26 @@
 # CodeScope — Architecture
 
-## Layers
+> Updated 2026-05-14 for the Rust + GPUI build. The earlier .NET 10 /
+> WPF architecture is preserved at tag `legacy/v0.2.6-final`; see
+> [ADR-0022](DECISIONS.md) and
+> [MIGRATION-csharp-to-rust.md](MIGRATION-csharp-to-rust.md).
+
+## Crates
 
 ```
-┌──────────────────────────────────────────┐
-│ CodeScope.App    (WPF host, DI, windows) │
-├──────────────────────────────────────────┤
-│ CodeScope.Ui     (ViewModels + Views)    │
-├──────────────────────────────────────────┤
-│ CodeScope.Core   (models + services)     │
-└──────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────┐
+│ codescope-rs        (GPUI shell, AppShell, dialogs)  │
+├──────────────────────────────────────────────────────┤
+│ codescope-terminal  (GPUI-native ConPTY/PTY view)    │
+├──────────────────────────────────────────────────────┤
+│ codescope-core      (models + services, no UI)       │
+└──────────────────────────────────────────────────────┘
 ```
 
-Dependency direction is strict: `App -> Ui -> Core`. `Core` has zero UI references (no WPF, no Wpf.Ui, no terminal control).
+Dependency direction is strict: `codescope-rs` depends on
+`codescope-core` and `codescope-terminal`; `codescope-core` has zero UI
+references (no GPUI, no windowing, no terminal). The workspace lives
+at `codescope-rs/Cargo.toml`. Cutover-3 flattens this to repo root.
 
 ## Runtime shape
 
@@ -20,10 +28,9 @@ Dependency direction is strict: `App -> Ui -> Core`. `Core` has zero UI referenc
 ┌──────────────┬────────────────────────────────────────┐
 │              │  [Tab 1]  [Tab 2]  [Tab 3]  [+]        │
 │  Sidebar     ├────────────────────────────────────────┤
-│  (Fase 2)    │                                         │
-│              │     EasyWindowsTerminalControl         │
-│  Projects    │     (pwsh -NoExit -Command "claude")   │
-│  ├ Proj A    │                                         │
+│              │                                         │
+│  Projects    │     codescope-terminal                  │
+│  ├ Proj A    │     (pwsh -NoExit -Command "claude")    │
 │  │  ├ main   │                                         │
 │  │  └ feat-x │                                         │
 │              ├────────────────────────────────────────┤
@@ -31,42 +38,105 @@ Dependency direction is strict: `App -> Ui -> Core`. `Core` has zero UI referenc
 └──────────────┴────────────────────────────────────────┘
 ```
 
+The window is composed of one or more **groups**. Each group owns its
+own tab strip and a single active terminal view. Layout (group widths,
+which tab is active in each group, collapsed sidebar nodes) persists
+to `layout.json`; the project / worktree / session tree persists to
+`projects.json` and is the source of truth for rehydration
+([ADR-0021](DECISIONS.md)).
+
 ## Core services
 
-- `IProjectStore` — reads/writes `%APPDATA%\CodeScope\projects.json` (System.Text.Json). Schema versioned via `version` field; migrations are additive.
-- `IAgentRegistry` — resolves agent profiles (command, args, resume flag) from config.
-- `IGitService` — shells out to `git` via `Process.Start`. All methods async + cancellable. Returns `Result<T>` for non-exceptional failures.
-- `ISessionManager` — owns the lifecycle of running terminal sessions. Knows how to spawn pwsh in a directory, wire a pseudo-console via `EasyWindowsTerminalControl`, and kill the whole process tree on dispose using a Win32 job object.
+`codescope-core` modules (under `codescope-rs/core/src/`):
+
+- `projects` — reads/writes `%APPDATA%\CodeScope\projects.json` via
+  `serde_json`. Schema versioned by the `version` field; migrations
+  are additive. JSON shape is byte-compatible with the retired C# build.
+- `agents` — resolves agent profiles (command, args, resume flag) from
+  config. Mirrors the C# `IAgentRegistry`.
+- `git` — shells out to `git` via `std::process::Command`. Async-aware
+  through the GPUI background executor; results returned as
+  `Result<T, …>` for non-exceptional failures.
+- `session_manager` — owns the lifecycle of running terminal sessions.
+  Spawns the shell in a directory, hands the pty to
+  `codescope-terminal`, and tears the process tree down on tab close
+  (Win32 job object on Windows; `setpgid` + `killpg` on Unix).
+- `claude_telemetry`, `claude_discovery`, `notifications`,
+  `update_check`, `layout`, `paths`, `settings`, `window_state`,
+  `attachments` — one module per concern, all UI-free.
+
+`codescope-rs/src/` hosts the GPUI shell (`app.rs` → `AppShell`,
+`view.rs`, `sidebar.rs`, dialogs, status bar). Render-state mutations
+go through `cx.notify()` rather than an MVVM relay-command layer.
 
 ## Process tree cleanup
 
-A tab hosts `pwsh.exe`, which spawns agent children (`claude.exe`, etc.). Killing the parent pwsh does not reliably kill its children. Fix: associate the whole launched process with a Win32 **job object** flagged `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. When the job handle is closed (on tab dispose), Windows terminates the entire tree.
+A tab hosts a shell (`pwsh.exe` on Windows; user's `SHELL` on Unix),
+which spawns agent children (`claude.exe`, `codex`, etc.). Killing the
+parent does not reliably kill its children.
 
-See `CodeScope.Core/Interop/ProcessTreeKiller.cs`.
+- **Windows:** the spawned process is associated with a Win32 **job
+  object** flagged `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Closing the
+  job handle on tab dispose terminates the whole tree.
+- **Unix:** each tab is its own process group via `setpgid`; tab close
+  calls `killpg(SIGTERM)` followed by `SIGKILL` on timeout.
+
+Both paths live in `codescope-terminal`.
 
 ## Config schema
 
-`%APPDATA%\CodeScope\projects.json`:
+`%APPDATA%\CodeScope\projects.json` (path is `paths::projects_json()`
+on every platform — `%APPDATA%` resolves to platform-appropriate
+directories on macOS / Linux):
 
 ```json
 {
   "version": 1,
-  "agents": [ { "id": "...", "displayName": "...", "command": "...", "resumeArgs": [], "newSessionArgs": [], "isDefault": true } ],
-  "projects": [ { "id": "...", "name": "...", "path": "...", "defaultBranch": "main", "worktreeRoot": "...", "sessions": [ { "id": "...", "worktreePath": "...", "branch": "...", "agentId": "...", "lastOpened": "2026-04-21T10:32:15Z" } ] } ]
+  "agents": [
+    { "id": "...", "displayName": "...", "command": "...",
+      "resumeArgs": [], "newSessionArgs": [], "isDefault": true }
+  ],
+  "projects": [
+    { "id": "...", "name": "...", "path": "...",
+      "defaultBranch": "main", "worktreeRoot": "...",
+      "sessions": [
+        { "id": "...", "worktreePath": "...", "branch": "...",
+          "agentId": "...", "lastOpened": "2026-04-21T10:32:15Z",
+          "closedAt": null }
+      ] }
+  ]
 }
 ```
 
-Unknown fields are preserved on roundtrip. `version` gates migrations.
+Unknown fields are preserved on roundtrip (`serde_json` with a
+`flatten`ed `extra: Map<String, Value>`). `version` gates migrations.
+
+`%LOCALAPPDATA%\CodeScope\layout.json` carries placement
+(`session_placements: Vec<SessionPlacement>` — see
+[ADR-0021](DECISIONS.md)).
 
 ## Threading and async
 
-- UI thread: WPF dispatcher only.
-- Git calls: async, cancellable via `CancellationToken`, debounced for status polling.
-- `ConfigureAwait(false)` in Core; UI layer uses default.
-- No `.Result` / `.Wait()` anywhere.
+- UI work runs on the GPUI main thread; mutations go via
+  `cx.spawn` / `cx.background_executor()` for off-thread work and
+  `cx.update` to land results back on the UI.
+- Git calls, telemetry polls, and update checks run on
+  `cx.background_executor()`. They are cancellation-aware where the
+  source crate supports it; otherwise short timeouts.
+- File-system watchers (`notify` crate) feed channels consumed by the
+  UI through `cx.spawn`.
+- No blocking syscalls on the main thread — `Notification::show`
+  (notify-rust) is one example punted to the background executor
+  because the underlying COM / NSUserNotification call blocks.
 
 ## Error handling
 
-- `Result<T>` pattern for expected failures (git nonzero exit, file missing).
-- Exceptions only for genuinely exceptional cases (invalid config, programmer error).
-- All `ILogger<T>` — console sink in Debug, file sink (rolling 10 MB) in Release.
+- `Result<T, …>` for expected failures (git nonzero exit, file
+  missing, JSON parse error).
+- `anyhow::Error` at the shell layer for surfaced-to-user errors;
+  typed errors inside `codescope-core` modules.
+- `panic` only for genuinely exceptional cases (invalid config,
+  programmer error) and is captured by the crash-log handler that
+  writes `%LOCALAPPDATA%\CodeScope\crash.log`.
+- Logging: `tracing` with a console sink in debug and a rolling file
+  sink (`console.log`, 10 MB cap) in release.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -559,3 +559,61 @@ sessions without a placement.
   (those predate resume-by-id and had no `projects.json` link
   anyway).
 
+---
+
+## ADR-0022 — Rust port becomes canonical CodeScope; C# build retired
+
+**Date:** 2026-05-14
+**Status:** Accepted
+
+The Rust port (`codescope-rs/`) has matched the C# build's feature set
+since `rs-v0.3.0-rc.5` (session 41) and has been the sole daily driver
+since rc.4. The last twenty merged PRs are all `(rs)`-namespaced; the
+C# tree under `src/CodeScope.{App,Core,Ui}/` has been untouched for
+weeks. Carrying both implementations costs: duplicated release
+pipelines, divergent build settings, a parity audit doc that goes
+stale within days, and a "where is the canonical answer for X"
+question on every change.
+
+The Rust port is also platform-portable in a way WPF is not. Velopack
+feeds now ship for Windows, macOS arm64/x64, and Linux x64 from one
+pipeline ([ADR-0019](#adr-0019), [PRs #201 / #202](https://github.com/maui1911/CodeScope/pulls)).
+
+Earlier ADRs in this file describe the C# stack as canonical
+(ADR-0001 .NET 10, ADR-0002 WPF, ADR-0003 EasyWindowsTerminalControl,
+ADR-0004 Wpf.Ui, ADR-0006 CommunityToolkit.Mvvm, etc.). Those decisions
+remain historically accurate for the `v0.2.X` line and are kept as
+written. From this ADR onward, the Rust + GPUI stack is the active
+record:
+
+* GPUI for the application shell (was: WPF + `Wpf.Ui`).
+* `codescope-terminal` (GPUI-native ConPTY/PTY) for terminal hosting
+  (was: `EasyWindowsTerminalControl`).
+* Cargo workspace at `codescope-rs/Cargo.toml` for builds (was:
+  `CodeScope.sln` + `Directory.Build.{props,targets}`).
+* `velopack-rs` for auto-update (was: Velopack .NET); pack id stays
+  `codescope-rs` through cutover-2 and is renamed to `codescope` in
+  cutover-3.
+* `serde_json` for `projects.json` / `layout.json` (was:
+  `System.Text.Json`). Same JSON shape — see
+  [docs/MIGRATION-csharp-to-rust.md](MIGRATION-csharp-to-rust.md).
+
+**Consequences:**
+
+* The "mirror C# implementation 1:1" workflow rule (introduced in
+  session 33 after PR #56 invented a non-existent UX) is retired
+  together with the C# code. Future deviations from the v0.2.6
+  behavior are normal product work, not parity violations.
+* `docs/PARITY-AUDIT.md` is closed-stamped historical.
+* The last commit where the C# source tree builds is tagged
+  `legacy/v0.2.6-final` on the cutover-1 merge commit. The C# code is
+  fully removed in cutover-2; the workspace is flattened and the
+  Velopack pack id is renamed to `codescope` in cutover-3.
+* Historical `v0.2.X` GitHub releases stay published; the
+  `update_check` floor filter (see [ADR-0020](#adr-0020) and PR #206)
+  keeps them out of the live update flow.
+* Solo dogfooding: no preflight migration release is shipped. Users
+  (= the developer) reinstall once between the `codescope-rs` and
+  `codescope` Velopack pack ids; `%APPDATA%\CodeScope\projects.json`
+  carries across unchanged.
+

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -5,9 +5,19 @@
 > **Intent:** cursor + last 1–2 sessions in depth, everything else a one-liner.
 > Old detail lives in `git log` — don't duplicate it here.
 
-> ### House rule for the Rust port
+> ### Rust is canonical (as of 2026-05-14)
 >
-> **The Rust port (`codescope-rs/`) is a 1:1 functional port of the C# CodeScope build (`src/CodeScope.App/`, `src/CodeScope.Core/`, `src/CodeScope.AgentCli/`).** Before implementing any feature on the Rust side, **read the equivalent C# code first** and mirror its behavior, button labels, dialogs, data shapes, and persistence layout. Functional parity is the goal — we are not redesigning. If a `HANDOFF.md` entry, README line, or "next entry point" disagrees with what the C# code actually does, the C# code wins; update the doc. Genuine platform-forced deviations (gpui vs WPF idiom) get a one-line comment and an entry in `docs/DECISIONS.md`. "Cleaner" or "more elegant" is not a reason on its own. (Reinforced in session 33 after PR #56 invented a non-existent UX.)
+> The Rust port (`codescope-rs/`) is the only active implementation. The
+> .NET 10 / WPF build was retired on 2026-05-14; the last commit where
+> the C# tree still builds is tagged `legacy/v0.2.6-final`. See
+> [ADR-0022](DECISIONS.md) and [MIGRATION-csharp-to-rust.md](MIGRATION-csharp-to-rust.md).
+> The "mirror C# 1:1" parity rule (introduced session 33) is retired
+> with it — future deviations from `v0.2.6` behavior are normal product
+> work, not parity violations.
+>
+> Cutover-2 (delete C# source) and cutover-3 (flatten `codescope-rs/`
+> to repo root, rename Velopack pack id to `codescope`, tag namespace
+> to `v*`) are tracked in `docs/superpowers/specs/2026-05-14-csharp-build-retirement-design.md`.
 
 **Last updated:** 2026-05-14 (session 41 — bell hookup, cross-platform Velopack, empty-state hero)
 **Branch:** `main`

--- a/docs/MIGRATION-csharp-to-rust.md
+++ b/docs/MIGRATION-csharp-to-rust.md
@@ -1,0 +1,91 @@
+# Migration: C# (.NET 10 / WPF) → Rust (GPUI)
+
+> Date: 2026-05-14
+> Status: historical note — written at the start of the C# build retirement.
+> Related: [ADR-0022](DECISIONS.md), spec at
+> `docs/superpowers/specs/2026-05-14-csharp-build-retirement-design.md`.
+
+## Why this happened
+
+CodeScope shipped as a .NET 10 / WPF app from `v0.1.0` (2026-03) through
+`v0.2.6` (2026-05-08). The Rust port (`codescope-rs/`) started in session
+30 as a learning exercise / cross-platform experiment, was promoted to a
+1:1 functional parity port by session 33, and reached daily-driver
+quality at `0.3.0-rc.5` (session 41).
+
+Three forces pushed the cutover:
+
+1. **Single-developer signal.** Recent work was already Rust-only —
+   roughly the last twenty merged PRs (`#194` onward) are `(rs)`-tagged,
+   and the C# tree had not been touched in weeks.
+2. **Cross-platform.** Velopack feeds now publish for Windows, macOS
+   (arm64 + x64), and Linux x64 from one Rust pipeline. WPF is
+   Windows-only by construction.
+3. **Maintenance tax.** Two parallel release pipelines
+   (`release.yml` + `rs--release.yml`), two build-property layers
+   (`Directory.Build.{props,targets}` + Cargo workspace), and a parity
+   audit doc (`docs/PARITY-AUDIT.md`) that needed manual upkeep on every
+   feature touch.
+
+## What was kept
+
+* **`%APPDATA%\CodeScope\projects.json`** — same JSON shape, same path.
+  The Rust port reads and writes the C# schema unchanged. Existing
+  session catalogs roll forward across the install switch with no
+  migration step.
+* **`%LOCALAPPDATA%\CodeScope\layout.json`** — same shape with one
+  forward-compatible addition: `session_placements` replaces the
+  legacy `open_tabs` array (one-shot migration on first load, see
+  [ADR-0021](DECISIONS.md)).
+* **All user-visible flows** — sidebar tree, tab strip, split groups,
+  command palette, overview grid, new-worktree dialog, new-project /
+  clone dialog, context menus, idle toasts. Layouts and labels match
+  the C# build line for line.
+* **Velopack auto-update infrastructure** — same release-feed concept,
+  different channels (`win` / `osx-arm64` / `osx-x64` / `linux-x64`).
+* **Keyboard shortcuts** — every mapping from the WPF `KeyBindings`
+  block carried over identically.
+
+## What was dropped
+
+* **`EasyWindowsTerminalControl`** (WPF ConPTY host) — replaced by
+  `codescope-terminal`, a GPUI-native ConPTY/PTY view that shares
+  ANSI parsing with the rest of GPUI's terminal stack.
+* **`Wpf.Ui` theme system + XAML resource dictionaries** — replaced by
+  a small Rust theme module (`codescope-rs/src/theme.rs`) that mirrors
+  the same token names.
+* **`CommunityToolkit.Mvvm` relay-command plumbing** — GPUI uses direct
+  view methods + `cx.notify()`; no MVVM indirection.
+* **`Directory.Build.{props,targets}`, `CodeScope.sln`, all
+  `.csproj`** — replaced by the Cargo workspace at
+  `codescope-rs/Cargo.toml`.
+* **C# `release.yml` workflow** — replaced by `rs--release.yml`, later
+  renamed back to `release.yml` in cutover-3.
+
+## Install hand-off
+
+The Rust build ships as `codescope-rs-win-Setup.exe` (Velopack pack id
+`codescope-rs`) through cutover-2. In cutover-3 the pack id is renamed
+to `codescope`, which strands the auto-update lineage exactly once:
+users on the old `codescope-rs` install need to uninstall and reinstall
+from the first post-rename release. The `%APPDATA%\CodeScope\` data
+directory is unchanged across that switch.
+
+## Where the old code lives
+
+The last commit with the C# source tree intact is tagged
+`legacy/v0.2.6-final` on the cutover-1 merge commit. Historical
+`v0.2.X` GitHub releases remain published as archive entries; the
+`update_check` floor filter keeps them out of the live update path.
+
+## Reference timeline
+
+| Phase | Tag / PR | Notes |
+| --- | --- | --- |
+| C# canonical | `v0.1.0` … `v0.2.6` | WPF build, single-platform |
+| Rust port begins | session 30 | learning exercise |
+| Rust port = parity goal | session 33 | "C# wins on conflict" rule |
+| Rust port = daily driver | `rs-v0.3.0-rc.5` | session 41 |
+| Cutover-1 (this PR) | `legacy/v0.2.6-final` tag | docs declare Rust canonical |
+| Cutover-2 | TBD | C# source removed |
+| Cutover-3 | TBD | tree flattened, pack id renamed |

--- a/docs/PARITY-AUDIT.md
+++ b/docs/PARITY-AUDIT.md
@@ -1,4 +1,12 @@
 # CodeScope Rust Port: Parity Audit
+
+> **Closed 2026-05-14.** The Rust port reached daily-driver parity at
+> `rs-v0.3.0-rc.5` (session 41) and the C# build was retired the same
+> day. See [ADR-0022](DECISIONS.md) and
+> [MIGRATION-csharp-to-rust.md](MIGRATION-csharp-to-rust.md). The
+> "mirror C# 1:1" rule that drove this audit is retired with the C#
+> code; gaps listed below are historical context, not active TODOs.
+
 ## Executive Summary
 
 The Rust port has completed 4 major subsystems: window-state & layout persistence, Claude telemetry, sidebar context menus, and the new-worktree dialog. The remaining work breaks into three tiers: missing agent telemetry services (Copilot, OpenCode, Pi) and single-feature dialogs (15 tiny items), cross-cutting system features (crash logging, keyboard shortcuts, notifications) totaling about 6-8 engineer-weeks of medium-difficulty work, and one structural blocker (session-state tracking) that gates everything UI-facing. This memo catalogs 25+ gaps discovered by file-by-file comparison of the C# implementation against current Rust code.


### PR DESCRIPTION
## Summary

Cutover-1 of the three-PR C# retirement sequence per [`docs/superpowers/specs/2026-05-14-csharp-build-retirement-design.md`](docs/superpowers/specs/2026-05-14-csharp-build-retirement-design.md).

Docs only — no code changes. The C# tree still builds on this commit; the last buildable C# state will be preserved at tag \`legacy/v0.2.6-final\` on this PR's merge commit. Cutover-2 (delete C# source) and cutover-3 (flatten \`codescope-rs/\` to repo root, rename Velopack pack id to \`codescope\`, retag namespace to \`v*\`) follow as separate PRs.

### What changed

- **New** [ADR-0022](docs/DECISIONS.md): Rust port becomes canonical CodeScope; C# build retired.
- **New** [\`docs/MIGRATION-csharp-to-rust.md\`](docs/MIGRATION-csharp-to-rust.md): why + how + what is kept / dropped across the cutover.
- **Update** \`CLAUDE.md\`: tech-stack non-negotiables now Rust + GPUI; mirror-C# workflow rule removed; \`CODESCOPE_DEV\` side-by-side block updated to \`cargo run\`.
- **Update** \`docs/HANDOFF.md\`: top banner replaces the "mirror C# 1:1" house rule with the Rust-canonical declaration and links to ADR-0022 and the migration doc.
- **Update** \`README.md\`: install section now lists per-platform Velopack assets (Windows / macOS arm64+x64 / Linux x64); build instructions are \`cargo\`; repo-layout block reflects \`codescope-rs/\`.
- **Update** \`docs/PARITY-AUDIT.md\`: closed-stamped historical at the top — the audit is no longer active.
- **Update** \`docs/ARCHITECTURE.md\`: rewritten from the Rust perspective (crates, services, threading, config schema).

## Test plan

- [x] \`grep -r "src/CodeScope" docs/ CLAUDE.md README.md\` — only historical references remain (migration doc, README "Historical note", HANDOFF banner)
- [x] \`grep -r "dotnet " docs/ CLAUDE.md README.md\` — no active build instructions remain
- [ ] Reviewer: verify ADR-0022 cross-links (ADR-0019, ADR-0020, ADR-0021) resolve in the rendered MD
- [ ] Reviewer: verify the Velopack asset table in README matches what \`rs-v0.3.0-rc.5\` actually published
- [ ] After merge: tag \`legacy/v0.2.6-final\` on the merge commit and push the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)