### PR TITLE
fix(rs): install panic hook before velopack + tape per-phase boot markers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,14 +65,21 @@ impl Render for Root {
 }
 
 fn main() -> Result<()> {
-    // Velopack install / uninstall / first-run / restarted-after-update
-    // hooks must dispatch before anything else — the Velopack
-    // bootstrap helper may need to exit/restart the process from this
-    // call. Safe no-op on builds that weren't installed via a Velopack
-    // bootstrapper (`cargo run`, cargo-dist MSI, unpacked zip).
-    // Mirrors the equivalent C# call site in `App.OnStartup`.
-    velopack_bridge::run_startup_hooks();
-
+    // Resolve paths + install the crash-log panic hook BEFORE
+    // velopack — the old order ran `VelopackApp::build().run()` first
+    // (on the theory "velopack can exit/restart from its hooks, so do
+    // it before any other side effects"), but any panic inside that
+    // call ran through the default panic handler (stderr + abort) —
+    // and stderr on the Windows GUI subsystem is a black hole, so
+    // crashes during the restarted-after-update hook left no
+    // `crash.log` and no observable trace. Reordering is safe:
+    // `AppPaths::detect` is a pure env-var read with no side effects,
+    // `ensure_dirs` is idempotent, and `install_panic_hook` no-ops on
+    // its second call via an `AtomicBool` guard — none of these
+    // execute "twice" in any harmful sense if velopack later restarts
+    // the process. User report: "update crashed nog steeds het
+    // programma" on v0.3.0-rc.10, no crash.log produced — exactly
+    // this gap.
     let paths = AppPaths::detect();
     if let Err(err) = paths.ensure_dirs() {
         eprintln!(
@@ -81,16 +88,29 @@ fn main() -> Result<()> {
             err
         );
     }
-
-    // Install the crash-log panic hook before any gpui state spins up so a
-    // panic during early boot still writes `%LOCALAPPDATA%\CodeScope\crash.log`
-    // (parity with C# `App.LogFatal`). Dev mode redirects to `CodeScope.Dev`
-    // automatically via `AppPaths`.
     codescope_core::crash_log::install_panic_hook(
         paths.clone(),
         env!("CODESCOPE_VERSION_DISPLAY").to_string(),
     );
 
+    // Per-phase boot tape — written line-by-line to `state_dir/boot.log`
+    // with the file handle dropped between phases so a process kill
+    // *after* the line is written still leaves the line on disk. Lets
+    // us tell, on the next no-crash-log crash, exactly which phase
+    // ate the process. Cheap; <10 lines per launch.
+    write_boot_phase(&paths, "main:enter");
+
+    // Velopack install / uninstall / first-run / restarted-after-update
+    // hooks. Safe no-op on builds that weren't installed via a Velopack
+    // bootstrapper (`cargo run`, cargo-dist MSI, unpacked zip).
+    // Mirrors the equivalent C# call site in `App.OnStartup`. With the
+    // panic hook now installed above, a Rust panic in here lands in
+    // `crash.log` instead of stderr.
+    write_boot_phase(&paths, "velopack:run_startup_hooks:enter");
+    velopack_bridge::run_startup_hooks();
+    write_boot_phase(&paths, "velopack:run_startup_hooks:exit");
+
+    write_boot_phase(&paths, "memory_watchdog:start_if_dev");
     // Dev-only memory watchdog — surfaces working-set creep every 5 min
     // so per-session terminal scrollback regressions don't go unnoticed
     // during long dev runs (parity with the C# build's
@@ -172,6 +192,7 @@ fn main() -> Result<()> {
     };
 
     let window_bounds = saved_window.map(window_state_to_bounds);
+    write_boot_phase(&paths, "state_loaded:settings+projects+layout+window");
     let paths = Arc::new(paths);
 
     // `with_assets` registers our static SVG icon set so
@@ -181,6 +202,10 @@ fn main() -> Result<()> {
     // `SvgRenderer` silently no-ops every `svg()` element (the
     // default `()` source returns `None`). See `crate::assets`.
     let app = gpui::Application::new().with_assets(crate::assets::AppAssets);
+    {
+        let boot_paths = paths.as_ref();
+        write_boot_phase(boot_paths, "gpui:application_built:about_to_run");
+    }
 
     app.run(move |cx| {
         // `window.json` save lives inside `AppShell::new` (observes
@@ -220,6 +245,33 @@ fn main() -> Result<()> {
     });
 
     Ok(())
+}
+
+/// Append a single timestamped phase marker to
+/// `state_dir/boot.log`. Opens, writes, and closes the file per call
+/// so a process kill *immediately after* the line was written still
+/// leaves the line on disk — what we need to tell, on the next
+/// no-crash-log crash, which phase ate the process.
+///
+/// The auto-update path is the motivating use case: velopack's
+/// `run_startup_hooks` can call `std::process::exit` or hard-crash
+/// from inside the restarted-after-update handler, and either of
+/// those bypasses the Rust panic handler entirely. The boot tape
+/// gives us a paper trail when `crash.log` stays empty.
+///
+/// I/O errors are silently dropped — best-effort diagnostic. Caller
+/// must ensure `paths.state_dir` exists (`ensure_dirs` does that
+/// idempotently before the first call).
+fn write_boot_phase(paths: &AppPaths, phase: &str) {
+    use std::fs::OpenOptions;
+    use std::io::Write as _;
+    let line = format!("{} {}\n", now_iso8601(), phase);
+    let path = paths.state_dir.join("boot.log");
+    let _ = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .and_then(|mut f| f.write_all(line.as_bytes()));
 }
 
 fn window_state_to_bounds(state: WindowState) -> WindowBounds {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,9 +77,9 @@ fn main() -> Result<()> {
     // `ensure_dirs` is idempotent, and `install_panic_hook` no-ops on
     // its second call via an `AtomicBool` guard — none of these
     // execute "twice" in any harmful sense if velopack later restarts
-    // the process. User report: "update crashed nog steeds het
-    // programma" on v0.3.0-rc.10, no crash.log produced — exactly
-    // this gap.
+    // the process. Motivated by a user report that v0.3.0-rc.10 still
+    // crashed during the auto-update without producing a `crash.log`
+    // — exactly this gap.
     let paths = AppPaths::detect();
     if let Err(err) = paths.ensure_dirs() {
         eprintln!(
@@ -98,6 +98,22 @@ fn main() -> Result<()> {
     // *after* the line is written still leaves the line on disk. Lets
     // us tell, on the next no-crash-log crash, exactly which phase
     // ate the process. Cheap; <10 lines per launch.
+    //
+    // Truncate at launch so the file only reflects the *current*
+    // run — without this the file grows unbounded across the
+    // lifetime of the install (5 lines / launch × N launches forever)
+    // and triaging "which phase died last" gets harder, not easier,
+    // the longer the install survives. Best-effort: a truncate
+    // failure (path is a directory, disk full, permission denied)
+    // silently falls through and the appender below behaves as it
+    // did before — old lines still in place, new lines tacked on.
+    {
+        let _ = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(paths.state_dir.join("boot.log"));
+    }
     write_boot_phase(&paths, "main:enter");
 
     // Resize-cascade diagnostic tape. PR #218/#219 fixed the
@@ -270,9 +286,13 @@ fn main() -> Result<()> {
 /// those bypasses the Rust panic handler entirely. The boot tape
 /// gives us a paper trail when `crash.log` stays empty.
 ///
-/// I/O errors are silently dropped — best-effort diagnostic. Caller
-/// must ensure `paths.state_dir` exists (`ensure_dirs` does that
-/// idempotently before the first call).
+/// I/O errors at any layer are silently dropped — best-effort
+/// diagnostic. `ensure_dirs` is called once from `main` and is
+/// allowed to fail without aborting startup, so this helper has to
+/// be robust against a missing `state_dir`: the `OpenOptions::open`
+/// call returns `Err`, the `let _ =` discards it, and the function
+/// returns without writing anything. A diagnostic mishap should
+/// never take down boot.
 fn write_boot_phase(paths: &AppPaths, phase: &str) {
     use std::fs::OpenOptions;
     use std::io::Write as _;

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,17 @@ fn main() -> Result<()> {
     // ate the process. Cheap; <10 lines per launch.
     write_boot_phase(&paths, "main:enter");
 
+    // Resize-cascade diagnostic tape. PR #218/#219 fixed the
+    // bounds-observer half of the cascade but the user-reported
+    // "release-build resize doesn't repaint until tab-swap" symptom
+    // still reproduces (and also on splitter drag, which never goes
+    // through `observe_window_bounds`), so at least one checkpoint
+    // along the canvas-layout → maybe_resize → apply_resize chain is
+    // still racing. Wire the per-launch path here; the terminal
+    // crate's `view.rs` taps it from each checkpoint. No-op until
+    // this call sets the path.
+    codescope_terminal::diag::set_log_path(paths.state_dir.join("terminal-resize.log"));
+
     // Velopack install / uninstall / first-run / restarted-after-update
     // hooks. Safe no-op on builds that weren't installed via a Velopack
     // bootstrapper (`cargo run`, cargo-dist MSI, unpacked zip).

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,20 +99,27 @@ fn main() -> Result<()> {
     // us tell, on the next no-crash-log crash, exactly which phase
     // ate the process. Cheap; <10 lines per launch.
     //
-    // Truncate at launch so the file only reflects the *current*
-    // run — without this the file grows unbounded across the
-    // lifetime of the install (5 lines / launch × N launches forever)
-    // and triaging "which phase died last" gets harder, not easier,
-    // the longer the install survives. Best-effort: a truncate
-    // failure (path is a directory, disk full, permission denied)
-    // silently falls through and the appender below behaves as it
-    // did before — old lines still in place, new lines tacked on.
+    // **Rotate, don't just truncate.** The motivating bug is "auto-
+    // update crashed and left no crash.log"; the user's natural next
+    // action is to relaunch, which would wipe the only forensic
+    // artifact if we just truncated. Rename the current tape to
+    // `boot.prev.log` (replacing any older prev) so the previous
+    // launch survives one more run — long enough for the user to
+    // grab it after a crash. Best-effort at every step: a missing
+    // current file (first launch) makes `rename` a no-op-Err we
+    // discard; a `rename` failure (cross-volume, permission, …)
+    // falls through to the truncate, which itself silently no-ops
+    // on failure; either way `write_boot_phase` below starts a
+    // fresh file. We never lose more than the run-before-last.
     {
+        let cur = paths.state_dir.join("boot.log");
+        let prev = paths.state_dir.join("boot.prev.log");
+        let _ = std::fs::rename(&cur, &prev);
         let _ = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
-            .open(paths.state_dir.join("boot.log"));
+            .open(&cur);
     }
     write_boot_phase(&paths, "main:enter");
 

--- a/terminal/src/diag.rs
+++ b/terminal/src/diag.rs
@@ -51,23 +51,31 @@ static DIAG_FILE: OnceLock<Mutex<Option<File>>> = OnceLock::new();
 /// touching state. Caller is the binary's `main()` after
 /// `AppPaths::detect()` resolves the per-mode state directory.
 ///
-/// **Opens with `truncate(true)`**: the resize cascade fires a handful
-/// of lines per user gesture, and a long-running install would
+/// **Rotate-then-truncate.** The resize cascade fires a handful of
+/// lines per user gesture, and a long-running install would
 /// accumulate megabytes of tape over weeks. Triaging "what happened
 /// in *this* repro" gets harder, not easier, the longer the file
-/// survives — so each launch starts with an empty tape. Persistent
-/// historical state lives in commit logs / bug reports, not in this
-/// file.
+/// survives — so each launch starts with an empty tape. We rotate
+/// the current file to a `.prev.log` sibling before truncating so
+/// the previous launch's tape survives one more run; the natural
+/// flow is "hit the bug → close the app → relaunch to grab the
+/// log" and a plain truncate would wipe the only forensic artifact
+/// at exactly the wrong moment.
 ///
-/// I/O errors (path is a directory, disk full at open time, permission
-/// denied) are silently dropped — best-effort instrumentation that
-/// must not abort startup. If the open fails the [`log`] calls below
-/// stay no-ops for the rest of the process lifetime.
+/// I/O errors at every layer are silently dropped — best-effort
+/// instrumentation that must not abort startup. A missing current
+/// file (first launch) makes `rename` a no-op-Err; a `rename`
+/// failure falls through to the truncate-open; if that itself
+/// fails the [`log`] calls below stay no-ops for the rest of the
+/// process lifetime.
 pub fn set_log_path(path: PathBuf) {
     let cell = DIAG_FILE.get_or_init(|| Mutex::new(None));
     let mut slot = cell.lock();
     if slot.is_some() {
         return;
+    }
+    if let Some(prev) = prev_path_for(&path) {
+        let _ = std::fs::rename(&path, &prev);
     }
     if let Ok(file) = OpenOptions::new()
         .write(true)
@@ -79,12 +87,34 @@ pub fn set_log_path(path: PathBuf) {
     }
 }
 
+/// Build the rotated-out filename next to `path`. Strips a single
+/// trailing extension and adds `.prev.<ext>` so
+/// `terminal-resize.log` rotates to `terminal-resize.prev.log`. A
+/// path with no extension or no file name short-circuits to `None`
+/// (caller skips the rename); we'd rather drop the rotation than
+/// stomp on something we don't understand.
+fn prev_path_for(path: &std::path::Path) -> Option<PathBuf> {
+    let stem = path.file_stem()?.to_str()?;
+    let ext = path.extension()?.to_str()?;
+    let parent = path.parent()?;
+    Some(parent.join(format!("{stem}.prev.{ext}")))
+}
+
 /// Append one timestamped line to the resize tape. No-op when
 /// `set_log_path` was never called (unit-test runs, or any host that
-/// doesn't want the diagnostics). Holds the file handle across the
-/// `write_all` so a process kill immediately after the call still
-/// leaves the line on disk — the same invariant the boot-tape in
-/// `src/main.rs` and the window-diag tape in `src/app.rs` rely on.
+/// doesn't want the diagnostics).
+///
+/// **Durability strategy:** this module keeps a *single long-lived*
+/// file handle open across the entire process lifetime and relies on
+/// `write_all` having handed the bytes to the kernel before any
+/// crash. A process kill after `write_all` returns still leaves the
+/// line on disk because the kernel buffer survives userspace
+/// teardown. Note this is a *different* strategy from the boot tape
+/// in `src/main.rs`, which open-write-closes per call and gets its
+/// durability from `close` flushing the kernel buffer — both achieve
+/// similar guarantees against a process kill but via different
+/// mechanisms, so don't read this comment and assume the boot tape
+/// works the same way.
 ///
 /// Format is `<iso8601> <line>\n` so the file can be piped through
 /// `grep` / `awk` and copied into a bug report without reformatting.

--- a/terminal/src/diag.rs
+++ b/terminal/src/diag.rs
@@ -51,18 +51,30 @@ static DIAG_FILE: OnceLock<Mutex<Option<File>>> = OnceLock::new();
 /// touching state. Caller is the binary's `main()` after
 /// `AppPaths::detect()` resolves the per-mode state directory.
 ///
+/// **Opens with `truncate(true)`**: the resize cascade fires a handful
+/// of lines per user gesture, and a long-running install would
+/// accumulate megabytes of tape over weeks. Triaging "what happened
+/// in *this* repro" gets harder, not easier, the longer the file
+/// survives — so each launch starts with an empty tape. Persistent
+/// historical state lives in commit logs / bug reports, not in this
+/// file.
+///
 /// I/O errors (path is a directory, disk full at open time, permission
-/// denied) are silently dropped — this is best-effort instrumentation
-/// and we don't want a logging mishap to abort startup. Caller must
-/// ensure the parent directory exists (`AppPaths::ensure_dirs` is the
-/// canonical call site for that).
+/// denied) are silently dropped — best-effort instrumentation that
+/// must not abort startup. If the open fails the [`log`] calls below
+/// stay no-ops for the rest of the process lifetime.
 pub fn set_log_path(path: PathBuf) {
     let cell = DIAG_FILE.get_or_init(|| Mutex::new(None));
     let mut slot = cell.lock();
     if slot.is_some() {
         return;
     }
-    if let Ok(file) = OpenOptions::new().create(true).append(true).open(&path) {
+    if let Ok(file) = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&path)
+    {
         *slot = Some(file);
     }
 }

--- a/terminal/src/diag.rs
+++ b/terminal/src/diag.rs
@@ -1,0 +1,85 @@
+//! Best-effort diagnostic tape for the resize cascade.
+//!
+//! The cascade `WindowBounds change → AppShell render → group/pane
+//! render → TerminalView canvas-layout → maybe_resize (stage) →
+//! debounce timer → apply_resize → Backend::resize` has at least four
+//! checkpoints where the chain can quietly break. PR #218/#219
+//! plugged one (bounds-observer `cx.notify()` racing
+//! `WindowInvalidator::invalidate_view`), but the user-reported
+//! "release-build resize doesn't repaint until I tab-swap" symptom
+//! still reproduces on `cargo run --release` — and *also* reproduces
+//! on splitter drag, which never goes through `observe_window_bounds`
+//! at all. So the same race lives on at least one more codepath.
+//!
+//! Static analysis can't pin which checkpoint is the live one; we
+//! need a per-launch tape that records every checkpoint's inputs and
+//! outputs in order. This module is that tape: a process-global
+//! file handle initialised once from the binary's `main()`, used by
+//! `TerminalView` to log canvas-layout, `maybe_resize`, and
+//! `apply_resize` entries.
+//!
+//! File path comes in from `main.rs` (via [`set_log_path`]) so dev
+//! mode (`CODESCOPE_DEV=1`) lands the log under
+//! `%LOCALAPPDATA%\CodeScope.Dev\terminal-resize.log` and prod under
+//! `%LOCALAPPDATA%\CodeScope\terminal-resize.log`. Until `set_log_path`
+//! is called the loggers are no-ops — keeps the unit-test surface
+//! quiet (no temp-file litter) and lets the terminal crate ship with
+//! diagnostics that only light up when the host wires them in.
+//!
+//! Keep this file lightweight: one open file handle, append-only,
+//! no rotation. The resize cascade fires a handful of times per user
+//! gesture, not at frame rate, so the I/O overhead is negligible. If
+//! the bug ever ships as fixed for real we'll either delete this
+//! module or gate it behind a feature flag.
+
+use std::fs::{File, OpenOptions};
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use parking_lot::Mutex;
+
+/// Open file handle for the resize tape. `OnceLock<Mutex<...>>` so
+/// `set_log_path` can populate the handle exactly once and `log` can
+/// take a mutable borrow for the `write_all` without re-opening per
+/// call. `None` inside the mutex means either the path was never set
+/// or the open failed; both cases short-circuit `log` to a no-op.
+static DIAG_FILE: OnceLock<Mutex<Option<File>>> = OnceLock::new();
+
+/// Configure the resize-diagnostic log file path. Idempotent — the
+/// first successful call wins; subsequent calls return without
+/// touching state. Caller is the binary's `main()` after
+/// `AppPaths::detect()` resolves the per-mode state directory.
+///
+/// I/O errors (path is a directory, disk full at open time, permission
+/// denied) are silently dropped — this is best-effort instrumentation
+/// and we don't want a logging mishap to abort startup. Caller must
+/// ensure the parent directory exists (`AppPaths::ensure_dirs` is the
+/// canonical call site for that).
+pub fn set_log_path(path: PathBuf) {
+    let cell = DIAG_FILE.get_or_init(|| Mutex::new(None));
+    let mut slot = cell.lock();
+    if slot.is_some() {
+        return;
+    }
+    if let Ok(file) = OpenOptions::new().create(true).append(true).open(&path) {
+        *slot = Some(file);
+    }
+}
+
+/// Append one timestamped line to the resize tape. No-op when
+/// `set_log_path` was never called (unit-test runs, or any host that
+/// doesn't want the diagnostics). Holds the file handle across the
+/// `write_all` so a process kill immediately after the call still
+/// leaves the line on disk — the same invariant the boot-tape in
+/// `src/main.rs` and the window-diag tape in `src/app.rs` rely on.
+///
+/// Format is `<iso8601> <line>\n` so the file can be piped through
+/// `grep` / `awk` and copied into a bug report without reformatting.
+pub fn log(line: &str) {
+    let Some(cell) = DIAG_FILE.get() else { return };
+    let mut slot = cell.lock();
+    let Some(file) = slot.as_mut() else { return };
+    let entry = format!("{} {}\n", codescope_core::now_iso8601(), line);
+    let _ = file.write_all(entry.as_bytes());
+}

--- a/terminal/src/lib.rs
+++ b/terminal/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod backend;
 pub mod colors;
+pub mod diag;
 pub mod event;
 pub mod input;
 pub mod mouse;

--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -1007,8 +1007,14 @@ impl Render for TerminalView {
                     let line_h_f32: f32 = line_height.into();
                     let bw: f32 = bounds.size.width.into();
                     let bh: f32 = bounds.size.height.into();
-                    let (last_cols, last_rows) = *last_size.lock();
                     if cell_w_f32 > 0.0 && line_h_f32 > 0.0 {
+                        // Lock acquisition scoped to the branch that
+                        // actually reads `last_cols`/`last_rows` — the
+                        // zero-dim branch below only logs that it
+                        // skipped, so paying for the mutex on every
+                        // first-frame render before font metrics
+                        // resolve is wasted work on the hot path.
+                        let (last_cols, last_rows) = *last_size.lock();
                         let cols = (bw / cell_w_f32).floor() as u16;
                         let rows = (bh / line_h_f32).floor() as u16;
                         crate::diag::log(&format!(

--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -722,6 +722,9 @@ impl TerminalView {
     /// called from idle re-renders.
     fn maybe_resize(&self, cols: u16, rows: u16, _cx: &mut Context<Self>) {
         if cols == 0 || rows == 0 {
+            crate::diag::log(&format!(
+                "maybe_resize: skipped (zero-dim) cols={cols} rows={rows}"
+            ));
             return;
         }
         let (cur_cols, cur_rows) = *self.last_size.lock();
@@ -729,6 +732,9 @@ impl TerminalView {
             // Already at the target; if a stale pending request would
             // try to undo it, drop it.
             self.pending_size.lock().take();
+            crate::diag::log(&format!(
+                "maybe_resize: noop (already_at_target) cols={cols} rows={rows}"
+            ));
             return;
         }
         let mut pending = self.pending_size.lock();
@@ -737,7 +743,9 @@ impl TerminalView {
                 // Same target already pending — let the existing
                 // `set_at` age toward `RESIZE_DEBOUNCE` instead of
                 // resetting it every idle re-render. See the doc
-                // comment above for why this matters.
+                // comment on `maybe_resize` for the full rationale.
+                // No log noise here: this branch hits on every
+                // idle re-render and would flood the tape.
             }
             _ => {
                 *pending = Some(PendingResize {
@@ -745,6 +753,9 @@ impl TerminalView {
                     rows,
                     set_at: Instant::now(),
                 });
+                crate::diag::log(&format!(
+                    "maybe_resize: staged cols={cols} rows={rows} from cur=({cur_cols},{cur_rows})"
+                ));
             }
         }
     }
@@ -754,11 +765,18 @@ impl TerminalView {
     fn apply_resize(&mut self, cols: u16, rows: u16, cx: &mut Context<Self>) {
         let (cur_cols, cur_rows) = *self.last_size.lock();
         if cols == cur_cols && rows == cur_rows {
+            crate::diag::log(&format!(
+                "apply_resize: noop (already_at_target) cols={cols} rows={rows}"
+            ));
             return;
         }
         *self.last_size.lock() = (cols, rows);
         let cell_w_f32: f32 = self.font.cell_width.into();
         let cell_h_f32: f32 = self.font.line_height.into();
+        crate::diag::log(&format!(
+            "apply_resize: backend.resize cols={cols} rows={rows} \
+             from cur=({cur_cols},{cur_rows}) cell=({cell_w_f32:.2},{cell_h_f32:.2})"
+        ));
         self.backend.resize(TerminalSize {
             num_lines: rows,
             num_cols: cols,
@@ -987,14 +1005,19 @@ impl Render for TerminalView {
 
                     let cell_w_f32: f32 = cell_width.into();
                     let line_h_f32: f32 = line_height.into();
+                    let bw: f32 = bounds.size.width.into();
+                    let bh: f32 = bounds.size.height.into();
+                    let (last_cols, last_rows) = *last_size.lock();
                     if cell_w_f32 > 0.0 && line_h_f32 > 0.0 {
-                        let w: f32 = bounds.size.width.into();
-                        let h: f32 = bounds.size.height.into();
-                        let cols = (w / cell_w_f32).floor() as u16;
-                        let rows = (h / line_h_f32).floor() as u16;
+                        let cols = (bw / cell_w_f32).floor() as u16;
+                        let rows = (bh / line_h_f32).floor() as u16;
+                        crate::diag::log(&format!(
+                            "canvas_layout: bounds=({bw:.1}x{bh:.1}) cell=({cell_w_f32:.2},{line_h_f32:.2}) \
+                             computed=({cols},{rows}) last=({last_cols},{last_rows}) diff={}",
+                            cols != last_cols || rows != last_rows
+                        ));
 
-                        let (cur_cols, cur_rows) = *last_size.lock();
-                        if cols != cur_cols || rows != cur_rows {
+                        if cols != last_cols || rows != last_rows {
                             weak.update(cx, |view, cx| {
                                 view.font.cell_width = cell_width;
                                 view.font.line_height = line_height;
@@ -1002,6 +1025,10 @@ impl Render for TerminalView {
                             })
                             .ok();
                         }
+                    } else {
+                        crate::diag::log(&format!(
+                            "canvas_layout: bounds=({bw:.1}x{bh:.1}) cell=(zero-dim, skipping resize)"
+                        ));
                     }
 
                     CanvasLayout {


### PR DESCRIPTION
## Summary

- User reported rc.9 → rc.10 auto-update crashed the program with **no \`crash.log\` produced**.
- Root cause: \`main()\` ran \`velopack_bridge::run_startup_hooks()\` before installing the panic hook. A Rust panic inside velopack's restarted-after-update / install / first-run hooks routed through the default panic handler — stderr + abort — and stderr on the Windows GUI subsystem is a black hole.
- Reorder: \`AppPaths::detect\` → \`ensure_dirs\` → \`install_panic_hook\` → velopack hooks. All three early steps are idempotent / pure / guarded, so the original "velopack must run before any side effect" rule still holds for the things it was meant to protect.
- For the harder case (native crash, no Rust panic — access violation, missing DLL) add \`write_boot_phase\` taping five startup phases to \`state_dir/boot.log\`. Open-write-close per line so a kill *after* the write still leaves the line on disk. An \`enter\` without a matching \`exit\` line on next crash pinpoints the failing phase.

## Test plan

- [ ] \`cargo check --bin codescope-rs\` clean (done locally)
- [ ] \`cargo clippy --bin codescope-rs --no-deps\` clean (done locally)
- [ ] After install, \`%LOCALAPPDATA%\CodeScope\boot.log\` contains the five phase markers on a normal launch
- [ ] Next auto-update crash: \`boot.log\` shows which phase died (panic also lands in crash.log if it's a Rust panic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)