### PR TITLE
fix(layout): tall sidebar no longer pushes the work area off-screen

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6899,7 +6899,7 @@ impl Render for AppShell {
                     ),
             );
 
-        let main_row = if self.sidebar_visible {
+        let mut main_row = if self.sidebar_visible {
             div()
                 .flex_grow()
                 .flex()
@@ -6920,6 +6920,14 @@ impl Render for AppShell {
                 .flex_row()
                 .child(work_area)
         };
+        // Mirror the sidebar body's `min_h(0)` trick: without it a
+        // flex child defaults to its intrinsic content height, so a
+        // sidebar taller than the window inflates this row past the
+        // root column's bounds and pushes the work area's bottom (and
+        // the status bar) off-screen (#260). Clamping min-height to 0
+        // keeps the row at the column's allocated height and lets the
+        // sidebar scroll internally instead.
+        main_row.style().min_size.height = Some(gpui::Length::Definite(px(0.0).into()));
 
         // While a splitter drag is in flight we listen for mouse
         // moves anywhere in the window (the cursor commonly leaves


### PR DESCRIPTION
Fixes #260.

## Problem

When the sidebar's content grows taller than the window, the terminal/CLI panes in the work area can no longer be scrolled all the way down — the bottom of the work area (and the status bar) gets pushed below the window edge.

## Root cause

The sidebar body is correctly scrollable (`flex_grow` + `min_h(0)` + `overflow_y_scroll` in `src/sidebar.rs`), but the `main_row` flex row that wraps sidebar + work area had no min-height clamp. In GPUI's flex layout a child defaults to its intrinsic content height, so a sidebar taller than the window inflated the row past the root column's bounds instead of letting the sidebar scroll internally.

## Fix

Apply the same `min_size.height = 0` clamp already used by the sidebar body, command palette list, overview body, and notifications list to `main_row` (both the sidebar-visible and sidebar-hidden variants).

## Validation

- `cargo clippy -p codescope --all-targets` clean on the change (the 18 pre-existing `doc_lazy_continuation` warnings in `src/app.rs` are untouched).
- Pure layout change; no test surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)