### PR TITLE
feat(updates): gate auto-apply behind an actionable toast

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -281,13 +281,42 @@ const CAPTION_CTRLS_W: f32 = 4.0 * 46.0;
 /// One on-screen toast — short status notification anchored bottom-
 /// right of the window. Mirrors C# `ToastHost` shape (Ok / Err /
 /// Info severities, auto-dismiss, top-newest stacking).
+///
+/// `expires_at: None` marks a *persistent* toast that the dismiss
+/// task leaves alone — used for offers the user must act on (e.g.
+/// "Install & restart" for a downloaded update). Such toasts stay
+/// until the user clicks the action or the explicit dismiss "×".
 #[derive(Clone)]
 struct Toast {
     id: u64,
     kind: ToastKind,
     title: SharedString,
     detail: Option<SharedString>,
-    expires_at: Instant,
+    expires_at: Option<Instant>,
+    action: Option<ToastAction>,
+}
+
+/// Optional call-to-action rendered as a button inside a toast. The
+/// `kind` is dispatched through [`AppShell::dispatch_toast_action`]
+/// so the toast layer stays UI-only and doesn't carry callbacks
+/// across thread boundaries (which is awkward in gpui's entity
+/// model).
+#[derive(Clone)]
+struct ToastAction {
+    label: SharedString,
+    kind: ToastActionKind,
+}
+
+/// Discriminator for [`ToastAction`]. Only one variant today — kept
+/// as an enum so a second action (e.g. "Dismiss & remind later")
+/// slots in without re-plumbing the toast layer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum ToastActionKind {
+    /// User clicked "Install & restart" on the update-ready toast.
+    /// Pulls `AppShell.staged_update` and calls
+    /// `velopack_bridge::apply_staged`. The apply call exits the
+    /// process; Update.exe then relaunches us on the new version.
+    ApplyStagedUpdate,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -655,6 +684,19 @@ pub struct AppShell {
     /// same notification entry on every tick. `None` until the first
     /// poll surfaces an `Available` result.
     last_announced_update: Option<String>,
+    /// Fully-downloaded Velopack update waiting for the user to
+    /// click "Install & restart". `Some` between
+    /// `stage_pending_update` returning `Ready` and the user (or a
+    /// follow-up poll for a newer version) consuming it. Held on the
+    /// shell — not in the toast — because `apply_staged` must run on
+    /// the main thread (velopack-rs ends in `std::process::exit(0)`
+    /// and exit from a worker thread races CRT teardown). The toast
+    /// only carries an opaque [`ToastActionKind`] discriminator; the
+    /// actual `StagedUpdate` lives here so the action handler can
+    /// `take()` it without needing to thread anything through the
+    /// render layer. Mirrors the gated-apply UX C# `UpdateService`
+    /// gained in PR #205.
+    staged_update: Option<Box<crate::velopack_bridge::StagedUpdate>>,
     /// In-memory snapshot of the on-disk session catalog used by
     /// the session-lifecycle helpers. Initialised at construction
     /// from a [`SessionManager::load_with_sweep`] pass so the
@@ -1166,7 +1208,13 @@ impl AppShell {
                 let result = this.update(cx, |this, cx| {
                     let now = Instant::now();
                     let before = this.toasts.len();
-                    this.toasts.retain(|t| t.expires_at > now);
+                    // Persistent toasts (`expires_at: None`) survive
+                    // every tick — they only leave via the explicit
+                    // dismiss "×" or by their action handler. Today
+                    // that's the update-ready offer; see
+                    // `push_action_toast`.
+                    this.toasts
+                        .retain(|t| t.expires_at.map(|e| e > now).unwrap_or(true));
                     if this.toasts.len() != before {
                         cx.notify();
                     }
@@ -1279,6 +1327,7 @@ impl AppShell {
             telemetry_tails: HashMap::new(),
             bell_bounds: None,
             last_announced_update: None,
+            staged_update: None,
             projects: projects_for_sessions,
             agent_registry,
             command_palette: None,
@@ -2014,9 +2063,20 @@ impl AppShell {
                         // * cargo-dist MSI / `cargo run` / unpacked
                         //   zip → keep the existing URL hint; the
                         //   user opens the release page themselves.
+                        // Detail text differs by install path:
+                        //
+                        // * Velopack install → "Downloading update…"
+                        //   so the user knows download is in flight.
+                        //   When the download finishes we replace
+                        //   the bell-popover entry with an actionable
+                        //   toast (see below) — the popover entry
+                        //   itself is informational only.
+                        // * cargo-dist MSI / `cargo run` / unpacked
+                        //   zip → keep the existing URL hint; the
+                        //   user opens the release page themselves.
                         let detail: SharedString = if velopack_supported {
                             "Downloading update in the background. \
-                             Restart CodeScope when prompted to install."
+                             You'll be prompted to install when it's ready."
                                 .into()
                         } else {
                             format!("A newer release is published. {url}").into()
@@ -2036,16 +2096,21 @@ impl AppShell {
                         // * Background — `stage_pending_update` does
                         //   `check_for_updates` + `download_updates`.
                         //   Heavy IO that must not block the UI.
-                        // * Main thread — `apply_staged` calls
-                        //   `apply_updates_and_restart`, which ends
-                        //   in `std::process::exit(0)` inside
-                        //   velopack-rs. Running that on a worker
-                        //   thread while GPUI's message loop is still
-                        //   active on main races CRT teardown against
-                        //   foreground state and crashes the process
-                        //   with no recoverable panic (observed on
-                        //   v0.3.0-rc.7). See `velopack_bridge`
-                        //   module docs for the failure analysis.
+                        // * Main thread — `apply_staged` is no longer
+                        //   called automatically. We stash the
+                        //   `StagedUpdate` on the shell and surface a
+                        //   persistent toast with an "Install &
+                        //   restart" action — the user clicks when
+                        //   ready, then `dispatch_toast_action` runs
+                        //   `apply_staged` on the main thread. This
+                        //   prevents the user-reported "the app
+                        //   crashed during update" perception caused
+                        //   by the auto-apply silently killing the
+                        //   running window before Update.exe could
+                        //   relaunch us. velopack-rs's
+                        //   `apply_updates_and_restart` still ends
+                        //   in `std::process::exit(0)`, which is why
+                        //   apply MUST run on the main thread.
                         //
                         // Errors are best-effort and only logged
                         // (matches C# `LogWarning(ex, …)`).
@@ -2058,19 +2123,28 @@ impl AppShell {
                         if this.upgrade().is_none() {
                             break;
                         }
-                        let _ = this.update(cx, |_this, _cx| {
+                        let version_for_toast = version.clone();
+                        let _ = this.update(cx, |this, cx| {
                             use crate::velopack_bridge::StageOutcome;
                             match staged {
                                 StageOutcome::Ready(s) => {
-                                    // Happy path doesn't return — the
-                                    // helper exits the process and
-                                    // the bootstrap relaunches us on
-                                    // the new version.
-                                    if let Err(msg) =
-                                        crate::velopack_bridge::apply_staged(s)
-                                    {
-                                        eprintln!("[velopack] apply failed: {msg}");
-                                    }
+                                    this.staged_update = Some(s);
+                                    this.push_action_toast(
+                                        ToastKind::Info,
+                                        format!(
+                                            "CodeScope {version_for_toast} ready to install"
+                                        ),
+                                        Some(
+                                            "Saves your session state, restarts on the \
+                                             new version."
+                                                .into(),
+                                        ),
+                                        ToastAction {
+                                            label: "Install & restart".into(),
+                                            kind: ToastActionKind::ApplyStagedUpdate,
+                                        },
+                                        cx,
+                                    );
                                 }
                                 StageOutcome::UpToDate => {
                                     // Race between our GitHub poll
@@ -3877,6 +3951,7 @@ impl AppShell {
                 };
                 let title = t.title.clone();
                 let detail = t.detail.clone();
+                let action = t.action.clone();
                 div()
                     .id(("toast", id))
                     .flex()
@@ -3914,6 +3989,36 @@ impl AppShell {
                                     .text_color(ink_dim)
                                     .text_size(px(11.0))
                                     .child(d)
+                            }))
+                            // Action button row — only rendered when
+                            // `Toast.action` is `Some`. Lives inside
+                            // the content column so it indents
+                            // beneath title/detail rather than
+                            // hugging the dismiss "×".
+                            .children(action.map(|a| {
+                                let kind = a.kind;
+                                let label = a.label.clone();
+                                div().pt_2().child(
+                                    div()
+                                        .id(("toast-action", id))
+                                        .px_3()
+                                        .py_1p5()
+                                        .rounded_sm()
+                                        .bg(accent_clean)
+                                        .text_color(ink)
+                                        .text_size(px(12.0))
+                                        .cursor_pointer()
+                                        .hover(move |s| s.opacity(0.85))
+                                        .on_mouse_down(
+                                            MouseButton::Left,
+                                            cx.listener(move |this, _, window, cx| {
+                                                this.dispatch_toast_action(
+                                                    id, kind, window, cx,
+                                                );
+                                            }),
+                                        )
+                                        .child(label),
+                                )
                             })),
                     )
                     .child(
@@ -5361,7 +5466,39 @@ impl AppShell {
             kind,
             title: title.into(),
             detail,
-            expires_at: Instant::now() + lifetime,
+            expires_at: Some(Instant::now() + lifetime),
+            action: None,
+        });
+        while self.toasts.len() > TOAST_VISIBLE_CAP {
+            self.toasts.pop_back();
+        }
+        cx.notify();
+    }
+
+    /// Push a *persistent* toast carrying an action affordance. The
+    /// auto-dismiss task leaves these alone (`expires_at: None`); the
+    /// toast stays until the user clicks the action or the dismiss
+    /// "×". Cap-eviction still applies — a flurry of regular toasts
+    /// could push a persistent one off the back, but that's bounded
+    /// by `TOAST_VISIBLE_CAP` and the persistent kinds we have today
+    /// are re-emitted on the next update-check tick anyway.
+    fn push_action_toast(
+        &mut self,
+        kind: ToastKind,
+        title: impl Into<SharedString>,
+        detail: Option<SharedString>,
+        action: ToastAction,
+        cx: &mut Context<Self>,
+    ) {
+        let id = self.next_toast_id;
+        self.next_toast_id += 1;
+        self.toasts.push_front(Toast {
+            id,
+            kind,
+            title: title.into(),
+            detail,
+            expires_at: None,
+            action: Some(action),
         });
         while self.toasts.len() > TOAST_VISIBLE_CAP {
             self.toasts.pop_back();
@@ -5542,6 +5679,54 @@ impl AppShell {
         self.toasts.retain(|t| t.id != id);
         if self.toasts.len() != before {
             cx.notify();
+        }
+    }
+
+    /// Handle a click on a toast's action button. Dispatches based
+    /// on the [`ToastActionKind`] discriminator the toast carried.
+    /// Dismisses the source toast so the user gets a visible
+    /// "click registered" signal — apply-staged then exits the
+    /// process within ~1 s anyway.
+    ///
+    /// `_window` is unused today but kept in the signature so
+    /// future action kinds that open dialogs / focus elements
+    /// don't have to reshape every call site.
+    fn dispatch_toast_action(
+        &mut self,
+        toast_id: u64,
+        kind: ToastActionKind,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.dismiss_toast(toast_id, cx);
+        match kind {
+            ToastActionKind::ApplyStagedUpdate => {
+                // `apply_staged` ends in `std::process::exit(0)`
+                // inside velopack-rs — must run on the main thread
+                // (we are). If the staged update is missing (rare:
+                // a concurrent UpToDate poll consumed it), surface
+                // a short error toast instead of silently no-oping.
+                let Some(staged) = self.staged_update.take() else {
+                    self.push_toast(
+                        ToastKind::Err,
+                        SharedString::from("Update no longer staged"),
+                        Some(SharedString::from(
+                            "Wait a moment for the next update check, then try again.",
+                        )),
+                        cx,
+                    );
+                    return;
+                };
+                if let Err(msg) = crate::velopack_bridge::apply_staged(staged) {
+                    eprintln!("[velopack] apply failed: {msg}");
+                    self.push_toast(
+                        ToastKind::Err,
+                        SharedString::from("Update failed"),
+                        Some(SharedString::from(msg)),
+                        cx,
+                    );
+                }
+            }
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5484,19 +5484,18 @@ impl AppShell {
             expires_at: Some(Instant::now() + lifetime),
             action: None,
         });
-        while self.toasts.len() > TOAST_VISIBLE_CAP {
-            self.toasts.pop_back();
-        }
+        self.evict_toasts_to_cap();
         cx.notify();
     }
 
     /// Push a *persistent* toast carrying an action affordance. The
     /// auto-dismiss task leaves these alone (`expires_at: None`); the
     /// toast stays until the user clicks the action or the dismiss
-    /// "×". Cap-eviction still applies — a flurry of regular toasts
-    /// could push a persistent one off the back, but that's bounded
-    /// by `TOAST_VISIBLE_CAP` and the persistent kinds we have today
-    /// are re-emitted on the next update-check tick anyway.
+    /// "×". Cap-eviction prefers non-persistent toasts (see
+    /// [`Self::evict_toasts_to_cap`]) so a flurry of regular toasts
+    /// can't push the action affordance — and its stashed
+    /// `staged_update` — off the back and leave the user without a
+    /// way to install until the next 3-hour poll.
     fn push_action_toast(
         &mut self,
         kind: ToastKind,
@@ -5515,10 +5514,29 @@ impl AppShell {
             expires_at: None,
             action: Some(action),
         });
-        while self.toasts.len() > TOAST_VISIBLE_CAP {
-            self.toasts.pop_back();
-        }
+        self.evict_toasts_to_cap();
         cx.notify();
+    }
+
+    /// Trim the visible-toast deque down to [`TOAST_VISIBLE_CAP`],
+    /// preferring **non-persistent** toasts as the eviction victim.
+    /// Only when every survivor is persistent do we fall back to
+    /// dropping the oldest persistent toast — that's the
+    /// degenerate "more action offers than visible slots" case
+    /// which doesn't exist today (only one persistent kind ships).
+    /// Closes a Copilot review on PR #232: without this preference
+    /// a burst of regular toasts could push the staged-update
+    /// action off the back, stranding `staged_update = Some` with
+    /// no UI affordance until the next 3-hour poll re-emits.
+    fn evict_toasts_to_cap(&mut self) {
+        while self.toasts.len() > TOAST_VISIBLE_CAP {
+            let victim_idx = self
+                .toasts
+                .iter()
+                .rposition(|t| t.expires_at.is_some())
+                .unwrap_or(self.toasts.len() - 1);
+            self.toasts.remove(victim_idx);
+        }
     }
 
     /// Walk every adopted-agent tab, diff its current telemetry state

--- a/src/app.rs
+++ b/src/app.rs
@@ -3998,17 +3998,32 @@ impl AppShell {
                             .children(action.map(|a| {
                                 let kind = a.kind;
                                 let label = a.label.clone();
+                                // Match the empty-state primary CTA: solid
+                                // accent fill with `gpui::black()` text +
+                                // SEMIBOLD so the call to action reads
+                                // cleanly on the accent — the previous
+                                // `ink` foreground was a near-white that
+                                // washed out against the accent fill in
+                                // most themes. Subtle l-bump on hover (same
+                                // formula `empty_state.rs` uses for
+                                // `accent_hover`) keeps the affordance.
+                                let accent = theme::accent(theme);
+                                let accent_hover = gpui::Hsla {
+                                    l: (accent.l + 0.08).min(1.0),
+                                    ..accent
+                                };
                                 div().pt_2().child(
                                     div()
                                         .id(("toast-action", id))
                                         .px_3()
                                         .py_1p5()
                                         .rounded_sm()
-                                        .bg(accent_clean)
-                                        .text_color(ink)
+                                        .bg(accent)
+                                        .text_color(gpui::black())
                                         .text_size(px(12.0))
+                                        .font_weight(gpui::FontWeight::SEMIBOLD)
                                         .cursor_pointer()
-                                        .hover(move |s| s.opacity(0.85))
+                                        .hover(move |s| s.bg(accent_hover))
                                         .on_mouse_down(
                                             MouseButton::Left,
                                             cx.listener(move |this, _, window, cx| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,17 @@ fn main() -> Result<()> {
             .open(&cur);
     }
     write_boot_phase(&paths, "main:enter");
+    // Log the full argv as a separate phase so the next time the
+    // post-update crash shows up we can tell *what* Update.exe
+    // passed in. The `--veloapp-updated` flag triggers velopack's
+    // unconditional `exit(0)` (see `velopack_bridge::run_startup_hooks`
+    // for the workaround) — knowing the actual argv on a fresh
+    // failure lets us tell that case from any future surprise flag
+    // we don't yet handle. One line per launch, no PII.
+    {
+        let argv: Vec<String> = std::env::args().skip(1).collect();
+        write_boot_phase(&paths, &format!("main:argv {argv:?}"));
+    }
 
     // Resize-cascade diagnostic tape. PR #218/#219 fixed the
     // bounds-observer half of the cascade but the user-reported


### PR DESCRIPTION
## Summary

Stop auto-applying staged Velopack updates the moment the download finishes. Show a persistent toast with an **Install & restart** button instead, so the user controls when the running window gets killed.

## Why

Reproducing the user-reported "the update mechanism still crashes the entire app" symptom locally via `Update.exe apply --verbose --log` showed there's no actual crash — the apply works end-to-end:

```
1. Extract new package        (~100ms)
2. Run --veloapp-obsolete hook (~225ms, velopack-rs exit(0) by design)
3. Backup + replace files     (~300ms)
4. Run --veloapp-updated hook  (~225ms, velopack-rs exit(0) by design)
5. Setting env VELOPACK_RESTART=true
6. Launch new exe normally    → window opens
```

But the user's running window vanishes at step 0 (`apply_updates_and_restart → exit(0)`), with ~1s of dead time before step 6's window appears — perceived as a hard crash even though the bell-popover toast literally promised _"Restart CodeScope when prompted to install."_

The old code never prompted; it just applied. This PR makes the toast match its own promise.

## Changes

- `Toast.expires_at: Option<Instant>` — `None` = persistent (dismiss loop skips).
- `Toast.action: Option<ToastAction>` + `ToastActionKind::ApplyStagedUpdate` enum so the toast carries an opaque discriminator, not a cross-thread callback.
- `AppShell.staged_update: Option<Box<StagedUpdate>>` — stashed on `Ready`, taken when user clicks. Held here (not in the toast) because `apply_staged` must run on the main thread.
- `push_action_toast` builder for the actionable variant; existing `push_toast` callers unchanged.
- `dispatch_toast_action` matches on the action kind, calls `apply_staged` for `ApplyStagedUpdate`. Surfaces an error toast if the staged update was consumed by a concurrent poll.
- Toast text updated to be accurate: _"Downloading update in the background. You'll be prompted to install when it's ready."_ → followed by the action toast with _"Saves your session state, restarts on the new version."_
- `main.rs` logs `env::args()` to `boot.log` so future unexplained startup deaths show which flag (if any) Update.exe passed in.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --lib` — 484 + 28 + others all pass
- [x] `cargo clippy --workspace --all-targets` — no new warnings on changed files
- [x] Sanity-launch dev with the new code — boots cleanly through all phases
- [ ] Manual on rc.13: trigger a poll, observe the "Install & restart" toast, click it, verify the apply + relaunch flow runs and no perceived crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)