### PR TITLE
feat(sidebar): adopt existing git worktrees on project add

### DIFF
--- a/core/src/projects.rs
+++ b/core/src/projects.rs
@@ -104,6 +104,46 @@ impl Project {
             .clone()
             .unwrap_or_else(|| format!("{}.worktrees", self.path))
     }
+
+    /// Discover existing git worktrees under this project's primary
+    /// `path` and adopt any that aren't already tracked in
+    /// `self.worktrees`. Errors (path isn't a git repo, `git` missing,
+    /// path doesn't exist on disk, etc.) are swallowed — the project
+    /// still ends up added with just its primary row, same as before.
+    ///
+    /// Called once at project-add time so users who already have
+    /// worktrees on disk see them in the sidebar immediately, without
+    /// having to re-register each one through the "New worktree"
+    /// dialog. Idempotent: re-running on an already-up-to-date
+    /// project is a no-op via path-equality dedup.
+    ///
+    /// Primary worktree (the one git's porcelain marks first) is
+    /// skipped — `Project::new` already seeded that row; the branch
+    /// backfill is the `WorktreeStatusPoller`'s job, not ours.
+    pub fn adopt_existing_worktrees(&mut self) {
+        let Ok(found) = crate::git::list_worktrees(Path::new(&self.path)) else {
+            return;
+        };
+        for info in found {
+            if info.is_primary {
+                continue;
+            }
+            let needle = normalise_project_path(&info.path);
+            if self
+                .worktrees
+                .iter()
+                .any(|wt| normalise_project_path(&wt.path) == needle)
+            {
+                continue;
+            }
+            self.worktrees.push(Worktree {
+                id: uuid::Uuid::new_v4().to_string(),
+                path: info.path,
+                branch: info.branch,
+                is_primary: false,
+            });
+        }
+    }
 }
 
 /// Rename a project's display name. Mirrors C# `SessionStore.RenameProjectAsync`
