### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "codescope"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
Patch bump for the release. cargo-dist requires the `v*` tag to match the workspace version, so this lands first and the tag goes on the merge commit.

## What's in v0.5.2

- **#280** — xterm modifier encoding for the named keys. Ctrl/Shift/Alt + arrows, Home/End, the tilde block and the F-keys previously reached the PTY stripped of their modifier, so `Ctrl+Left` was indistinguishable from `Left`. Also: `Ctrl+Backspace` now sends BS rather than DEL (which is what makes it delete a word), and SGR 2 (faint) text finally renders dimmed instead of at full strength.
- **#281** — `[dev]` marker in the window title and titlebar, so a dev build is distinguishable from the installed build it runs beside.
- **#282** — HANDOFF refresh.

Patch rather than minor: two fixes to existing behaviour plus a dev-only marker no end user sees.

## Release-validation note

`docs/RELEASE-VALIDATION.md` §6 and §6b are marked MANDATORY, and they exist to catch two specific failure modes: a missing `self_update` compression feature (extraction fails after a successful download) and a truncated download passing unverified into extraction.

Both live entirely in paths that are **byte-identical to the `v0.5.1` tag**:

```
git diff --stat v0.5.1..HEAD -- Cargo.toml dist-workspace.toml installer/ \
  .github/workflows/release.yml src/update.rs core/src/update_check.rs build.rs
(empty)
```

Every one of the 763 changed lines since the tag is in `terminal/src/`, `src/app.rs`, `src/main.rs`, `CLAUDE.md` and `docs/HANDOFF.md`. That is evidence the extraction and download paths cannot have regressed — it is **not** a substitute for the click-through, and it does not cover §1's fresh-install check, which is worth doing on a real installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
