### PR TITLE
docs+fix: README features, plus repair Ctrl+Shift+, on US Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Snap a worktree into its own workspace with `Ctrl+\`. Two agents, side by side, 
 
 ![Overview grid](docs/screenshots/overview.png)
 
+### Paste screenshots straight into the prompt
+
+`Ctrl+V` of a clipboard image stores the bytes under `<worktree>/.codescope/attachments/<timestamp>-<hash>.<ext>` and pastes the slash-normalized relative path into the focused terminal — so any agent that accepts a file path (Claude, Codex, OpenCode, …) ingests it without you switching to a file dialog. The path is git-ignored automatically via `.git/info/exclude`, so screenshots don't leak into commits.
+
+### Themes
+
+Six built-ins selectable from the settings dialog (`Ctrl+Shift+,`): `codescope-default`, `vs-code-dark`, `one-dark`, `solarized-dark`, `tokyo-night`, `light`. Live-applied to chrome and the in-tree terminal. Persisted as the `theme` key in `settings.json`, so hand-editing works too.
+
 ### Also in the box
 
 - **Sidebar tree** — Projects → Worktrees → Sessions, drag-and-drop to add a project, F2 to rename.
@@ -61,6 +69,7 @@ Grab the latest release from the [**Releases page**](https://github.com/maui1911
 
 - `git` on `PATH`
 - At least one agent CLI on `PATH` (`claude`, `codex`, `copilot`, `opencode`, `pi`, etc.)
+- **Windows only:** PowerShell 7+ (`pwsh.exe`) on `PATH`. CodeScope spawns `pwsh.exe` for every terminal tab and for the `-Command "& { <agent> }"` wrapper that auto-types the agent CLI — legacy `powershell.exe` (Windows PowerShell 5.1) is not used. Override with the `CODESCOPE_SHELL` env var if you want a different shell.
 
 > **No Rust toolchain needed** — the release is self-contained.
 
@@ -99,6 +108,7 @@ For installer / Velopack packaging see `.github/workflows/release.yml`.
 | `Ctrl+Tab` / `Ctrl+Shift+Tab` | Next / previous tab |
 | `Ctrl+1`…`Ctrl+9` | Jump to tab by index |
 | `Ctrl+K`, `Ctrl+Shift+P` | Command palette |
+| `Ctrl+Shift+,` | Open settings (theme, font, cursor, default agent) |
 | `Ctrl+Shift+O` | Toggle overview |
 | `Ctrl+F` | Focus sidebar filter |
 | `Ctrl+Shift+Enter` | Open selected worktree in a new group |

--- a/src/app.rs
+++ b/src/app.rs
@@ -6106,8 +6106,20 @@ impl AppShell {
                     self.open_command_palette(window, cx);
                 }
             }
-            // Ctrl+Shift+, opens the Settings dialog.
+            // Ctrl+Shift+, opens the Settings dialog. Accepts both
+            // keystroke shapes gpui surfaces: bare `","` with
+            // `mods.shift` set (non-US layouts, most non-Windows
+            // platforms) and the US-Windows folded glyph `"<"` with
+            // shift cleared (the Windows adapter folds shifted
+            // punctuation the same way it folds shifted digits to
+            // `!@#$%^&*(` — see `keystroke_digit_index`). Without the
+            // second arm the chord silently doesn't fire on the most
+            // common Windows install.
             "," if mods.shift => {
+                cx.stop_propagation();
+                self.open_settings_dialog(window, cx);
+            }
+            "<" if !mods.shift => {
                 cx.stop_propagation();
                 self.open_settings_dialog(window, cx);
             }

--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -935,8 +935,16 @@ pub(crate) fn is_app_level_shortcut(key: &str, mods: &gpui::Modifiers) -> bool {
         return true;
     }
     // Ctrl+Shift+, — open Settings. Plain Ctrl+, stays with the
