### PR TITLE
feat(dev): mark dev builds in the window title and titlebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,9 @@ methods — `projects_file()`, `layout_file()`, `window_file()`,
 - macOS: `~/Library/Application Support/CodeScope/` →
   `~/Library/Application Support/CodeScope.Dev/` (both config and
   state — Apple's HIG keeps them together)
-- window title → `CodeScope [dev] — …`
+- window title → `CodeScope [dev]` (taskbar / alt-tab), plus a
+  matching accent-coloured `[dev]` badge next to the wordmark in the
+  custom titlebar. Installed builds stay `CodeScope`
 
 The Dev store is independent — projects opened in the dev build are
 separate from the installed build's projects. Typical loop: keep the

--- a/src/app.rs
+++ b/src/app.rs
@@ -6837,7 +6837,7 @@ impl Render for AppShell {
             // to test the wrong one. Accent-coloured rather than faint:
             // this is the one label you want to catch at a glance. The
             // OS window title carries the same marker, see
-            // `main::window_title`.
+            // `crate::window_title`.
             .when(self.paths.dev_mode, |row| {
                 row.child(
                     div()

--- a/src/app.rs
+++ b/src/app.rs
@@ -6830,6 +6830,25 @@ impl Render for AppShell {
                     .text_color(theme::ink(&theme))
                     .child("CodeScope"),
             )
+            // `[dev]` marker — only on a `CODESCOPE_DEV` run. The
+            // documented dev loop keeps an installed CodeScope open
+            // next to the dev build (it hosts the sessions working on
+            // this repo), and two identical windows are a reliable way
+            // to test the wrong one. Accent-coloured rather than faint:
+            // this is the one label you want to catch at a glance. The
+            // OS window title carries the same marker, see
+            // `main::window_title`.
+            .when(self.paths.dev_mode, |row| {
+                row.child(
+                    div()
+                        .font(theme::font_mono())
+                        .text_size(px(10.0))
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .text_color(theme::accent(&theme))
+                        .flex_none()
+                        .child("[dev]"),
+                )
+            })
             // Flex filler so the version slug pushes to the right edge
             // of the sidebar column (mirrors `Grid.Column="3"` in
             // `MainWindow.xaml`'s brand grid).

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,8 +298,8 @@ fn main() -> Result<()> {
 /// the sessions working on this repo, so it can't be closed — see
 /// `CLAUDE.md`). Two windows both called "CodeScope" are impossible to
 /// tell apart in the taskbar, which is exactly the confusion this
-/// avoids. The visible wordmark carries the same marker; see
-/// `AppShell::render`'s brand cluster.
+/// avoids. The visible wordmark carries the same marker; see the brand
+/// cluster in [`crate::app::AppShell`]'s render.
 fn window_title(dev_mode: bool) -> &'static str {
     if dev_mode {
         "CodeScope [dev]"

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,9 @@ fn main() -> Result<()> {
 
     let window_bounds = saved_window.map(window_state_to_bounds);
     write_boot_phase(&paths, "state_loaded:settings+projects+layout+window");
+    // Captured before `paths` moves into the window closure — the OS
+    // window title has to be decided up front, at `open_window`.
+    let window_title = window_title(paths.dev_mode);
     let paths = Arc::new(paths);
 
     // `with_assets` registers our static SVG icon set so
@@ -258,7 +261,7 @@ fn main() -> Result<()> {
                 WindowOptions {
                     window_bounds,
                     titlebar: Some(TitlebarOptions {
-                        title: Some("CodeScope".into()),
+                        title: Some(window_title.into()),
                         appears_transparent: true,
                         ..Default::default()
                     }),
@@ -285,6 +288,24 @@ fn main() -> Result<()> {
     });
 
     Ok(())
+}
+
+/// OS window title — what the taskbar, alt-tab and
+/// `Get-Process | Select MainWindowTitle` show.
+///
+/// Dev builds get a `[dev]` marker because the documented dev loop runs
+/// them *alongside* an installed CodeScope (the installed build hosts
+/// the sessions working on this repo, so it can't be closed — see
+/// `CLAUDE.md`). Two windows both called "CodeScope" are impossible to
+/// tell apart in the taskbar, which is exactly the confusion this
+/// avoids. The visible wordmark carries the same marker; see
+/// `AppShell::render`'s brand cluster.
+fn window_title(dev_mode: bool) -> &'static str {
+    if dev_mode {
+        "CodeScope [dev]"
+    } else {
+        "CodeScope"
+    }
 }
 
 /// Append a single timestamped phase marker to
@@ -338,6 +359,29 @@ fn window_state_to_bounds(state: WindowState) -> WindowBounds {
         WindowBounds::Maximized(bounds)
     } else {
         WindowBounds::Windowed(bounds)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::window_title;
+
+    #[test]
+    fn dev_runs_are_distinguishable_in_the_taskbar() {
+        // The whole point: an installed build and a dev build run side
+        // by side, so the titles must differ.
+        assert_eq!(window_title(false), "CodeScope");
+        assert_eq!(window_title(true), "CodeScope [dev]");
+        assert_ne!(window_title(true), window_title(false));
+    }
+
+    #[test]
+    fn release_title_stays_the_bare_product_name() {
+        // Nothing in the tree matches on the window title, so this
+        // guards the user-facing side only: an installed build must
+        // never leak dev chrome into alt-tab.
+        assert!(!window_title(false).contains("dev"));
+        assert!(!window_title(false).contains('['));
     }
 }
 


### PR DESCRIPTION
`CLAUDE.md` promised a `CodeScope [dev] — …` window title for `CODESCOPE_DEV` runs. It was never implemented — `src/main.rs` hardcoded `title: Some("CodeScope".into())`, and there was no `[dev]` string anywhere in the tree.

That matters more than a cosmetic nit, because the documented dev loop **requires** both builds to run at once: the installed build hosts the sessions working on this repo, so it can't be closed to test a dev build. Two windows both called "CodeScope" are indistinguishable in the taskbar, in alt-tab, and in `Get-Process | Select MainWindowTitle` — a reliable way to test the wrong one. That happened while verifying #280.

## What changed

- **`src/main.rs`** — `window_title(dev_mode)` decides the OS title, captured before `paths` moves into the window closure (the title has to be set at `open_window`). Two unit tests: the dev and release titles differ, and the release title never leaks dev chrome.
- **`src/app.rs`** — an accent-coloured `[dev]` badge next to the wordmark in the custom titlebar. This is the one users actually look at: the titlebar is `appears_transparent`, so the OS title only shows up in the taskbar and alt-tab.
- **`CLAUDE.md`** — describes what is now rendered. The ` — …` suffix is dropped rather than implemented: a dynamic project-name title is a separate feature and nothing asked for it.

## Verification

Both builds running side by side:

```
   Id MainWindowTitle build
   -- --------------- -----
 9200 CodeScope       installed
20296 CodeScope [dev] dev
```

And a `PrintWindow` capture of the dev titlebar confirms the badge renders between the wordmark and the version slug, in the accent colour, at the right baseline.

`cargo test --bin codescope`: 131 passed. Clippy on the bin produces the same 6 pre-existing warnings as `main` — none from this change.

## Merge note

Independent of #280 (branched from `main`, no overlapping files). #280's HANDOFF entry records this gap as "not done here — out of scope for this PR"; whichever of the two merges second should flip that line to point at this PR. Deliberately kept out of this branch so the two don't conflict on `docs/HANDOFF.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
