### PR TITLE
chore: fix clippy doc-comment warnings across the workspace

### DIFF
--- a/core/src/git.rs
+++ b/core/src/git.rs
@@ -331,8 +331,8 @@ pub fn remove_worktree(repo: &Path, path: &Path, force: bool) -> Result<()> {
 /// * `"↑N"` / `"↓N"` / `"↑N ↓N"` — clean but out of sync,
 /// * `"idle"` — clean and in sync with upstream,
 /// * `""`     — no upstream and not dirty (the C# build still
-///              shows "idle"; we hide the label so a brand-new
-///              standalone branch doesn't claim sync state).
+///   shows "idle"; we hide the label so a brand-new standalone
+///   branch doesn't claim sync state).
 pub fn worktree_status_label(status: &GitStatus) -> String {
     worktree_status_label_with_ci(status, crate::pr::CiStatus::None)
 }

--- a/core/src/theme/builtin.rs
+++ b/core/src/theme/builtin.rs
@@ -299,7 +299,7 @@ mod tests {
     //! * `Fig.Color.Ink`        = `#FFFFFFFF`
     //! * `Fig.Color.InkMuted`   = `#FFA6A6A6`
     //! * `Fig.Color.Divider`    = `#22FFFFFF` (alpha-blended white over
-    //!    `Canvas` flattens to ≈ `#222222`)
+    //!   `Canvas` flattens to ≈ `#222222`)
     //! * `Framer.Color.Blue`    = `#FF0099FF`
     //!
     //! Any accidental drift in these values silently shifts the chrome

--- a/src/app.rs
+++ b/src/app.rs
@@ -5521,9 +5521,9 @@ impl AppShell {
     ///
     /// Cap-eviction respects persistence: a flurry of regular toasts
     /// won't drop the persistent one off the back. If we're still over
-    /// cap after removing all expirables (extremely unlikely — would mean
-    /// >TOAST_VISIBLE_CAP open action prompts at once) the oldest
-    /// persistent wins.
+    /// cap after removing all expirables (extremely unlikely — would
+    /// mean more than `TOAST_VISIBLE_CAP` open action prompts at once)
+    /// the oldest persistent wins.
     pub(crate) fn push_action_toast(
         &mut self,
         kind: ToastKind,
@@ -7558,11 +7558,6 @@ impl AppShell {
 }
 
 impl AppShell {
-    /// Build one group's tab strip section + body pane. Returned as a
-    /// pair so `render` can interleave dividers between adjacent
-    /// groups while keeping the strip and the pane below it in the
-    /// same column.
-
     /// Handle a left-press on any of the title-bar drag regions
     /// (brand mark, strip-left padding, per-group trailing whitespace).
     ///
@@ -7678,6 +7673,10 @@ impl AppShell {
         window.start_window_move();
     }
 
+    /// Build one group's tab strip section + body pane. Returned as a
+    /// pair so `render` can interleave dividers between adjacent
+    /// groups while keeping the strip and the pane below it in the
+    /// same column.
     fn render_group(
         &self,
         theme: &Arc<Theme>,

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -8,10 +8,10 @@
 //! - **Projects**  — focus / select the project in the sidebar.
 //! - **Worktrees** — open or focus its session.
 //! - **Agents**   — start a new session running that agent in the
-//!                  active worktree.
+//!   active worktree.
 //! - **Themes**   — live-apply (writes `settings.theme`, re-renders chrome).
 //! - **Commands** — static built-ins (toggle overview / sidebar, new
-//!                  project, open settings, reload theme).
+//!   project, open settings, reload theme).
 //!
 //! Arrow keys move selection; Enter activates the highlighted row;
 //! Esc closes. The dropdown is grouped by kind so the user can

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -682,8 +682,8 @@ impl Sidebar {
     }
 
     /// Drive the caret blink for the sidebar-owned dialogs
-    /// ("Add project", "New worktree from branch"; rename + settings
-    /// + command palette live on AppShell with their own timer).
+    /// ("Add project", "New worktree from branch"; rename, settings
+    /// and command palette live on AppShell with their own timer).
     /// Shares the [`crate::app::TEXT_BLINK_PERIOD`] cadence so paired
     /// inputs across the two entities flip in lockstep — two timers
     /// on the same ms-grid drift by at most one tick across a

--- a/src/text_field.rs
+++ b/src/text_field.rs
@@ -20,8 +20,8 @@
 //! This module owns the data side (a small editable buffer with a
 //! caret index, char-boundary-safe) plus a custom gpui [`Element`]
 //! that shapes the rendered line, paints the caret at
-//! `ShapedLine::x_for_index(caret_byte)`, and caches the shaped line
-//! + the painted bounds back onto the field so the parent's
+//! `ShapedLine::x_for_index(caret_byte)`, and caches the shaped
+//! line + the painted bounds back onto the field so the parent's
 //! `on_mouse_down` listener can read them and translate a click
 //! position into a byte index via `ShapedLine::closest_index_for_x`.
 //!

--- a/terminal/src/colors.rs
+++ b/terminal/src/colors.rs
@@ -104,8 +104,8 @@ impl ColorPalette {
     /// Themes shipped from the built-in registry always provide a full
     /// 256-entry `extended` table. If a theme loaded from disk (or a
     /// future hand-edited file) supplies fewer than 256 entries we
-    /// synthesize the missing slots with the standard xterm 6×6×6 cube
-    /// + 24-step grayscale ramp — the terminal renderer indexes
+    /// synthesize the missing slots with the standard xterm 6×6×6
+    /// cube + 24-step grayscale ramp — the terminal renderer indexes
     /// straight into this table for `Color::Indexed`, so a partial
     /// table would otherwise paint as black.
     pub fn from_theme_palette(palette: &codescope_core::ThemePalette) -> Self {


### PR DESCRIPTION
Clears the long-standing doc-comment clippy debt (16 warnings under rust 1.95). Three categories, all cosmetic — no behavior changes:

- **`doc_lazy_continuation`** — lines starting with `+` parse as Markdown list items, making the following lines unindented continuations. Rewrapped so `+` never starts a line (`src/sidebar.rs`, `src/text_field.rs`, `terminal/src/colors.rs`).
- **`doc_overindented_list_items`** — visually-aligned bullet continuations trimmed to the 2-space Markdown standard (`core/src/git.rs`, `core/src/theme/builtin.rs`, `src/command_palette.rs`).
- **`src/app.rs`** — a `>`-initial line parsed as a blockquote (reworded to "more than `TOAST_VISIBLE_CAP`"), and `render_group`'s doc block had been orphaned above the titlebar drag handler by a later insertion — moved back onto its function.

`cargo clippy --workspace --all-targets` reports zero doc warnings; full test suite green (647 tests). The remaining non-doc clippy findings (too-many-arguments, enum size, etc.) are intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)