### PR TITLE
feat(sidebar): highlight the active tab's project/worktree (#248)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3360,6 +3360,9 @@ impl AppShell {
                 // every other app chord) still fires from the empty
                 // state. Copilot caught this on PR #184.
                 self.focus_handle.focus(window);
+                // No focused tab left — clear the sidebar's active
+                // context highlight (issue #248).
+                self.push_sidebar_active_context(cx);
                 cx.notify();
                 return;
             }
@@ -3463,6 +3466,10 @@ impl AppShell {
         // is the gpui-blessed way to suppress that ancestor auto-focus; it
         // resets per dispatch so calls outside an event are harmless.
         window.prevent_default();
+        // Follow the focused tab in the sidebar — highlight the
+        // project/worktree row it belongs to (issue #248). Cheap +
+        // no-ops in the sidebar when the context is unchanged.
+        self.push_sidebar_active_context(cx);
         cx.notify();
         if prev_focused != group_idx {
             self.save_layout();
@@ -5205,6 +5212,32 @@ impl AppShell {
         }
         self.sidebar.update(cx, |sidebar, cx| {
             sidebar.set_session_paths(busy, active, cx);
+        });
+    }
+
+    /// Canonicalised worktree path of the currently focused tab (the
+    /// active tab in the focused group), or `None` when the focused
+    /// group is empty or the tab has no working directory. Unlike the
+    /// `push_sidebar_session_paths` sets, this does *not* require an
+    /// adopted agent session — a plain shell tab still has a worktree
+    /// context worth highlighting (issue #248).
+    fn focused_tab_worktree_path(&self) -> Option<String> {
+        let group = self.groups.get(self.focused_group)?;
+        let tab = group.tabs.get(group.active_tab)?;
+        let wd = tab.working_directory.as_ref()?;
+        let canon = codescope_core::path_canon::canonicalize_path(&wd.to_string_lossy());
+        (!canon.is_empty()).then_some(canon)
+    }
+
+    /// Push the focused tab's worktree path to the sidebar so the
+    /// matching project/worktree row gets the accent-tinted "active
+    /// context" highlight (issue #248). Called from `activate_tab` (the
+    /// universal tab-activation funnel) and from `close_tab` when the
+    /// last tab closes and there's no longer a focused tab.
+    fn push_sidebar_active_context(&self, cx: &mut Context<Self>) {
+        let path = self.focused_tab_worktree_path();
+        self.sidebar.update(cx, |sidebar, cx| {
+            sidebar.set_active_context(path, cx);
         });
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3554,6 +3554,10 @@ impl AppShell {
         // (the previously focused group's). Once the user types Ctrl+T
         // / clicks +, `activate_tab` will rehome focus.
         self.focus_handle.focus(window);
+        // The newly-focused group is empty, so there's no active tab —
+        // clear the sidebar's active-context wash (#248). It returns
+        // when `activate_tab` runs for a tab opened here.
+        self.push_sidebar_active_context(cx);
         cx.notify();
         self.save_layout();
     }
@@ -6042,6 +6046,9 @@ impl AppShell {
         if self.groups[idx].tabs.is_empty() {
             self.focused_group = idx;
             self.focus_handle.focus(window);
+            // Focused an empty group — no active tab, so clear the
+            // sidebar's active-context wash (#248).
+            self.push_sidebar_active_context(cx);
             cx.notify();
             return;
         }

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -558,6 +558,17 @@ pub struct Sidebar {
     /// the C# `WorktreeViewModel.HasActiveSession` boolean — same
     /// 2 px rail trigger on the sidebar row chrome.
     active_paths: HashSet<String>,
+    /// Canonicalised worktree path of the *currently focused* tab (the
+    /// active tab in the focused group), or `None` when no tab is
+    /// focused or it isn't tied to a tracked worktree. Distinct from
+    /// `active_paths`, which marks *every* worktree with a live session:
+    /// this marks the single row the user is looking at right now.
+    /// Drives the accent-tinted "active context" wash on the matching
+    /// worktree row and a fainter wash on its parent project row (so a
+    /// collapsed project still shows the active tab is inside it). Pushed
+    /// by `AppShell::push_sidebar_active_context` (issue #248). A new
+    /// Rust behaviour — the C# build never followed the focused tab.
+    active_context_path: Option<String>,
     /// Whether the Overview panel is currently on stage. Pushed by
     /// `AppShell::set_show_overview`; drives the footer "Overview"
     /// button's active look (accent rail + accent foreground) so the
@@ -644,6 +655,7 @@ impl Sidebar {
             expanded_worktrees: HashSet::new(),
             busy_paths: HashSet::new(),
             active_paths: HashSet::new(),
+            active_context_path: None,
             overview_visible: false,
             agent_registry,
             filter: String::new(),
@@ -739,6 +751,19 @@ impl Sidebar {
         }
         self.busy_paths = busy;
         self.active_paths = active;
+        cx.notify();
+    }
+
+    /// Set the focused tab's worktree path (canonicalised by the
+    /// caller) so the matching sidebar row gets the accent-tinted
+    /// "active context" wash. `None` clears it (e.g. the last tab in
+    /// the workspace was closed). No-op + no notify when unchanged, so
+    /// re-pushing the same context on a redraw is free. Issue #248.
+    pub fn set_active_context(&mut self, path: Option<String>, cx: &mut Context<Self>) {
+        if self.active_context_path == path {
+            return;
+        }
+        self.active_context_path = path;
         cx.notify();
     }
 
@@ -2697,6 +2722,17 @@ impl Render for Sidebar {
                 !wt.canonical_path.is_empty()
                     && self.busy_paths.contains(&wt.canonical_path)
             });
+            // Issue #248: does the currently focused tab live in one of
+            // this project's worktrees? If so the project row carries a
+            // faint accent wash — which is the *only* active-context cue
+            // when the project is collapsed and its child worktree row
+            // is hidden. Compared against the same per-row cached
+            // `canonical_path` as `any_busy_child`.
+            let is_active_context_project = self.active_context_path.as_ref().is_some_and(|p| {
+                worktrees
+                    .iter()
+                    .any(|wt| !wt.canonical_path.is_empty() && &wt.canonical_path == p)
+            });
             // Sidebar row hover / selection fill — `#141414`
             // (Surface.Color.Elev). C# `SidebarView.xaml` hard-codes
             // `#141414` on both `IsMouseOver` and `IsSelected` triggers,
@@ -2704,6 +2740,12 @@ impl Render for Sidebar {
             // the `frost_10` overlay we used before.
             let bg = if active {
                 theme::surface_elev(&theme)
+            } else if is_active_context_project {
+                // Faint accent wash — distinct from the solid grey
+                // selection fill above. Selection wins when a project is
+                // both selected and the active context; the child
+                // worktree row still carries the stronger wash.
+                theme::active_context_wash_dim(&theme)
             } else {
                 gpui::transparent_black()
             };
@@ -2916,6 +2958,13 @@ impl Render for Sidebar {
                     !wt_canon.is_empty() && self.active_paths.contains(wt_canon);
                 let has_busy_session =
                     !wt_canon.is_empty() && self.busy_paths.contains(wt_canon);
+                // Issue #248: is this the worktree of the currently
+                // focused tab? Exactly one row matches at a time (the
+                // active tab in the focused group). Gets the stronger
+                // accent wash — distinct from the thin `has_active_session`
+                // rail (which marks *any* worktree with a live session).
+                let is_active_context = !wt_canon.is_empty()
+                    && self.active_context_path.as_deref() == Some(wt_canon);
                 let dot_color = if has_busy_session {
                     theme::signal_warn()
                 } else if has_active_session {
@@ -2942,6 +2991,15 @@ impl Render for Sidebar {
                 } else {
                     gpui::transparent_black()
                 };
+                // Base row fill — accent wash for the focused tab's
+                // worktree (#248), transparent otherwise. The `.hover`
+                // fill below overrides it on pointer-over, which is the
+                // intended momentary feedback.
+                let active_context_bg = if is_active_context {
+                    theme::active_context_wash(&theme)
+                } else {
+                    gpui::transparent_black()
+                };
                 let wt_row = div()
                     .id(("worktree", id_hash(&wt_row_id)))
                     .h(px(28.0))
@@ -2950,6 +3008,7 @@ impl Render for Sidebar {
                     .items_center()
                     .border_l_2()
                     .border_color(rail_color)
+                    .bg(active_context_bg)
                     // 32 px content inset (was 34 before the 2 px rail
                     // was added) so the dot sits at the same column as
                     // before. Border lives outside `pl` in gpui's box

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -560,8 +560,12 @@ pub struct Sidebar {
     active_paths: HashSet<String>,
     /// Canonicalised worktree path of the *currently focused* tab (the
     /// active tab in the focused group), or `None` when no tab is
-    /// focused or it isn't tied to a tracked worktree. Distinct from
-    /// `active_paths`, which marks *every* worktree with a live session:
+    /// focused or it has no working directory. The path is stored as-is;
+    /// if it doesn't match any tracked worktree row (e.g. a tab opened
+    /// in an unrelated directory) it simply highlights nothing — the
+    /// render does the matching, so no up-front filtering is needed.
+    /// Distinct from `active_paths`, which marks *every* worktree with a
+    /// live session:
     /// this marks the single row the user is looking at right now.
     /// Drives the accent-tinted "active context" wash on the matching
     /// worktree row and a fainter wash on its parent project row (so a

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -85,6 +85,17 @@ pub fn frost_50(theme: &Theme) -> Hsla { with_alpha(theme.chrome.ink, 0.50) }
 pub fn ink_dim(theme: &Theme) -> Hsla { with_alpha(theme.chrome.ink, 0.60) }
 pub fn ink_ghost(theme: &Theme) -> Hsla { with_alpha(theme.chrome.ink, 0.40) }
 
+/// Accent-tinted background washes for the "active tab context"
+/// highlight (issue #248) — the sidebar rows tied to the currently
+/// focused tab. A low-alpha accent fill reads as "your active tab lives
+/// here", distinct from both the solid grey `surface_elev` click-
+/// selection fill and the thin accent rail. The worktree row gets the
+/// stronger wash; the parent project row gets the fainter one so a
+/// collapsed project still hints at the context without competing with
+/// its (hidden) child worktree row.
+pub fn active_context_wash(theme: &Theme) -> Hsla { with_alpha(theme.chrome.accent, 0.14) }
+pub fn active_context_wash_dim(theme: &Theme) -> Hsla { with_alpha(theme.chrome.accent, 0.07) }
+
 /// Worktree clean indicator. Reuses the accent colour so a fully-
 /// clean worktree visually rhymes with the focus / accent rail
 /// elsewhere in the chrome.


### PR DESCRIPTION
Closes #248.

## What

The sidebar now follows the focused terminal tab. The worktree row that owns the **active tab in the focused group** gets an accent-tinted background wash, and its **parent project row** gets a fainter wash — so a collapsed project still communicates that the active tab is inside it.

## Why a new treatment (not reusing selection)

Per the issue, the active-context highlight is deliberately distinct from the two existing sidebar cues, which mean different things:

- **Grey `surface_elev` fill** = the user-clicked *selected* project (where new sessions spawn). Unchanged; wins over the wash when a project is both selected and the active context.
- **Thin accent rail** = a worktree has *any* live session (`HasActiveSession`). Unchanged.
- **NEW accent-tinted wash** = the single worktree/project the focused tab lives in right now.

The retired C# build never followed the focused tab (its sidebar only had user-click `TreeViewItem.IsSelected`), so this is new behaviour rather than parity — verified against `legacy/v0.2.6-final`.

## How

- `Sidebar::active_context_path: Option<String>` + `set_active_context()` — the canonicalised worktree path of the focused tab. Render matches it against each worktrees cached `canonical_path`: the matching worktree row gets `theme::active_context_wash` (accent @ 14%), and any project containing it gets `active_context_wash_dim` (accent @ 7%, the only cue when the project is collapsed).
- `AppShell::push_sidebar_active_context()` resolves `groups[focused_group].tabs[active_tab].working_directory` and pushes it. Called from:
  - `activate_tab` — the universal tab-activation funnel (tab switch, group focus, `next/prev_tab`, tab move between/to-new group, spawn, restore all route through it);
  - `close_tab` — when the last tab in the workspace closes and no focused tab remains (clears to `None`).
- Two theme accessors (`active_context_wash` / `_dim`) reuse the accent at low alpha via the existing `with_alpha` helper.

Unlike the session-path sets, this does **not** require an adopted agent session — a plain shell tab still has a worktree context worth highlighting.

## Testing

- `cargo check` / `cargo clippy -p codescope --all-targets` / `cargo build` — clean on changed files.
- Visual / manual (GPUI has no UIA, so the maintainer drives):
  - Switch tabs across worktrees → wash moves to the focused tabs row immediately.
  - Move a tab to another group / focus another group → wash follows.
  - Collapse the active project → project row keeps the faint wash.
  - Close the last tab → wash clears.
  - Selection (grey) and active-context (blue wash) can both be visible on different rows without conflicting with dirty/PR/status indicators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)