### PR TITLE
fix(sidebar): keep busy halo centered on dot when sidebar is narrow

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -2990,6 +2990,7 @@ impl Render for Sidebar {
                             .bg(dot_color);
                         let container = div()
                             .relative()
+                            .flex_shrink_0()
                             .w(px(14.0))
                             .h(px(14.0))
                             .flex()


### PR DESCRIPTION
## Summary

- Busy worktree rows draw a 6 px dot and a 12 px halo inside a 14×14 container. The halo is `absolute()` at `top(1) left(1)` while the dot is centered via `items_center/justify_center`.
- The container had no explicit `flex_shrink_0()`, so a narrow sidebar would let the flex row shrink it. The dot followed the new center; the absolutely-positioned halo did not. Result: visible drift between dot and halo (screenshot in conversation).
- Fix: add `.flex_shrink_0()` to the dot+halo container so it stays a hard 14×14 regardless of row width.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 634/634 pass
- [ ] Manual: drag sidebar to its minimum width with a busy worktree visible; halo stays centered on the dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)