### PR TITLE
fix(titlebar): reliable window drag + double-click maximize on Windows

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -25,13 +25,93 @@
 > `.github/workflows/release.yml` (was `rs--release.yml`) and now
 > triggers on plain `v*` tags.
 
-**Last updated:** 2026-05-19 (session 45 — tab-focus fix, full auto-update rip (runtime + CI), boot.log mode 0600, **first stable `v0.3.0` cut**)
-**Branch:** `main`
-**Head:** `cb457f6` (feat(updates): rip auto-update entirely, #244)
-**Release:** `v0.3.0` — first non-rc tag. Cuts off the `rc.N` cadence that ran rc.7 → rc.15. Pipeline triggered by `git push origin v0.3.0`; only cargo-dist artefacts (MSI / `.tar.xz`) now — velopack packaging was stripped in #244 along with the runtime.
-**Build status:** ✅ `cargo build --workspace` clean. Tests: 454 core + 120 bin + 28 terminal + 1 doctest = **603 total**, all passing (−37 from session 44: 30 `update_check` + 7 `velopack_bridge` tests vanished with their modules).
-**Uncommitted work:** none — PRs #240 + #244 shipped, session-45 bump-PR opens this entry.
-**Open issues:** #238 (terminal pane doesn't receive keyboard focus after tab click) closed by #240.
+**Last updated:** 2026-05-24 (session 46 — Windows titlebar drag + double-click-maximize rework, #251)
+**Branch:** `main` (work shipped on `fix/titlebar-doubleclick-maximize` → PR #251, squash-merged once Copilot was clean)
+**Head:** #251 — titlebar drag/double-click rework, on top of #249 (auto-update restored via `self_update` + Inno Setup; `codescope-rs` → `CodeScope` rename) and #250 (Cargo.lock deflate sync — see cursor).
+**Release:** version is now `0.3.1` (bumped in #249). Auto-update is **back** (manual-apply via `self_update` + Inno Setup installer); Velopack stays retired — see CLAUDE.md non-negotiables.
+**Build status:** ✅ `cargo check` + `cargo clippy --bin codescope` clean on changed files. Session 46 was a UI change (no test surface — TDD is for `codescope-core` logic, not gpui views), so the full `cargo test --workspace` suite was **not** re-run this session.
+**Uncommitted work:** none on the titlebar branch. **PR #250 still open** (Cargo.lock deflate sync) — see cursor.
+**Open issues:** none tracked. Pre-existing clippy debt in `src/app.rs` (18 warnings) untouched.
+
+### Session 46 — Windows titlebar drag + double-click-maximize rework (#251)
+
+User reported the custom caption row felt broken on Windows: a single
+click on a maximized window restored it, double-click-to-maximize was
+unreliable, and dragging "felt vague" — especially dragging *upward*,
+which often did nothing while down/sideways worked.
+
+This took several wrong turns before the evidence (temporary `eprintln!`
+diagnostics in the dev build, read back from the background-task stderr
+log) made the real constraints clear. Three gpui/Win32 facts, verified
+against the gpui-0.2.2 source and Zed's `PlatformTitleBar`:
+
+1. **`Window::start_window_move()` is a no-op on Windows** — a default
+   trait method (`platform.rs:536`) that `WindowsWindow` never overrides.
+   So a window move can only be started by posting
+   `WM_NCLBUTTONDOWN(HTCAPTION)` ourselves (`win32_titlebar::start_drag`).
+   Zed relies on the same native path; the gpui example `window_shadow.rs`
+   uses `start_window_move`, which silently does nothing on Windows.
+2. **gpui does not dispatch mouse-*move* events while the cursor is over a
+   `WindowControlArea` region** (treated as platform-owned). Diagnostics
+   confirmed: presses reach our handler across the whole title bar, but
+   the drag-threshold only fired once the cursor crossed *below* the 40 px
+   caption into the content area. That's why a move-threshold made upward
+   drags fail (cursor leaves the window top before any move fires) while
+   downward drags worked.
+3. **`start_drag`'s synthetic `WM_NCLBUTTONDOWN(LPARAM(0))` corrupts
+   gpui's `ClickState`** — the bogus screen-origin position resets
+   `last_position`, so the *second* click of a double-click reads as
+   `click_count == 1`. This silently broke double-click-to-maximize, but
+   only on the windowed path (the maximized path doesn't start a drag on
+   the press, so its `click_count` stays correct).
+
+**Final design (`handle_titlebar_press` / `update_titlebar_drag` in
+`src/app.rs`):**
+
+- **Windowed:** start the OS drag *on the press* — the only reliable
+  signal, since moves don't fire over the title bar. `start_drag`'s modal
+  move loop then tracks the cursor natively in every direction; a click
+  with no drag is a harmless no-op. `start_drag` is called directly (not
+  via `window.defer`) — its `ReleaseCapture()` can emit
+  `WM_CAPTURECHANGED`, but gpui doesn't handle that message and the modal
+  loop only begins once the posted `WM_NCLBUTTONDOWN` is pumped after the
+  listener returns.
+- **Maximized:** *arm* on the press (store origin in `titlebar_press`) and
+  start the restore-and-drag only once the cursor moves into the content
+  area (`update_titlebar_drag`, fed by the root `on_mouse_move`). A bare
+  click no longer restores; you un-maximize by dragging *down*, which is
+  exactly where moves fire.
+- **Double-click → toggle maximize/restore:** gpui's `click_count >= 2`
+  *plus* our own time+space check (`last_titlebar_down`, 500 ms / 6 px),
+  the latter gated to **Windows + non-maximized** to recover the
+  echo-corrupted count. Copilot's one review finding flagged that the
+  fallback shouldn't run where `click_count` is already reliable
+  (non-Windows, maximized) — scoped accordingly in `95456fb`.
+
+User verified in the dev build across windowed/maximized: single-click
+no-op, all-direction drag, double-click maximize, maximized double-click
+restore, drag-down-to-restore. No test surface (UI); `cargo check` +
+`cargo clippy` clean on `src/app.rs`.
+
+**Context — what landed since session 45 (never separately HANDOFF'd):**
+- **#249** restored in-app auto-update via the `self_update` crate + Inno
+  Setup installer, and renamed `codescope-rs` → `CodeScope` everywhere
+  user-visible. Version is now `0.3.1`. Velopack stays retired.
+- **#250** (`fix/cargo-lock-deflate-sync`) syncs `Cargo.lock` for the
+  `compression-zip-deflate` feature; **still open**.
+
+**Cursor for next session:**
+1. **PR #250 still open** — Cargo.lock deflate sync. Merge it (or confirm
+   superseded). Note: cargo runs on a branch off `main` re-add `zopfli` to
+   `Cargo.lock` until #250 lands, so `git checkout -- Cargo.lock` before
+   committing on feature branches to avoid churn.
+2. **Pre-existing clippy debt** in `src/app.rs` (18 warnings), including an
+   orphaned doc comment ("Build one group's tab strip…") just above
+   `handle_titlebar_press`. Out of scope this session; a cleanup pass
+   would clear them.
+3. **Release validation for the restored auto-update (#249)** — see
+   `docs/RELEASE-VALIDATION.md` §6 (mandatory archive-extraction
+   regression: the flow must reach "Installing" → "Update installed").
 
 ### Session 45 — tab-focus fix, total auto-update rip, first stable `v0.3.0` cut
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -7480,18 +7480,28 @@ impl AppShell {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Double-click detection. `click_count` is authoritative when no
-        // drag echo intervened (the maximized path never starts a drag on
-        // the press). For the windowed path the echo resets gpui's
-        // `ClickState`, so we also accept two presses that land close in
-        // time and space by our own reckoning. See `last_titlebar_down`.
+        // Double-click detection. gpui's `click_count` honours the OS
+        // double-click time + spatial tolerance and is authoritative
+        // *except* on the Windows windowed path: starting the drag on the
+        // press posts a synthetic `WM_NCLBUTTONDOWN(LPARAM(0))` that
+        // corrupts gpui's `ClickState`, so the real second click reads as
+        // count 1. Only there do we fall back to our own time+space
+        // check. We deliberately do NOT apply it on non-Windows (no drag
+        // echo) or maximized Windows (the press doesn't start a drag, so
+        // `click_count` stays correct) — a hard-coded threshold there
+        // would only risk false positives that diverge from the user's OS
+        // double-click settings.
         let now = std::time::Instant::now();
         let prev = self.last_titlebar_down.replace((now, event.position));
-        let own_double = prev.is_some_and(|(t, p)| {
-            now.duration_since(t) < std::time::Duration::from_millis(500)
-                && (event.position.x - p.x).abs() < px(6.0)
-                && (event.position.y - p.y).abs() < px(6.0)
-        });
+        #[cfg(target_os = "windows")]
+        let own_double = !window.is_maximized()
+            && prev.is_some_and(|(t, p)| {
+                now.duration_since(t) < std::time::Duration::from_millis(500)
+                    && (event.position.x - p.x).abs() < px(6.0)
+                    && (event.position.y - p.y).abs() < px(6.0)
+            });
+        #[cfg(not(target_os = "windows"))]
+        let own_double = false;
         if event.click_count >= 2 || own_double {
             self.titlebar_press = None;
             self.last_titlebar_down = None; // don't let a third click re-toggle

--- a/src/app.rs
+++ b/src/app.rs
@@ -604,21 +604,28 @@ pub struct AppShell {
     /// Left rail. Lives behind a feature flag in the layout state —
     /// hidden when the user collapses the sidebar (later).
     sidebar: Entity<Sidebar>,
-    /// Timestamp of the most recent left-mouse-down inside any of the
-    /// title-bar drag regions. Used to detect titlebar double-clicks
-    /// while filtering out the *synthetic* `WM_NCLBUTTONDOWN` event
-    /// our own `start_drag` posts: when we `PostMessageW(WM_NCLBUTTONDOWN,
-    /// HTCAPTION)` the OS turns it back into a non-client mouse-down
-    /// that gpui re-dispatches through our listener stack with
-    /// `click_count` already bumped to 2 (gpui's `ClickState` treats
-    /// the synthetic press as a continuation of the real click).
-    /// That would otherwise toggle maximize on every single click and
-    /// no-op on every real double-click. We discriminate by
-    /// time-delta from the previous press: synthetic events arrive
-    /// in the same message-loop tick (sub-millisecond), real human
-    /// double-clicks are 100 ms+ apart. Anything under 10 ms is
-    /// treated as the synthetic echo and ignored.
-    last_titlebar_press_at: Option<std::time::Instant>,
+    /// Set to the press origin only while a *maximized* window has an
+    /// armed-but-not-yet-started title-bar drag; `None` otherwise.
+    /// A windowed press starts its drag immediately and never sets this
+    /// (see [`AppShell::handle_titlebar_press`]); a maximized press arms
+    /// it so [`AppShell::update_titlebar_drag`] can start the
+    /// restore-and-drag once the cursor moves into the content area, and
+    /// `on_mouse_up` clears it. The stored point isn't read back — it's
+    /// just an "armed" marker — but is kept as an origin in case a future
+    /// change wants a movement threshold. Double-click is handled
+    /// separately — see [`AppShell::last_titlebar_down`].
+    titlebar_press: Option<gpui::Point<gpui::Pixels>>,
+    /// `(time, position)` of the previous title-bar left-press, for our
+    /// own double-click detection. We can't rely solely on gpui's
+    /// `MouseDownEvent::click_count` for the *windowed* case: starting
+    /// the drag on the press posts a synthetic `WM_NCLBUTTONDOWN` whose
+    /// `LPARAM(0)` makes gpui's `ClickState` record a bogus position,
+    /// which resets the count so the real second click reads as 1 — and
+    /// double-click-to-maximize silently breaks. We therefore also fire
+    /// the maximize toggle when two presses land close in time *and*
+    /// space ourselves. (Maximized double-click never starts a drag, so
+    /// `click_count` stays correct there; this is the windowed fix.)
+    last_titlebar_down: Option<(std::time::Instant, gpui::Point<gpui::Pixels>)>,
     /// Global blink phase for dialog input fields (rename, new-project,
     /// new-worktree, settings, command palette). `true` paints the
     /// caret bar; `false` hides it. Flipped on a 530 ms cadence by the
@@ -1317,7 +1324,8 @@ impl AppShell {
             settings,
             theme,
             sidebar,
-            last_titlebar_press_at: None,
+            titlebar_press: None,
+            last_titlebar_down: None,
             text_blink_phase: true,
             notifications: crate::notifications::Notifications::new(),
             last_session_state: HashMap::new(),
@@ -6885,12 +6893,15 @@ impl Render for AppShell {
             .key_context("AppShell")
             .track_focus(&self.focus_handle)
             .on_key_down(cx.listener(Self::on_key_down))
-            .on_mouse_move(cx.listener(|this, event: &gpui::MouseMoveEvent, _, cx| {
+            .on_mouse_move(cx.listener(|this, event: &gpui::MouseMoveEvent, window, cx| {
                 if this.splitter_drag.is_some() {
                     this.update_splitter_drag(event.position.x, cx);
                 }
                 if this.sidebar_drag.is_some() {
                     this.update_sidebar_drag(event.position.x, cx);
+                }
+                if this.titlebar_press.is_some() {
+                    this.update_titlebar_drag(event, window, cx);
                 }
             }))
             .on_mouse_up(
@@ -6898,6 +6909,7 @@ impl Render for AppShell {
                 cx.listener(|this, _, _, cx| {
                     this.end_splitter_drag(cx);
                     this.end_sidebar_drag(cx);
+                    this.titlebar_press = None;
                 }),
             )
             .size_full()
@@ -7437,19 +7449,30 @@ impl AppShell {
     /// same column.
 
     /// Handle a left-press on any of the title-bar drag regions
-    /// (brand mark, strip-left padding, per-group trailing
-    /// whitespace). Discriminates real human clicks from the
-    /// *synthetic* `WM_NCLBUTTONDOWN` echo our own `start_drag` posts:
+    /// (brand mark, strip-left padding, per-group trailing whitespace).
     ///
-    /// 1. Sub-10 ms after the previous press ⇒ synthetic, ignore.
-    /// 2. 10–500 ms after the previous press ⇒ real double-click,
-    ///    toggle maximize.
-    /// 3. Otherwise ⇒ first press of a real click sequence, start
-    ///    the OS drag (or window-move on non-Windows).
+    /// A double-click (gpui's `click_count >= 2`, derived from the OS
+    /// double-click time + spatial tolerance) toggles maximize/restore.
     ///
-    /// On non-Windows there's no synthetic echo because we use
-    /// `start_window_move` instead of `PostMessage`, but the same
-    /// time-delta logic still gives us double-click → zoom_window.
+    /// A single press starts the window drag. The split below is forced
+    /// by a gpui quirk: it does **not** dispatch mouse-*move* events
+    /// while the cursor is over the title bar (it treats a
+    /// `WindowControlArea` region as platform-owned), so a
+    /// move-threshold can't reliably detect a drag there — only the
+    /// press is dependable.
+    ///
+    /// - **Windowed:** start the OS drag immediately on the press.
+    ///   `start_drag`'s modal move loop then tracks the cursor natively
+    ///   in every direction, and a click with no drag is a harmless
+    ///   no-op (nothing to restore).
+    /// - **Maximized:** `start_drag` restores eagerly, so starting on
+    ///   the press would restore on a bare click. Instead *arm* a drag
+    ///   and let [`AppShell::update_titlebar_drag`] start it once the
+    ///   cursor moves down into the content area — the natural
+    ///   un-maximize gesture, and the one place moves actually fire.
+    ///
+    /// Non-Windows uses `start_window_move` (no eager restore), so it
+    /// can start on the press in every case.
     #[allow(unused_variables)]
     fn handle_titlebar_press(
         &mut self,
@@ -7457,34 +7480,75 @@ impl AppShell {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Double-click detection. `click_count` is authoritative when no
+        // drag echo intervened (the maximized path never starts a drag on
+        // the press). For the windowed path the echo resets gpui's
+        // `ClickState`, so we also accept two presses that land close in
+        // time and space by our own reckoning. See `last_titlebar_down`.
         let now = std::time::Instant::now();
-        let prev = self.last_titlebar_press_at;
-        self.last_titlebar_press_at = Some(now);
-
-        if let Some(prev_t) = prev {
-            let dt = now.duration_since(prev_t);
-            if dt < std::time::Duration::from_millis(10) {
-                // Synthetic echo from our own PostMessage(WM_NCLBUTTONDOWN).
-                // Roll the timestamp back so a *real* second click
-                // measures from the original press, not from the echo.
-                self.last_titlebar_press_at = Some(prev_t);
-                return;
-            }
-            if dt < std::time::Duration::from_millis(500) {
-                #[cfg(target_os = "windows")]
-                window.defer(cx, |window, _| {
-                    crate::win32_titlebar::toggle_maximize(window);
-                });
-                #[cfg(not(target_os = "windows"))]
-                window.zoom_window();
-                return;
-            }
+        let prev = self.last_titlebar_down.replace((now, event.position));
+        let own_double = prev.is_some_and(|(t, p)| {
+            now.duration_since(t) < std::time::Duration::from_millis(500)
+                && (event.position.x - p.x).abs() < px(6.0)
+                && (event.position.y - p.y).abs() < px(6.0)
+        });
+        if event.click_count >= 2 || own_double {
+            self.titlebar_press = None;
+            self.last_titlebar_down = None; // don't let a third click re-toggle
+            #[cfg(target_os = "windows")]
+            window.defer(cx, |window, _| {
+                crate::win32_titlebar::toggle_maximize(window);
+            });
+            #[cfg(not(target_os = "windows"))]
+            window.zoom_window();
+            return;
         }
 
         #[cfg(target_os = "windows")]
-        window.defer(cx, |window, _| {
+        if window.is_maximized() {
+            self.titlebar_press = Some(event.position);
+        } else {
+            self.titlebar_press = None;
             crate::win32_titlebar::start_drag(window);
-        });
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            self.titlebar_press = None;
+            window.start_window_move();
+        }
+    }
+
+    /// Window-level mouse-move hook that starts a *maximized* window's
+    /// restore-and-drag once the cursor leaves the title bar. Only an
+    /// armed press on a maximized window reaches here with
+    /// `titlebar_press` set (a windowed press already started its drag in
+    /// [`AppShell::handle_titlebar_press`]); the move is delivered once
+    /// the cursor crosses into the content area, where — unlike over the
+    /// title bar — gpui does dispatch mouse-moves. By that point the
+    /// cursor has clearly left the caption, so any movement counts; the
+    /// pressed-button guard keeps a stray armed press from turning a
+    /// plain hover into a drag.
+    #[allow(unused_variables)]
+    fn update_titlebar_drag(
+        &mut self,
+        event: &gpui::MouseMoveEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if event.pressed_button != Some(MouseButton::Left) {
+            return;
+        }
+        if self.titlebar_press.take().is_none() {
+            return;
+        }
+        // `start_drag` is safe to call directly (not via `window.defer`):
+        // its `ReleaseCapture()` can synchronously emit
+        // `WM_CAPTURECHANGED`, but gpui doesn't handle that message, and
+        // the modal move loop only begins once the posted
+        // `WM_NCLBUTTONDOWN` is pumped after this listener returns.
+        #[cfg(target_os = "windows")]
+        crate::win32_titlebar::start_drag(window);
         #[cfg(not(target_os = "windows"))]
         window.start_window_move();
     }


### PR DESCRIPTION
## Problem

The custom caption row had two issues on Windows that made it feel unreliable:

1. **Single click on a maximized window restored it.** The manual `start_drag` posted `SC_RESTORE` on the *press*, not on an actual drag, so any click un-maximized the window.
2. **Dragging felt vague and frequently failed for upward/sideways motion.** The drag relied on a mouse-move threshold, but gpui does **not** dispatch mouse-move events while the cursor is over a `WindowControlArea` region. As a result the drag only engaged once the cursor crossed into the content area *below* the title bar — so dragging up or sideways often never started.

## Investigation

Confirmed against the gpui 0.2.2 source and Zed's `PlatformTitleBar`:

- `Window::start_window_move()` is a **no-op on Windows** (default trait method, not overridden by `WindowsWindow`), so a window move can only be started by posting `WM_NCLBUTTONDOWN(HTCAPTION)` — which is what `win32_titlebar::start_drag` does.
- gpui suppresses its own mouse-move dispatch over `WindowControlArea` regions (it treats them as platform-owned), so a move-threshold can't reliably detect a drag there. The **press** is the only dependable signal. Instrumented logging confirmed presses reach the handler across the whole title bar, but moves only fire once the cursor reaches `y ≥ titlebar_height`.

## Fix (`handle_titlebar_press`)

- **Windowed:** start the OS drag immediately on the press. `start_drag`'s modal move loop then tracks the cursor natively in every direction; a click with no drag is a harmless no-op (nothing to restore).
- **Maximized:** arm on press and start the restore-and-drag only once the cursor moves into the content area (`update_titlebar_drag`), so a bare click no longer restores. (You drag a maximized window *downward* to un-maximize, which is exactly where moves fire.)
- **Double-click → maximize/restore:** detected via gpui's `click_count` **plus** our own time+position check. The windowed drag posts a synthetic `WM_NCLBUTTONDOWN` whose `LPARAM(0)` makes gpui's `ClickState` record a bogus position, resetting the count so the real second click reads as `1` — which silently broke double-click-to-maximize. The own-reckoning check restores it without false-firing on single clicks or drags.

## Testing

Manually verified in a dev build (Layer 2), windowed and maximized:

- Windowed: drag up / down / sideways all engage immediately; single click is a no-op; double-click maximizes.
- Maximized: single click does nothing; double-click restores; dragging down restores-and-moves under the cursor.

No new clippy warnings (the 18 pre-existing warnings are unchanged; one orphaned doc comment above `handle_titlebar_press` predates this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)