### PR TITLE
fix(focus): route keyboard focus to terminal on tab click (#238)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3641,6 +3641,16 @@ impl AppShell {
         self.focused_group = group_idx;
         let handle = self.groups[group_idx].tabs[tab_idx].terminal.read(cx).focus_handle(cx);
         handle.focus(window);
+        // The AppShell root has `track_focus(&self.focus_handle)`, which makes
+        // gpui register a bubble-phase mouse-down listener that auto-focuses
+        // AppShell on any click inside it (see `paint_mouse_listeners` in
+        // gpui's `div.rs`). When a tab is clicked, our user listener fires
+        // first (bubble runs deepest-child first), focuses the terminal, then
+        // AppShell's auto-focus fires and steals focus back — leaving the
+        // first keystrokes after the tab switch unrouted. `prevent_default`
+        // is the gpui-blessed way to suppress that ancestor auto-focus; it
+        // resets per dispatch so calls outside an event are harmless.
+        window.prevent_default();
         cx.notify();
         if prev_focused != group_idx {
             self.save_layout();


### PR DESCRIPTION
## Summary
- Closes #238: after clicking a CodeScope tab, the first keystrokes were lost until the user clicked inside the terminal pane.
- Root cause: `AppShell` has `.track_focus(&self.focus_handle)`, which makes gpui register a bubble-phase mouse-down listener that auto-focuses the AppShell root on any click inside it (see `paint_mouse_listeners` in gpui's `div.rs`). In the bubble phase listeners fire deepest-child first, so the tab's `on_mouse_down` correctly called `activate_tab` (which focuses the terminal), but AppShell's auto-focus then fired and stole focus back to the root — leaving subsequent keys to hit AppShell's shortcut-only handler instead of the terminal's pty.
- Fix: call `window.prevent_default()` in `activate_tab` after focusing the terminal. This is the gpui-blessed signal for "I already handled the focus transfer for this click"; gpui's own auto-focus listener checks `!window.default_prevented()` before acting. `default_prevented` is reset per dispatch event, so the call is a harmless no-op when `activate_tab` is invoked from non-mouse paths (keyboard `next_tab`/`prev_tab`, layout restore, command palette, etc.).
- Also resolves the secondary symptom the issue mentions ("returning after alt-tab"): once the user can no longer accidentally land focus on AppShell, alt-tab restores focus to whatever was actually typing (the terminal) instead of the silently-focused shell.

## Test plan
- [ ] `cargo check --workspace --all-targets` ✅ (clean)
- [ ] `cargo clippy --workspace --all-targets` ✅ (no new warnings)
- [ ] Manual: `CODESCOPE_DEV=1 cargo run --bin codescope-rs`, open two tabs in different groups, alternate between them and confirm the first keystroke after each tab click lands in the new terminal (no extra click required).
- [ ] Manual: alt-tab away and back; the previously-active terminal still receives input on return.
- [ ] Manual: keyboard `Ctrl+Tab` / `Ctrl+Shift+1..9` continue to focus the right terminal (regression check for the non-mouse paths through `activate_tab`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)