### PR TITLE
chore: bump version to 0.3.0-rc.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.12"
+version = "0.3.0-rc.13"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.12"
+version = "0.3.0-rc.13"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
## Summary

Picks up the update-UX overhaul:

- #232: Velopack auto-apply is gated behind a persistent toast with an **Install & restart** action. Stops the user-reported "the app crashed during update" perception — the apply mechanism worked end-to-end but `apply_updates_and_restart`'s instant `exit(0)` killed the running window with no warning, leaving a ~1s gap before Update.exe's post-apply relaunch. Now the toast matches what its own text always promised. Includes argv logging to `boot.log` for future startup diagnostics.

## Test plan

- [x] `cargo build --workspace` clean
- [ ] Release pipeline succeeds across Linux x64 / macOS arm64+x64 / Windows x64
- [ ] Manual: install rc.13, wait for next poll cycle to surface an rc.14 (or use a local Velopack feed), click "Install & restart" — verify clean apply with no perceived crash, and `boot.log` shows the post-update argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)