### PR TITLE
chore: bump version to 0.3.0-rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.5"
+version = "0.3.0-rc.7"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["vendor/gpui-terminal"]
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.5"
+version = "0.3.0-rc.7"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
## Summary

First release-version bump after the C# build retirement. Pushes the workspace to \`0.3.0-rc.7\` so the next tag push (\`v0.3.0-rc.7\`) cuts the first release under the new \`codescope\` Velopack pack id.

Skips rc.6 to keep the version number obviously post-cutover — rc.5 was the last pre-cutover release; rc.6 was a build number that never shipped.

### Release plan (after merge)

1. \`git tag v0.3.0-rc.7\`
2. \`git push origin v0.3.0-rc.7\`
3. Watch \`.github/workflows/release.yml\` in Actions; it will publish:
   - \`codescope-win-Setup.exe\` + \`releases.win.json\` + nupkg
   - \`codescope-osx-arm64.app.zip\` + \`releases.osx-arm64.json\` + nupkg
   - \`codescope-osx-x64.app.zip\` + \`releases.osx-x64.json\` + nupkg
   - \`codescope-linux-x64.AppImage\` + \`releases.linux-x64.json\` + nupkg
4. User-side: uninstall the current \`codescope-rs\` install, install the new \`codescope-*-Setup.exe\`. \`%APPDATA%\CodeScope\projects.json\` carries across unchanged.

## Test plan

- [x] \`cargo check --workspace\` clean — Cargo.lock updated.
- [ ] Reviewer: verify only \`Cargo.toml\` + \`Cargo.lock\` change.
- [ ] Post-merge: tag push triggers the workflow and all four platform feeds publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)