### PR TITLE
fix: sync Cargo.lock with compression-zip-deflate feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7749,10 +7749,12 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
+ "flate2",
  "indexmap",
  "memchr",
  "thiserror 2.0.18",
  "time",
+ "zopfli",
 ]
 
 [[package]]
@@ -7771,6 +7773,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"


### PR DESCRIPTION
## Summary

Follow-up to #249. That PR added `compression-zip-deflate` to the `self_update` dependency in `Cargo.toml`, but the matching `Cargo.lock` regeneration (the `zip` crate now pulls `flate2` + `zopfli` for DEFLATE decompression) was never committed — `git add Cargo.toml` omitted `Cargo.lock` at that commit. The squash-merge of #249 therefore landed an out-of-sync lockfile on `main`.

## Impact

`cargo build` (non-locked) silently regenerates the lockfile, so release builds were unaffected, but `cargo build --locked` / `--frozen` would fail on `main` until this lands.

## Change

Pure `Cargo.lock` sync — adds the `zopfli` package entry and `flate2` + `zopfli` to the `zip` crate's dependency list. No source or manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)