### PR TITLE
feat: working-tree diff viewer (Ctrl+Shift+D)

### DIFF
--- a/core/src/diff.rs
+++ b/core/src/diff.rs
@@ -264,16 +264,30 @@ fn parse_hunk_header(header: &str) -> Option<(u32, u32)> {
     Some((old_start, new_start))
 }
 
-/// Strip the `a/` / `b/` prefix (and optional quoting) from a
-/// `---` / `+++` path. Returns `None` for `/dev/null`.
+/// Strip the `a/` / `b/` prefix (and optional C-quoting, decoded the
+/// same way as `paths_from_diff_git`) from a `---` / `+++` path.
+/// Returns `None` for `/dev/null`.
 fn strip_diff_path(raw: &str, prefix: &str) -> Option<String> {
     let raw = raw.trim_end();
-    let raw = raw.strip_prefix('"').unwrap_or(raw);
-    let raw = raw.strip_suffix('"').unwrap_or(raw);
-    if raw == "/dev/null" {
+    let decoded = if raw.starts_with('"') {
+        match take_c_quoted(raw) {
+            Some((value, _)) => value,
+            // Unterminated quote — keep the raw text rather than
+            // dropping the line.
+            None => raw.to_string(),
+        }
+    } else {
+        raw.to_string()
+    };
+    if decoded == "/dev/null" {
         return None;
     }
-    Some(raw.strip_prefix(prefix).unwrap_or(raw).to_string())
+    Some(
+        decoded
+            .strip_prefix(prefix)
+            .unwrap_or(&decoded)
+            .to_string(),
+    )
 }
 
 /// Best-effort path split of the `a/<p> b/<p>` tail of a `diff --git`

--- a/core/src/diff.rs
+++ b/core/src/diff.rs
@@ -112,6 +112,10 @@ pub struct DiffLine {
 /// empty vec.
 pub fn parse_unified_diff(input: &str) -> Vec<DiffFile> {
     let mut files: Vec<DiffFile> = Vec::new();
+    // Running (old, new) line numbers for the hunk currently being
+    // filled — reset by every `@@` header. Kept outside the hunk so
+    // appending a line is O(1) instead of re-counting the hunk.
+    let mut counters: (u32, u32) = (0, 0);
 
     for line in input.lines() {
         let line = line.strip_suffix('\r').unwrap_or(line);
@@ -141,17 +145,17 @@ pub fn parse_unified_diff(input: &str) -> Vec<DiffFile> {
             // falls through to header handling below.
             match line.as_bytes().first() {
                 Some(b'+') => {
-                    push_hunk_line(hunk, LineKind::Added, &line[1..]);
+                    push_hunk_line(hunk, LineKind::Added, &line[1..], &mut counters);
                     file.added += 1;
                     continue;
                 }
                 Some(b'-') => {
-                    push_hunk_line(hunk, LineKind::Removed, &line[1..]);
+                    push_hunk_line(hunk, LineKind::Removed, &line[1..], &mut counters);
                     file.removed += 1;
                     continue;
                 }
                 Some(b' ') => {
-                    push_hunk_line(hunk, LineKind::Context, &line[1..]);
+                    push_hunk_line(hunk, LineKind::Context, &line[1..], &mut counters);
                     continue;
                 }
                 // `\ No newline at end of file` — metadata, not text.
@@ -159,7 +163,7 @@ pub fn parse_unified_diff(input: &str) -> Vec<DiffFile> {
                 // Empty context line: git emits a fully blank line for
                 // a context line whose content is empty.
                 None => {
-                    push_hunk_line(hunk, LineKind::Context, "");
+                    push_hunk_line(hunk, LineKind::Context, "", &mut counters);
                     continue;
                 }
                 _ => {}
@@ -168,6 +172,7 @@ pub fn parse_unified_diff(input: &str) -> Vec<DiffFile> {
 
         if let Some(header) = line.strip_prefix("@@ ") {
             if let Some((old_start, new_start)) = parse_hunk_header(header) {
+                counters = (old_start, new_start);
                 file.hunks.push(DiffHunk {
                     header: line.to_string(),
                     old_start,
@@ -212,22 +217,33 @@ pub fn parse_unified_diff(input: &str) -> Vec<DiffFile> {
     files
 }
 
-/// Append a line to `hunk`, deriving its old/new line numbers from the
-/// hunk's running counters.
-fn push_hunk_line(hunk: &mut DiffHunk, kind: LineKind, text: &str) {
-    let (mut next_old, mut next_new) = (hunk.old_start, hunk.new_start);
-    for l in &hunk.lines {
-        if l.old_no.is_some() {
-            next_old += 1;
-        }
-        if l.new_no.is_some() {
-            next_new += 1;
-        }
-    }
+/// Append a line to `hunk`, consuming line numbers from the parser's
+/// running `(old, new)` counters (reset by each `@@` header). O(1)
+/// per line — re-deriving the numbers from the hunk contents would
+/// make parsing quadratic on large hunks.
+fn push_hunk_line(
+    hunk: &mut DiffHunk,
+    kind: LineKind,
+    text: &str,
+    counters: &mut (u32, u32),
+) {
     let (old_no, new_no) = match kind {
-        LineKind::Context => (Some(next_old), Some(next_new)),
-        LineKind::Added => (None, Some(next_new)),
-        LineKind::Removed => (Some(next_old), None),
+        LineKind::Context => {
+            let nos = (Some(counters.0), Some(counters.1));
+            counters.0 += 1;
+            counters.1 += 1;
+            nos
+        }
+        LineKind::Added => {
+            let nos = (None, Some(counters.1));
+            counters.1 += 1;
+            nos
+        }
+        LineKind::Removed => {
+            let nos = (Some(counters.0), None);
+            counters.0 += 1;
+            nos
+        }
     };
     hunk.lines.push(DiffLine {
         kind,
@@ -405,14 +421,28 @@ fn untracked_file_entry(worktree: &Path, rel_path: &str) -> DiffFile {
         truncated: false,
     };
 
+    // Bounded read: pull at most cap+1 bytes off disk (the +1 tells
+    // truncation apart from an exactly-cap-sized file) so a multi-GB
+    // untracked artifact never lands in memory just to be previewed.
     let abs = worktree.join(rel_path);
-    let too_big = std::fs::metadata(&abs)
-        .map(|m| m.len() > MAX_UNTRACKED_BYTES)
-        .unwrap_or(false);
-    let Ok(bytes) = std::fs::read(&abs) else {
-        entry.binary = true;
-        return entry;
+    let bytes = {
+        use std::io::Read as _;
+        let Ok(file) = std::fs::File::open(&abs) else {
+            entry.binary = true;
+            return entry;
+        };
+        let mut buf = Vec::new();
+        if file
+            .take(MAX_UNTRACKED_BYTES + 1)
+            .read_to_end(&mut buf)
+            .is_err()
+        {
+            entry.binary = true;
+            return entry;
+        }
+        buf
     };
+    let too_big = bytes.len() as u64 > MAX_UNTRACKED_BYTES;
     if bytes[..bytes.len().min(8192)].contains(&0) {
         entry.binary = true;
         return entry;

--- a/core/src/diff.rs
+++ b/core/src/diff.rs
@@ -369,9 +369,22 @@ pub fn worktree_diff(worktree: &Path) -> Result<Vec<DiffFile>> {
     let has_head = run_git(worktree, &["rev-parse", "--verify", "--quiet", "HEAD"]).is_ok();
 
     let mut files = if has_head {
+        // `core.quotepath=false`: default git octal-escapes non-ASCII
+        // filenames in the `diff --git`/`---`/`+++` headers, which
+        // `parse_unified_diff` would pass through verbatim as mangled
+        // display paths. Force raw (UTF-8) paths instead — same reason
+        // the status call below uses `-z`.
         let output = run_git(
             worktree,
-            &["diff", "HEAD", "-M", "--no-color", "--no-ext-diff"],
+            &[
+                "-c",
+                "core.quotepath=false",
+                "diff",
+                "HEAD",
+                "-M",
+                "--no-color",
+                "--no-ext-diff",
+            ],
         )
         .context("git diff HEAD")?;
         parse_unified_diff(&String::from_utf8_lossy(&output.stdout))
@@ -715,6 +728,24 @@ Binary files a/img.png and b/img.png differ
         assert_eq!(files.len(), 1);
         assert!(files[0].binary);
         assert!(files[0].hunks.is_empty());
+    }
+
+    /// Without `-c core.quotepath=false`, default git octal-escapes
+    /// non-ASCII names in the `diff --git` headers and the viewer
+    /// would display the mangled `"n\303\266tes.txt"` form.
+    #[test]
+    fn tracked_non_ascii_path_displays_raw() {
+        let Some((_guard, repo)) = init_repo() else { return };
+        let name = "nötes.txt";
+        std::fs::write(repo.join(name), "a\n").unwrap();
+        run(&repo, &["add", "-A"]);
+        run(&repo, &["commit", "-m", "seed", "-q"]);
+        std::fs::write(repo.join(name), "a\nb\n").unwrap();
+        let files = worktree_diff(&repo).expect("diff succeeds");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, name);
+        assert_eq!(files[0].status, FileStatus::Modified);
+        assert_eq!(files[0].added, 1);
     }
 
     /// Without `-z`, default `core.quotepath` octal-escapes non-ASCII

--- a/core/src/diff.rs
+++ b/core/src/diff.rs
@@ -277,16 +277,95 @@ fn strip_diff_path(raw: &str, prefix: &str) -> Option<String> {
 }
 
 /// Best-effort path split of the `a/<p> b/<p>` tail of a `diff --git`
-/// line. Ambiguous for paths with spaces — the `+++` / `---` handlers
-/// overwrite with the authoritative value when those lines arrive.
+/// line. Handles git's C-quoted form (`"a/sp ace"`, emitted even under
+/// `core.quotepath=false` for names with quotes/control bytes) and
+/// disambiguates bare names containing spaces via the equal-halves
+/// heuristic. Matters most for binary diffs, which have no `---` /
+/// `+++` lines to overwrite with the authoritative value.
 fn paths_from_diff_git(rest: &str) -> (String, String) {
     let rest = rest.trim();
-    if let Some(idx) = rest.find(" b/") {
+
+    // Quoted form: parse the leading C-quoted token; the second half
+    // is either quoted too or the bare remainder.
+    if rest.starts_with('"') {
+        if let Some((old_raw, rem)) = take_c_quoted(rest) {
+            let rem = rem.trim_start();
+            let new_raw = if rem.starts_with('"') {
+                take_c_quoted(rem).map(|(s, _)| s)
+            } else if !rem.is_empty() {
+                Some(rem.to_string())
+            } else {
+                None
+            };
+            if let Some(new_raw) = new_raw {
+                let old = old_raw.strip_prefix("a/").unwrap_or(&old_raw);
+                let new = new_raw.strip_prefix("b/").unwrap_or(&new_raw);
+                return (old.to_string(), new.to_string());
+            }
+        }
+        return (rest.to_string(), rest.to_string());
+    }
+
+    // Bare form: prefer a ` b/` split where both halves agree — the
+    // common non-rename case stays correct even when the name itself
+    // contains ` b/`. Renames fall back to the first occurrence (the
+    // rename header's explicit `rename from/to` lines are unambiguous
+    // and the `---`/`+++` overwrite applies to their text hunks).
+    let candidates: Vec<usize> = rest.match_indices(" b/").map(|(i, _)| i).collect();
+    for &idx in &candidates {
+        let old = rest[..idx].strip_prefix("a/").unwrap_or(&rest[..idx]);
+        let new = &rest[idx + 3..];
+        if old == new {
+            return (old.to_string(), new.to_string());
+        }
+    }
+    if let Some(&idx) = candidates.first() {
         let old = rest[..idx].strip_prefix("a/").unwrap_or(&rest[..idx]);
         let new = &rest[idx + 3..];
         return (old.to_string(), new.to_string());
     }
     (rest.to_string(), rest.to_string())
+}
+
+/// Parse a leading C-quoted string (git's path quoting: `\"`, `\\`,
+/// `\t`, `\n`, `\r`, and octal `\NNN` byte escapes). Returns the
+/// decoded value plus the remainder after the closing quote, or `None`
+/// when the input doesn't start with a quote / never closes it.
+fn take_c_quoted(s: &str) -> Option<(String, &str)> {
+    let inner = s.strip_prefix('"')?;
+    let bytes = inner.as_bytes();
+    let mut out: Vec<u8> = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                return Some((String::from_utf8_lossy(&out).into_owned(), &inner[i + 1..]));
+            }
+            b'\\' if i + 1 < bytes.len() => {
+                i += 1;
+                match bytes[i] {
+                    b'n' => out.push(b'\n'),
+                    b't' => out.push(b'\t'),
+                    b'r' => out.push(b'\r'),
+                    b'0'..=b'7' => {
+                        let mut val: u32 = 0;
+                        let mut digits = 0;
+                        while digits < 3 && i < bytes.len() && (b'0'..=b'7').contains(&bytes[i]) {
+                            val = val * 8 + u32::from(bytes[i] - b'0');
+                            i += 1;
+                            digits += 1;
+                        }
+                        i -= 1; // loop tail re-adds one
+                        out.push(val as u8);
+                    }
+                    other => out.push(other),
+                }
+            }
+            b => out.push(b),
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Compute the changed char span between two versions of a line by
@@ -409,7 +488,10 @@ pub fn worktree_diff(worktree: &Path) -> Result<Vec<DiffFile>> {
         let code = &entry[..3];
         // Rename/copy entries carry the original path as the *next*
         // NUL field — consume it so it can't be misread as an entry.
-        if code.starts_with('R') || code.starts_with('C') {
+        // R/C can sit in either XY column (staged vs. worktree rename
+        // detection), so scan both status chars.
+        let xy = &code[..2];
+        if xy.contains('R') || xy.contains('C') {
             let _ = fields.next();
         }
         if code == "?? " {
@@ -521,6 +603,33 @@ index 0000000..3333333
 +# Title
 +body
 ";
+
+    #[test]
+    fn diff_git_paths_quoted_binary_with_spaces() {
+        // Binary diffs have no ---/+++ overwrite, so the diff --git
+        // split must already be right for quoted spaced names.
+        let diff = "diff --git \"a/sp ace.bin\" \"b/sp ace.bin\"\n\
+                    index 1111111..2222222 100644\n\
+                    Binary files \"a/sp ace.bin\" and \"b/sp ace.bin\" differ\n";
+        let files = parse_unified_diff(diff);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "sp ace.bin");
+        assert!(files[0].binary);
+    }
+
+    #[test]
+    fn diff_git_paths_bare_with_spaces() {
+        let (old, new) = paths_from_diff_git("a/foo bar.bin b/foo bar.bin");
+        assert_eq!(old, "foo bar.bin");
+        assert_eq!(new, "foo bar.bin");
+    }
+
+    #[test]
+    fn c_quoted_octal_escapes_decode() {
+        let (val, rest) = take_c_quoted("\"a/n\\303\\266tes \\\"q\\\".txt\" tail").unwrap();
+        assert_eq!(val, "a/nötes \"q\".txt");
+        assert_eq!(rest, " tail");
+    }
 
     #[test]
     fn parses_files_hunks_and_counts() {

--- a/core/src/diff.rs
+++ b/core/src/diff.rs
@@ -379,31 +379,33 @@ pub fn worktree_diff(worktree: &Path) -> Result<Vec<DiffFile>> {
         Vec::new()
     };
 
-    let status = run_git(worktree, &["status", "--porcelain", "--untracked-files=all"])
-        .context("git status --porcelain")?;
+    // `-z`: NUL-terminated entries with RAW paths — no C-style
+    // quoting/escaping to undo, so names with spaces, quotes, or
+    // backslash escapes resolve on disk exactly as git reported them.
+    let status = run_git(
+        worktree,
+        &["status", "--porcelain", "-z", "--untracked-files=all"],
+    )
+    .context("git status --porcelain -z")?;
     let stdout = String::from_utf8_lossy(&status.stdout);
-    let mut untracked: Vec<DiffFile> = stdout
-        .lines()
-        .filter_map(|l| l.strip_prefix("?? "))
-        .map(|p| {
-            let path = unquote_porcelain_path(p);
-            untracked_file_entry(worktree, &path)
-        })
-        .collect();
+    let mut untracked: Vec<DiffFile> = Vec::new();
+    let mut fields = stdout.split('\0');
+    while let Some(entry) = fields.next() {
+        // Entry shape: two status chars + space + path.
+        let Some(path) = entry.get(3..) else { continue };
+        let code = &entry[..3];
+        // Rename/copy entries carry the original path as the *next*
+        // NUL field — consume it so it can't be misread as an entry.
+        if code.starts_with('R') || code.starts_with('C') {
+            let _ = fields.next();
+        }
+        if code == "?? " {
+            untracked.push(untracked_file_entry(worktree, path));
+        }
+    }
     untracked.sort_by(|a, b| a.path.cmp(&b.path));
     files.append(&mut untracked);
     Ok(files)
-}
-
-/// Porcelain quotes paths containing special chars (`"a b.txt"`).
-/// Strip the quotes; embedded escapes are left as-is (the entry still
-/// renders, existence-dependent features degrade gracefully).
-fn unquote_porcelain_path(raw: &str) -> String {
-    let raw = raw.trim();
-    raw.strip_prefix('"')
-        .and_then(|r| r.strip_suffix('"'))
-        .unwrap_or(raw)
-        .to_string()
 }
 
 /// Build the synthetic all-added [`DiffFile`] for an untracked path.
@@ -713,5 +715,20 @@ Binary files a/img.png and b/img.png differ
         assert_eq!(files.len(), 1);
         assert!(files[0].binary);
         assert!(files[0].hunks.is_empty());
+    }
+
+    /// Without `-z`, default `core.quotepath` octal-escapes non-ASCII
+    /// names in porcelain output (`"n\303\266tes \303\274.txt"`); the
+    /// on-disk lookup then fails and the entry is mis-flagged binary.
+    #[test]
+    fn untracked_non_ascii_path_resolves() {
+        let Some((_guard, repo)) = init_repo() else { return };
+        let name = "nötes ü.txt";
+        std::fs::write(repo.join(name), "hello\n").unwrap();
+        let files = worktree_diff(&repo).expect("diff succeeds");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, name);
+        assert!(!files[0].binary, "quoted path failed to resolve on disk");
+        assert_eq!(files[0].added, 1);
     }
 }

--- a/core/src/diff.rs
+++ b/core/src/diff.rs
@@ -1,0 +1,687 @@
+//! Working-tree diff model for the in-app diff viewer.
+//!
+//! Two halves:
+//!
+//! * A pure unified-diff parser ([`parse_unified_diff`]) that turns
+//!   `git diff` output into files → hunks → lines, with per-line old /
+//!   new line numbers and intraline change emphasis so the renderer
+//!   can paint pixel-level highlights without re-deriving anything.
+//! * A collector ([`worktree_diff`]) that shells out to `git` (per the
+//!   project rule: no libgit2) and folds untracked files in as
+//!   synthetic all-added entries, because "what changed in this
+//!   worktree" includes the file you just created.
+//!
+//! The parser is deliberately tolerant: anything it doesn't recognise
+//! inside a file section (mode lines, index lines, `\ No newline at
+//! end of file`) is skipped rather than failing the whole diff — a
+//! viewer that drops one exotic header is useful, one that errors on
+//! it is not.
+
+use std::path::Path;
+
+use anyhow::{Context as _, Result};
+
+use crate::git::run_git;
+
+/// Hard cap on synthesized untracked-file content, in bytes. Untracked
+/// files are read straight from disk; without a cap a stray multi-MB
+/// log file would balloon the snapshot and the render tree.
+const MAX_UNTRACKED_BYTES: u64 = 262_144;
+
+/// Hard cap on synthesized untracked-file content, in lines. Same
+/// rationale as [`MAX_UNTRACKED_BYTES`].
+const MAX_UNTRACKED_LINES: usize = 5_000;
+
+/// How a file changed relative to `HEAD`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileStatus {
+    Added,
+    Modified,
+    Deleted,
+    Renamed,
+    /// Not known to git at all — synthesized from the working tree.
+    Untracked,
+}
+
+impl FileStatus {
+    /// Single-letter badge for list rows (`A`/`M`/`D`/`R`/`U`).
+    pub fn badge(self) -> &'static str {
+        match self {
+            FileStatus::Added => "A",
+            FileStatus::Modified => "M",
+            FileStatus::Deleted => "D",
+            FileStatus::Renamed => "R",
+            FileStatus::Untracked => "U",
+        }
+    }
+}
+
+/// One changed file: identity plus its hunks and roll-up counts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffFile {
+    /// New path, slash-separated as git emits it.
+    pub path: String,
+    /// Previous path when `status == Renamed`.
+    pub old_path: Option<String>,
+    pub status: FileStatus,
+    /// Binary change — no hunks, the viewer shows a placeholder.
+    pub binary: bool,
+    pub hunks: Vec<DiffHunk>,
+    /// Total added lines across hunks.
+    pub added: u32,
+    /// Total removed lines across hunks.
+    pub removed: u32,
+    /// True when content was cut off at a display cap (untracked files
+    /// larger than [`MAX_UNTRACKED_BYTES`] / [`MAX_UNTRACKED_LINES`]).
+    pub truncated: bool,
+}
+
+/// One `@@`-delimited hunk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffHunk {
+    /// The raw `@@ -a,b +c,d @@ context` line, for display.
+    pub header: String,
+    pub old_start: u32,
+    pub new_start: u32,
+    pub lines: Vec<DiffLine>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineKind {
+    Context,
+    Added,
+    Removed,
+}
+
+/// One line inside a hunk, prefix stripped, with the line numbers it
+/// occupies on each side (`None` on the side it doesn't exist on).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffLine {
+    pub kind: LineKind,
+    pub old_no: Option<u32>,
+    pub new_no: Option<u32>,
+    pub text: String,
+    /// Char range (`start..end` into `text`'s chars) that actually
+    /// changed, for paired removed/added lines — the renderer paints
+    /// this span with a stronger tint. `None` = whole-line change.
+    pub emphasis: Option<(usize, usize)>,
+}
+
+/// Parse `git diff` unified output (`--no-color`) into [`DiffFile`]s.
+/// Pure and total: unknown lines are skipped, an empty input yields an
+/// empty vec.
+pub fn parse_unified_diff(input: &str) -> Vec<DiffFile> {
+    let mut files: Vec<DiffFile> = Vec::new();
+
+    for line in input.lines() {
+        let line = line.strip_suffix('\r').unwrap_or(line);
+
+        if let Some(rest) = line.strip_prefix("diff --git ") {
+            files.push(DiffFile {
+                path: paths_from_diff_git(rest).1,
+                old_path: None,
+                status: FileStatus::Modified,
+                binary: false,
+                hunks: Vec::new(),
+                added: 0,
+                removed: 0,
+                truncated: false,
+            });
+            continue;
+        }
+        let Some(file) = files.last_mut() else {
+            continue;
+        };
+
+        if let Some(hunk) = file.hunks.last_mut()
+            && !line.starts_with("@@ ")
+        {
+            // Inside a hunk body every line starts with '+', '-',
+            // ' ' or '\' — anything else ends the hunk section and
+            // falls through to header handling below.
+            match line.as_bytes().first() {
+                Some(b'+') => {
+                    push_hunk_line(hunk, LineKind::Added, &line[1..]);
+                    file.added += 1;
+                    continue;
+                }
+                Some(b'-') => {
+                    push_hunk_line(hunk, LineKind::Removed, &line[1..]);
+                    file.removed += 1;
+                    continue;
+                }
+                Some(b' ') => {
+                    push_hunk_line(hunk, LineKind::Context, &line[1..]);
+                    continue;
+                }
+                // `\ No newline at end of file` — metadata, not text.
+                Some(b'\\') => continue,
+                // Empty context line: git emits a fully blank line for
+                // a context line whose content is empty.
+                None => {
+                    push_hunk_line(hunk, LineKind::Context, "");
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(header) = line.strip_prefix("@@ ") {
+            if let Some((old_start, new_start)) = parse_hunk_header(header) {
+                file.hunks.push(DiffHunk {
+                    header: line.to_string(),
+                    old_start,
+                    new_start,
+                    lines: Vec::new(),
+                });
+            }
+        } else if line.starts_with("new file mode") {
+            file.status = FileStatus::Added;
+        } else if line.starts_with("deleted file mode") {
+            file.status = FileStatus::Deleted;
+        } else if let Some(from) = line.strip_prefix("rename from ") {
+            file.status = FileStatus::Renamed;
+            file.old_path = Some(from.to_string());
+        } else if let Some(to) = line.strip_prefix("rename to ") {
+            file.status = FileStatus::Renamed;
+            file.path = to.to_string();
+        } else if line.starts_with("Binary files ") || line.starts_with("GIT binary patch") {
+            file.binary = true;
+        } else if let Some(new_path) = line.strip_prefix("+++ ") {
+            // `+++ b/<path>` is the most reliable path source (the
+            // `diff --git` split is ambiguous for paths containing
+            // spaces). `/dev/null` means deletion — keep the `---`
+            // side's path instead.
+            if let Some(p) = strip_diff_path(new_path, "b/") {
+                file.path = p;
+            }
+        } else if let Some(old_path) = line.strip_prefix("--- ")
+            && let Some(p) = strip_diff_path(old_path, "a/")
+        {
+            if file.status == FileStatus::Deleted {
+                file.path = p;
+            } else if file.status == FileStatus::Renamed && file.old_path.is_none() {
+                file.old_path = Some(p);
+            }
+        }
+    }
+
+    for file in &mut files {
+        apply_intraline_emphasis(file);
+    }
+    files
+}
+
+/// Append a line to `hunk`, deriving its old/new line numbers from the
+/// hunk's running counters.
+fn push_hunk_line(hunk: &mut DiffHunk, kind: LineKind, text: &str) {
+    let (mut next_old, mut next_new) = (hunk.old_start, hunk.new_start);
+    for l in &hunk.lines {
+        if l.old_no.is_some() {
+            next_old += 1;
+        }
+        if l.new_no.is_some() {
+            next_new += 1;
+        }
+    }
+    let (old_no, new_no) = match kind {
+        LineKind::Context => (Some(next_old), Some(next_new)),
+        LineKind::Added => (None, Some(next_new)),
+        LineKind::Removed => (Some(next_old), None),
+    };
+    hunk.lines.push(DiffLine {
+        kind,
+        old_no,
+        new_no,
+        text: text.to_string(),
+        emphasis: None,
+    });
+}
+
+/// Parse `-<old>[,<n>] +<new>[,<m>] @@ ...` (the part after `@@ `).
+fn parse_hunk_header(header: &str) -> Option<(u32, u32)> {
+    let mut parts = header.split(' ');
+    let old = parts.next()?.strip_prefix('-')?;
+    let new = parts.next()?.strip_prefix('+')?;
+    let old_start = old.split(',').next()?.parse().ok()?;
+    let new_start = new.split(',').next()?.parse().ok()?;
+    Some((old_start, new_start))
+}
+
+/// Strip the `a/` / `b/` prefix (and optional quoting) from a
+/// `---` / `+++` path. Returns `None` for `/dev/null`.
+fn strip_diff_path(raw: &str, prefix: &str) -> Option<String> {
+    let raw = raw.trim_end();
+    let raw = raw.strip_prefix('"').unwrap_or(raw);
+    let raw = raw.strip_suffix('"').unwrap_or(raw);
+    if raw == "/dev/null" {
+        return None;
+    }
+    Some(raw.strip_prefix(prefix).unwrap_or(raw).to_string())
+}
+
+/// Best-effort path split of the `a/<p> b/<p>` tail of a `diff --git`
+/// line. Ambiguous for paths with spaces — the `+++` / `---` handlers
+/// overwrite with the authoritative value when those lines arrive.
+fn paths_from_diff_git(rest: &str) -> (String, String) {
+    let rest = rest.trim();
+    if let Some(idx) = rest.find(" b/") {
+        let old = rest[..idx].strip_prefix("a/").unwrap_or(&rest[..idx]);
+        let new = &rest[idx + 3..];
+        return (old.to_string(), new.to_string());
+    }
+    (rest.to_string(), rest.to_string())
+}
+
+/// Compute the changed char span between two versions of a line by
+/// trimming the common prefix and suffix. Returns `(old_span, new_span)`
+/// as char ranges, or `None` when the lines are identical.
+pub fn intraline_emphasis(old: &str, new: &str) -> Option<((usize, usize), (usize, usize))> {
+    if old == new {
+        return None;
+    }
+    let old_chars: Vec<char> = old.chars().collect();
+    let new_chars: Vec<char> = new.chars().collect();
+
+    let mut prefix = 0;
+    while prefix < old_chars.len()
+        && prefix < new_chars.len()
+        && old_chars[prefix] == new_chars[prefix]
+    {
+        prefix += 1;
+    }
+    let mut suffix = 0;
+    while suffix < old_chars.len() - prefix
+        && suffix < new_chars.len() - prefix
+        && old_chars[old_chars.len() - 1 - suffix] == new_chars[new_chars.len() - 1 - suffix]
+    {
+        suffix += 1;
+    }
+    Some((
+        (prefix, old_chars.len() - suffix),
+        (prefix, new_chars.len() - suffix),
+    ))
+}
+
+/// Pair removed/added blocks inside each hunk and stamp intraline
+/// emphasis on both sides. Pairing is positional: the i-th removed
+/// line of a contiguous removed-block pairs with the i-th added line
+/// of the added-block that immediately follows it — the way unified
+/// diffs lay out a modification.
+fn apply_intraline_emphasis(file: &mut DiffFile) {
+    for hunk in &mut file.hunks {
+        let mut i = 0;
+        while i < hunk.lines.len() {
+            if hunk.lines[i].kind != LineKind::Removed {
+                i += 1;
+                continue;
+            }
+            let removed_start = i;
+            while i < hunk.lines.len() && hunk.lines[i].kind == LineKind::Removed {
+                i += 1;
+            }
+            let added_start = i;
+            while i < hunk.lines.len() && hunk.lines[i].kind == LineKind::Added {
+                i += 1;
+            }
+            let pairs = (added_start - removed_start).min(i - added_start);
+            for p in 0..pairs {
+                let old_idx = removed_start + p;
+                let new_idx = added_start + p;
+                if let Some((old_span, new_span)) = intraline_emphasis(
+                    &hunk.lines[old_idx].text,
+                    &hunk.lines[new_idx].text,
+                ) {
+                    hunk.lines[old_idx].emphasis = Some(old_span);
+                    hunk.lines[new_idx].emphasis = Some(new_span);
+                }
+            }
+        }
+    }
+}
+
+/// Collect the full working-tree diff of `worktree` against `HEAD`:
+/// tracked changes (staged *and* unstaged — the viewer answers "what
+/// did this session change", not "what is in the index") plus
+/// untracked files as synthetic all-added entries. Untracked entries
+/// sort after the tracked ones, each side alphabetical (git's own
+/// ordering for the tracked half).
+///
+/// On a repo with no commits yet every file is untracked, so the
+/// missing-`HEAD` case degrades naturally to the untracked-only path.
+pub fn worktree_diff(worktree: &Path) -> Result<Vec<DiffFile>> {
+    let has_head = run_git(worktree, &["rev-parse", "--verify", "--quiet", "HEAD"]).is_ok();
+
+    let mut files = if has_head {
+        let output = run_git(
+            worktree,
+            &["diff", "HEAD", "-M", "--no-color", "--no-ext-diff"],
+        )
+        .context("git diff HEAD")?;
+        parse_unified_diff(&String::from_utf8_lossy(&output.stdout))
+    } else {
+        Vec::new()
+    };
+
+    let status = run_git(worktree, &["status", "--porcelain", "--untracked-files=all"])
+        .context("git status --porcelain")?;
+    let stdout = String::from_utf8_lossy(&status.stdout);
+    let mut untracked: Vec<DiffFile> = stdout
+        .lines()
+        .filter_map(|l| l.strip_prefix("?? "))
+        .map(|p| {
+            let path = unquote_porcelain_path(p);
+            untracked_file_entry(worktree, &path)
+        })
+        .collect();
+    untracked.sort_by(|a, b| a.path.cmp(&b.path));
+    files.append(&mut untracked);
+    Ok(files)
+}
+
+/// Porcelain quotes paths containing special chars (`"a b.txt"`).
+/// Strip the quotes; embedded escapes are left as-is (the entry still
+/// renders, existence-dependent features degrade gracefully).
+fn unquote_porcelain_path(raw: &str) -> String {
+    let raw = raw.trim();
+    raw.strip_prefix('"')
+        .and_then(|r| r.strip_suffix('"'))
+        .unwrap_or(raw)
+        .to_string()
+}
+
+/// Build the synthetic all-added [`DiffFile`] for an untracked path.
+/// Reads from disk with byte/line caps; a read failure or NUL byte in
+/// the prefix marks the entry binary instead of erroring the diff.
+fn untracked_file_entry(worktree: &Path, rel_path: &str) -> DiffFile {
+    let mut entry = DiffFile {
+        path: rel_path.to_string(),
+        old_path: None,
+        status: FileStatus::Untracked,
+        binary: false,
+        hunks: Vec::new(),
+        added: 0,
+        removed: 0,
+        truncated: false,
+    };
+
+    let abs = worktree.join(rel_path);
+    let too_big = std::fs::metadata(&abs)
+        .map(|m| m.len() > MAX_UNTRACKED_BYTES)
+        .unwrap_or(false);
+    let Ok(bytes) = std::fs::read(&abs) else {
+        entry.binary = true;
+        return entry;
+    };
+    if bytes[..bytes.len().min(8192)].contains(&0) {
+        entry.binary = true;
+        return entry;
+    }
+
+    let text = String::from_utf8_lossy(&bytes[..bytes.len().min(MAX_UNTRACKED_BYTES as usize)]);
+    let mut lines: Vec<&str> = text.lines().collect();
+    let line_capped = lines.len() > MAX_UNTRACKED_LINES;
+    if line_capped {
+        lines.truncate(MAX_UNTRACKED_LINES);
+    }
+    entry.truncated = too_big || line_capped;
+
+    let mut hunk = DiffHunk {
+        header: format!("@@ -0,0 +1,{} @@", lines.len()),
+        old_start: 0,
+        new_start: 1,
+        lines: Vec::with_capacity(lines.len()),
+    };
+    for (idx, line) in lines.iter().enumerate() {
+        hunk.lines.push(DiffLine {
+            kind: LineKind::Added,
+            old_no: None,
+            new_no: Some(idx as u32 + 1),
+            text: (*line).to_string(),
+            emphasis: None,
+        });
+    }
+    entry.added = hunk.lines.len() as u32;
+    if !hunk.lines.is_empty() {
+        entry.hunks.push(hunk);
+    }
+    entry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+diff --git a/src/main.rs b/src/main.rs
+index 1111111..2222222 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,4 +1,4 @@
+ fn main() {
+-    println!(\"hello\");
++    println!(\"world\");
+ }
+ // tail
+@@ -10,2 +10,3 @@ mod tests {
+ line_a
++line_b
+ line_c
+diff --git a/docs/new.md b/docs/new.md
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/docs/new.md
+@@ -0,0 +1,2 @@
++# Title
++body
+";
+
+    #[test]
+    fn parses_files_hunks_and_counts() {
+        let files = parse_unified_diff(SAMPLE);
+        assert_eq!(files.len(), 2);
+
+        let main = &files[0];
+        assert_eq!(main.path, "src/main.rs");
+        assert_eq!(main.status, FileStatus::Modified);
+        assert_eq!(main.hunks.len(), 2);
+        assert_eq!((main.added, main.removed), (2, 1));
+
+        let new = &files[1];
+        assert_eq!(new.path, "docs/new.md");
+        assert_eq!(new.status, FileStatus::Added);
+        assert_eq!((new.added, new.removed), (2, 0));
+    }
+
+    #[test]
+    fn line_numbers_track_both_sides() {
+        let files = parse_unified_diff(SAMPLE);
+        let hunk = &files[0].hunks[0];
+        assert_eq!(hunk.header, "@@ -1,4 +1,4 @@");
+        assert_eq!((hunk.old_start, hunk.new_start), (1, 1));
+
+        let nums: Vec<(Option<u32>, Option<u32>)> =
+            hunk.lines.iter().map(|l| (l.old_no, l.new_no)).collect();
+        assert_eq!(
+            nums,
+            vec![
+                (Some(1), Some(1)),  // context: fn main() {
+                (Some(2), None),     // removed: println hello
+                (None, Some(2)),     // added: println world
+                (Some(3), Some(3)),  // context: }
+                (Some(4), Some(4)),  // context: // tail
+            ]
+        );
+
+        let hunk2 = &files[0].hunks[1];
+        assert_eq!((hunk2.old_start, hunk2.new_start), (10, 10));
+        assert_eq!(hunk2.lines[1].new_no, Some(11));
+    }
+
+    #[test]
+    fn paired_lines_get_intraline_emphasis() {
+        let files = parse_unified_diff(SAMPLE);
+        let hunk = &files[0].hunks[0];
+        let removed = &hunk.lines[1];
+        let added = &hunk.lines[2];
+        // `    println!("hello");` vs `    println!("world");`
+        // common prefix `    println!("` = 14 chars, common suffix `");` = 3.
+        assert_eq!(removed.emphasis, Some((14, 19)));
+        assert_eq!(added.emphasis, Some((14, 19)));
+        // Unpaired added line in hunk 2 keeps whole-line emphasis.
+        assert_eq!(files[0].hunks[1].lines[1].emphasis, None);
+    }
+
+    #[test]
+    fn parses_rename_delete_and_binary() {
+        let input = "\
+diff --git a/old_name.rs b/new_name.rs
+similarity index 97%
+rename from old_name.rs
+rename to new_name.rs
+diff --git a/gone.txt b/gone.txt
+deleted file mode 100644
+--- a/gone.txt
++++ /dev/null
+@@ -1,1 +0,0 @@
+-bye
+diff --git a/img.png b/img.png
+Binary files a/img.png and b/img.png differ
+";
+        let files = parse_unified_diff(input);
+        assert_eq!(files.len(), 3);
+
+        assert_eq!(files[0].status, FileStatus::Renamed);
+        assert_eq!(files[0].path, "new_name.rs");
+        assert_eq!(files[0].old_path.as_deref(), Some("old_name.rs"));
+
+        assert_eq!(files[1].status, FileStatus::Deleted);
+        assert_eq!(files[1].path, "gone.txt");
+        assert_eq!((files[1].added, files[1].removed), (0, 1));
+
+        assert!(files[2].binary);
+        assert!(files[2].hunks.is_empty());
+    }
+
+    #[test]
+    fn empty_input_yields_no_files() {
+        assert!(parse_unified_diff("").is_empty());
+    }
+
+    #[test]
+    fn intraline_emphasis_trims_prefix_and_suffix() {
+        assert_eq!(
+            intraline_emphasis("let x = 1;", "let x = 2;"),
+            Some(((8, 9), (8, 9)))
+        );
+        // Pure insertion: empty old span at the insertion point.
+        assert_eq!(
+            intraline_emphasis("ab", "axb"),
+            Some(((1, 1), (1, 2)))
+        );
+        // Identical lines pair to None.
+        assert_eq!(intraline_emphasis("same", "same"), None);
+    }
+
+    #[test]
+    fn hunk_header_without_counts_parses() {
+        assert_eq!(parse_hunk_header("-1 +1 @@"), Some((1, 1)));
+        assert_eq!(parse_hunk_header("-10,4 +12,6 @@ fn x()"), Some((10, 12)));
+        assert_eq!(parse_hunk_header("garbage"), None);
+    }
+
+    // ─── Integration tests against a real repo ──────────────────────
+
+    fn init_repo() -> Option<(tempfile::TempDir, std::path::PathBuf)> {
+        if crate::process::no_window_command("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            eprintln!("skipping: `git` not on PATH");
+            return None;
+        }
+        let dir = tempfile::tempdir().ok()?;
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).ok()?;
+        run(&repo, &["-c", "init.defaultBranch=main", "init", "-q"]);
+        run(&repo, &["config", "user.email", "test@example.invalid"]);
+        run(&repo, &["config", "user.name", "Test"]);
+        Some((dir, repo))
+    }
+
+    fn run(repo: &Path, args: &[&str]) {
+        let output = crate::process::no_window_command("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("spawn git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    #[test]
+    fn worktree_diff_reports_modified_and_untracked() {
+        let Some((_guard, repo)) = init_repo() else { return };
+        std::fs::write(repo.join("tracked.txt"), "one\ntwo\n").unwrap();
+        run(&repo, &["add", "tracked.txt"]);
+        run(&repo, &["commit", "-m", "seed", "-q"]);
+
+        std::fs::write(repo.join("tracked.txt"), "one\nTWO\n").unwrap();
+        std::fs::write(repo.join("fresh.txt"), "hello\nworld\n").unwrap();
+
+        let files = worktree_diff(&repo).expect("diff succeeds");
+        assert_eq!(files.len(), 2, "got: {files:#?}");
+
+        let tracked = &files[0];
+        assert_eq!(tracked.path, "tracked.txt");
+        assert_eq!(tracked.status, FileStatus::Modified);
+        assert_eq!((tracked.added, tracked.removed), (1, 1));
+        // Paired change two→TWO: whole word differs.
+        let removed = tracked.hunks[0]
+            .lines
+            .iter()
+            .find(|l| l.kind == LineKind::Removed)
+            .unwrap();
+        assert_eq!(removed.text, "two");
+
+        let fresh = &files[1];
+        assert_eq!(fresh.path, "fresh.txt");
+        assert_eq!(fresh.status, FileStatus::Untracked);
+        assert_eq!(fresh.added, 2);
+        assert_eq!(fresh.hunks[0].lines[1].text, "world");
+        assert_eq!(fresh.hunks[0].lines[1].new_no, Some(2));
+    }
+
+    #[test]
+    fn worktree_diff_on_clean_repo_is_empty() {
+        let Some((_guard, repo)) = init_repo() else { return };
+        run(&repo, &["commit", "--allow-empty", "-m", "init", "-q"]);
+        let files = worktree_diff(&repo).expect("diff succeeds");
+        assert!(files.is_empty(), "got: {files:#?}");
+    }
+
+    #[test]
+    fn worktree_diff_without_head_lists_everything_untracked() {
+        let Some((_guard, repo)) = init_repo() else { return };
+        std::fs::write(repo.join("first.txt"), "a\n").unwrap();
+        let files = worktree_diff(&repo).expect("diff succeeds");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].status, FileStatus::Untracked);
+    }
+
+    #[test]
+    fn untracked_binary_file_is_flagged_not_expanded() {
+        let Some((_guard, repo)) = init_repo() else { return };
+        std::fs::write(repo.join("blob.bin"), [0u8, 159, 146, 150]).unwrap();
+        let files = worktree_diff(&repo).expect("diff succeeds");
+        assert_eq!(files.len(), 1);
+        assert!(files[0].binary);
+        assert!(files[0].hunks.is_empty());
+    }
+}

--- a/core/src/git.rs
+++ b/core/src/git.rs
@@ -584,7 +584,9 @@ pub(crate) fn parse_ahead_behind(line: &str) -> (u32, u32) {
 
 /// Run `git <args...>` in `cwd`. Returns the captured `Output` on
 /// success; bubbles up stderr (trimmed) on non-zero exit.
-fn run_git(cwd: &Path, args: &[&str]) -> Result<Output> {
+/// `pub(crate)` so sibling git-consumers (`crate::diff`) reuse the
+/// same no-window spawn + error shape instead of growing their own.
+pub(crate) fn run_git(cwd: &Path, args: &[&str]) -> Result<Output> {
     let output = no_window_command("git")
         .args(args)
         .current_dir(cwd)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod agents;
 pub mod attachments;
 pub mod command_palette;
 pub mod crash_log;
+pub mod diff;
 pub mod git;
 pub mod layout;
 pub mod memory_watchdog;

--- a/src/app.rs
+++ b/src/app.rs
@@ -719,6 +719,14 @@ pub struct AppShell {
     /// shortcut, and the in-panel "← Back to workspace" link.
     /// Mirrors C# `MainViewModel.IsOverviewVisible`.
     show_overview: bool,
+    /// Diff viewer panel state; `Some` = visible, replacing the work
+    /// area exactly like `show_overview` does (the two are mutually
+    /// exclusive — opening one closes the other). See
+    /// [`crate::diff_viewer`].
+    pub(crate) diff_viewer: Option<crate::diff_viewer::DiffViewerState>,
+    /// Monotonic sequence for diff-viewer background requests, so a
+    /// stale `git diff` result can never clobber a newer one.
+    pub(crate) diff_request_seq: u64,
     /// Open Settings dialog, if any. Surfaces `settings.json` fields
     /// via a centered modal — the Rust port's replacement for the C#
     /// build's hand-edit-the-file workflow. See ADR-0018. Visible
@@ -996,6 +1004,9 @@ impl AppShell {
                 }
                 SidebarEvent::ReopenSession { session_id } => {
                     this.reopen_session(session_id.clone(), window, cx);
+                }
+                SidebarEvent::OpenDiff { worktree_path } => {
+                    this.open_diff_viewer(Some(worktree_path.clone()), cx);
                 }
                 SidebarEvent::OpenRenameDialog { target, current_name } => {
                     // Reload `projects.json` before opening so the
@@ -1337,6 +1348,8 @@ impl AppShell {
             agent_registry,
             command_palette: None,
             show_overview: false,
+            diff_viewer: None,
+            diff_request_seq: 0,
             settings_dialog: None,
             rename_dialog: None,
             confirm_dialog: None,
@@ -2922,6 +2935,11 @@ impl AppShell {
     pub(crate) fn set_show_overview(&mut self, value: bool, cx: &mut Context<Self>) {
         if self.show_overview == value {
             return;
+        }
+        // Overview and the diff viewer share the work-area slot;
+        // flipping the Overview on dismisses an open diff viewer.
+        if value {
+            self.close_diff_viewer(cx);
         }
         self.show_overview = value;
         // Push the new state into the sidebar so its footer
@@ -5225,7 +5243,7 @@ impl AppShell {
     /// `push_sidebar_session_paths` sets, this does *not* require an
     /// adopted agent session — a plain shell tab still has a worktree
     /// context worth highlighting (issue #248).
-    fn focused_tab_worktree_path(&self) -> Option<String> {
+    pub(crate) fn focused_tab_worktree_path(&self) -> Option<String> {
         let group = self.groups.get(self.focused_group)?;
         let tab = group.tabs.get(group.active_tab)?;
         let wd = tab.working_directory.as_ref()?;
@@ -6129,6 +6147,7 @@ impl AppShell {
         //   Ctrl+Shift+,            settings dialog
         //   Ctrl+Shift+P            command palette (toggle)
         //   Ctrl+Shift+O            overview pane (toggle)
+        //   Ctrl+Shift+D            diff viewer (toggle)
         //   Ctrl+Shift+\            split right
         //   Ctrl+Shift+G            open active tab's remote in browser
         //   Ctrl+Shift+R            open active tab's PR in browser
@@ -6214,6 +6233,14 @@ impl AppShell {
                 cx.stop_propagation();
                 let next = !self.show_overview;
                 self.set_show_overview(next, cx);
+            }
+            // Ctrl+Shift+D — toggle the diff viewer for the focused
+            // tab's worktree. Plain Ctrl+D stays with the terminal
+            // (EOF / readline delete-char — agents and shells rely
+            // on it).
+            "d" if mods.shift => {
+                cx.stop_propagation();
+                self.toggle_diff_viewer(cx);
             }
             // Ctrl+Shift+G — open the active tab's worktree origin
             // remote in the browser. Plain Ctrl+G is "abort" /
@@ -6770,12 +6797,12 @@ impl Render for AppShell {
                 }),
             );
 
-        // While the Overview is visible the per-group tab strip is
-        // structurally meaningless — its only target (the group
-        // grid below) is hidden. Render an empty placeholder so the
-        // caption row keeps the same layout footprint but doesn't
-        // surface stale tab affordances.
-        let tab_strip_inline = if self.show_overview {
+        // While the Overview (or the diff viewer) is visible the
+        // per-group tab strip is structurally meaningless — its only
+        // target (the group grid below) is hidden. Render an empty
+        // placeholder so the caption row keeps the same layout
+        // footprint but doesn't surface stale tab affordances.
+        let tab_strip_inline = if self.show_overview || self.diff_viewer.is_some() {
             div()
                 .flex()
                 .flex_row()
@@ -6845,7 +6872,11 @@ impl Render for AppShell {
         // anchored on either side / below so the user can dismiss
         // via the same sidebar button. Mirrors the C# build's
         // `IsOverviewVisible` DataTrigger swap in `MainWindow.xaml`.
-        let work_area: gpui::AnyElement = if self.show_overview {
+        let work_area: gpui::AnyElement = if self.diff_viewer.is_some() {
+            // Diff viewer wins the slot — `set_show_overview(true)`
+            // closes it, so the two can't be up at the same time.
+            self.render_diff_viewer(&theme, cx).into_any_element()
+        } else if self.show_overview {
             self.render_overview(&theme, cx).into_any_element()
         } else if projects_empty {
             // First-run hero takes over the work area whenever no
@@ -7190,6 +7221,11 @@ impl AppShell {
                     let next = !self.show_overview;
                     self.set_show_overview(next, cx);
                 }
+                BuiltInCommand::ToggleDiffViewer => {
+                    // Same entry point as the Ctrl+Shift+D chord and
+                    // the worktree menu's "View changes" row.
+                    self.toggle_diff_viewer(cx);
+                }
                 BuiltInCommand::ToggleSidebar => {
                     self.toggle_sidebar(cx);
                 }
@@ -7260,6 +7296,7 @@ impl AppShell {
             BuiltInCommand::NewSession,
             BuiltInCommand::ToggleSidebar,
             BuiltInCommand::ToggleOverview,
+            BuiltInCommand::ToggleDiffViewer,
             BuiltInCommand::NewProject,
             BuiltInCommand::OpenSettings,
             BuiltInCommand::ReloadTheme,

--- a/src/app.rs
+++ b/src/app.rs
@@ -5251,6 +5251,18 @@ impl AppShell {
         (!canon.is_empty()).then_some(canon)
     }
 
+    /// The focused tab's working directory as a real filesystem path,
+    /// suitable for spawning `git` in. Contrast with
+    /// [`Self::focused_tab_worktree_path`], which returns the
+    /// `path_canon` *comparison key* (lowercased, colon-stripped,
+    /// slash-normalised) used for sidebar highlight matching — feeding
+    /// that to the OS fails on Windows ("c/dev/…" has no drive).
+    pub(crate) fn focused_tab_working_directory(&self) -> Option<std::path::PathBuf> {
+        let group = self.groups.get(self.focused_group)?;
+        let tab = group.tabs.get(group.active_tab)?;
+        tab.working_directory.clone()
+    }
+
     /// Push the focused tab's worktree path to the sidebar so the
     /// matching project/worktree row gets the accent-tinted "active
     /// context" highlight (issue #248). Called from `activate_tab` (the

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -85,6 +85,10 @@ pub enum BuiltInCommand {
     /// sidebar's `OpenOverview` event the same way the footer button
     /// does. Keymap hint: Ctrl+Shift+O.
     ToggleOverview,
+    /// Toggle the diff viewer for the focused tab's worktree —
+    /// same panel the `Ctrl+Shift+D` chord and the worktree menu's
+    /// "View changes" row open. Keymap hint: Ctrl+Shift+D.
+    ToggleDiffViewer,
     /// Show / hide the sidebar. Keymap hint: Ctrl+Shift+B.
     ToggleSidebar,
     /// Open the "Add project" dialog. Keymap hint: none (the `+` button).
@@ -120,6 +124,7 @@ impl BuiltInCommand {
     pub fn title(self) -> &'static str {
         match self {
             BuiltInCommand::ToggleOverview => "Toggle overview",
+            BuiltInCommand::ToggleDiffViewer => "View diff",
             BuiltInCommand::ToggleSidebar => "Toggle sidebar",
             BuiltInCommand::NewProject => "New project",
             BuiltInCommand::NewSession => "New session",
@@ -135,6 +140,7 @@ impl BuiltInCommand {
     pub fn hint(self) -> &'static str {
         match self {
             BuiltInCommand::ToggleOverview => "Ctrl+Shift+O",
+            BuiltInCommand::ToggleDiffViewer => "Ctrl+Shift+D",
             BuiltInCommand::ToggleSidebar => "Ctrl+Shift+B",
             BuiltInCommand::NewProject => "+",
             BuiltInCommand::NewSession => "Ctrl+Shift+T",

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -124,7 +124,7 @@ impl BuiltInCommand {
     pub fn title(self) -> &'static str {
         match self {
             BuiltInCommand::ToggleOverview => "Toggle overview",
-            BuiltInCommand::ToggleDiffViewer => "View diff",
+            BuiltInCommand::ToggleDiffViewer => "Toggle diff viewer",
             BuiltInCommand::ToggleSidebar => "Toggle sidebar",
             BuiltInCommand::NewProject => "New project",
             BuiltInCommand::NewSession => "New session",

--- a/src/diff_viewer.rs
+++ b/src/diff_viewer.rs
@@ -1,0 +1,703 @@
+//! Diff viewer — full-pane working-tree diff for one worktree.
+//!
+//! Toggled via `Ctrl+Shift+D`, the command palette ("View diff"), or
+//! the sidebar worktree menu's "View changes" row. While visible it
+//! replaces the work area (per-group tab strip + terminal grid) the
+//! same way the Overview panel does, so the sidebar + status bar stay
+//! anchored and the dismiss affordances stay where the user expects
+//! them.
+//!
+//! Data comes from [`codescope_core::diff::worktree_diff`] — tracked
+//! changes against `HEAD` plus untracked files — computed on the
+//! background executor so a large diff never stalls the UI thread.
+//! The layout is a master/detail split: file list with status badges
+//! and per-file +/− counts on the left, the selected file's hunks on
+//! the right with old/new line-number gutters, tinted added/removed
+//! rows, and intraline emphasis on paired changes.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use codescope_core::Theme;
+use codescope_core::diff::{DiffFile, DiffLine, FileStatus, LineKind};
+use gpui::prelude::FluentBuilder as _;
+use gpui::{
+    AppContext as _, Context, Hsla, InteractiveElement, IntoElement, MouseButton, ParentElement,
+    SharedString, StatefulInteractiveElement, Styled, div, px,
+};
+
+use crate::app::{AppShell, ToastKind};
+use crate::theme;
+
+/// Hard cap on rendered diff lines for the selected file. Beyond this
+/// the detail pane appends a truncation notice instead — a 50k-line
+/// generated-file diff must not turn into 50k gpui elements.
+const MAX_RENDERED_LINES: usize = 4_000;
+
+/// Everything the diff viewer needs to render. `Some` on
+/// [`AppShell::diff_viewer`] = panel visible (mirrors how
+/// `show_overview` gates the Overview).
+pub(crate) struct DiffViewerState {
+    /// Worktree the diff was computed for.
+    pub worktree: PathBuf,
+    pub files: Vec<DiffFile>,
+    /// Index into `files` of the file shown in the detail pane.
+    pub selected: usize,
+    /// True while the background computation is in flight.
+    pub loading: bool,
+    pub error: Option<String>,
+    /// Sequence stamp of the request that produced (or will produce)
+    /// `files`. A stale background result — the user hit refresh, or
+    /// re-opened for another worktree, before the previous `git diff`
+    /// returned — compares unequal and is dropped.
+    pub request_id: u64,
+}
+
+impl AppShell {
+    /// `Ctrl+Shift+D` / palette entry point: close if open, otherwise
+    /// open for the focused tab's worktree.
+    pub(crate) fn toggle_diff_viewer(&mut self, cx: &mut Context<Self>) {
+        if self.diff_viewer.is_some() {
+            self.close_diff_viewer(cx);
+        } else {
+            self.open_diff_viewer(None, cx);
+        }
+    }
+
+    /// Open the diff viewer for `worktree`, or for the focused tab's
+    /// worktree when `None`. No-ops with a toast when neither resolves
+    /// — a diff viewer with no repo to diff is dead UI.
+    pub(crate) fn open_diff_viewer(
+        &mut self,
+        worktree: Option<PathBuf>,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(worktree) =
+            worktree.or_else(|| self.focused_tab_worktree_path().map(PathBuf::from))
+        else {
+            self.push_toast(
+                ToastKind::Info,
+                SharedString::new_static("No worktree to diff"),
+                Some(SharedString::new_static(
+                    "Focus a session tab first, or use the worktree menu's View changes.",
+                )),
+                cx,
+            );
+            return;
+        };
+
+        // The diff viewer and the Overview occupy the same work-area
+        // slot; opening one dismisses the other.
+        self.set_show_overview(false, cx);
+
+        self.diff_request_seq += 1;
+        let request_id = self.diff_request_seq;
+        self.diff_viewer = Some(DiffViewerState {
+            worktree: worktree.clone(),
+            files: Vec::new(),
+            selected: 0,
+            loading: true,
+            error: None,
+            request_id,
+        });
+        cx.notify();
+        self.spawn_diff_request(worktree, request_id, cx);
+    }
+
+    pub(crate) fn close_diff_viewer(&mut self, cx: &mut Context<Self>) {
+        if self.diff_viewer.take().is_some() {
+            cx.notify();
+        }
+    }
+
+    /// Re-run the diff for the currently shown worktree, keeping the
+    /// existing content on screen until the fresh result lands (no
+    /// flash-to-empty on refresh).
+    pub(crate) fn refresh_diff_viewer(&mut self, cx: &mut Context<Self>) {
+        let Some(state) = self.diff_viewer.as_mut() else {
+            return;
+        };
+        self.diff_request_seq += 1;
+        let request_id = self.diff_request_seq;
+        state.request_id = request_id;
+        state.loading = true;
+        state.error = None;
+        let worktree = state.worktree.clone();
+        cx.notify();
+        self.spawn_diff_request(worktree, request_id, cx);
+    }
+
+    /// Compute `worktree_diff` on the background executor and fold the
+    /// result back into `diff_viewer` — unless the panel was closed or
+    /// a newer request superseded this one in the meantime.
+    fn spawn_diff_request(
+        &mut self,
+        worktree: PathBuf,
+        request_id: u64,
+        cx: &mut Context<Self>,
+    ) {
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_spawn(async move {
+                    codescope_core::diff::worktree_diff(&worktree)
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                let Some(state) = this.diff_viewer.as_mut() else {
+                    return;
+                };
+                if state.request_id != request_id {
+                    return;
+                }
+                state.loading = false;
+                match result {
+                    Ok(files) => {
+                        // Keep the selection pinned to the same file
+                        // across a refresh when it still exists;
+                        // otherwise snap back to the top.
+                        let prev_path = state.files.get(state.selected).map(|f| f.path.clone());
+                        state.selected = prev_path
+                            .and_then(|p| files.iter().position(|f| f.path == p))
+                            .unwrap_or(0);
+                        state.files = files;
+                        state.error = None;
+                    }
+                    Err(err) => {
+                        state.error = Some(format!("{err:#}"));
+                    }
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    /// Render the full-pane diff viewer. Wired in by `render` when
+    /// `diff_viewer.is_some()`; the caller substitutes this element
+    /// for the work-area cluster, same as the Overview swap.
+    pub(crate) fn render_diff_viewer(
+        &self,
+        theme: &Arc<Theme>,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let canvas = theme::canvas(theme);
+        let divider = theme::divider(theme);
+        let ink = theme::ink(theme);
+        let accent = theme::accent(theme);
+
+        // SAFETY-of-unwrap: only called when `diff_viewer.is_some()`
+        // (the render swap checks), but degrade gracefully anyway.
+        let Some(state) = self.diff_viewer.as_ref() else {
+            return div().into_any_element();
+        };
+
+        let total_added: u32 = state.files.iter().map(|f| f.added).sum();
+        let total_removed: u32 = state.files.iter().map(|f| f.removed).sum();
+        let subtitle: SharedString = if state.loading && state.files.is_empty() {
+            SharedString::new_static("computing…")
+        } else if let Some(err) = &state.error {
+            SharedString::from(format!("error: {err}"))
+        } else {
+            let n = state.files.len();
+            let files_part = if n == 1 {
+                "1 file".to_string()
+            } else {
+                format!("{n} files")
+            };
+            SharedString::from(format!("{files_part} · +{total_added} −{total_removed}"))
+        };
+
+        // ── Header strip — mirrors the Overview header layout ────
+        let eyebrow = div()
+            .px(px(7.0))
+            .py(px(3.0))
+            .border_1()
+            .border_color(accent)
+            .rounded(px(3.0))
+            .text_size(px(10.0))
+            .text_color(accent)
+            .font(theme::font_mono())
+            .child("DIFF");
+
+        let worktree_label = div()
+            .ml(px(16.0))
+            .text_size(px(12.0))
+            .text_color(ink)
+            .font(theme::font_mono())
+            .truncate()
+            .child(SharedString::from(
+                state.worktree.to_string_lossy().into_owned(),
+            ));
+
+        let subtitle_el = div()
+            .ml(px(12.0))
+            .text_size(px(12.0))
+            .text_color(if state.error.is_some() {
+                theme::danger()
+            } else {
+                theme::ink_dim(theme)
+            })
+            .font(theme::font_sans())
+            .flex_shrink_0()
+            .child(subtitle);
+
+        let refresh_button = div()
+            .id("diff-refresh")
+            .px(px(10.0))
+            .py(px(5.0))
+            .rounded(px(4.0))
+            .text_size(px(13.0))
+            .text_color(theme::ink_dim(theme))
+            .cursor_pointer()
+            .hover(move |s| s.bg(theme::frost_10(theme)).text_color(ink))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _, cx| {
+                    this.refresh_diff_viewer(cx);
+                }),
+            )
+            .child(if state.loading { "↻ Refreshing…" } else { "↻ Refresh" });
+
+        let back_button = div()
+            .id("diff-back")
+            .px(px(10.0))
+            .py(px(5.0))
+            .rounded(px(4.0))
+            .text_size(px(13.0))
+            .text_color(accent)
+            .cursor_pointer()
+            .hover(move |s| s.bg(theme::frost_10(theme)))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _, cx| {
+                    this.close_diff_viewer(cx);
+                }),
+            )
+            .child("← Back to workspace");
+
+        let header = div()
+            .h(px(56.0))
+            .px(px(24.0))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(8.0))
+            .border_b_1()
+            .border_color(divider)
+            .bg(canvas)
+            .child(eyebrow)
+            .child(worktree_label)
+            .child(subtitle_el)
+            .child(div().flex_grow())
+            .child(refresh_button)
+            .child(back_button);
+
+        // ── Empty / placeholder states ───────────────────────────
+        if state.files.is_empty() {
+            let (line_a, line_b): (SharedString, SharedString) = if state.loading {
+                (
+                    SharedString::new_static("Computing diff…"),
+                    SharedString::new_static(""),
+                )
+            } else if state.error.is_some() {
+                (
+                    SharedString::new_static("Couldn't compute the diff"),
+                    SharedString::new_static("Is this folder a git worktree?"),
+                )
+            } else {
+                (
+                    SharedString::new_static("Working tree clean"),
+                    SharedString::new_static("No changes against HEAD, and nothing untracked."),
+                )
+            };
+            return div()
+                .flex()
+                .flex_col()
+                .flex_grow()
+                .size_full()
+                .bg(canvas)
+                .text_color(ink)
+                .child(header)
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .flex_grow()
+                        .items_center()
+                        .justify_center()
+                        .gap(px(6.0))
+                        .child(
+                            div()
+                                .text_size(px(18.0))
+                                .text_color(theme::ink_dim(theme))
+                                .font(theme::font_sans())
+                                .child(line_a),
+                        )
+                        .child(
+                            div()
+                                .text_size(px(12.0))
+                                .text_color(theme::text_faint())
+                                .font(theme::font_sans())
+                                .child(line_b),
+                        ),
+                )
+                .into_any_element();
+        }
+
+        let selected = state.selected.min(state.files.len() - 1);
+
+        // ── File list (master) ───────────────────────────────────
+        let mut file_rows: Vec<gpui::AnyElement> = Vec::with_capacity(state.files.len());
+        for (ix, file) in state.files.iter().enumerate() {
+            file_rows.push(
+                self.render_diff_file_row(theme, file, ix, ix == selected, cx)
+                    .into_any_element(),
+            );
+        }
+        let mut file_list = div()
+            .id("diff-file-list")
+            .w(px(300.0))
+            .flex_shrink_0()
+            .flex()
+            .flex_col()
+            .overflow_y_scroll()
+            .border_r_1()
+            .border_color(divider)
+            .py(px(6.0))
+            .children(file_rows);
+        file_list.style().min_size.height = Some(gpui::Length::Definite(px(0.0).into()));
+
+        // ── Detail pane ──────────────────────────────────────────
+        let mut detail = div()
+            .id("diff-detail")
+            .flex_grow()
+            .flex()
+            .flex_col()
+            .overflow_y_scroll()
+            .child(self.render_diff_detail(theme, &state.files[selected]));
+        detail.style().min_size.height = Some(gpui::Length::Definite(px(0.0).into()));
+
+        let mut body = div()
+            .flex()
+            .flex_row()
+            .flex_grow()
+            .child(file_list)
+            .child(detail);
+        body.style().min_size.height = Some(gpui::Length::Definite(px(0.0).into()));
+
+        div()
+            .flex()
+            .flex_col()
+            .flex_grow()
+            .size_full()
+            .bg(canvas)
+            .text_color(ink)
+            .child(header)
+            .child(body)
+            .into_any_element()
+    }
+
+    /// One row in the file list: status badge, path, +/− counts.
+    fn render_diff_file_row(
+        &self,
+        theme: &Arc<Theme>,
+        file: &DiffFile,
+        ix: usize,
+        is_selected: bool,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let badge_color = status_color(file.status);
+        let row_bg = theme::active_context_wash(theme);
+        let hover_bg = theme::frost_10(theme);
+
+        let counts: SharedString = if file.binary {
+            SharedString::new_static("bin")
+        } else {
+            SharedString::from(format!("+{} −{}", file.added, file.removed))
+        };
+
+        div()
+            .id(SharedString::from(format!("diff-file-{ix}")))
+            .px(px(12.0))
+            .py(px(5.0))
+            .mx(px(4.0))
+            .rounded(px(4.0))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(8.0))
+            .cursor_pointer()
+            .when(is_selected, |s| s.bg(row_bg))
+            .when(!is_selected, |s| s.hover(move |s| s.bg(hover_bg)))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, _, cx| {
+                    if let Some(state) = this.diff_viewer.as_mut()
+                        && state.selected != ix
+                    {
+                        state.selected = ix;
+                        cx.notify();
+                    }
+                }),
+            )
+            .child(
+                div()
+                    .w(px(14.0))
+                    .flex_shrink_0()
+                    .text_size(px(11.0))
+                    .text_color(badge_color)
+                    .font(theme::font_mono())
+                    .child(file.status.badge()),
+            )
+            .child(
+                div()
+                    .flex_grow()
+                    .text_size(px(11.5))
+                    .text_color(theme::ink_dim(theme))
+                    .font(theme::font_mono())
+                    .truncate()
+                    .child(SharedString::from(file.path.clone())),
+            )
+            .child(
+                div()
+                    .flex_shrink_0()
+                    .text_size(px(10.0))
+                    .text_color(theme::text_faint())
+                    .font(theme::font_mono())
+                    .child(counts),
+            )
+    }
+
+    /// The selected file's hunks: a file header bar, then hunk header
+    /// + line rows, capped at [`MAX_RENDERED_LINES`].
+    fn render_diff_detail(&self, theme: &Arc<Theme>, file: &DiffFile) -> impl IntoElement {
+        let divider = theme::divider(theme);
+
+        let title: SharedString = match (&file.old_path, file.status) {
+            (Some(old), FileStatus::Renamed) => {
+                SharedString::from(format!("{old} → {}", file.path))
+            }
+            _ => SharedString::from(file.path.clone()),
+        };
+
+        let file_header = div()
+            .px(px(16.0))
+            .py(px(10.0))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(8.0))
+            .border_b_1()
+            .border_color(divider)
+            .child(
+                div()
+                    .text_size(px(11.0))
+                    .text_color(status_color(file.status))
+                    .font(theme::font_mono())
+                    .child(file.status.badge()),
+            )
+            .child(
+                div()
+                    .text_size(px(12.5))
+                    .text_color(theme::ink(theme))
+                    .font(theme::font_mono())
+                    .truncate()
+                    .child(title),
+            )
+            .child(div().flex_grow())
+            .child(
+                div()
+                    .flex_shrink_0()
+                    .text_size(px(11.0))
+                    .text_color(theme::text_faint())
+                    .font(theme::font_mono())
+                    .child(SharedString::from(format!(
+                        "+{} −{}",
+                        file.added, file.removed
+                    ))),
+            );
+
+        let mut sections: Vec<gpui::AnyElement> = Vec::new();
+
+        if file.binary {
+            sections.push(centered_note("Binary file — no preview.").into_any_element());
+        } else if file.hunks.is_empty() {
+            sections.push(
+                centered_note("No textual changes (mode or metadata only).")
+                    .into_any_element(),
+            );
+        } else {
+            let mut rendered = 0usize;
+            'hunks: for hunk in &file.hunks {
+                sections.push(
+                    div()
+                        .px(px(16.0))
+                        .py(px(4.0))
+                        .my(px(4.0))
+                        .bg(theme::frost_10(theme))
+                        .text_size(px(11.0))
+                        .text_color(theme::accent(theme))
+                        .font(theme::font_mono())
+                        .child(SharedString::from(hunk.header.clone()))
+                        .into_any_element(),
+                );
+                for line in &hunk.lines {
+                    if rendered >= MAX_RENDERED_LINES {
+                        sections.push(
+                            centered_note(
+                                "Diff truncated for display — open the file to see the rest.",
+                            )
+                            .into_any_element(),
+                        );
+                        break 'hunks;
+                    }
+                    sections.push(render_diff_line(theme, line).into_any_element());
+                    rendered += 1;
+                }
+            }
+        }
+
+        if file.truncated {
+            sections.push(
+                centered_note("Large untracked file — preview capped.").into_any_element(),
+            );
+        }
+
+        div()
+            .flex()
+            .flex_col()
+            .pb(px(24.0))
+            .child(file_header)
+            .children(sections)
+    }
+}
+
+/// Status-letter colour: additions green, deletions red, everything
+/// else accent-ish / faint. Matches the +/− count colouring intuition.
+fn status_color(status: FileStatus) -> Hsla {
+    match status {
+        FileStatus::Added | FileStatus::Untracked => theme::signal_ok(),
+        FileStatus::Deleted => theme::signal_warn(),
+        FileStatus::Modified | FileStatus::Renamed => theme::text_faint(),
+    }
+}
+
+/// Muted full-width notice row used for binary / truncation / empty
+/// placeholders inside the detail pane.
+fn centered_note(text: &'static str) -> impl IntoElement {
+    div()
+        .px(px(16.0))
+        .py(px(12.0))
+        .text_size(px(11.5))
+        .text_color(theme::text_faint())
+        .font(theme::font_sans())
+        .child(SharedString::new_static(text))
+}
+
+/// One diff line: old/new line-number gutters, marker, content with
+/// optional intraline emphasis. Added/removed rows get a translucent
+/// green/red wash; the emphasised span gets a stronger one.
+fn render_diff_line(theme: &Arc<Theme>, line: &DiffLine) -> impl IntoElement {
+    let (marker, row_bg, span_bg): (&'static str, Option<Hsla>, Option<Hsla>) = match line.kind {
+        LineKind::Added => (
+            "+",
+            Some(alpha(theme::signal_ok(), 0.10)),
+            Some(alpha(theme::signal_ok(), 0.28)),
+        ),
+        LineKind::Removed => (
+            "−",
+            Some(alpha(theme::signal_warn(), 0.10)),
+            Some(alpha(theme::signal_warn(), 0.28)),
+        ),
+        LineKind::Context => (" ", None, None),
+    };
+
+    let num = |n: Option<u32>| -> SharedString {
+        match n {
+            Some(n) => SharedString::from(n.to_string()),
+            None => SharedString::new_static(""),
+        }
+    };
+
+    let text_color = match line.kind {
+        LineKind::Context => theme::ink_dim(theme),
+        _ => theme::ink(theme),
+    };
+
+    // Intraline emphasis: split the content into pre / changed / post
+    // spans. The span boundaries are char indices from the core layer.
+    let mut content = div()
+        .flex()
+        .flex_row()
+        .text_size(px(12.0))
+        .text_color(text_color)
+        .font(theme::font_mono());
+    match line.emphasis {
+        Some((start, end)) if start < end && line.kind != LineKind::Context => {
+            let chars: Vec<char> = line.text.chars().collect();
+            let pre: String = chars[..start.min(chars.len())].iter().collect();
+            let mid: String = chars[start.min(chars.len())..end.min(chars.len())]
+                .iter()
+                .collect();
+            let post: String = chars[end.min(chars.len())..].iter().collect();
+            if !pre.is_empty() {
+                content = content.child(SharedString::from(pre));
+            }
+            let mut mid_el = div().child(SharedString::from(mid));
+            if let Some(bg) = span_bg {
+                mid_el = mid_el.bg(bg).rounded(px(2.0));
+            }
+            content = content.child(mid_el);
+            if !post.is_empty() {
+                content = content.child(SharedString::from(post));
+            }
+        }
+        _ => {
+            content = content.child(SharedString::from(line.text.clone()));
+        }
+    }
+
+    let mut row = div()
+        .px(px(16.0))
+        .flex()
+        .flex_row()
+        .items_start()
+        .gap(px(0.0))
+        .child(gutter_cell(num(line.old_no)))
+        .child(gutter_cell(num(line.new_no)))
+        .child(
+            div()
+                .w(px(18.0))
+                .flex_shrink_0()
+                .text_size(px(12.0))
+                .text_color(text_color)
+                .font(theme::font_mono())
+                .child(marker),
+        )
+        .child(content);
+    if let Some(bg) = row_bg {
+        row = row.bg(bg);
+    }
+    row
+}
+
+/// Right-aligned fixed-width line-number cell.
+fn gutter_cell(n: SharedString) -> impl IntoElement {
+    div()
+        .w(px(44.0))
+        .flex_shrink_0()
+        .flex()
+        .justify_end()
+        .pr(px(8.0))
+        .text_size(px(10.5))
+        .text_color(theme::text_faint())
+        .font(theme::font_mono())
+        .child(n)
+}
+
+/// `color` with its alpha replaced — gpui washes are how the rest of
+/// the chrome derives tints (cf. `theme::active_context_wash`).
+fn alpha(mut color: Hsla, a: f32) -> Hsla {
+    color.a = a;
+    color
+}

--- a/src/diff_viewer.rs
+++ b/src/diff_viewer.rs
@@ -72,9 +72,10 @@ impl AppShell {
         worktree: Option<PathBuf>,
         cx: &mut Context<Self>,
     ) {
-        let Some(worktree) =
-            worktree.or_else(|| self.focused_tab_worktree_path().map(PathBuf::from))
-        else {
+        // NB: `focused_tab_working_directory`, not the canonicalised
+        // `focused_tab_worktree_path` — the latter is a comparison key
+        // (lowercased, colon-stripped), not a path git can run in.
+        let Some(worktree) = worktree.or_else(|| self.focused_tab_working_directory()) else {
             self.push_toast(
                 ToastKind::Info,
                 SharedString::new_static("No worktree to diff"),

--- a/src/diff_viewer.rs
+++ b/src/diff_viewer.rs
@@ -164,7 +164,15 @@ impl AppShell {
                         state.error = None;
                     }
                     Err(err) => {
-                        state.error = Some(format!("{err:#}"));
+                        // The header subtitle is a single-line row;
+                        // anyhow's `:#` chain is one line, but wrapped
+                        // git stderr can smuggle newlines into a
+                        // message — flatten all whitespace runs.
+                        let flat = format!("{err:#}")
+                            .split_whitespace()
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        state.error = Some(flat);
                     }
                 }
                 cx.notify();

--- a/src/diff_viewer.rs
+++ b/src/diff_viewer.rs
@@ -646,22 +646,33 @@ fn render_diff_line(theme: &Arc<Theme>, line: &DiffLine) -> impl IntoElement {
         .font(theme::font_mono());
     match line.emphasis {
         Some((start, end)) if start < end && line.kind != LineKind::Context => {
-            let chars: Vec<char> = line.text.chars().collect();
-            let pre: String = chars[..start.min(chars.len())].iter().collect();
-            let mid: String = chars[start.min(chars.len())..end.min(chars.len())]
-                .iter()
-                .collect();
-            let post: String = chars[end.min(chars.len())..].iter().collect();
-            if !pre.is_empty() {
-                content = content.child(SharedString::from(pre));
+            // Map the char-index span to byte offsets in one pass so the
+            // three spans can be sliced as `&str` — no per-line
+            // `Vec<char>` + intermediate `String`s on the UI thread.
+            let mut start_b = line.text.len();
+            let mut end_b = line.text.len();
+            for (count, (b, _)) in line.text.char_indices().enumerate() {
+                if count == start {
+                    start_b = b;
+                }
+                if count == end {
+                    end_b = b;
+                    break;
+                }
             }
-            let mut mid_el = div().child(SharedString::from(mid));
+            let pre = &line.text[..start_b];
+            let mid = &line.text[start_b..end_b];
+            let post = &line.text[end_b..];
+            if !pre.is_empty() {
+                content = content.child(SharedString::from(pre.to_owned()));
+            }
+            let mut mid_el = div().child(SharedString::from(mid.to_owned()));
             if let Some(bg) = span_bg {
                 mid_el = mid_el.bg(bg).rounded(px(2.0));
             }
             content = content.child(mid_el);
             if !post.is_empty() {
-                content = content.child(SharedString::from(post));
+                content = content.child(SharedString::from(post.to_owned()));
             }
         }
         _ => {

--- a/src/diff_viewer.rs
+++ b/src/diff_viewer.rs
@@ -511,10 +511,13 @@ impl AppShell {
                     .text_size(px(11.0))
                     .text_color(theme::text_faint())
                     .font(theme::font_mono())
-                    .child(SharedString::from(format!(
-                        "+{} −{}",
-                        file.added, file.removed
-                    ))),
+                    // "+0 −0" on a binary diff would read as "no
+                    // changes" — mirror the file list's "bin" badge.
+                    .child(if file.binary {
+                        SharedString::new_static("bin")
+                    } else {
+                        SharedString::from(format!("+{} −{}", file.added, file.removed))
+                    }),
             );
 
         let mut sections: Vec<gpui::AnyElement> = Vec::new();
@@ -522,10 +525,18 @@ impl AppShell {
         if file.binary {
             sections.push(centered_note("Binary file — no preview.").into_any_element());
         } else if file.hunks.is_empty() {
-            sections.push(
-                centered_note("No textual changes (mode or metadata only).")
-                    .into_any_element(),
-            );
+            // Empty hunks mean different things per status: an empty
+            // new/untracked file has no content to show, a rename can
+            // be content-identical, and a tracked file can change
+            // mode-only. Don't claim "mode only" for the others.
+            let note = match file.status {
+                FileStatus::Added | FileStatus::Untracked => "Empty file.",
+                FileStatus::Renamed => "Renamed — content unchanged.",
+                FileStatus::Modified | FileStatus::Deleted => {
+                    "No textual changes (mode or metadata only)."
+                }
+            };
+            sections.push(centered_note(note).into_any_element());
         } else {
             let mut rendered = 0usize;
             'hunks: for hunk in &file.hunks {

--- a/src/diff_viewer.rs
+++ b/src/diff_viewer.rs
@@ -1,6 +1,7 @@
 //! Diff viewer — full-pane working-tree diff for one worktree.
 //!
-//! Toggled via `Ctrl+Shift+D`, the command palette ("View diff"), or
+//! Toggled via `Ctrl+Shift+D`, the command palette ("Toggle diff
+//! viewer"), or
 //! the sidebar worktree menu's "View changes" row. While visible it
 //! replaces the work area (per-group tab strip + terminal grid) the
 //! same way the Overview panel does, so the sidebar + status bar stay
@@ -238,6 +239,8 @@ impl AppShell {
                 state.worktree.to_string_lossy().into_owned(),
             ));
 
+        // Shrinkable + truncating: a long git error must squeeze, not
+        // push the Refresh / Back buttons out of the 56px header.
         let subtitle_el = div()
             .ml(px(12.0))
             .text_size(px(12.0))
@@ -247,7 +250,8 @@ impl AppShell {
                 theme::ink_dim(theme)
             })
             .font(theme::font_sans())
-            .flex_shrink_0()
+            .min_w(px(0.0))
+            .truncate()
             .child(subtitle);
 
         let refresh_button = div()

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod app;
 mod assets;
 mod command_palette;
 mod dialogs;
+mod diff_viewer;
 mod empty_state;
 mod idle_notifier;
 mod notifications;

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -294,6 +294,10 @@ pub enum SidebarEvent {
     /// a "coming soon" toast — so this event is a placeholder hook
     /// the host can wire up to the real Overview once it lands.
     OpenOverview,
+    /// User picked "View changes" in a worktree's context menu. The
+    /// host opens the full-pane diff viewer for that worktree —
+    /// same panel `Ctrl+Shift+D` opens for the focused tab.
+    OpenDiff { worktree_path: PathBuf },
     /// Reopen a soft-closed session by id. AppShell looks up the row,
     /// calls `SessionManager::reopen`, then spawns a tab pinned to
     /// the persisted `worktree_path` + `agent_id`. Mirrors C#
@@ -4543,11 +4547,25 @@ impl Sidebar {
                 )
             })
             // ── Git ─────────────────────────────────────────────
-            // Pull / Copy branch / Open remote in browser. The
-            // dirty-state aware Rebase + Discard rows from the C#
-            // build land when the worktree polling infra does;
-            // these three are stateless enough to ship now.
+            // View changes / Pull / Copy branch / Open remote in
+            // browser. The dirty-state aware Rebase + Discard rows
+            // from the C# build land when the worktree polling infra
+            // does; these are stateless enough to ship now.
             .child(div().h_px().bg(divider).my_1())
+            .child({
+                let path_for_diff = PathBuf::from(&worktree.path);
+                item(
+                    "wt-menu-view-changes",
+                    "View changes",
+                    false,
+                    Box::new(move |this, _window, cx| {
+                        cx.emit(SidebarEvent::OpenDiff {
+                            worktree_path: path_for_diff.clone(),
+                        });
+                        this.close_menu(cx);
+                    }),
+                )
+            })
             .child({
                 let id_for_pull = worktree_id.clone();
                 item(

--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -1269,6 +1269,14 @@ mod tests {
     }
 
     #[test]
+    fn ctrl_shift_d_bubbles_for_diff_viewer() {
+        // Plain Ctrl+D is the shell's EOF / logout and stays with the
+        // terminal; only the shifted chord toggles the diff viewer.
+        assert!(is_app_level_shortcut("d", &ctrl_shift()));
+        assert!(!is_app_level_shortcut("d", &ctrl()));
+    }
+
+    #[test]
     fn ctrl_shift_b_bubbles_for_sidebar() {
         // Ctrl+Shift+B opens the sidebar. Plain Ctrl+B is readline
         // backward-char and stays with the terminal.

--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -929,6 +929,11 @@ pub(crate) fn is_app_level_shortcut(key: &str, mods: &gpui::Modifiers) -> bool {
     if key == "o" && mods.shift {
         return true;
     }
+    // Ctrl+Shift+D — diff viewer. Plain Ctrl+D stays with the
+    // terminal (EOF / readline delete-char).
+    if key == "d" && mods.shift {
+        return true;
+    }
     // Ctrl+Shift+B — toggle sidebar. Plain Ctrl+B stays with the
     // terminal (readline backward-char).
     if key == "b" && mods.shift {


### PR DESCRIPTION
Closes #258.

## What

A full-pane diff viewer showing a worktree's changes against `HEAD` — staged + unstaged + untracked. It takes over the work area exactly like the Overview does (sidebar + status bar stay anchored), with three entry points:

- **Ctrl+Shift+D** — toggles the viewer for the focused tab's worktree (chord added to the terminal bubble list; plain Ctrl+D stays with the terminal for EOF/readline).
- **Command palette** — new "View diff" action.
- **Worktree context menu** — new "View changes" row at the top of the Git section.

## Design

Master/detail split:
- **File list** (left): status badge (`A`/`M`/`D`/`R`/`U`, colour-coded), path in mono, per-file `+n −m` counts; click to select, selection uses the active-context wash.
- **Detail pane** (right): file header (rename shown as `old → new`), hunk headers in accent on a frost strip, lines with dual old/new line-number gutters, translucent green/red row washes, and a **stronger intraline emphasis span** on positionally paired removed/added lines (common prefix/suffix trim) — the "really nice" part.
- Header strip mirrors the Overview: `DIFF` eyebrow, worktree path, `N files · +A −R` totals, ↻ Refresh (keeps file selection pinned), ← Back to workspace.
- Explicit states for loading, clean tree, non-repo errors, binary files, mode-only changes, and capped previews.

## Architecture

- **`core/src/diff.rs` (new, TDD)**: pure `parse_unified_diff` (files → hunks → lines with both-side line numbers), `intraline_emphasis`, and `worktree_diff` which shells out to `git diff HEAD -M --no-color --no-ext-diff` + `git status --porcelain` (per the no-libgit2 rule, reusing `git.rs`'s `run_git`). Untracked files become synthetic all-added entries with byte/line caps and NUL-sniff binary detection; a repo with no `HEAD` yet degrades to untracked-only.
- **`src/diff_viewer.rs` (new)**: `DiffViewerState` on `AppShell` (mirrors `show_overview`; the two are mutually exclusive). The diff runs via `cx.background_spawn` with a request-sequence stamp so a stale result can't clobber a newer one. Rendering caps at 4 000 lines per file with a visible truncation notice.

## Validation

- `cargo test --workspace`: **625 passed** (11 new in `core::diff`, incl. integration tests against real temp git repos).
- `cargo clippy -p codescope -p codescope-core --all-targets` clean on the change (the 18 pre-existing `doc_lazy_continuation` warnings in `src/app.rs` untouched).
- Visual pass in the dev build still owed — GPUI has no automation surface, so please give it a quick look (`CODESCOPE_DEV=1 cargo run --bin codescope`, open a session in a dirty worktree, Ctrl+Shift+D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)