### PR TITLE
chore: bump version to 0.3.0-rc.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.11"
+version = "0.3.0-rc.12"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.11"
+version = "0.3.0-rc.12"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
## Summary

Picks up one rehydrate-side fix:

- #230: cold-start rehydrate + manual reopen now rescue legacy rows that carry `agent_id: null` (pre-PR-#223 spawn-side bug) by falling back to `settings.default_agent`. When the row also has an `agent_session_id` (positive evidence it was an agent row), the resolved id is written back into `projects.json` so the row heals in one boot. Fixes the rc.11 "one of my Claude tabs rehydrated as PowerShell after install" symptom.

## Test plan

- [x] `cargo build --workspace` clean.
- [ ] Release pipeline succeeds across Linux x64 / macOS arm64+x64 / Windows x64.
- [ ] Manual: install rc.12 on top of rc.11, confirm legacy `agent_id: null` row resumes as the configured default agent and `projects.json` shows the backfilled `agent_id` after a cold-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)