### PR TITLE
fix(updates): disable velopack startup auto-apply

### DIFF
--- a/src/velopack_bridge.rs
+++ b/src/velopack_bridge.rs
@@ -189,8 +189,30 @@ pub enum StageOutcome {
 /// missing manifest" and returns without side effects. Safe to call
 /// from `cargo run`, from a cargo-dist MSI install, or from an
 /// unpacked zip; it just won't do anything.
+///
+/// ## `set_auto_apply_on_startup(false)`
+///
+/// velopack-rs's `VelopackApp::run()` defaults `auto_apply == true`:
+/// on every startup that isn't a post-restart relaunch, it scans
+/// `<install>/packages/` for a `.nupkg` with `version > current`
+/// and — if one exists — fires `apply_updates_and_restart` directly,
+/// which ends in `std::process::exit(0)` and triggers the same
+/// "the app crashed during update" perception PR #232 set out to
+/// fix. PR #232 only gated the **download → apply** path through
+/// the actionable toast; the **startup-discovers-pending → apply**
+/// path stayed wide open. So a user who closed the app between
+/// "toast appeared" and "I clicked Install & restart" would on the
+/// next launch hit the silent auto-apply they thought they had
+/// opted out of.
+///
+/// Disable it. The toast is now the only path to apply, on every
+/// launch. Velopack still cleans up obsolete local packages, still
+/// fires the install / restarted hooks, still discovers the same
+/// `latest_full` — it just doesn't unilaterally apply it.
 pub fn run_startup_hooks() {
-    velopack::VelopackApp::build().run();
+    velopack::VelopackApp::build()
+        .set_auto_apply_on_startup(false)
+        .run();
 }
 
 /// Check for and download any pending update via Velopack.


### PR DESCRIPTION
## Summary

PR #232 gated the download → apply path behind the actionable toast, but velopack-rs's `VelopackApp::run()` has its own auto-apply branch on startup (`velopack/src/app.rs:180-191`): when `auto_apply == true` (default) and a `version > current` `.nupkg` sits in `<install>/packages/`, it fires `apply_updates_and_restart` directly — bypassing our toast entirely. So a user who closed the app between "toast appeared" and "I clicked Install & restart" would hit the silent auto-apply they thought they had opted out of, reviving the perceived crash.

Fix: `.set_auto_apply_on_startup(false)` in `run_startup_hooks`. The toast is now the only path to apply, on every launch. Velopack still cleans up obsolete local packages, still fires install / restarted hooks, still discovers the same `latest_full` — it just doesn't unilaterally apply it.

This is intentionally being merged into rc.14 (release pipeline cancelled and tag deleted) rather than rolled into rc.15, because shipping rc.14 with the gap defeats the user-visible promise of PR #232.

## Test plan

- [x] `cargo build --workspace` clean.
- [ ] Manual on rc.14: download an update, restart before clicking the toast, verify on next launch the toast re-appears and no silent apply fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)