### PR TITLE
chore: bump version to 0.3.0-rc.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.7"
+version = "0.3.0-rc.8"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["vendor/gpui-terminal"]
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.7"
+version = "0.3.0-rc.8"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` from `0.3.0-rc.7` to `0.3.0-rc.8`.
- First release after PR #213 (sidebar busy halo centering fix). Validates the end-to-end auto-update flow from an installed rc.7 under the new `codescope` Velopack pack id.

## Test plan

- [x] `cargo build --workspace` clean
- [ ] After merge: push `v0.3.0-rc.8` tag → release workflow publishes Velopack bundles for all four platforms
- [ ] Manual: installed rc.7 detects rc.8 and auto-applies the delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)