### PR TITLE
chore: bump version to 0.3.0-rc.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.13"
+version = "0.3.0-rc.14"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.13"
+version = "0.3.0-rc.14"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
## Summary

Picks up:

- #234: README documents the Windows pwsh requirement, the Ctrl+V screenshot paste flow, the built-in theme set, and the Ctrl+Shift+, settings shortcut. Plus a fix that makes that same Ctrl+Shift+, actually fire on US-layout Windows — gpui's Windows adapter folds `Shift+,` to `"<"` with shift cleared, so the prior `","` + `mods.shift` check silently never matched.

## Test plan

- [x] `cargo build --workspace` clean.
- [ ] Release pipeline succeeds across Linux x64 / macOS arm64+x64 / Windows x64.
- [ ] Manual: install rc.14, press Ctrl+Shift+, → Settings dialog opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)