### PR TITLE
fix(rs): force re-render on window bounds change

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -976,14 +976,35 @@ impl AppShell {
         // Persist live window geometry. The observer fires for every
         // resize / move tick; we just stash the latest state and let
         // the background debounce task hit disk once the dust settles.
+        //
+        // Also force a re-render on every bounds change. gpui's
+        // `Window::bounds_changed` calls `self.refresh()` itself, but
+        // `refresh()` early-exits when `not_drawing()` is false (gpui-
+        // 0.2.2 `window.rs:1367`) — i.e. if the bounds change is
+        // delivered while a paint is in flight, the dirty flag gets
+        // dropped. On Windows under release-build timing, `WM_SIZE`
+        // for the maximize ↔ restore transition tends to arrive
+        // mid-frame, so no follow-up frame is scheduled and the
+        // entity tree keeps the pre-transition layout bounds for the
+        // terminal panes — even though `viewport_size` itself is up
+        // to date. Symptom: terminals stay at the pre-maximize size
+        // until something else (tab swap, output, focus change)
+        // marks the tree dirty. `cx.notify()` on the AppShell entity
+        // queues a re-render outside the active draw, which cascades
+        // through `render_group` → tab content → `TerminalView`'s
+        // canvas prepaint, picking up the new bounds and triggering
+        // `maybe_resize`. Harmless when `Window::refresh()` already
+        // did its job — the entity dirty marker collapses with the
+        // window's own dirty flag for the same frame.
         cx.observe_window_bounds(window, {
             let pending = pending_window_save.clone();
-            move |_, window, _| {
+            move |_, window, cx| {
                 let state = window_state_from_window(window);
                 *pending.lock() = Some(PendingWindowSave {
                     state,
                     set_at: Instant::now(),
                 });
+                cx.notify();
             }
         })
         .detach();


### PR DESCRIPTION
## Summary

User-reported (Dutch): \"er is toch echt een repaint van de terminals probleem als hij van een gerestorede state naar maximized gaat. pas als ik dan van tabje wissel dan repaint hij de terminals weer en neemt ie alle ruimte in die hij kan hebben.\" — restore → maximize doesn't repaint the terminal panes to fill the new space; only a tab swap does. Could not reproduce in \`cargo run\` debug.

## Root cause hypothesis

gpui's \`Window::bounds_changed\` calls \`self.refresh()\`, but \`refresh()\` early-exits when \`not_drawing()\` is false (gpui-0.2.2 \`window.rs:1367\`):

\`\`\`rust
pub fn refresh(&mut self) {
    if self.invalidator.not_drawing() {
        self.refreshing = true;
        self.invalidator.set_dirty(true);
    }
}
\`\`\`

When \`WM_SIZE\` for the maximize ↔ restore transition arrives mid-frame on Windows under release-build timing — which is typical for our custom-titlebar path (\`SC_MAXIMIZE\` posted back through \`DefWindowProc\`, resize lands while the current paint is still in flight) — the dirty flag gets dropped. \`viewport_size\` is updated correctly, but the entity tree keeps the pre-transition layout bounds for the terminal panes. Symptom: terminals stay at the pre-maximize size until something else marks the tree dirty.

Tab swap calls \`cx.notify()\` on AppShell, which forces a fresh render → \`render_group\` re-runs → terminal pane gets new bounds → \`TerminalView\`'s canvas prepaint detects the dimension change → \`maybe_resize\` → debounce → \`apply_resize\`. That's why tab swap fixes it.

## Fix

Extend the existing \`observe_window_bounds\` callback in \`AppShell::new\` (already there for state-save debouncing) to call \`cx.notify()\`. The entity dirty mark queues a re-render outside the active draw, so \`Window::refresh()\`'s \`not_drawing\` guard doesn't matter.

## Caveat

This is hypothesis-driven from static analysis. The bug only reproduces in release builds (user could not trigger it in \`cargo run\` debug — matches the second-pass note in the existing investigation memory). Live confirmation has to wait for rc.9 to ship and reach the user's installed copy.

The change is defensively safe either way — calling \`cx.notify()\` in a bounds observer is the documented gpui pattern for \"ensure the tree picks up a viewport change\" and has no cost when the window was already going to redraw (dirty markers collapse for the same frame).

## Test plan

- [x] \`cargo build --workspace\` clean.
- [x] \`cargo test --workspace\` — 633 tests, all pass.
- [x] \`cargo clippy --workspace --all-targets\` — no new warnings on changed file.
- [ ] **Live release-build validation** — once rc.9 is installed, perform restore → maximize on a window with active terminals and confirm they fill the new space without needing a tab swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)