### PR TITLE
chore: bump version to 0.3.0-rc.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "codescope-rs"
-version = "0.3.0-rc.14"
+version = "0.3.0-rc.15"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope-rs"
-version = "0.3.0-rc.14"
+version = "0.3.0-rc.15"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
Picks up two bug fixes since rc.14:

- #240: \`fix(focus): route keyboard focus to the terminal on tab click\` — tabs now hand focus to the embedded terminal instead of holding it on the chrome, so typing immediately reaches the shell.
- #241: \`fix(tabs): accept tab drop anywhere in the group's workspace column\` — the drop target was previously the tab strip only, which made the drag look broken when the user released a few pixels below.

## Test plan

- [x] \`cargo build --workspace\` clean.
- [ ] Tag \`v0.3.0-rc.15\` after merge — release workflow auto-fires on \`v*\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)