@@ -315,6 +355,77 @@ pub fn normalise_project_path(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::process::no_window_command;
+
+    /// Skip-aware test helper — initialises a real git repo under a
+    /// tempdir and runs an empty seed commit so HEAD is real. Returns
+    /// `None` when `git` isn't on PATH so a CI image without git in
+    /// scope still goes green (same convention as `core::git::tests`).
+    fn init_repo_with_commit() -> Option<(tempfile::TempDir, std::path::PathBuf)> {
+        if no_window_command("git").arg("--version").output().is_err() {
+            eprintln!("skipping: `git` not on PATH");
+            return None;
+        }
+        let dir = tempfile::tempdir().ok()?;
+        let repo = dir.path().join("repo");
+        // Pre-create the default worktree root so `git worktree add`
+        // doesn't have to (it errors on a missing parent dir).
+        let worktrees_root = dir.path().join("repo.worktrees");
+        std::fs::create_dir_all(&repo).ok()?;
+        std::fs::create_dir_all(&worktrees_root).ok()?;
+        for args in [
+            &["-c", "init.defaultBranch=main", "init", "-q"][..],
+            &["config", "user.email", "test@example.invalid"][..],
+            &["config", "user.name", "Test"][..],
+            &["commit", "--allow-empty", "-m", "init", "-q"][..],
+        ] {
+            let out = no_window_command("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .ok()?;
+            if !out.status.success() {
+                return None;
+            }
+        }
+        Some((dir, repo))
+    }
+
+    #[test]
+    fn adopt_existing_worktrees_picks_up_non_primary_rows() {
+        let Some((_guard, repo)) = init_repo_with_commit() else {
+            return;
+        };
+        let wt_path = repo.parent().unwrap().join("repo.worktrees").join("feat-x");
+        crate::git::add_worktree(&repo, &wt_path, "feat/x", None)
+            .expect("git worktree add succeeds");
+
+        let mut project = Project::new(repo.to_string_lossy().to_string());
+        assert_eq!(project.worktrees.len(), 1, "fresh project = primary only");
+
+        project.adopt_existing_worktrees();
+        assert_eq!(project.worktrees.len(), 2, "feat/x should be adopted");
+        let feat = &project.worktrees[1];
+        assert!(!feat.is_primary, "discovered worktree is non-primary");
+        assert!(feat.path.ends_with("feat-x"), "path: {}", feat.path);
+        assert_eq!(feat.branch.as_deref(), Some("feat/x"));
+        assert!(!feat.id.is_empty() && feat.id != "primary", "real uuid id");
+
+        // Idempotent: a second call must not duplicate the entry.
+        project.adopt_existing_worktrees();
+        assert_eq!(project.worktrees.len(), 2, "second pass no-ops");
+    }
+
+    #[test]
+    fn adopt_existing_worktrees_swallows_non_git_path() {
+        // Path that isn't a git repo at all — must not panic, must not
+        // mutate the worktrees list.
+        let dir = tempfile::tempdir().unwrap();
+        let mut project = Project::new(dir.path().to_string_lossy().to_string());
+        let before = project.worktrees.len();
+        project.adopt_existing_worktrees();
+        assert_eq!(project.worktrees.len(), before, "no change on non-git path");
+    }
 
     #[test]
     fn missing_file_yields_empty_config() {

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -2404,7 +2404,15 @@ impl Sidebar {
             self.select(idx, cx);
             return;
         }
-        let project = Project::new(path);
+        let mut project = Project::new(path);
+        // If the user already has worktrees on disk for this repo
+        // (typical for anyone who adds a project they've been working
+        // in for a while), pull them into the project record now so
+        // they show up in the sidebar immediately. Swallows errors —
+        // a non-git folder, missing `git` binary, or a permission
+        // hiccup just lands the project with its primary row alone,
+        // matching the pre-existing behaviour.
+        project.adopt_existing_worktrees();
         let new_id = project.id.clone();
         // Clone-then-save: failure leaves `self.projects` untouched.
         let mut next = self.projects.clone();


### PR DESCRIPTION
## Summary

User-reported (Dutch): \"als ik een nieuw project open en er staan worktrees op de standaard worktree directory dan moet je die ook toevoegen automatisch.\" — when adding a new project, the existing on-disk worktrees should appear in the sidebar automatically, not require re-registering each via the **New worktree** dialog.

## Change

- New `Project::adopt_existing_worktrees(&mut self)` in `core/projects.rs`. Shells `git worktree list --porcelain` against the project's primary path; for each non-primary entry whose path isn't already in `self.worktrees`, pushes a `Worktree { id: uuid, path, branch, is_primary: false }`. Errors are swallowed (non-git folder, missing `git` binary, permission hiccup) so the project still ends up added with its primary row alone — matches the pre-existing behaviour for those edge cases.
- `Sidebar::add_project` calls it once between `Project::new` and the `projects.json` save, so the disk write captures the discovered rows in a single atomic commit.

Note on scope: the helper picks up **every** worktree git knows about, not only the ones under `worktree_root_path()`. The user's wording mentioned the default directory because that's where their worktrees live, but git can register worktrees anywhere — and a user who placed one manually elsewhere presumably still wants it in their sidebar. Easy to tighten to a path-prefix filter later if that turns out wrong.

## Test plan

- [x] \`cargo build --workspace\` clean.
- [x] \`cargo test --workspace\` — 482 core (+2 new) + 127 bin + 28 terminal + 1 doc tests, all pass.
  - \`adopt_existing_worktrees_picks_up_non_primary_rows\` — real git repo + \`git worktree add feat-x\`; asserts the row is adopted with the right branch / path leaf / is_primary flag, and that a second call doesn't duplicate.
  - \`adopt_existing_worktrees_swallows_non_git_path\` — empty tempdir; asserts no panic and no mutation.
- [x] \`cargo clippy --workspace --all-targets\` — no warnings on changed files.
- [ ] Live: add a project that already has 2–3 worktrees on disk, confirm they appear in the sidebar immediately without needing the New worktree dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)