### PR TITLE
fix(theme): repaint running terminals on theme change

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2983,12 +2983,10 @@ impl AppShell {
     /// Apply a freshly-loaded `Settings` to the shell. Resolves the
     /// theme by name from the built-in registry, swaps both the
     /// settings and theme `Arc`s, and forwards the new theme to the
-    /// sidebar so its chrome repaints in the same frame. Existing
-    /// terminals keep their baked-in palette / font; the swap takes
-    /// effect for chrome immediately and for new tabs on next spawn.
-    /// Live-reapplying palette / font to running terminals lands
-    /// when the renderer exposes that knob — until then a settings
-    /// edit fully takes over only after the next Ctrl+Shift+T.
+    /// sidebar so its chrome repaints in the same frame. Running
+    /// terminals get the new palette pushed via
+    /// `push_palette_to_terminals` so the grid recolours live too;
+    /// font changes still take effect on next spawn only.
     pub(crate) fn apply_settings(&mut self, settings: Settings, cx: &mut Context<Self>) {
         let theme = Arc::new(codescope_core::theme::builtin::by_name(&settings.theme));
         // Rebuild the AgentRegistry from the new settings so the
@@ -3004,6 +3002,7 @@ impl AppShell {
             sidebar.apply_theme(theme, cx);
             sidebar.apply_agent_registry(agent_registry, cx);
         });
+        self.push_palette_to_terminals(cx);
         cx.notify();
     }
 
@@ -3020,7 +3019,26 @@ impl AppShell {
         self.sidebar.update(cx, |sidebar, cx| {
             sidebar.apply_theme(theme, cx);
         });
+        self.push_palette_to_terminals(cx);
         cx.notify();
+    }
+
+    /// Re-derive the terminal colour palette from the active theme and
+    /// push it into every open tab's `TerminalView`, recolouring the
+    /// running grids in place (#257). Terminals bake their palette in
+    /// at spawn time, so without this a theme switch only repainted
+    /// the chrome and the consoles kept the old colours until the tab
+    /// was reopened.
+    fn push_palette_to_terminals(&mut self, cx: &mut Context<Self>) {
+        let palette = ColorPalette::from_theme_palette(&self.theme.palette);
+        for group in &self.groups {
+            for tab in &group.tabs {
+                let palette = palette.clone();
+                tab.terminal.update(cx, |view, cx| {
+                    view.set_palette(palette, cx);
+                });
+            }
+        }
     }
 
     /// Read-only borrow of the on-disk path bundle. Used by the

--- a/terminal/src/backend.rs
+++ b/terminal/src/backend.rs
@@ -284,6 +284,14 @@ impl Backend {
         self.events.clone()
     }
 
+    /// Push a new palette into the event proxy so OSC 4 / 10-12 colour
+    /// queries answer against the live theme instead of the spawn-time
+    /// one. Pairs with re-snapshotting on the View side — both halves
+    /// together make a theme switch fully take over a running terminal.
+    pub fn update_palette(&self, palette: &ColorPalette) {
+        self.proxy.update_palette(palette.clone());
+    }
+
     /// Capture a styled snapshot of the visible grid. Each line is a
     /// list of [`StyledRun`]s with already-resolved gpui colours, flags,
     /// and exact column positions, so the renderer can paint quads and

