### PR TITLE
fix: restore keyboard focus after closing dialogs and the command palette

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -795,6 +795,21 @@ impl AppShell {
         cx: &mut Context<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
+        // Whenever the focused element disappears from the tree — a
+        // dialog or the command palette closing is the common case —
+        // gpui leaves the window with no focus at all, and keystrokes
+        // (including the global chords on this entity's root handler)
+        // stop dispatching entirely until the user clicks something
+        // (#270). Catch that here and hand focus back to the active
+        // tab's terminal, falling back to the AppShell root handle so
+        // the chords keep working when no tab is open.
+        cx.on_focus_lost(window, |this: &mut AppShell, window, cx| {
+            let handle = this
+                .focused_tab_terminal_handle(cx)
+                .unwrap_or_else(|| this.focus_handle.clone());
+            handle.focus(window);
+        })
+        .detach();
         // The sidebar reads sidebar-* fields and selectedProjectId
         // out of the same `LayoutState`; we keep our own clone for
         // the group fields so save-on-change here doesn't trample
@@ -5269,6 +5284,16 @@ impl AppShell {
         (!canon.is_empty()).then_some(canon)
     }
 
+    /// Focus handle of the focused group's active tab terminal, if
+    /// any tab is open. Used by the window focus-lost hook (see
+    /// `AppShell::new`) to pick where focus should land after the
+    /// focused element vanished from the tree.
+    fn focused_tab_terminal_handle(&self, cx: &gpui::App) -> Option<gpui::FocusHandle> {
+        let group = self.groups.get(self.focused_group)?;
+        let tab = group.tabs.get(group.active_tab)?;
+        Some(tab.terminal.read(cx).focus_handle(cx))
+    }
+
     /// The focused tab's working directory as a real filesystem path,
     /// suitable for spawning `git` in. Contrast with
     /// [`Self::focused_tab_worktree_path`], which returns the
@@ -7140,9 +7165,10 @@ impl AppShell {
         cx.notify();
     }
 
-    /// Close without dispatching. Drops the state; the focus handle is
-    /// dropped with it so a follow-up key press routes to the AppShell
-    /// root handler again.
+    /// Close without dispatching. Drops the state; the focus handle
+    /// dies with it, which fires the window focus-lost hook registered
+    /// in `AppShell::new` — that hook re-focuses the active terminal
+    /// (or the AppShell root), keeping keyboard input alive (#270).
     pub fn close_command_palette(&mut self, cx: &mut Context<Self>) {
         if self.command_palette.take().is_some() {
             cx.notify();

--- a/src/app.rs
+++ b/src/app.rs
@@ -52,7 +52,7 @@ use codescope_terminal::{
 use gpui::StatefulInteractiveElement;
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    AppContext, ClipboardItem, Context, Entity, FocusHandle, Focusable, InteractiveElement,
+    App, AppContext, ClipboardItem, Context, Entity, FocusHandle, Focusable, InteractiveElement,
     IntoElement, KeyDownEvent, MouseButton, ParentElement, Render, SharedString, Styled, Window,
     WindowBounds, WindowControlArea, div, px, svg,
 };
@@ -5288,7 +5288,7 @@ impl AppShell {
     /// any tab is open. Used by the window focus-lost hook (see
     /// `AppShell::new`) to pick where focus should land after the
     /// focused element vanished from the tree.
-    fn focused_tab_terminal_handle(&self, cx: &gpui::App) -> Option<gpui::FocusHandle> {
+    fn focused_tab_terminal_handle(&self, cx: &App) -> Option<FocusHandle> {
         let group = self.groups.get(self.focused_group)?;
         let tab = group.tabs.get(group.active_tab)?;
         Some(tab.terminal.read(cx).focus_handle(cx))


### PR DESCRIPTION
Fixes #270.

After closing the command palette or any dialog (Escape, Cancel, submit, or an async completion), the dialog's `FocusHandle` died with its state and nothing was refocused. Window focus became `None`, and since gpui only dispatches keystrokes along the focus path, all keyboard input — including AppShell's global chords — went dead until the user clicked somewhere.

**Fix:** one central `cx.on_focus_lost` hook registered in `AppShell::new` (gpui's documented mechanism for exactly this case: *"the node that was focused is removed from the tree, and this callback lets you choose a default place to restore the user's focus"*). When the focused element vanishes, focus is handed to the active tab's terminal, falling back to the AppShell root handle when no tab is open. This covers every close path — all five dialogs/palette, cancel buttons, backdrop clicks, submits and async completions — without threading `&mut Window` through any of them. The stale comment on `close_command_palette` (which wrongly assumed keys reroute to the root handler) is corrected.

**Verified with gpui-driver on a live build:**
- palette → Escape → Ctrl+Shift+P now dispatches again and reopens the palette (was `dispatched: false` before);
- palette → New project dialog → Escape → typing lands directly in the terminal prompt, no click needed.

`cargo test -p codescope` green (125 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)