### PR TITLE
fix(rs): rehydrate legacy null agent_id rows as default agent

### DIFF
--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -411,6 +411,33 @@ impl SessionManager {
         Err(anyhow!("session '{session_id}' not found"))
     }
 
+    /// Backfill `agent_id` on a persisted session row. Returns `true`
+    /// when the value changed, `false` when it already matched (idempotent).
+    ///
+    /// Used by the cold-rehydrate + reopen fallback paths to repair
+    /// legacy rows that were persisted before the spawn-side started
+    /// stamping `agent_id` (pre-PR-#223). When such a row is resumed
+    /// under `settings.default_agent`, this writes the resolved id back
+    /// so the next boot doesn't need the fallback again. Mirrors the
+    /// shape of [`Self::update_agent_session_id`].
+    pub fn update_agent_id(
+        cfg: &mut ProjectsConfig,
+        session_id: &str,
+        agent_id: Option<&str>,
+    ) -> Result<bool> {
+        for project in cfg.projects.iter_mut() {
+            if let Some(s) = project.sessions.iter_mut().find(|s| s.id == session_id) {
+                let next = agent_id.map(|x| x.to_string());
+                if s.agent_id == next {
+                    return Ok(false);
+                }
+                s.agent_id = next;
+                return Ok(true);
+            }
+        }
+        Err(anyhow!("session '{session_id}' not found"))
+    }
+
     /// Lenient discovery-callback entry point: stamp `agent_session_id`
     /// on the session whose CodeScope id is `session_id`, returning
     /// `false` instead of erroring when the session id isn't found.
