### PR TITLE
fix(rs): sync soft-close to sidebar + double-click reopens last closed session

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2605,7 +2605,17 @@ impl AppShell {
             Ok(_pruned) => {
                 if let Err(err) = self.projects.save(&self.paths) {
                     eprintln!("warning: failed to persist session soft-close: {err:#}");
-                    return;
+                    // Fall through to the sidebar mirror anyway —
+                    // the in-memory `closed_at` stamp is correct,
+                    // only the disk write failed. Letting the
+                    // sidebar see the new state keeps both snapshots
+                    // consistent until the next save retry; the
+                    // alternative (early-return) reintroduced the
+                    // exact "closed row doesn't appear in history
+                    // until a later sidebar mutation" symptom this
+                    // helper is supposed to prevent. `reopen_session`
+                    // uses the same pattern. (Copilot review on
+                    // PR #223.)
                 }
                 let projects_for_sidebar = self.projects.clone();
                 self.sidebar.update(cx, |sidebar, cx| {

--- a/src/app.rs
+++ b/src/app.rs
@@ -2609,13 +2609,13 @@ impl AppShell {
                     // the in-memory `closed_at` stamp is correct,
                     // only the disk write failed. Letting the
                     // sidebar see the new state keeps both snapshots
-                    // consistent until the next save retry; the
-                    // alternative (early-return) reintroduced the
-                    // exact "closed row doesn't appear in history
-                    // until a later sidebar mutation" symptom this
-                    // helper is supposed to prevent. `reopen_session`
-                    // uses the same pattern. (Copilot review on
-                    // PR #223.)
+                    // consistent until the next save retry; an early
+                    // return here would leave the sidebar's copy
+                    // stale until some unrelated mutation refreshed
+                    // it, which is the exact "closed row doesn't
+                    // show in history" symptom this helper is
+                    // supposed to prevent. `reopen_session` uses
+                    // the same pattern.
                 }
                 let projects_for_sidebar = self.projects.clone();
                 self.sidebar.update(cx, |sidebar, cx| {
@@ -6766,14 +6766,25 @@ impl AppShell {
                 // sidebar's OpenSession event hits.
                 self.open_or_focus_session(working_directory, title, None, false, window, cx);
             }
-            PaletteActionKind::Agent { command, display_name, .. } => {
+            PaletteActionKind::Agent { id, command, display_name } => {
                 // Start a fresh tab running the agent. `auto_type` is
                 // the command name; the shell will resolve it via PATH
                 // (claude / codex / opencode / etc — same UX as the
-                // sidebar's "New Claude session" rows).
+                // sidebar's "New Claude session" rows). `id` is the
+                // profile id (already on the palette action variant)
+                // and gets forwarded directly to the spawn so the
+                // persisted `Session.agent_id` is the user's actual
+                // pick even for custom profiles where `id != command`.
                 let cwd = self.active_project_path(cx).map(std::path::PathBuf::from);
                 let title: SharedString = display_name.clone().into();
-                self.spawn_palette_agent_tab(cwd, title, command.into(), window, cx);
+                self.spawn_palette_agent_tab(
+                    cwd,
+                    title,
+                    id.clone().into(),
+                    command.into(),
+                    window,
+                    cx,
+                );
             }
             PaletteActionKind::Theme { id, display_name } => {
                 // Live-apply: rewrite settings.theme, persist, and
@@ -7008,28 +7019,30 @@ impl AppShell {
     /// Spawn a new tab pinned to a working directory and auto-type a
     /// command into it — used by the palette's Agent action. Wrapped
     /// to keep the dispatch arm thin.
+    ///
+    /// `agent_id` is the profile id the palette dispatcher pulled
+    /// straight off `PaletteActionKind::Agent.id`. Threading it
+    /// through here (instead of re-deriving from `auto_type` via
+    /// `agent_id_from_auto_type`) keeps custom profiles where
+    /// `id != command` round-trippable — without this the spawn
+    /// would persist `agent_id: None` for any user-defined agent
+    /// whose command isn't one of the built-in names, and `reopen_
+    /// session` would fall back to the default agent instead of
+    /// resuming the row the user actually picked.
     fn spawn_palette_agent_tab(
         &mut self,
         working_directory: Option<std::path::PathBuf>,
         title: SharedString,
+        agent_id: SharedString,
         auto_type: SharedString,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Palette agent action spawns explicitly through this path
-        // with a known agent. The caller-side palette wiring doesn't
-        // currently surface the profile id alongside the auto_type
-        // string (it builds the auto_type from the agent_id at
-        // dispatch time) — re-derive via `agent_id_from_auto_type`
-        // so the persisted row matches the agent the user actually
-        // picked.
-        let persist_id = codescope_core::agent_id_from_auto_type(Some(auto_type.as_ref()))
-            .map(|aid| SharedString::from(aid.as_str()));
         self.spawn_tab_in(
             working_directory,
             Some(title),
             Some(auto_type),
-            persist_id,
+            Some(agent_id),
             None,
             window,
             cx,

--- a/src/app.rs
+++ b/src/app.rs
@@ -814,16 +814,25 @@ impl AppShell {
                     auto_type,
                     force_new,
                 } => {
-                    // Focus-or-open by default: walk every group's
-                    // tabs for one whose `working_directory` matches
-                    // and activate it. Only fall through to a fresh
-                    // spawn when nothing matches *or* the caller
-                    // explicitly asked for `force_new` (the
-                    // "New session" / "New Claude session" menu
-                    // rows). This is what the user means by
-                    // "clicking a worktree shouldn't pile up new
-                    // sessions every time".
+                    // Three-tier "open session" resolution, mirroring
+                    // the C# `MainViewModel.OnTreeDoubleClick` flow:
+                    //
+                    //   1. An open tab pinned to this `wd` already
+                    //      exists → just focus it.
+                    //   2. No open tab, but the worktree has a
+                    //      soft-closed session in history → reopen
+                    //      the most-recently-closed one. This is the
+                    //      user expectation for "double-click the
+                    //      same branch again" — pick up where you
+                    //      left off, don't keep stamping fresh
+                    //      free-floating sessions.
+                    //   3. Otherwise → spawn a brand new session
+                    //      (the same path `force_new` takes
+                    //      unconditionally for explicit "New
+                    //      session" / "New <agent> session" menu
+                    //      rows).
                     if !*force_new {
+                        // Tier 1: focus an already-open tab.
                         let mut focus_target: Option<(usize, usize)> = None;
                         for (g_idx, group) in this.groups.iter().enumerate() {
                             for (t_idx, tab) in group.tabs.iter().enumerate() {
@@ -840,7 +849,48 @@ impl AppShell {
                             this.activate_tab(g_idx, t_idx, window, cx);
                             return;
                         }
+
+                        // Tier 2: reopen the most-recent closed
+                        // session for this worktree. Path matching
+                        // goes through `paths_match` so a `\\`-vs-`/`
+                        // mismatch between the spawn event and the
+                        // persisted `worktree_path` doesn't drop the
+                        // history hit (same reason
+                        // `locate_project_for_path` uses it). Sort
+                        // by `closed_at` desc — newest first —
+                        // mirroring the sidebar's history disclosure
+                        // ordering so a double-click and the visible
+                        // top-of-history row stay in lockstep. ISO-
+                        // 8601 sorts lexicographically the same way
+                        // it sorts chronologically, so a plain str
+                        // cmp is enough.
+                        let wd_str = working_directory.to_string_lossy();
+                        let most_recent_closed = this
+                            .projects
+                            .projects
+                            .iter()
+                            .flat_map(|p| p.sessions.iter())
+                            .filter(|s| s.closed_at.is_some())
+                            .filter(|s| {
+                                codescope_core::path_canon::paths_match(
+                                    &s.worktree_path,
+                                    &wd_str,
+                                )
+                            })
+                            .max_by(|a, b| {
+                                a.closed_at.as_deref().cmp(&b.closed_at.as_deref())
+                            })
+                            .map(|s| s.id.clone());
+                        if let Some(session_id) = most_recent_closed {
+                            this.reopen_session(session_id, window, cx);
+                            return;
+                        }
                     }
+
+                    // Tier 3: spawn a fresh session. Reached when
+                    // `force_new` was set explicitly OR when there
+                    // is neither an open tab nor a closed session
+                    // for this worktree.
                     this.spawn_tab_in(
                         Some(working_directory.clone()),
                         Some(title.clone()),
@@ -2491,7 +2541,16 @@ impl AppShell {
     /// `projects.json` (path matched no project at spawn time) is a
     /// silent no-op rather than an error. Reload-then-mutate-then-save
     /// keeps us in sync with concurrent sidebar writes.
-    fn soft_close_session(&mut self, session_id: &str) {
+    ///
+    /// After a successful close we push the freshly-mutated
+    /// `ProjectsConfig` into the sidebar entity — the sidebar keeps
+    /// its own copy of `projects` and builds the per-worktree
+    /// closed-session disclosure off it at render time, so without
+    /// this push the new `closed_at` stamp would only become visible
+    /// after the next sidebar-side mutation refreshed the snapshot.
+    /// Mirrors the same `replace_projects` + `cx.notify()` dance
+    /// `reopen_session` does for the reverse transition.
+    fn soft_close_session(&mut self, session_id: &str, cx: &mut Context<Self>) {
         match ProjectsConfig::load(&self.paths) {
             Ok(cfg) => {
                 self.projects = cfg;
@@ -2504,7 +2563,13 @@ impl AppShell {
             Ok(_pruned) => {
                 if let Err(err) = self.projects.save(&self.paths) {
                     eprintln!("warning: failed to persist session soft-close: {err:#}");
+                    return;
                 }
+                let projects_for_sidebar = self.projects.clone();
+                self.sidebar.update(cx, |sidebar, cx| {
+                    sidebar.replace_projects(projects_for_sidebar);
+                    cx.notify();
+                });
             }
             Err(_) => {
                 // Free-floating session (no project context at spawn
@@ -3215,7 +3280,7 @@ impl AppShell {
         // failure logs and proceeds; the in-memory tab state is the
         // source of truth for what's on screen.
         if !codescope_session_id.is_empty() {
-            self.soft_close_session(&codescope_session_id);
+            self.soft_close_session(&codescope_session_id, cx);
         }
         let Some(group) = self.groups.get_mut(group_idx) else { return };
         if tab_idx >= group.tabs.len() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -812,6 +812,7 @@ impl AppShell {
                     working_directory,
                     title,
                     auto_type,
+                    agent_id,
                     force_new,
                 } => {
                     // Three-tier "open session" resolution, mirroring
@@ -890,11 +891,36 @@ impl AppShell {
                     // Tier 3: spawn a fresh session. Reached when
                     // `force_new` was set explicitly OR when there
                     // is neither an open tab nor a closed session
-                    // for this worktree.
+                    // for this worktree. The `agent_id` from the
+                    // event is denormalised alongside `auto_type`
+                    // (same `AgentProfile`) so the persisted Session
+                    // row can record which agent backed this tab —
+                    // without that stamp `reopen_session` would
+                    // later see `agent_id: None` and fall back to a
+                    // plain shell.
+                    //
+                    // "Open session" / generic worktree click emit
+                    // both fields as `None` (the emitter doesn't
+                    // know yet whether the spawn will actually
+                    // happen — focus-or-open might short-circuit it
+                    // away). For those we resolve the default agent
+                    // *here*, at the moment we know a fresh spawn
+                    // is happening, so the new row still gets a
+                    // useful `agent_id`.
+                    let (effective_agent_id, effective_auto_type) =
+                        match (agent_id.clone(), auto_type.clone()) {
+                            (Some(id), at) => (Some(id), at),
+                            (None, Some(at)) => (None, Some(at)),
+                            (None, None) => match default_agent_launch_for(&this.settings) {
+                                Some((id, at)) => (Some(id), at),
+                                None => (None, None),
+                            },
+                        };
                     this.spawn_tab_in(
                         Some(working_directory.clone()),
                         Some(title.clone()),
-                        auto_type.clone(),
+                        effective_auto_type,
+                        effective_agent_id,
                         None,
                         window,
                         cx,
@@ -2269,6 +2295,14 @@ impl AppShell {
                 Some(path),
                 Some(title),
                 auto,
+                // Rehydrate path: the persisted row already carries
+                // the `agent_id` we want (or `None` for legacy
+                // pre-fix rows / plain-shell sessions), and
+                // `restore_session_id = Some` short-circuits the
+                // `allocate_session_id` persistence branch entirely
+                // — projects.json is the source of truth, this
+                // arg is ignored once `restore_session_id` is set.
+                entry.agent_id.clone().map(SharedString::from),
                 Some(entry.session_id.clone()),
                 window,
                 cx,
@@ -2466,6 +2500,7 @@ impl AppShell {
     fn allocate_session_id(
         &mut self,
         working_directory: Option<&std::path::Path>,
+        persist_agent_id: Option<String>,
         restore_session_id: Option<String>,
     ) -> String {
         if let Some(id) = restore_session_id {
@@ -2498,7 +2533,14 @@ impl AppShell {
             id: new_id.clone(),
             worktree_path: wd.to_string_lossy().into_owned(),
             branch: None,
-            agent_id: None,
+            // Persist the agent the spawn was for so a later
+            // `reopen_session` lookup resolves the right profile —
+            // see the `persist_agent_id` doc on `spawn_tab_in` for
+            // the full rationale. `None` ends up as `null` in
+            // projects.json and lets reopen fall back to the
+            // current `Settings.default_agent` (handled in
+            // `reopen_session`).
+            agent_id: persist_agent_id,
             display_name: None,
             worktree_id,
             last_opened: None,
@@ -2805,8 +2847,22 @@ impl AppShell {
         // fall back to `resume_args` (`pi -c`, `copilot --continue`,
         // bare `claude`). Mirrors C# `SessionManager.CreateAgentSession`
         // resume branch + `JoinResumeByIdArgs`.
-        let auto_type: Option<SharedString> = restored
+        //
+        // Legacy / pre-fix rows persisted before the spawn-side
+        // started stamping `agent_id` (or plain-shell sessions
+        // closed under the old code path) come back with
+        // `restored.agent_id = None`. Falling back to a plain shell
+        // there is what surfaced the user-reported bug "reopen via
+        // worktree double-click hands me a shell instead of
+        // Claude". Resolve the current `Settings.default_agent` as
+        // the rescue value so a legacy row still reopens in the
+        // configured agent. New rows persisted after this PR will
+        // carry their own `agent_id` and never need the fallback.
+        let resolved_agent_id: Option<String> = restored
             .agent_id
+            .clone()
+            .or_else(|| default_agent_launch_for(&self.settings).map(|(id, _)| id.to_string()));
+        let auto_type: Option<SharedString> = resolved_agent_id
             .as_deref()
             .and_then(|id| self.agent_registry.get_by_id(id))
             .and_then(|profile| {
@@ -2821,6 +2877,7 @@ impl AppShell {
             Some(working_directory),
             Some(title),
             auto_type,
+            resolved_agent_id.map(SharedString::from),
             Some(restored.id),
             window,
             cx,
@@ -3002,21 +3059,6 @@ impl AppShell {
         &self.settings
     }
 
-    /// Resolve the default agent's auto-type command string from
-    /// `Settings.default_agent` via `AgentRegistry::from_settings`.
-    /// Returns `<command> [<new_session_args>...]` joined by spaces.
-    /// `None` only when the resulting registry has zero agents — in
-    /// practice `from_settings` re-seeds the built-ins when
-    /// `settings.agents` is empty and `get_default()` falls back to
-    /// the first profile, so a typo'd / missing `default_agent` still
-    /// resolves to *some* agent (just not the user's preferred one).
-    /// Mirrors the sidebar's "New session ▸" default-row builder
-    /// (see `render_new_session_row`) so Ctrl+Shift+T lands on the
-    /// same agent the worktree menu's primary click would.
-    pub(crate) fn default_agent_auto_type(&self) -> Option<SharedString> {
-        default_agent_auto_type_for(&self.settings)
-    }
-
     /// Open a fresh shell session and append it as a new tab. The new
     /// tab becomes the active one and the terminal grabs focus.
     ///
@@ -3037,12 +3079,15 @@ impl AppShell {
         // working directory to land the agent in — a plain shell
         // fallback keeps the empty / no-project state usable.
         let has_project_context = self.sidebar.read(cx).active_project().is_some();
-        let auto_type = if has_project_context {
-            self.default_agent_auto_type()
+        let (agent_id, auto_type) = if has_project_context {
+            match default_agent_launch_for(&self.settings) {
+                Some((id, at)) => (Some(id), at),
+                None => (None, None),
+            }
         } else {
-            None
+            (None, None)
         };
-        self.spawn_tab_in(None, None, auto_type, None, window, cx);
+        self.spawn_tab_in(None, None, auto_type, agent_id, None, window, cx);
     }
 
     fn spawn_tab_in(
@@ -3050,6 +3095,25 @@ impl AppShell {
         working_directory: Option<std::path::PathBuf>,
         title_override: Option<SharedString>,
         auto_type: Option<SharedString>,
+        // Agent profile id to stamp on the persisted `Session` row.
+        // Threaded through from `SidebarEvent::OpenSession` (or
+        // resolved at the spawn site via
+        // [`default_agent_launch_for`] when the emitter didn't know
+        // yet whether a fresh spawn would happen). `None` is the
+        // correct value for plain-shell spawns; non-`None` lets a
+        // later `reopen_session` rebuild the agent's auto_type by
+        // looking the id up in `AgentRegistry` instead of falling
+        // back to a plain shell because the row was stored with
+        // `agent_id: None`.
+        //
+        // Named `persist_agent_id` (not just `agent_id`) to keep it
+        // out of the way of `Tab.agent_id` — the latter is a runtime
+        // detection value derived from `auto_type` via
+        // `agent_id_from_auto_type`, used for telemetry-bus routing,
+        // and lives on the live `Tab` struct; this one is the
+        // *persisted* identifier that ends up in `projects.json`
+        // and is read back at reopen.
+        persist_agent_id: Option<SharedString>,
         // `Some` on the launch-time rehydrate path so the freshly
         // spawned `Tab` adopts an existing session row rather than
         // appending a new one. `None` on every other call site
@@ -3180,8 +3244,11 @@ impl AppShell {
         // row through `SessionManager::open`. Mirrors C#
         // `MainViewModel.NewSessionAsync` (open path) vs. cold-start
         // session restore.
-        let session_id =
-            self.allocate_session_id(working_directory_for_tab.as_deref(), restore_session_id);
+        let session_id = self.allocate_session_id(
+            working_directory_for_tab.as_deref(),
+            persist_agent_id.as_ref().map(|s| s.to_string()),
+            restore_session_id,
+        );
         let group_idx = self.focused_group;
         let group = &mut self.groups[group_idx];
         // Capture the entity so the fallback `auto_type` job below can
@@ -6907,10 +6974,21 @@ impl AppShell {
                 }
             }
         }
+        // Palette / "open or focus" fresh spawn — resolve the
+        // default agent here so the new row is persisted with the
+        // right id (mirrors the OpenSession handler's Tier 3).
+        let (effective_agent_id, effective_auto_type) = match auto_type.clone() {
+            Some(at) => (None, Some(at)),
+            None => match default_agent_launch_for(&self.settings) {
+                Some((id, at)) => (Some(id), at),
+                None => (None, None),
+            },
+        };
         self.spawn_tab_in(
             Some(working_directory),
             Some(title),
-            auto_type,
+            effective_auto_type,
+            effective_agent_id,
             None,
             window,
             cx,
@@ -6928,7 +7006,24 @@ impl AppShell {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.spawn_tab_in(working_directory, Some(title), Some(auto_type), None, window, cx);
+        // Palette agent action spawns explicitly through this path
+        // with a known agent. The caller-side palette wiring doesn't
+        // currently surface the profile id alongside the auto_type
+        // string (it builds the auto_type from the agent_id at
+        // dispatch time) — re-derive via `agent_id_from_auto_type`
+        // so the persisted row matches the agent the user actually
+        // picked.
+        let persist_id = codescope_core::agent_id_from_auto_type(Some(auto_type.as_ref()))
+            .map(|aid| SharedString::from(aid.as_str()));
+        self.spawn_tab_in(
+            working_directory,
+            Some(title),
+            Some(auto_type),
+            persist_id,
+            None,
+            window,
+            cx,
+        );
     }
 
     /// Active project's working directory, if any. Used by the agent
@@ -7695,31 +7790,32 @@ fn push_non_empty_font_candidate(candidates: &mut Vec<String>, family: &str) {
     }
 }
 
-/// Resolve the default agent's auto-type command string from a
-/// `Settings` snapshot. Pulled out of `AppShell::default_agent_auto_type`
-/// as a free function so it can be unit-tested without a gpui context.
-/// Returns `<command> [<new_session_args>...]` joined by spaces.
+/// Paired `(agent_id, auto_type)` resolver — the agent id half is
+/// what gets persisted on the `Session` row at spawn time so a later
+/// `reopen_session` can resolve the same agent profile back out of
+/// the registry, instead of falling through to a plain shell because
+/// the closed row carries `agent_id: None`. The auto_type half is the
+/// command string the host auto-types into the freshly-spawned pty
+/// to launch the agent inline (same value
+/// `default_agent_auto_type_for` returns on its own — this helper is
+/// the union of the two pieces of information that live on the same
+/// `AgentProfile`).
 ///
-/// `None` in two cases:
-///
-/// 1. `AgentRegistry::from_settings` yields an empty list and
-///    `get_default()` returns `None`. Today this only happens if
-///    `settings.agents` was passed in non-empty but every entry was
-///    filtered out somewhere upstream — `from_settings` re-seeds the
-///    built-in profiles when `settings.agents` is empty, and
-///    `get_default()` falls back to the first profile when no
-///    `is_default` flag is set, so a typo'd / missing `default_agent`
-///    still resolves to *some* agent (just not the user's preferred
-///    one).
-/// 2. The resolved profile has an empty `command`. This is a
-///    defensive fallback in `build_new_session_auto_type` — a
-///    hand-edited `settings.json` with a blank `command` would
-///    otherwise emit a leading-space argv. Returning `None` lets the
-///    caller fall back to a plain shell instead of auto-typing junk.
-fn default_agent_auto_type_for(settings: &Settings) -> Option<SharedString> {
+/// Returns `None` only when the registry has no default agent at all
+/// (empty list and `get_default()` is `None`). Returns
+/// `Some((id, None))` when a default agent exists but its `command`
+/// is empty / whitespace — preserves the id so reopen can name the
+/// profile, but skips auto-typing to avoid feeding a leading-space
+/// argv to the pty (same `Option` semantics
+/// `build_new_session_auto_type` already documents).
+fn default_agent_launch_for(
+    settings: &Settings,
+) -> Option<(SharedString, Option<SharedString>)> {
     let registry = codescope_core::AgentRegistry::from_settings(settings);
     let profile = registry.get_default()?;
-    codescope_core::build_new_session_auto_type(profile).map(SharedString::from)
+    let id: SharedString = profile.id.clone().into();
+    let auto_type = codescope_core::build_new_session_auto_type(profile).map(SharedString::from);
+    Some((id, auto_type))
 }
 
 /// Pure transition classifier for the bell notification — extracted so
@@ -7935,28 +8031,29 @@ mod tests {
         assert_eq!(keystroke_digit_index("", true), None);
     }
 
-    // ─── default_agent_auto_type_for ───────────────────────────────
+    // ─── default_agent_launch_for ──────────────────────────────────
     //
-    // Ctrl+Shift+T / the "+ new tab" button route through this helper
-    // to look up the user's preferred agent CLI from the registry. The
-    // tests below pin the contract `on_key_down` for Ctrl+Shift+T
-    // relies on: a vanilla Settings yields the Claude command; flipping
-    // `default_agent` picks the matching profile; an empty `agents`
-    // override returns `None` so the caller can fall back to a plain
-    // shell.
+    // Ctrl+Shift+T / the "+ new tab" button + the worktree
+    // double-click handler all route through this helper to look up
+    // the user's preferred agent CLI from the registry. The tests
+    // below pin the contract `on_key_down` for Ctrl+Shift+T relies
+    // on: a vanilla Settings yields the Claude profile; flipping
+    // `default_agent` picks the matching one; an empty `agents`
+    // override falls back to built-ins. The auto_type half of the
+    // returned pair is what gets typed into the freshly-spawned pty
+    // — the id half is what gets persisted on the `Session` row so
+    // `reopen_session` can resolve the same agent profile later.
 
     #[test]
-    fn default_agent_auto_type_for_default_settings_returns_claude() {
-        // Built-in default — vanilla settings should auto-type `claude`
-        // (no extra args; new-session args are empty in the built-in
-        // Claude profile).
+    fn default_agent_launch_for_default_settings_returns_claude() {
         let settings = Settings::default();
-        let cmd = default_agent_auto_type_for(&settings).expect("default present");
-        assert_eq!(cmd.as_ref(), "claude");
+        let (id, cmd) = default_agent_launch_for(&settings).expect("default present");
+        assert_eq!(id.as_ref(), "claude");
+        assert_eq!(cmd.as_deref().map(|s| s.as_ref()), Some("claude"));
     }
 
     #[test]
-    fn default_agent_auto_type_for_honours_default_agent_setting() {
+    fn default_agent_launch_for_honours_default_agent_setting() {
         // User changed `settings.default_agent` to Codex — the helper
         // must follow, otherwise Ctrl+Shift+T would silently keep
         // spawning Claude after the user reconfigured their default.
@@ -7964,11 +8061,9 @@ mod tests {
             default_agent: "codex".into(),
             ..Settings::default()
         };
-        let cmd = default_agent_auto_type_for(&settings).expect("default present");
-        // The built-in Codex profile uses the `codex` command. Asserting
-        // the prefix keeps the test resilient to future new-session-arg
-        // additions on the built-in profile while still catching a
-        // wrong-profile regression.
+        let (id, cmd) = default_agent_launch_for(&settings).expect("default present");
+        assert_eq!(id.as_ref(), "codex");
+        let cmd = cmd.expect("codex profile has a command");
         assert!(
             cmd.as_ref() == "codex" || cmd.as_ref().starts_with("codex "),
             "expected codex command, got {cmd:?}",
@@ -7976,7 +8071,7 @@ mod tests {
     }
 
     #[test]
-    fn default_agent_auto_type_for_joins_new_session_args() {
+    fn default_agent_launch_for_joins_new_session_args() {
         // A user-defined profile with new-session args should serialise
         // as `<command> <arg1> <arg2>...` so the terminal gets a single
         // ready-to-run line.
@@ -7995,22 +8090,23 @@ mod tests {
             }],
             ..Settings::default()
         };
-        let cmd = default_agent_auto_type_for(&settings).expect("default present");
-        assert_eq!(cmd.as_ref(), "my-cli --init fresh");
+        let (id, cmd) = default_agent_launch_for(&settings).expect("default present");
+        assert_eq!(id.as_ref(), "custom");
+        assert_eq!(cmd.as_deref().map(|s| s.as_ref()), Some("my-cli --init fresh"));
     }
 
     #[test]
-    fn default_agent_auto_type_for_empty_agents_falls_back_to_built_ins() {
+    fn default_agent_launch_for_empty_agents_falls_back_to_built_ins() {
         // Empty `agents` overrides → `from_settings` re-seeds the
-        // built-in agent set, so `default_agent_auto_type_for` still
-        // returns a Some (Claude). This pins the contract Ctrl+Shift+T
-        // relies on: a fresh / empty profile list never strands the
-        // user without an agent.
+        // built-in agent set, so the helper still returns `Some`
+        // (Claude). This pins the contract Ctrl+Shift+T relies on: a
+        // fresh / empty profile list never strands the user without
+        // an agent.
         let settings = Settings {
             agents: vec![],
             ..Settings::default()
         };
-        assert!(default_agent_auto_type_for(&settings).is_some());
+        assert!(default_agent_launch_for(&settings).is_some());
     }
 
     // ─── classify_activity_transition ──────────────────────────────

--- a/src/dialogs/new_worktree.rs
+++ b/src/dialogs/new_worktree.rs
@@ -555,6 +555,7 @@ impl Sidebar {
                         working_directory: std::path::PathBuf::from(&folder),
                         title: format!("{project_name} · {branch}").into(),
                         auto_type: None,
+                        agent_id: None,
                         force_new: true,
                     });
                 }

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -244,6 +244,20 @@ pub enum SidebarEvent {
         /// the agent inline; `None` just opens a plain shell. The
         /// host adds the trailing CR.
         auto_type: Option<SharedString>,
+        /// Agent profile id to stamp on the persisted `Session` row
+        /// when this event spawns a fresh tab. Denormalised
+        /// alongside `auto_type` so the host doesn't have to
+        /// re-resolve the registry from the command string —
+        /// emitters that resolve the profile already have the id at
+        /// hand (`AgentProfile.id`). When `Some`, `reopen_session`
+        /// can later rebuild the same auto_type for that row by
+        /// looking the id up in the registry, instead of falling
+        /// back to a plain shell because the closed row was
+        /// stored with `agent_id: None`. `None` is the correct value
+        /// for plain-shell spawns ("Open session" with no agent,
+        /// new-worktree dialog's bare spawn) and the
+        /// no-default-agent fallback in the project menu.
+        agent_id: Option<SharedString>,
         /// When `true`, the host always spawns a fresh tab — used by
         /// the project menu's "New session" / "New Claude session"
         /// rows, the worktree menu's "New Claude session" row, and
@@ -1409,21 +1423,31 @@ impl Sidebar {
         cx.notify();
     }
 
-    /// Build the auto-type command string for the registry's default
-    /// agent (e.g. `"claude"` with the built-in Claude profile, or
-    /// `"my-cli --init fresh"` for a custom profile whose
-    /// `new_session_args` is `["--init", "fresh"]`). Used by the
-    /// double-click handler on a worktree row so opening a tab from
-    /// the sidebar lands in the user's configured default agent
-    /// instead of a plain shell. Mirrors AppShell::default_agent_auto_type
-    /// but reads from the sidebar's own cached registry — the two are
-    /// kept in lockstep via `apply_agent_registry`. The argv→string
-    /// joining lives in `codescope_core::build_new_session_auto_type`
-    /// so this path can't drift from `default_agent_auto_type_for` /
-    /// `render_new_session_submenu`.
-    fn default_agent_auto_type(&self) -> Option<SharedString> {
+    /// Resolve the registry's default agent into a paired
+    /// `(agent_id, auto_type)` launch spec — used by the
+    /// `SidebarEvent::OpenSession` emission sites that want a fresh
+    /// tab pinned to the user's configured default agent. The id is
+    /// the bare profile identifier (e.g. `"claude"`) and the
+    /// auto_type is the command string (`"claude"`, or
+    /// `"my-cli --init fresh"` for a custom profile with
+    /// `new_session_args`). Both pieces are needed: `auto_type`
+    /// drives what gets typed into the freshly-spawned pty, and
+    /// `agent_id` is persisted on the `Session` row so a later
+    /// `reopen_session` can rebuild the same auto_type without
+    /// having to re-guess from the command string.
+    ///
+    /// Returns `None` only when the registry has no default agent at
+    /// all. Returns `Some((id, None))` when a default agent exists
+    /// but its `command` is empty / whitespace — record the id so
+    /// reopen can still surface the right profile name, but skip
+    /// auto-typing to avoid feeding a leading-space argv to the pty.
+    /// Mirrors `default_agent_launch_for` in app.rs (same registry
+    /// shape, kept in lockstep by `apply_agent_registry`).
+    fn default_agent_launch(&self) -> Option<(SharedString, Option<SharedString>)> {
         let profile = self.agent_registry.get_default()?;
-        codescope_core::build_new_session_auto_type(profile).map(SharedString::from)
+        let id: SharedString = profile.id.clone().into();
+        let auto_type = codescope_core::build_new_session_auto_type(profile).map(SharedString::from);
+        Some((id, auto_type))
     }
 
     /// Open the project context menu at `position` (window coords)
@@ -2947,11 +2971,15 @@ impl Render for Sidebar {
                                 // via `apply_agent_registry` on save —
                                 // so a freshly-saved default takes
                                 // effect on the very next double-click.
-                                let auto_type = this.default_agent_auto_type();
+                                let (agent_id, auto_type) = match this.default_agent_launch() {
+                                    Some((id, at)) => (Some(id), at),
+                                    None => (None, None),
+                                };
                                 cx.emit(SidebarEvent::OpenSession {
                                     working_directory: PathBuf::from(&wt_path_for_event),
                                     title: title_label.clone(),
                                     auto_type,
+                                    agent_id,
                                     force_new: false,
                                 });
                             } else {
@@ -3701,14 +3729,22 @@ impl Sidebar {
         // Default agent — the row's primary click target (and the row
         // the submenu's "Default" entry highlights). Uses the shared
         // core helper so the parent-row click matches the submenu's
-        // "Default" entry, `Sidebar::default_agent_auto_type`, and
-        // `default_agent_auto_type_for` byte-for-byte. Resolves the
-        // profile via `get_default()` directly — no second `get_by_id`
-        // lookup, no intermediate `default_id` clone.
-        let default_cmd = self
+        // "Default" entry, `Sidebar::default_agent_launch`, and
+        // `default_agent_launch_for` byte-for-byte. Pairs the
+        // resolved `(agent_id, auto_type)` so the
+        // `SidebarEvent::OpenSession` emission below can persist the
+        // id on the session row — without it `reopen_session` would
+        // see `agent_id: None` and fall back to a plain shell.
+        let (default_id, default_cmd): (Option<String>, Option<String>) = match self
             .agent_registry
             .get_default()
-            .and_then(codescope_core::build_new_session_auto_type);
+        {
+            Some(profile) => (
+                Some(profile.id.clone()),
+                codescope_core::build_new_session_auto_type(profile),
+            ),
+            None => (None, None),
+        };
 
         let path = PathBuf::from(worktree_path);
         let title = title_prefix.clone();
@@ -3753,6 +3789,7 @@ impl Sidebar {
                             working_directory: path.clone(),
                             title: title.clone(),
                             auto_type: Some(cmd.into()),
+                            agent_id: default_id.clone().map(SharedString::from),
                             force_new: true,
                         });
                         this.close_menu(cx);
@@ -3764,6 +3801,7 @@ impl Sidebar {
                             working_directory: path.clone(),
                             title: title.clone(),
                             auto_type: None,
+                            agent_id: None,
                             force_new: true,
                         });
                         this.close_menu(cx);
@@ -3862,6 +3900,7 @@ impl Sidebar {
             // emitting `Some("")` would auto-type a `-Command "& {  }"`
             // scriptblock on Windows pwsh, which is *not* "no command".
             let cmd = codescope_core::build_new_session_auto_type(profile);
+            let agent_id_str: SharedString = profile.id.clone().into();
             let frost_hover = frost;
             let base_color = if is_default { ink } else { ink_dim };
             let hover_color = ink;
@@ -3885,6 +3924,7 @@ impl Sidebar {
                             working_directory: path.clone(),
                             title: title.clone(),
                             auto_type: cmd.clone().map(SharedString::from),
+                            agent_id: Some(agent_id_str.clone()),
                             force_new: true,
                         });
                         this.close_menu(cx);
@@ -4350,11 +4390,19 @@ impl Sidebar {
                         // focus-or-open rather than always-spawn —
                         // so a user already running a session for
                         // this worktree gets routed to it instead of
-                        // accidentally piling up duplicates.
+                        // accidentally piling up duplicates. When
+                        // the host falls through to a fresh spawn
+                        // (no open tab, no closed-history hit) it
+                        // resolves the default agent itself, so we
+                        // can leave `auto_type` / `agent_id` empty
+                        // here — same shape as a plain worktree row
+                        // click before the double-click branch
+                        // resolves the registry.
                         cx.emit(SidebarEvent::OpenSession {
                             working_directory: path_for_open.clone(),
                             title: title_for_open.clone(),
                             auto_type: None,
+                            agent_id: None,
                             force_new: false,
                         });
                         this.close_menu(cx);


### PR DESCRIPTION
## Summary

Two session-lifecycle bugs surfaced after PR #221 made the spawn-side persist properly:

1. **Closed sessions never appeared in the sidebar history disclosure.** `soft_close_session` stamped `closed_at` and saved to disk, but didn't push the new `ProjectsConfig` to the `Sidebar` entity. The sidebar keeps its own copy and builds the history bucket off it at render time, so the row stayed invisible until some unrelated sidebar mutation happened to refresh. Mirrors the `replace_projects` + `cx.notify()` push `reopen_session` already does for the reverse transition. Plumbs `cx` through `soft_close_session` (sole caller is `close_tab`).
2. **Double-clicking a worktree always spawned a fresh session,** even when the worktree had a closed one in history. Expected behaviour: double-click = "pick up where I left off"; explicit \"New session\" menu rows = force-new. `SidebarEvent::OpenSession` handler now resolves in three tiers: open-tab focus → most-recent-closed reopen → fresh spawn. `force_new` still short-circuits straight to spawn. Path matching for the closed-session lookup uses `paths_match` so a `\` vs `/` mismatch between the event payload and the persisted `worktree_path` doesn't drop the hit (same rule PR #221 applied to `locate_project_for_path`). Newest-first ordering matches the sidebar history disclosure ordering so a double-click reopens exactly the row the user sees at the top.

## Test plan

- [ ] `cargo check --bin codescope-rs` clean (done locally)
- [ ] `cargo clippy --workspace --all-targets` clean (done locally)
- [ ] Open a session in a worktree, close it → row appears in that worktree's history disclosure on the same frame (no sidebar mutation needed)
- [ ] Double-click the same worktree → reopens the most-recently-closed session, does **not** spawn a new one
- [ ] Right-click worktree → \"New session\" / \"New <agent> session\" still spawns fresh (force_new path unchanged)
- [ ] Double-click a worktree with no closed sessions → spawns fresh (tier 3 fallback)
- [ ] Open + close two sessions in same worktree, then double-click → reopens the most-recently-closed (newer one), not the older one

🤖 Generated with [Claude Code](https://claude.com/claude-code)