--- a/terminal/src/event.rs
+++ b/terminal/src/event.rs
@@ -88,7 +88,9 @@ struct Inner {
     /// don't get a quick response. Sending the answer from the
     /// event-loop thread directly (instead of routing through gpui's
     /// async update tick on the View) keeps round-trip below a frame.
-    palette: ColorPalette,
+    /// Behind a mutex so a theme switch can swap it mid-session and
+    /// colour queries keep matching what's painted on screen.
+    palette: Mutex<ColorPalette>,
     /// Latest `WindowSize` the View pushed to the backend, used to
     /// answer `\x1b[14t` text-area-size queries instantly. The View
     /// updates this on every resize.
@@ -104,7 +106,7 @@ impl EventProxy {
             inner: Arc::new(Inner {
                 tx,
                 pty_writer: OnceLock::new(),
-                palette,
+                palette: Mutex::new(palette),
                 size: Arc::new(Mutex::new(initial_size)),
             }),
         };
@@ -121,6 +123,13 @@ impl EventProxy {
     /// answers reflect the latest layout. Cheap — just a mutex write.
     pub fn update_size(&self, size: WindowSize) {
         *self.inner.size.lock() = size;
+    }
+
+    /// Swap the palette used to answer OSC 4 / 10-12 colour queries so
+    /// TUIs probing colours after a theme switch get values that match
+    /// what's actually painted. Cheap — just a mutex write.
+    pub fn update_palette(&self, palette: ColorPalette) {
+        *self.inner.palette.lock() = palette;
     }
 
     fn forward(&self, event: BackendEvent) {
@@ -168,7 +177,7 @@ impl EventListener for EventProxy {
             // OSC 4 overrides are rare and not worth the deadlock risk
             // of locking the term from the event loop thread.
             Event::ColorRequest(index, response) => {
-                let rgb = self.inner.palette.resolve_rgb_no_overrides(index);
+                let rgb = self.inner.palette.lock().resolve_rgb_no_overrides(index);
                 self.write_pty(response(rgb));
             }
             Event::TextAreaSizeRequest(response) => {

--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -267,12 +267,14 @@ impl TerminalView {
     /// Swap the colour palette and immediately re-resolve the current
     /// grid against it, so the terminal repaints in the new colours on
     /// this frame instead of keeping its spawn-time palette until the
-    /// next PTY event. The app shell calls this for every open tab
-    /// when the user switches theme.
+    /// next PTY event. The backend's event proxy gets the new palette
+    /// too, so OSC 4 / 10-12 colour queries from running TUIs answer
+    /// in the live theme's colours. The app shell calls this for every
+    /// open tab when the user switches theme.
     pub fn set_palette(&mut self, palette: ColorPalette, cx: &mut Context<Self>) {
+        self.backend.update_palette(&palette);
         self.palette = palette;
-        self.snapshot = self.backend.snapshot(&self.palette);
-        cx.notify();
+        self.refresh_snapshot(cx);
     }
 
     /// Snap the cursor to its visible phase. Called whenever the user

--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -264,6 +264,17 @@ impl TerminalView {
         self.backend.write_input(bytes);
     }
 
+    /// Swap the colour palette and immediately re-resolve the current
+    /// grid against it, so the terminal repaints in the new colours on
+    /// this frame instead of keeping its spawn-time palette until the
+    /// next PTY event. The app shell calls this for every open tab
+    /// when the user switches theme.
+    pub fn set_palette(&mut self, palette: ColorPalette, cx: &mut Context<Self>) {
+        self.palette = palette;
+        self.snapshot = self.backend.snapshot(&self.palette);
+        cx.notify();
+    }
+
     /// Snap the cursor to its visible phase. Called whenever the user
     /// types so the cursor never disappears mid-keystroke.
     fn show_cursor_now(&self) {


### PR DESCRIPTION
Fixes #257.

## Problem

Switching theme in the Settings dialog live-applied the new colours to the app chrome, but every open console kept its old colours until the app was restarted (or the tab reopened).

## Root cause

`TerminalView` bakes its `ColorPalette` in at construction; there was no setter, and `AppShell::apply_settings` / `set_theme_preview` only forwarded the new theme to the sidebar. The terminal's async drain task kept re-resolving snapshots against the frozen spawn-time palette.

## Fix

- New `TerminalView::set_palette()` (terminal/src/view.rs): swaps the palette, immediately re-resolves the grid snapshot against it, and notifies — so the recolour lands on the current frame, not on the next PTY event.
- New `AppShell::push_palette_to_terminals()` (src/app.rs): derives the palette from the active theme and pushes it into every open tab. Called from both `apply_settings` (Save) and `set_theme_preview` (live preview while clicking through the theme list — Cancel also restores correctly, since it reapplies the open-time snapshot through the same preview path).
- Updated the now-stale `apply_settings` doc comment (it documented the missing-knob limitation this PR removes). Font changes still take effect on next spawn only.

## Validation

- `cargo clippy -p codescope -p codescope-terminal --all-targets` clean on the change (18 pre-existing `doc_lazy_continuation` warnings untouched).
- `cargo test -p codescope-terminal`: 28 passed.
- No new test surface: the change is GPUI entity plumbing; the palette→colour resolution it reuses is covered by existing backend tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)