### PR TITLE
chore: bump version to 0.3.0-rc.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.10"
+version = "0.3.0-rc.11"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.10"
+version = "0.3.0-rc.11"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
## Summary

Cuts rc.11 with the resize-repaint fix + crash diagnostics from this batch:

- **#227** — `TerminalView::maybe_resize` preserves `set_at` when the pending request already targets the same `(cols, rows)`. Fixes the release-build "resize doesn't repaint until tab-swap" symptom for both window resize and splitter drag (the second never went through `observe_window_bounds` at all, so the previous bounds-observer fix didn't cover it).
- **#225** — panic hook installed before velopack startup hooks (auto-update Rust panics now produce \`crash.log\`), per-phase \`boot.log\` tape with rotation, and the resize-cascade \`terminal-resize.log\` tape (rotated to \`.prev\`) that pinned #227's root cause.

## Test plan

- [ ] \`cargo build --release --bin codescope-rs\` clean (done locally)
- [ ] Velopack release pipeline cuts rc.11 artifacts on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)