### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "codescope"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
Version bump for the v0.4.0 release.

Bumps the `codescope` package `0.3.1` → `0.4.0` (Cargo.toml + Cargo.lock). A minor release covering everything since v0.3.0:

- #249 — auto-update restored via `self_update` + Inno Setup; `codescope-rs` → `CodeScope` rename
- #251 — reliable titlebar drag + double-click maximize on Windows
- #247 / #252 — single-instance enforcement (per-session named mutex)
- #246 — new-project dialog focus fix
- #248 / #253 — sidebar active-tab highlight

cargo-dist requires the release tag to match the workspace version, so this lands first; pushing `v0.4.0` afterwards triggers the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)