### PR TITLE
chore(rs): log window-bounds + maximize transitions to window-diag.log

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -969,7 +969,9 @@ impl AppShell {
         // debounce task hit disk once the dust settles.
         cx.observe_window_bounds(window, {
             let pending = pending_window_save.clone();
+            let diag_paths = paths.clone();
             move |_, window, cx| {
+                append_window_diag(&diag_paths, "bounds_changed", window);
                 let state = window_state_from_window(window);
                 *pending.lock() = Some(PendingWindowSave {
                     state,
@@ -5960,8 +5962,13 @@ impl Render for AppShell {
         #[cfg(target_os = "windows")]
         let maximize_btn = maximize_btn.on_mouse_down(
             MouseButton::Left,
-            cx.listener(|_, _, window, cx| {
-                window.defer(cx, |window, _| crate::win32_titlebar::toggle_maximize(window));
+            cx.listener(|this, _, window, cx| {
+                append_window_diag(&this.paths, "maximize_clicked_pre", window);
+                let diag_paths = this.paths.clone();
+                window.defer(cx, move |window, _| {
+                    crate::win32_titlebar::toggle_maximize(window);
+                    append_window_diag(&diag_paths, "maximize_clicked_post", window);
+                });
             }),
         );
         #[cfg(target_os = "windows")]
@@ -7448,6 +7455,64 @@ impl AppShell {
 }
 
 // ─── Window-state extraction ────────────────────────────────────────
+
+/// Append one diagnostic line to `state_dir/window-diag.log`. Used to
+/// chase an intermittent Windows bug where the maximised window ends
+/// up positioned ~75 px below the monitor's work-area top (and runs
+/// off the bottom of the screen). The bug is live-race-only — it
+/// doesn't reproduce by loading a saved `window.json` — so the only
+/// way to catch it is to keep a continuous tape of bounds-observer
+/// ticks + caption-button clicks. The log line embeds a full Win32
+/// snapshot from [`crate::win32_titlebar::diag_snapshot`] on Windows
+/// so we can correlate `WindowBounds` (what gpui thinks) with the
+/// actual HWND rect, `WINDOWPLACEMENT`, and monitor work-area.
+///
+/// I/O errors are silently dropped — this is best-effort
+/// instrumentation, not load-bearing state. Caller is the bounds
+/// observer (fires on every resize tick) and the min/max/close
+/// caption-button click handlers.
+fn append_window_diag(paths: &AppPaths, event: &str, window: &Window) {
+    use std::fs::OpenOptions;
+    use std::io::Write as _;
+    let bounds = window.window_bounds();
+    let viewport = window.viewport_size();
+    let scale = window.scale_factor();
+    let is_max = window.is_maximized();
+    let bounds_kind = match bounds {
+        WindowBounds::Windowed(_) => "Windowed",
+        WindowBounds::Maximized(_) => "Maximized",
+        WindowBounds::Fullscreen(_) => "Fullscreen",
+    };
+    let (bx, by, bw, bh) = match bounds {
+        WindowBounds::Windowed(b) | WindowBounds::Maximized(b) | WindowBounds::Fullscreen(b) => (
+            f32::from(b.origin.x),
+            f32::from(b.origin.y),
+            f32::from(b.size.width),
+            f32::from(b.size.height),
+        ),
+    };
+    let vp_w = f32::from(viewport.width);
+    let vp_h = f32::from(viewport.height);
+
+    #[cfg(target_os = "windows")]
+    let win32 = crate::win32_titlebar::diag_snapshot(window)
+        .unwrap_or_else(|| "win32=unavailable".to_string());
+    #[cfg(not(target_os = "windows"))]
+    let win32 = "win32=n/a".to_string();
+
+    let ts = now_iso8601();
+    let line = format!(
+        "{ts} event={event} bounds={bounds_kind}(({bx:.1},{by:.1},{bw:.1},{bh:.1})) \
+         viewport=({vp_w:.1},{vp_h:.1}) scale={scale} is_maximized={is_max} {win32}\n"
+    );
+
+    let path = paths.state_dir.join("window-diag.log");
+    let _ = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .and_then(|mut f| f.write_all(line.as_bytes()));
+}
 
 /// Snapshot the platform window into the on-disk `WindowState`. We
 /// always store the *restore* bounds so unmaximising lands at a

--- a/src/app.rs
+++ b/src/app.rs
@@ -7456,6 +7456,25 @@ impl AppShell {
 
 // ─── Window-state extraction ────────────────────────────────────────
 
+/// Process-global handle to `state_dir/window-diag.log`, kept open
+/// across calls so each [`append_window_diag`] tick is a single
+/// `WriteFile` syscall instead of `CreateFile` → `WriteFile` →
+/// `CloseHandle`. Matters during interactive drag-resize where the
+/// observer fires at frame rate: on Windows with antivirus filter
+/// drivers a `CreateFile` round-trip is routinely 1-5 ms, enough to
+/// introduce visible jank *and* alter the timing of the maximise-race
+/// we're trying to catch — diagnostic I/O is supposed to observe the
+/// system, not perturb it. (Copilot review on PR #222.)
+///
+/// `parking_lot::Mutex` because contention is non-existent (only the
+/// UI thread writes) and the std `Mutex` poison-on-panic semantics
+/// add noise to a best-effort logger. `Option<File>` because the
+/// open may legitimately fail (state_dir not writable, disk full,
+/// etc.) and we want to retry on the next tick rather than caching
+/// the failure forever.
+static WINDOW_DIAG_FILE: std::sync::OnceLock<parking_lot::Mutex<Option<std::fs::File>>> =
+    std::sync::OnceLock::new();
+
 /// Append one diagnostic line to `state_dir/window-diag.log`. Used to
 /// chase an intermittent Windows bug where the maximised window ends
 /// up positioned ~75 px below the monitor's work-area top (and runs
@@ -7467,12 +7486,15 @@ impl AppShell {
 /// so we can correlate `WindowBounds` (what gpui thinks) with the
 /// actual HWND rect, `WINDOWPLACEMENT`, and monitor work-area.
 ///
+/// Holds a process-global file handle ([`WINDOW_DIAG_FILE`]) to avoid
+/// re-opening the file on every tick — see that static's doc for the
+/// "diagnostic I/O must not perturb the race" rationale.
+///
 /// I/O errors are silently dropped — this is best-effort
-/// instrumentation, not load-bearing state. Caller is the bounds
-/// observer (fires on every resize tick) and the min/max/close
-/// caption-button click handlers.
+/// instrumentation, not load-bearing state. Callers are the bounds
+/// observer (fires on every resize tick) and the maximize
+/// caption-button click handler.
 fn append_window_diag(paths: &AppPaths, event: &str, window: &Window) {
-    use std::fs::OpenOptions;
     use std::io::Write as _;
     let bounds = window.window_bounds();
     let viewport = window.viewport_size();
@@ -7494,11 +7516,22 @@ fn append_window_diag(paths: &AppPaths, event: &str, window: &Window) {
     let vp_w = f32::from(viewport.width);
     let vp_h = f32::from(viewport.height);
 
+    // Win32 fragment is emitted with the same key set on every
+    // branch (success / open-call failure / non-Windows) so a grep
+    // for `hwnd_rect=` or `rcWork=` matches every row, not just the
+    // success path. The earlier `win32=unavailable` / `win32=n/a`
+    // placeholders had asymmetric keys and broke field-level greps
+    // — Copilot review on PR #222.
+    const WIN32_MISSING: &str =
+        "hwnd_rect=? zoomed=? showCmd=? rcNormal=? ptMaxPos=? flags=? rcMonitor=? rcWork=? dpi=?";
     #[cfg(target_os = "windows")]
     let win32 = crate::win32_titlebar::diag_snapshot(window)
-        .unwrap_or_else(|| "win32=unavailable".to_string());
+        .unwrap_or_else(|| WIN32_MISSING.to_string());
     #[cfg(not(target_os = "windows"))]
-    let win32 = "win32=n/a".to_string();
+    let win32 = {
+        let _ = window;
+        WIN32_MISSING.to_string()
+    };
 
     let ts = now_iso8601();
     let line = format!(
@@ -7506,12 +7539,18 @@ fn append_window_diag(paths: &AppPaths, event: &str, window: &Window) {
          viewport=({vp_w:.1},{vp_h:.1}) scale={scale} is_maximized={is_max} {win32}\n"
     );
 
-    let path = paths.state_dir.join("window-diag.log");
-    let _ = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .and_then(|mut f| f.write_all(line.as_bytes()));
+    let cell = WINDOW_DIAG_FILE.get_or_init(|| parking_lot::Mutex::new(None));
+    let mut slot = cell.lock();
+    if slot.is_none() {
+        let path = paths.state_dir.join("window-diag.log");
+        match std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+            Ok(f) => *slot = Some(f),
+            Err(_) => return,
+        }
+    }
+    if let Some(file) = slot.as_mut() {
+        let _ = file.write_all(line.as_bytes());
+    }
 }
 
 /// Snapshot the platform window into the on-disk `WindowState`. We

--- a/src/win32_titlebar.rs
+++ b/src/win32_titlebar.rs
@@ -23,6 +23,9 @@
 use gpui::Window;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use windows::Win32::Foundation::{HWND, LPARAM, POINT, RECT, WPARAM};
+use windows::Win32::Graphics::Gdi::{
+    GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromWindow,
+};
 use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx, CoUninitialize};
 use windows::Win32::UI::Input::KeyboardAndMouse::ReleaseCapture;
 use windows::Win32::UI::Shell::ShellExecuteW;
@@ -213,6 +216,71 @@ pub fn minimize(window: &Window) {
             WPARAM(SC_MINIMIZE as usize),
             LPARAM(0),
         );
+    }
+}
+
+/// One-line snapshot of every Win32 piece of state that determines
+/// where a maximised window ends up — emitted from the bounds-change
+/// observer + caption-button click handlers so we can grep
+/// `window-diag.log` for the moment the geometry went bad.
+///
+/// Returns `None` only when the HWND can't be resolved (window has
+/// already been dropped); every other field is best-effort and falls
+/// back to a `?` placeholder if the underlying Win32 call fails so the
+/// log line still parses cleanly.
+///
+/// Format is intentionally one line, key=value pairs separated by
+/// spaces, so it can be piped through `grep`/`awk` and copied into a
+/// PR/issue body without losing structure.
+pub fn diag_snapshot(window: &Window) -> Option<String> {
+    let hwnd = hwnd(window)?;
+    unsafe {
+        let mut rect = RECT::default();
+        let win_rect = GetWindowRect(hwnd, &mut rect)
+            .map(|_| format!("({},{},{},{})", rect.left, rect.top, rect.right, rect.bottom))
+            .unwrap_or_else(|_| "?".to_string());
+
+        let zoomed = IsZoomed(hwnd).as_bool();
+
+        let mut placement = WINDOWPLACEMENT {
+            length: std::mem::size_of::<WINDOWPLACEMENT>() as u32,
+            ..Default::default()
+        };
+        let placement_str = if GetWindowPlacement(hwnd, &mut placement).is_ok() {
+            let n = placement.rcNormalPosition;
+            format!(
+                "showCmd={} rcNormal=({},{},{},{}) ptMaxPos=({},{}) flags={:#x}",
+                placement.showCmd,
+                n.left, n.top, n.right, n.bottom,
+                placement.ptMaxPosition.x, placement.ptMaxPosition.y,
+                placement.flags.0,
+            )
+        } else {
+            "showCmd=? rcNormal=? ptMaxPos=? flags=?".to_string()
+        };
+
+        let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        let mut mi = MONITORINFO {
+            cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+            ..Default::default()
+        };
+        let monitor_str = if GetMonitorInfoW(monitor, &mut mi).as_bool() {
+            let m = mi.rcMonitor;
+            let w = mi.rcWork;
+            format!(
+                "rcMonitor=({},{},{},{}) rcWork=({},{},{},{})",
+                m.left, m.top, m.right, m.bottom,
+                w.left, w.top, w.right, w.bottom,
+            )
+        } else {
+            "rcMonitor=? rcWork=?".to_string()
+        };
+
+        let dpi = GetDpiForWindow(hwnd);
+
+        Some(format!(
+            "hwnd_rect={win_rect} zoomed={zoomed} {placement_str} {monitor_str} dpi={dpi}"
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary

- Diagnose an intermittent Windows-only bug where clicking maximize on the custom-chrome window occasionally leaves the window ~75 px below the monitor's work-area top, with the bottom running off-screen. Reported live by the user; couldn't be reproduced on demand and a `window.json` replay into the dev store didn't reproduce either — so it's a live race during the transition, not stale saved state.
- Add a continuous, lightweight tape: every bounds-observer tick and every maximize click writes one line to `state_dir/window-diag.log` with the `WindowBounds` variant, viewport, scale, `is_maximized`, plus the full Win32 snapshot (`GetWindowRect`, `GetWindowPlacement` showCmd/rcNormalPosition/ptMaxPosition/flags, `MonitorFromWindow`+`MONITORINFO` rcMonitor/rcWork, `GetDpiForWindow`). Next time the bug appears we can grep for the moment HWND-rect diverges from the monitor work-area.
- Cross-platform: non-Windows fills the Win32 slot with `win32=n/a`. I/O errors are silently dropped — best-effort instrumentation, not load-bearing state. No log rotation yet; fine for the few days needed to catch the bug.

## Test plan

- [ ] `cargo check --bin codescope-rs` clean (done locally)
- [ ] `cargo clippy --workspace --all-targets` clean on changed surface (done locally)
- [ ] After build, click maximize a few times → `%LOCALAPPDATA%\CodeScope\window-diag.log` (prod) or `%LOCALAPPDATA%\CodeScope.Dev\window-diag.log` (dev) contains lines like `<iso8601> event=maximize_clicked_pre bounds=Windowed((…)) … hwnd_rect=(…) showCmd=… rcMonitor=… rcWork=… dpi=…`
- [ ] When the original positioning bug recurs, the log line for the divergent tick will show `hwnd_rect.top != rcWork.top` — that's the smoking gun the static analysis missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)