### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "codescope"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
Patch release covering the in-app update robustness fixes since v0.5.0:

- **#275** — the updater verifies `received == Content-Length` and retries truncated downloads. A TLS-inspecting proxy / antivirus middlebox clipping a large HTTPS download now fails honestly ("Download incomplete") and self-heals on retry, instead of silently accepting a short zip that later fails extraction with "Could not find EOCD".
- **#276** — `dist/truncating_server.py` + RELEASE-VALIDATION §6b guard that resilience (the gap that let the bug ship: §6 served from localhost, which never truncates).

§6/§6b were exercised end-to-end this session against the real updater (self-heal + honest-failure both confirmed); the extraction path (§6) is unchanged from v0.5.0, which passed. Tag `v0.5.1` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)