### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "codescope"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
Minor release covering everything since v0.4.0:

- **Working-tree diff viewer** — Ctrl+Shift+D / worktree context menu (#266, #258)
- Tall sidebar no longer pushes the work area off-screen (#262, #260)
- Theme switches repaint running terminals immediately (#263, #257)
- OSC 52 copy honoured so CLI agents can write the system clipboard (#264, #259)
- File paths in terminal output are Ctrl+clickable (#265, #261)
- Paste (Ctrl+V / Cmd+V / Shift+Insert) works in all dialog text fields (#268)
- Keyboard focus is restored after closing any dialog or the command palette (#271, #270)
- Internal: clippy doc-comment debt cleared (#269)

**Release steps after merge:** run the mandatory `RELEASE-VALIDATION.md` §6 dev-mode archive-extraction regression check, then tag `v0.5.0` to trigger the release pipeline. The §4 in-app update validation (installed v0.4.0 → v0.5.0) is run by the user on the published release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)