-    // terminal in case the agent / shell has bound it.
+    // terminal in case the agent / shell has bound it. Accept both
+    // shapes: bare `","` with shift (non-US / non-Windows) and
+    // US-Windows folded `"<"` with shift cleared — gpui's Windows
+    // adapter folds shifted punctuation the same way it folds
+    // shifted digits. Without the second arm the chord is lost
+    // because the bubble-up check never matches.
     if key == "," && mods.shift {
+        return true;
+    }
+    if key == "<" && !mods.shift {
         return true;
     }
     // Ctrl+Shift+G — open active tab's worktree remote in browser.
@@ -1264,11 +1272,26 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_shift_comma_bubbles_for_settings() {
-        // Only the shifted form opens Settings — plain Ctrl+, may
-        // be bound inside the terminal by user tooling.
+    fn ctrl_shift_comma_bubbles_in_both_keystroke_shapes() {
+        // Ctrl+Shift+, opens the Settings dialog. gpui surfaces the
+        // chord in two shapes depending on platform / layout — both
+        // must bubble or the chord silently doesn't work on US
+        // Windows (the most common install):
+        //
+        //   - bare `","` with `mods.shift` set (non-US layouts, most
+        //     non-Windows platforms)
+        //   - US-Windows folded `"<"` with shift cleared (same
+        //     folding the Windows adapter does for shifted digits →
+        //     `!@#$%^&*(`)
         assert!(is_app_level_shortcut(",", &ctrl_shift()));
+        assert!(is_app_level_shortcut("<", &ctrl()));
+        // Plain Ctrl+, stays with the terminal in case the agent /
+        // shell has bound it. Plain `<` with shift still set is the
+        // "non-folding layout sent the shifted character anyway"
+        // edge case — also stays with the terminal so we don't
+        // double-fire.
         assert!(!is_app_level_shortcut(",", &ctrl()));
+        assert!(!is_app_level_shortcut("<", &ctrl_shift()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two threads in one PR — the README change uncovered a real bug in the keybinding it documents, so they ship together.

### README additions

- **Windows-only requirement**: PowerShell 7+ (`pwsh.exe`) on PATH. The terminal layer (`src/app.rs:2980`, `:3349`) and the agent-via-pwsh wrapper both hard-code `pwsh.exe`; legacy `powershell.exe` (Windows PowerShell 5.1) is never spawned. `CODESCOPE_SHELL` env var overrides.
- **Paste screenshots straight into the prompt**: documents the `Ctrl+V` clipboard-image flow that stores bytes under `<worktree>/.codescope/attachments/` and pastes the relative path. Auto-excluded via `.git/info/exclude` so screenshots can't leak into commits.
- **Themes**: six built-ins (`codescope-default`, `vs-code-dark`, `one-dark`, `solarized-dark`, `tokyo-night`, `light`) selectable from the settings dialog (`Ctrl+Shift+,`), live-applied to chrome + the in-tree terminal.
- `Ctrl+Shift+,` added to the keyboard shortcuts table.

### Keybinding fix

While writing the shortcut into the README I checked whether it actually fired. It didn't, on the most common install: gpui's Windows adapter folds shifted punctuation the same way it folds shifted digits — `Shift+,` becomes `"<"` with `mods.shift` cleared (cf. `keystroke_digit_index` for the digit case). The previous `key == "," && mods.shift` arm in both the AppShell handler (`src/app.rs:6110`) and the terminal's `is_app_level_shortcut` (`terminal/src/view.rs:939`) therefore never matched: Ctrl+Shift+, silently went to the PTY instead of opening Settings.

Add the folded shape (`"<"` with `!mods.shift`) as a second arm in both call sites and lock the dual-shape contract in a test mirroring `ctrl_shift_digit_bubbles_only_for_one_through_nine`. The single-shape `ctrl_shift_comma_bubbles_for_settings` test deleted to avoid asserting the same thing twice.

## Test plan

- [x] `cargo test --workspace --lib` clean, including the new dual-shape comma test.
- [x] Manual: dev build launched, `Ctrl+Shift+,` now opens the Settings dialog on US-layout Windows (user-confirmed).
- [x] No regressions in the existing Ctrl+Shift+* chord set (every other letter/digit chord already routes through the same dispatcher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)