@@ -936,6 +963,41 @@ mod tests {
         SessionManager::rename(&mut cfg, "s1", Some("Re")).unwrap();
         SessionManager::rename(&mut cfg, "s1", None).unwrap();
         assert!(cfg.projects[0].sessions[0].display_name.is_none());
+    }
+
+    #[test]
+    fn update_agent_id_backfills_and_is_idempotent() {
+        // A legacy row with `agent_id = None` (pre-PR-#223 spawn-side
+        // bug) must accept a backfill. Calling again with the same
+        // value reports `false` so the caller can skip the save. A
+        // follow-up with `None` clears it back.
+        let mut cfg = ProjectsConfig::default();
+        let mut p = make_project("p1");
+        p.sessions.push(make_session("legacy", None));
+        cfg.projects.push(p);
+        assert!(cfg.projects[0].sessions[0].agent_id.is_none());
+
+        let changed = SessionManager::update_agent_id(&mut cfg, "legacy", Some("claude")).unwrap();
+        assert!(changed);
+        assert_eq!(
+            cfg.projects[0].sessions[0].agent_id.as_deref(),
+            Some("claude"),
+        );
+
+        let changed = SessionManager::update_agent_id(&mut cfg, "legacy", Some("claude")).unwrap();
+        assert!(!changed, "no-op write must not report a change");
+
+        let changed = SessionManager::update_agent_id(&mut cfg, "legacy", None).unwrap();
+        assert!(changed);
+        assert!(cfg.projects[0].sessions[0].agent_id.is_none());
+    }
+
+    #[test]
+    fn update_agent_id_unknown_session_errors() {
+        let mut cfg = ProjectsConfig::default();
+        cfg.projects.push(make_project("p1"));
+        let err = SessionManager::update_agent_id(&mut cfg, "ghost", Some("claude")).unwrap_err();
+        assert!(err.to_string().contains("ghost"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2270,7 +2270,15 @@ impl AppShell {
                 .agent_id
                 .clone()
                 .or_else(|| default_agent_launch_for(&self.settings).map(|(id, _)| id.to_string()));
+            // Gate the persistence on `agent_session_id.is_some()` —
+            // only agent rows ever stamp that UUID, so its presence
+            // is positive evidence the row was an agent. Rows with
+            // both fields `None` could be legacy plain shells; writing
+            // `claude` to those would be a permanent regression for
+            // users who intend them as shells. Matches Copilot's
+            // review on #230 and the same gate `reopen_session` uses.
             if entry.agent_id.is_none()
+                && entry.agent_session_id.is_some()
                 && let Some(id) = resolved_agent_id.clone()
             {
                 pending_backfills.push((entry.session_id.clone(), id));
@@ -2844,13 +2852,22 @@ impl AppShell {
             }
         };
         // Legacy / pre-PR-#223 rows come back with `agent_id = None`
-        // even though the user has been running them as Claude. The
+        // even though the user has been running them as an agent. The
         // launch-side fallback below picks `settings.default_agent` so
         // the tab still resumes correctly; mirror that decision into
         // the persisted row so the next cold-start rehydrate doesn't
-        // need the same rescue. New rows already carry their own
-        // `agent_id` so this no-ops (`update_agent_id` is idempotent).
-        let backfill_agent_id: Option<String> = if restored.agent_id.is_none() {
+        // need the same rescue.
+        //
+        // Gate the persistence on `agent_session_id.is_some()` — only
+        // agent rows ever stamp that UUID, so its presence is positive
+        // evidence the row was an agent. Rows with both fields `None`
+        // could be legacy plain shells (or pre-fix agent rows that
+        // never logged a session id); writing `claude` to those would
+        // be a permanent regression for users who intend them as
+        // shells. The narrower gate matches Copilot's review on #230.
+        let backfill_agent_id: Option<String> = if restored.agent_id.is_none()
+            && restored.agent_session_id.is_some()
+        {
             default_agent_launch_for(&self.settings).map(|(id, _)| id.to_string())
         } else {
             None

--- a/src/app.rs
+++ b/src/app.rs
@@ -2220,6 +2220,12 @@ impl AppShell {
         let group_count = self.groups.len();
         let mut active_by_group: Vec<Option<usize>> = vec![None; group_count];
         let mut spawned_any = false;
+        // `(session_id, resolved_agent_id)` pairs to backfill into
+        // projects.json after the loop. Populated only when a
+        // rehydrated row had `agent_id = None` and we rescued it via
+        // `settings.default_agent` — see the loop body for context.
+        // Empty in the steady state once all legacy rows are healed.
+        let mut pending_backfills: Vec<(String, String)> = Vec::new();
 
         // Suppress per-spawn `save_layout` writes while the loop runs;
         // we flush a single complete snapshot at the end. Without this,
@@ -2251,14 +2257,32 @@ impl AppShell {
             // after the loop.
             self.focused_group = group_idx;
 
+            // Legacy / pre-PR-#223 rows come back with `agent_id =
+            // None` (the spawn side started stamping the id only
+            // after that fix). Falling back to a plain shell there
+            // is the "1 of my Claude tabs rehydrated as PowerShell"
+            // bug reported on rc.11. Mirror `reopen_session`: rescue
+            // via `settings.default_agent` so the tab resumes as the
+            // configured agent. The backfill list below pushes the
+            // resolved id back into projects.json so the next boot
+            // skips the fallback entirely.
+            let resolved_agent_id: Option<String> = entry
+                .agent_id
+                .clone()
+                .or_else(|| default_agent_launch_for(&self.settings).map(|(id, _)| id.to_string()));
+            if entry.agent_id.is_none()
+                && let Some(id) = resolved_agent_id.clone()
+            {
+                pending_backfills.push((entry.session_id.clone(), id));
+            }
+
             // Resume-by-id when we have an agent + its session UUID.
             // `build_resume_auto_type` returns `claude --resume <id>` /
             // `pi --session <id>` / `copilot --resume=<id>` depending on
             // the agent profile. Falls back to the agent's "most recent"
             // resume args when the persisted `agent_session_id` is
             // missing, and to `None` for plain shells.
-            let agent_profile = entry
-                .agent_id
+            let agent_profile = resolved_agent_id
                 .as_deref()
                 .and_then(|aid| self.agent_registry.get_by_id(aid));
             let auto: Option<SharedString> = agent_profile
@@ -2301,14 +2325,14 @@ impl AppShell {
                 Some(path),
                 Some(title),
                 auto,
-                // Rehydrate path: the persisted row already carries
-                // the `agent_id` we want (or `None` for legacy
-                // pre-fix rows / plain-shell sessions), and
-                // `restore_session_id = Some` short-circuits the
-                // `allocate_session_id` persistence branch entirely
-                // — projects.json is the source of truth, this
-                // arg is ignored once `restore_session_id` is set.
-                entry.agent_id.clone().map(SharedString::from),
+                // Rehydrate path: pass `resolved_agent_id` so the
+                // in-memory tab state knows which agent it's running,
+                // even when projects.json still carries the legacy
+                // `agent_id: null`. `restore_session_id = Some`
+                // short-circuits the `allocate_session_id`
+                // persistence branch — the disk-side backfill goes
+                // through the `pending_backfills` flush below.
+                resolved_agent_id.clone().map(SharedString::from),
                 Some(entry.session_id.clone()),
                 window,
                 cx,
@@ -2325,6 +2349,35 @@ impl AppShell {
         // need to clear this — otherwise a later user action would
         // silently no-op every save_layout.
         self.suppress_layout_save = false;
+
+        // Heal legacy `agent_id = None` rows we rescued via the
+        // default-agent fallback. One disk write per rehydrate
+        // covers every row at once; subsequent boots skip the
+        // fallback because the row now carries the resolved id.
+        if !pending_backfills.is_empty() {
+            let mut changed = false;
+            for (sid, aid) in &pending_backfills {
+                match codescope_core::SessionManager::update_agent_id(
+                    &mut self.projects,
+                    sid,
+                    Some(aid),
+                ) {
+                    Ok(true) => changed = true,
+                    Ok(false) => {}
+                    Err(err) => {
+                        eprintln!(
+                            "warning: failed to backfill agent_id on rehydrate \
+                             (session {sid}): {err:#}"
+                        );
+                    }
+                }
+            }
+            if changed
+                && let Err(err) = self.projects.save(&self.paths)
+            {
+                eprintln!("warning: failed to persist rehydrate backfill: {err:#}");
+            }
+        }
 
         if !spawned_any {
             // Every live session's worktree was missing — leave the
@@ -2790,6 +2843,24 @@ impl AppShell {
                 return;
             }
         };
+        // Legacy / pre-PR-#223 rows come back with `agent_id = None`
+        // even though the user has been running them as Claude. The
+        // launch-side fallback below picks `settings.default_agent` so
+        // the tab still resumes correctly; mirror that decision into
+        // the persisted row so the next cold-start rehydrate doesn't
+        // need the same rescue. New rows already carry their own
+        // `agent_id` so this no-ops (`update_agent_id` is idempotent).
+        let backfill_agent_id: Option<String> = if restored.agent_id.is_none() {
+            default_agent_launch_for(&self.settings).map(|(id, _)| id.to_string())
+        } else {
+            None
+        };
+        if let Some(id) = backfill_agent_id.as_deref()
+            && let Err(err) =
+                SessionManager::update_agent_id(&mut self.projects, &session_id, Some(id))
+        {
+            eprintln!("warning: failed to backfill agent_id on reopen: {err:#}");
+        }
         if let Err(err) = self.projects.save(&self.paths) {
             eprintln!("warning: failed to persist session reopen: {err:#}");
         }


### PR DESCRIPTION
## Summary

- Pre-PR-#223 spawn-side never persisted `agent_id` on the `Session` row, so rows written before that fix carry `agent_id: null` in `projects.json` even though the user was running them as Claude.
- `reopen_session` (`src/app.rs:2877`) already rescues those rows via `settings.default_agent`; the cold-start rehydrate path did not, so those tabs came back as generic shells on a fresh restart (visible on rc.11 right after installing).
- This PR mirrors the reopen fallback in `rehydrate_or_cold_start` and adds a disk-side backfill that writes the resolved `agent_id` back into `projects.json` so the next boot doesn't need the fallback again.

## Changes

- `SessionManager::update_agent_id` — new idempotent helper alongside `update_agent_session_id`. Returns `Ok(true)` on change, `Ok(false)` on no-op, `Err` when the session id is unknown.
- `rehydrate_or_cold_start` resolves `entry.agent_id.or_else(default_agent_launch_for)` and threads the resolved id into both the auto-type lookup and `spawn_tab_in`. A `pending_backfills` list captures rescued rows and flushes them via a single `projects.json` save after the loop.
- `reopen_session` now invokes `update_agent_id` when its existing fallback fires, so legacy rows heal in one boot regardless of entry path (rehydrate or manual reopen).

## Test plan

- [x] `cargo test -p codescope-core --lib` — 484 passed, including two new tests for `update_agent_id` (backfill idempotency + unknown-session error).
- [x] `cargo build --workspace` clean.
- [x] `cargo clippy --workspace --all-targets` no new warnings on changed files.
- [ ] Manual: install dev build, confirm a row with `agent_id: null` and a valid `agent_session_id` rehydrates as the configured default agent and that `projects.json` shows `agent_id: "claude"` after the cold-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)