### PR TITLE
fix(new-project): keep focus on dialog so URL field accepts keystrokes

### DIFF
--- a/src/dialogs/new_project.rs
+++ b/src/dialogs/new_project.rs
@@ -918,8 +918,14 @@ impl Sidebar {
             .hover(move |s| s.bg(frost).text_color(ink))
             .on_mouse_down(
                 MouseButton::Left,
-                cx.listener(|this, _, _, cx| {
+                cx.listener(|this, _, window, cx| {
                     cx.stop_propagation();
+                    // Keep AppShell's bubble auto-focus off the dialog
+                    // card on this click — a failed submit (e.g. the
+                    // duplicate-path guard) leaves the dialog open, so
+                    // focus must stay put. Harmless on Cancel, which
+                    // closes the dialog regardless.
+                    window.prevent_default();
                     this.cancel_new_project_dialog(cx);
                 }),
             )
@@ -941,8 +947,13 @@ impl Sidebar {
                     .cursor_pointer()
                     .on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(|this, _, _, cx| {
+                        cx.listener(|this, _, window, cx| {
                             cx.stop_propagation();
+                            // A duplicate-path submit keeps the dialog
+                            // open with an inline error; suppress
+                            // AppShell's bubble auto-focus so the user
+                            // can keep editing without re-clicking.
+                            window.prevent_default();
                             this.submit_new_project_dialog(cx);
                         }),
                     );

--- a/src/dialogs/new_project.rs
+++ b/src/dialogs/new_project.rs
@@ -393,6 +393,12 @@ impl Sidebar {
         let parent = default_clone_parent(&existing_paths, home.as_deref());
         let focus_handle = cx.focus_handle();
         focus_handle.focus(window);
+        // AppShell's root `track_focus(&self.focus_handle)` registers a
+        // bubble-phase auto-focus that would otherwise steal focus to
+        // AppShell on the same click that opened the dialog, leaving
+        // keystrokes routed to AppShell's chord-only handler. Same
+        // primitive `activate_tab` uses (see `src/app.rs`).
+        window.prevent_default();
         let state = NewProjectDialogState::new(parent, focus_handle);
         self.set_new_project_dialog(Some(state));
         self.close_menu_no_notify();
@@ -665,8 +671,11 @@ impl Sidebar {
                 .cursor_pointer()
                 .on_mouse_down(
                     MouseButton::Left,
-                    cx.listener(move |this, _, _, cx| {
+                    cx.listener(move |this, _, window, cx| {
                         cx.stop_propagation();
+                        // Keep AppShell's bubble auto-focus from
+                        // stealing focus off the dialog card.
+                        window.prevent_default();
                         this.set_new_project_mode(target, cx);
                     }),
                 )
@@ -778,8 +787,9 @@ impl Sidebar {
                 .items_center()
                 .on_mouse_down(
                     MouseButton::Left,
-                    cx.listener(move |this, event: &MouseDownEvent, _, cx| {
+                    cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                         cx.stop_propagation();
+                        window.prevent_default();
                         this.focus_new_project_field(this_field, cx);
                         if let Some(state) = this.new_project_dialog_mut() {
                             let idx = state
@@ -807,6 +817,7 @@ impl Sidebar {
                     &state.existing_path,
                     Box::new(cx.listener(|this, _, window, cx| {
                         cx.stop_propagation();
+                        window.prevent_default();
                         this.pick_existing_project_folder(window, cx);
                     })),
                 );
@@ -826,6 +837,7 @@ impl Sidebar {
                     state.parent.text(),
                     Box::new(cx.listener(|this, _, window, cx| {
                         cx.stop_propagation();
+                        window.prevent_default();
                         this.pick_clone_parent_folder(window, cx);
                     })),
                 );
@@ -964,7 +976,14 @@ impl Sidebar {
             .on_key_down(cx.listener(handle_key_down))
             .on_mouse_down(
                 MouseButton::Left,
-                cx.listener(|_, _, _, cx| cx.stop_propagation()),
+                cx.listener(|_, _, window, cx| {
+                    cx.stop_propagation();
+                    // Clicks on the card's padding / header bubble
+                    // through here without hitting a child listener;
+                    // suppress AppShell's bubble auto-focus so the
+                    // dialog's focus handle isn't yanked away.
+                    window.prevent_default();
+                }),
             )
             .child(header)
             .child(mode_toggle)


### PR DESCRIPTION
## Summary

- Add-Project → Clone from URL: typing did nothing in the URL / Folder Name fields.
- Root cause: `AppShell` has `track_focus(&self.focus_handle)` at the root, which registers a bubble-phase auto-focus that re-focuses AppShell on any click inside the app — unless the event has `prevent_default` set. The new-project dialog never called `prevent_default`, so the "+" click that opened it, the segmented "Clone from URL" toggle, and the URL/Name field clicks all yanked focus back to AppShell. AppShell's `on_key_down` is chord-only (Ctrl/Cmd/Alt), so plain keystrokes were silently dropped.
- Same primitive as #240 (route keyboard focus to terminal on tab click): call `window.prevent_default()` after each explicit `focus()` and on every in-dialog mouse handler that should keep focus on the card.

## Test plan

- [ ] Sidebar → "+ Add project" → toggle "Clone from URL" → click the URL field and type a URL → characters appear.
- [ ] Without clicking the URL field first (Tab into it / start typing right after the toggle click): characters appear.
- [ ] Folder Name field accepts typing once focused.
- [ ] Browse buttons (existing-mode folder + clone-mode parent) still open the OS picker.
- [ ] Escape / Enter still cancel / submit.
- [ ] Existing-folder mode still works (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)