### PR TITLE
fix(dialogs): support paste in all dialog text fields

### DIFF
--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -271,6 +271,17 @@ impl CommandPaletteState {
         self.refresh_filter();
     }
 
+    /// Paste `s` into the search query (control chars stripped by
+    /// `TextField::insert_str`); the filter refreshes once for the
+    /// whole string rather than per character.
+    pub fn insert_str(&mut self, s: &str) -> bool {
+        let changed = self.query.insert_str(s);
+        if changed {
+            self.refresh_filter();
+        }
+        changed
+    }
+
     pub fn backspace(&mut self) -> bool {
         let changed = self.query.backspace();
         if changed {
@@ -576,6 +587,18 @@ fn handle_key_down(
     let mods = &event.keystroke.modifiers;
     if key == "p" && (mods.control || mods.platform) && mods.shift {
         shell.close_command_palette(cx);
+        return;
+    }
+
+    if crate::text_field::is_paste_chord(&event.keystroke) {
+        let pasted = cx.read_from_clipboard().and_then(|item| item.text());
+        let changed = pasted
+            .and_then(|text| shell.command_palette_mut().map(|s| s.insert_str(&text)))
+            .unwrap_or(false);
+        if changed {
+            shell.wake_text_blink(cx);
+            cx.notify();
+        }
         return;
     }
 

--- a/src/dialogs/new_project.rs
+++ b/src/dialogs/new_project.rs
@@ -195,6 +195,36 @@ impl NewProjectDialogState {
         true
     }
 
+    /// Paste `s` into the focused field. Same auto-derive +
+    /// read-only rules as [`Self::insert_char`], but the name redrive
+    /// runs once for the whole string instead of per character.
+    pub fn insert_str(&mut self, s: &str) -> bool {
+        if self.focused_field_mut().is_none() {
+            return false;
+        }
+        let changed = match self.focused_field {
+            DialogField::Url => {
+                let c = self.url.insert_str(s);
+                if c {
+                    self.maybe_redrive_name();
+                }
+                c
+            }
+            DialogField::Parent => self.parent.insert_str(s),
+            DialogField::Name => {
+                let c = self.name.insert_str(s);
+                if c {
+                    self.name_auto = false;
+                }
+                c
+            }
+        };
+        if changed {
+            self.error = None;
+        }
+        changed
+    }
+
     pub fn backspace(&mut self) -> bool {
         if self.focused_field_mut().is_none() {
             return false;
@@ -1050,6 +1080,18 @@ fn handle_key_down(
         .new_project_dialog()
         .map(|s| s.mode)
         .unwrap_or(DialogMode::Existing);
+
+    if crate::text_field::is_paste_chord(&event.keystroke) {
+        let pasted = cx.read_from_clipboard().and_then(|item| item.text());
+        let changed = pasted
+            .and_then(|text| sidebar.new_project_dialog_mut().map(|s| s.insert_str(&text)))
+            .unwrap_or(false);
+        if changed {
+            sidebar.wake_text_blink(cx);
+            cx.notify();
+        }
+        return;
+    }
 
     match key {
         "escape" => {

--- a/src/dialogs/new_worktree.rs
+++ b/src/dialogs/new_worktree.rs
@@ -235,6 +235,11 @@ impl NewWorktreeDialogState {
             true
         })
     }
+    /// Paste `s` into the focused field (control chars stripped by
+    /// `TextField::insert_str`).
+    pub fn insert_str(&mut self, s: &str) -> bool {
+        self.with_focused_field(|f| f.insert_str(s))
+    }
     pub fn backspace(&mut self) -> bool {
         self.with_focused_field(|f| f.backspace())
     }
@@ -1230,6 +1235,18 @@ fn handle_key_down(
         .dialog()
         .map(|s| s.base_popup_open)
         .unwrap_or(false);
+
+    if crate::text_field::is_paste_chord(&event.keystroke) {
+        let pasted = cx.read_from_clipboard().and_then(|item| item.text());
+        let changed = pasted
+            .and_then(|text| sidebar.dialog_mut().map(|s| s.insert_str(&text)))
+            .unwrap_or(false);
+        if changed {
+            sidebar.wake_text_blink(cx);
+            cx.notify();
+        }
+        return;
+    }
 
     match key {
         "escape" => {

--- a/src/dialogs/rename.rs
+++ b/src/dialogs/rename.rs
@@ -444,6 +444,26 @@ fn handle_key_down(
     let key = event.keystroke.key.as_str();
     cx.stop_propagation();
 
+    if crate::text_field::is_paste_chord(&event.keystroke) {
+        let pasted = cx.read_from_clipboard().and_then(|item| item.text());
+        let changed = pasted
+            .and_then(|text| {
+                shell.rename_dialog.as_mut().map(|s| {
+                    let c = s.name.insert_str(&text);
+                    if c {
+                        s.error = None;
+                    }
+                    c
+                })
+            })
+            .unwrap_or(false);
+        if changed {
+            shell.wake_text_blink(cx);
+            cx.notify();
+        }
+        return;
+    }
+
     match key {
         "escape" => {
             shell.cancel_rename_dialog(cx);

--- a/src/dialogs/settings.rs
+++ b/src/dialogs/settings.rs
@@ -129,6 +129,16 @@ impl SettingsDialogState {
         true
     }
 
+    /// Paste `s` into the focused field (control chars stripped by
+    /// `TextField::insert_str`).
+    pub fn insert_str(&mut self, s: &str) -> bool {
+        let changed = self.focused_field_mut().insert_str(s);
+        if changed {
+            self.error = None;
+        }
+        changed
+    }
+
     pub fn backspace(&mut self) -> bool {
         let changed = self.focused_field_mut().backspace();
         if changed {
@@ -858,6 +868,18 @@ fn handle_key_down(
 ) {
     let key = event.keystroke.key.as_str();
     cx.stop_propagation();
+
+    if crate::text_field::is_paste_chord(&event.keystroke) {
+        let pasted = cx.read_from_clipboard().and_then(|item| item.text());
+        let changed = pasted
+            .and_then(|text| shell.settings_dialog.as_mut().map(|s| s.insert_str(&text)))
+            .unwrap_or(false);
+        if changed {
+            shell.wake_text_blink(cx);
+            cx.notify();
+        }
+        return;
+    }
 
     match key {
         "escape" => {

--- a/src/text_field.rs
+++ b/src/text_field.rs
@@ -35,9 +35,9 @@ use std::sync::Arc;
 
 use codescope_core::Theme;
 use gpui::{
-    App, Bounds, ElementId, GlobalElementId, Hsla, InspectorElementId, IntoElement, LayoutId,
-    PaintQuad, ParentElement, Pixels, Point, ShapedLine, SharedString, Style, TextRun, Window,
-    div, fill, point, px, relative, size,
+    App, Bounds, ElementId, GlobalElementId, Hsla, InspectorElementId, IntoElement, Keystroke,
+    LayoutId, PaintQuad, ParentElement, Pixels, Point, ShapedLine, SharedString, Style, TextRun,
+    Window, div, fill, point, px, relative, size,
 };
 use parking_lot::Mutex;
 
@@ -145,6 +145,23 @@ impl TextField {
         self.caret = caret + ch.len_utf8();
     }
 
+    /// Insert every non-control char of `s` at the caret (the paste
+    /// path). Control characters are stripped rather than rejected so
+    /// a multi-line clipboard value still yields a usable single-line
+    /// field — lines are joined, which matches what a URL or name
+    /// field wants from a trailing-newline copy. Returns `true` when
+    /// the buffer actually changed.
+    pub fn insert_str(&mut self, s: &str) -> bool {
+        let mut changed = false;
+        for ch in s.chars() {
+            if !ch.is_control() {
+                self.insert_char(ch);
+                changed = true;
+            }
+        }
+        changed
+    }
+
     /// Delete the char to the left of the caret (Backspace). Returns
     /// `true` when the buffer actually shrank — `false` on a no-op
     /// (caret at start). The return drives whether the caller should
@@ -246,6 +263,20 @@ impl TextField {
             c -= 1;
         }
         c
+    }
+}
+
+/// Shared paste-chord test for the dialog key handlers: Ctrl+V
+/// (Cmd+V via gpui's `platform` modifier on macOS) or Shift+Insert.
+/// Shift is tolerated on the V chord so Ctrl+Shift+V pastes too;
+/// Alt is rejected because Ctrl+Alt (AltGr) types glyphs on several
+/// European layouts and must keep reaching the `key_char` path.
+pub fn is_paste_chord(keystroke: &Keystroke) -> bool {
+    let mods = &keystroke.modifiers;
+    match keystroke.key.as_str() {
+        "v" => !mods.alt && (mods.control || mods.platform),
+        "insert" => mods.shift && !mods.control && !mods.alt && !mods.platform,
+        _ => false,
     }
 }
 
@@ -589,5 +620,64 @@ mod tests {
         // Past the end → clamp to end.
         f.set_caret(99);
         assert_eq!(f.caret(), 6);
+    }
+
+    #[test]
+    fn insert_str_inserts_at_caret() {
+        let mut f = TextField::with_text("ac");
+        f.move_left();
+        assert!(f.insert_str("b"));
+        assert_eq!(f.text(), "abc");
+        assert_eq!(f.caret(), 2);
+    }
+
+    #[test]
+    fn insert_str_strips_control_chars() {
+        let mut f = TextField::new();
+        assert!(f.insert_str("https://example.com/repo.git\r\n"));
+        assert_eq!(f.text(), "https://example.com/repo.git");
+        assert_eq!(f.caret(), f.text().len());
+    }
+
+    #[test]
+    fn insert_str_joins_multiline_clipboard() {
+        let mut f = TextField::new();
+        assert!(f.insert_str("one\ntwo\tthree"));
+        assert_eq!(f.text(), "onetwothree");
+    }
+
+    #[test]
+    fn insert_str_control_only_is_noop() {
+        let mut f = TextField::with_text("x");
+        assert!(!f.insert_str("\r\n\t"));
+        assert!(!f.insert_str(""));
+        assert_eq!(f.text(), "x");
+    }
+
+    #[test]
+    fn paste_chord_matches_platform_conventions() {
+        use gpui::Modifiers;
+        let ks = |key: &str, modifiers: Modifiers| Keystroke {
+            modifiers,
+            key: key.into(),
+            key_char: None,
+        };
+        let ctrl = Modifiers { control: true, ..Default::default() };
+        let cmd = Modifiers { platform: true, ..Default::default() };
+        let ctrl_shift = Modifiers { control: true, shift: true, ..Default::default() };
+        let ctrl_alt = Modifiers { control: true, alt: true, ..Default::default() };
+        let shift = Modifiers { shift: true, ..Default::default() };
+
+        assert!(is_paste_chord(&ks("v", ctrl)));
+        assert!(is_paste_chord(&ks("v", cmd)));
+        assert!(is_paste_chord(&ks("v", ctrl_shift)));
+        assert!(is_paste_chord(&ks("insert", shift)));
+
+        // AltGr (Ctrl+Alt) types glyphs on some layouts — not a paste.
+        assert!(!is_paste_chord(&ks("v", ctrl_alt)));
+        assert!(!is_paste_chord(&ks("v", shift)));
+        assert!(!is_paste_chord(&ks("v", Modifiers::default())));
+        assert!(!is_paste_chord(&ks("insert", ctrl)));
+        assert!(!is_paste_chord(&ks("insert", Modifiers::default())));
     }
 }

--- a/src/text_field.rs
+++ b/src/text_field.rs
@@ -152,14 +152,14 @@ impl TextField {
     /// field wants from a trailing-newline copy. Returns `true` when
     /// the buffer actually changed.
     pub fn insert_str(&mut self, s: &str) -> bool {
-        let mut changed = false;
-        for ch in s.chars() {
-            if !ch.is_control() {
-                self.insert_char(ch);
-                changed = true;
-            }
+        let filtered: String = s.chars().filter(|ch| !ch.is_control()).collect();
+        if filtered.is_empty() {
+            return false;
         }
-        changed
+        let caret = self.clamped_caret();
+        self.text.insert_str(caret, &filtered);
+        self.caret = caret + filtered.len();
+        true
     }
 
     /// Delete the char to the left of the caret (Backspace). Returns


### PR DESCRIPTION
Pasting into dialog text inputs did nothing — most painfully in **New project → Clone from URL**, where a full URL had to be typed by hand.

**Cause:** dialog inputs use the minimal `TextField` (`src/text_field.rs`) and the dialog key handlers only consume per-character `key_char` keystrokes. Ctrl+V arrives as bare `v` with the control modifier and no `key_char`, so it fell through unhandled. (The terminal pane has its own paste path; the dialogs never got one.)

**Fix:**
- `TextField::insert_str` — inserts clipboard text at the caret, stripping control characters so a multi-line or trailing-newline copy still yields a valid single-line value (tests included).
- `text_field::is_paste_chord` — shared chord test: Ctrl+V / Cmd+V (gpui `platform` modifier) / Ctrl+Shift+V / Shift+Insert; Ctrl+Alt (AltGr) is rejected so glyph-typing layouts keep reaching the `key_char` path (tests included).
- Wired into all five `TextField` surfaces: new-project dialog (URL/parent/name, with the URL→name auto-derive running once per paste instead of per char), rename dialog, new-worktree dialog, settings dialog, and the command-palette search (single filter refresh per paste).

**Testing:** `cargo test -p codescope` green (125 tests, 12 in `text_field`); clippy clean on the changed lines (remaining warnings in touched files are pre-existing doc-comment debt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)