### PR TITLE
chore: bump version to 0.3.0-rc.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.9"
+version = "0.3.0-rc.10"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.9"
+version = "0.3.0-rc.10"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
## Summary

Cuts rc.10 with the session-history + window-diag work from this batch:

- **#221** — `locate_project_for_path` uses `paths_match` so spawn → close lands in worktree history regardless of slash convention.
- **#222** — bounds-observer + maximize-click handlers tape one line per transition to `state_dir/window-diag.log` so the intermittent ~75 px maximize bug captures its smoking-gun tick on next repro.
- **#223** — `soft_close_session` mirrors to sidebar on the same tick; double-click reopens last-closed via three-tier resolution; spawn persists `Session.agent_id` so reopen brings back the right agent (with fallback to `Settings.default_agent` for legacy `agent_id: None` rows).

## Test plan

- [ ] `cargo build --release --bin codescope-rs` clean (done locally)
- [ ] Velopack release pipeline cuts the rc.10 artifacts on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)