### PR TITLE
chore: bump version to 0.3.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.8"
+version = "0.3.0-rc.9"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.8"
+version = "0.3.0-rc.9"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
## Summary

Cuts rc.9 to ship the terminal-repaint follow-up landed in #219.

rc.7/rc.8 had `cx.notify()` in `observe_window_bounds` (PR #218). That race-shares with `Window::refresh()` — `WindowInvalidator::invalidate_view` only flips `dirty = true` when `draw_phase == None`, so a bounds change delivered mid-frame on Windows release timing left the entity tree stale, and terminal panes stayed at the pre-maximize size until a tab swap.

rc.9 pairs the notify with `window.on_next_frame`, which guarantees a fresh `draw_phase == None` callback context and reliably schedules the next frame.

## Test plan

- [x] `cargo build --workspace` clean.
- [x] Live release-build validation on the same gestures that reproduce the bug on rc.7/rc.8 — confirmed by user in #219.
- [ ] Tag + release, smoke auto-update from installed rc.8 → rc.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)