### PR TITLE
fix(terminal): honour OSC 52 copy so CLI apps can write the clipboard

### DIFF
--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -25,6 +25,7 @@ use parking_lot::Mutex;
 
 use crate::backend::{Backend, TerminalSize, TerminalSnapshot};
 use crate::colors::ColorPalette;
+use crate::event::BackendEvent;
 use crate::input::keystroke_to_bytes;
 use crate::mouse::{self, MouseEventKind};
 use crate::paint::paint_snapshot;
@@ -164,11 +165,26 @@ impl TerminalView {
         let pending_size: Arc<Mutex<Option<PendingResize>>> = Arc::new(Mutex::new(None));
 
         cx.spawn(async move |this, cx| {
-            while let Ok(_event) = events.recv_async().await {
+            while let Ok(event) = events.recv_async().await {
                 if this
-                    .update(cx, |view: &mut Self, cx| {
-                        view.snapshot = view.backend.snapshot(&view.palette);
-                        cx.notify();
+                    .update(cx, |view: &mut Self, cx| match event {
+                        // OSC 52 copy: the program running in the
+                        // terminal (e.g. Copilot CLI's "copy to
+                        // clipboard" action) asked us to set the system
+                        // clipboard. Alacritty has already base64-
+                        // decoded the payload.
+                        BackendEvent::ClipboardStore(text) => {
+                            cx.write_to_clipboard(ClipboardItem::new_string(text));
+                        }
+                        // OSC 52 paste requests are deliberately not
+                        // honoured: answering would let any program
+                        // running in the terminal silently read the
+                        // user's clipboard.
+                        BackendEvent::ClipboardLoad => {}
+                        _ => {
+                            view.snapshot = view.backend.snapshot(&view.palette);
+                            cx.notify();
+                        }
                     })
                     .is_err()
                 {


### PR DESCRIPTION
Fixes #259.

## Problem

Selecting text inside Copilot CLI (or any TUI that offers its own "copy" action) showed the CLI's *"copied to clipboard"* confirmation, but the system clipboard stayed empty.

## Root cause

TUIs that run inside a terminal emulator can't touch the system clipboard directly — they emit an **OSC 52** escape sequence and rely on the emulator to perform the write. Our pipeline already carried that request almost all the way:

- alacritty parses OSC 52 and raises `Event::ClipboardStore` (payload already base64-decoded),
- `EventProxy` forwards it as `BackendEvent::ClipboardStore(text)` (terminal/src/event.rs),
- …but `TerminalView`'s event-drain loop bound every event as `_event` and only re-snapshotted the grid, so the clipboard request was silently dropped (terminal/src/view.rs).

## Fix

Match on the drained event in the loop:

- `ClipboardStore(text)` → `cx.write_to_clipboard(ClipboardItem::new_string(text))`.
- `ClipboardLoad` (OSC 52 *paste request*) → deliberately ignored: honouring it would let any program running in the terminal silently read the user's clipboard. This matches the default posture of most terminal emulators.
- Everything else keeps the existing snapshot + notify behaviour.

The terminal's own selection copy (Ctrl+C / Ctrl+Shift+C with a selection) was already working and is unchanged.

## Validation

- `cargo clippy -p codescope-terminal --all-targets` clean on the change (2 pre-existing doc warnings in `colors.rs` untouched).
- `cargo test -p codescope-terminal`: 28 passed.
- No new test surface: the change is gpui entity glue around the already-tested event forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)