### PR TITLE
fix(sessions): stop two tabs sharing one agent transcript id

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1922,14 +1922,20 @@ impl AppShell {
                     /// selection happens so the two selection rounds
                     /// below can run over the whole workspace instead
                     /// of deciding tab-by-tab as we walk it.
+    ///
+                    /// Holds indices rather than copies of the tab's
+                    /// state: selection re-reads the tab through them,
+                    /// so a tick that adopts nothing (the overwhelming
+                    /// majority, at ~350 ms) allocates nothing beyond
+                    /// the hit list itself.
                     struct Scan {
                         group_idx: usize,
                         tab_idx: usize,
                         agent_id: codescope_core::AgentId,
-                        working_directory: String,
-                        codescope_session_id: String,
-                        adopted: Option<String>,
-                        fired: HashSet<String>,
+                        /// Mirrors `Tab::adopted_session_id.is_some()`
+                        /// — the two selection rounds only need the
+                        /// flag, not the id.
+                        has_adoption: bool,
                         /// `(agent session id, transcript mtime)`.
                         hits: Vec<(String, SystemTime)>,
                     }
@@ -2034,10 +2040,7 @@ impl AppShell {
                                 group_idx: g_idx,
                                 tab_idx: t_idx,
                                 agent_id,
-                                working_directory: wd_str,
-                                codescope_session_id: tab.session_id.clone(),
-                                adopted: tab.adopted_session_id.clone(),
-                                fired: tab.fired_session_ids.clone(),
+                                has_adoption: tab.adopted_session_id.is_some(),
                                 hits,
                             });
                         }
@@ -2073,13 +2076,27 @@ impl AppShell {
                     // out for good. Stable sort, so iteration order
                     // still decides within each class.
                     let mut order: Vec<usize> = (0..scans.len()).collect();
-                    order.sort_by_key(|&i| scans[i].adopted.is_some());
+                    order.sort_by_key(|&i| scans[i].has_adoption);
                     let mut found = Vec::new();
                     for i in order {
                         let s = &scans[i];
-                        let Some(sid) =
-                            select_adoption(&s.hits, &s.fired, s.adopted.as_deref(), &claimed)
+                        // Re-read the tab instead of carrying copies of
+                        // its state through the scan — nothing has
+                        // mutated `groups` since, and the clones below
+                        // only happen for a tab that actually adopts.
+                        let Some(tab) = this
+                            .groups
+                            .get(s.group_idx)
+                            .and_then(|g| g.tabs.get(s.tab_idx))
                         else {
+                            continue;
+                        };
+                        let Some(sid) = select_adoption(
+                            &s.hits,
+                            &tab.fired_session_ids,
+                            tab.adopted_session_id.as_deref(),
+                            &claimed,
+                        ) else {
                             continue;
                         };
                         claimed.insert(sid.clone());
@@ -2087,10 +2104,14 @@ impl AppShell {
                             group_idx: s.group_idx,
                             tab_idx: s.tab_idx,
                             agent_id: s.agent_id,
-                            previous_agent_session_id: s.adopted.clone(),
+                            previous_agent_session_id: tab.adopted_session_id.clone(),
                             new_agent_session_id: sid,
-                            working_directory: s.working_directory.clone(),
-                            codescope_session_id: s.codescope_session_id.clone(),
+                            working_directory: tab
+                                .working_directory
+                                .as_ref()
+                                .map(|wd| wd.to_string_lossy().into_owned())
+                                .unwrap_or_default(),
+                            codescope_session_id: tab.session_id.clone(),
                         });
                     }
                     for f in found {

--- a/src/app.rs
+++ b/src/app.rs
@@ -151,6 +151,60 @@ struct Tab {
     agent_id: Option<codescope_core::AgentId>,
 }
 
+/// Pick the transcript a tab should adopt this tick: the newest
+/// candidate it hasn't already fired and that no *other* tab has
+/// claimed.
+///
+/// `claimed` holds every agent session id owned by any tab (adopted or
+/// previously fired) plus the ids handed out earlier in the same pass.
+/// Without that filter two tabs sharing a working directory — the
+/// normal case, since "new session" opens another tab on the project's
+/// primary path — see the same `~/.claude/projects/<encoded-cwd>/`
+/// listing, and a tab whose own agent hasn't written yet adopts its
+/// neighbour's transcript. `persist_agent_session_id` then writes that
+/// id onto the wrong row in `projects.json`, so both sessions resume
+/// the same conversation on the next launch (observed: three `Werk`
+/// rows pointing at one Claude session).
+///
+/// The tab's own `adopted` id is exempt from the claim check so a
+/// restored tab can re-fire the transcript it is resuming.
+///
+/// The caller runs this in two rounds — tabs with no adoption yet
+/// first — so a tab that already owns a transcript can't rotate onto
+/// the one its neighbour just minted.
+///
+/// Remaining ceilings, both needing the agent to report its own id
+/// back to us before they can close:
+///
+/// * Several same-cwd tabs that *all* already own a transcript: a
+///   `/clear` rotation in one of them is taken by whichever comes
+///   first in iteration order.
+/// * The dev build and the installed build share
+///   `~/.claude/projects/` but keep separate `projects.json` stores,
+///   so neither sees the other's claims. A tab in one instance can
+///   still adopt a transcript minted in the other.
+fn select_adoption(
+    hits: &[(String, SystemTime)],
+    fired: &HashSet<String>,
+    adopted: Option<&str>,
+    claimed: &HashSet<String>,
+) -> Option<String> {
+    let mut newest: Option<(SystemTime, &str)> = None;
+    for (sid, mtime) in hits {
+        if fired.contains(sid) {
+            continue;
+        }
+        if claimed.contains(sid) && adopted != Some(sid.as_str()) {
+            continue;
+        }
+        let take = newest.map(|(prev, _)| *mtime >= prev).unwrap_or(true);
+        if take {
+            newest = Some((*mtime, sid.as_str()));
+        }
+    }
+    newest.map(|(_, sid)| sid.to_owned())
+}
+
 /// One column in the work area: a tab strip + the currently-selected
 /// tab's terminal. Mirrors `EditorGroupViewModel` from the C# build —
 /// flat list, no recursion. The group's identity is its `id` so we can
@@ -1864,7 +1918,22 @@ impl AppShell {
                         /// `projects.json::Session.id`.
                         codescope_session_id: String,
                     }
-                    let mut found = Vec::new();
+                    /// One tab's scan result, captured before any
+                    /// selection happens so the two selection rounds
+                    /// below can run over the whole workspace instead
+                    /// of deciding tab-by-tab as we walk it.
+                    struct Scan {
+                        group_idx: usize,
+                        tab_idx: usize,
+                        agent_id: codescope_core::AgentId,
+                        working_directory: String,
+                        codescope_session_id: String,
+                        adopted: Option<String>,
+                        fired: HashSet<String>,
+                        /// `(agent session id, transcript mtime)`.
+                        hits: Vec<(String, SystemTime)>,
+                    }
+                    let mut scans: Vec<Scan> = Vec::new();
                     let mut any_active = false;
                     for (g_idx, group) in this.groups.iter().enumerate() {
                         for (t_idx, tab) in group.tabs.iter().enumerate() {
@@ -1951,35 +2020,78 @@ impl AppShell {
                                     continue;
                                 }
                             };
-                            let mut newest: Option<(SystemTime, String)> = None;
-                            for (sid, path) in hits {
-                                if tab.fired_session_ids.contains(&sid) {
-                                    continue;
-                                }
-                                let mtime = std::fs::metadata(&path)
-                                    .ok()
-                                    .and_then(|m| m.modified().ok())
-                                    .unwrap_or(SystemTime::UNIX_EPOCH);
-                                let take = newest
-                                    .as_ref()
-                                    .map(|(prev, _)| mtime >= *prev)
-                                    .unwrap_or(true);
-                                if take {
-                                    newest = Some((mtime, sid));
-                                }
-                            }
-                            if let Some((_, sid)) = newest {
-                                found.push(Found {
-                                    group_idx: g_idx,
-                                    tab_idx: t_idx,
-                                    agent_id,
-                                    previous_agent_session_id: tab.adopted_session_id.clone(),
-                                    new_agent_session_id: sid,
-                                    working_directory: wd_str,
-                                    codescope_session_id: tab.session_id.clone(),
-                                });
-                            }
+                            let hits: Vec<(String, SystemTime)> = hits
+                                .into_iter()
+                                .map(|(sid, path)| {
+                                    let mtime = std::fs::metadata(&path)
+                                        .ok()
+                                        .and_then(|m| m.modified().ok())
+                                        .unwrap_or(SystemTime::UNIX_EPOCH);
+                                    (sid, mtime)
+                                })
+                                .collect();
+                            scans.push(Scan {
+                                group_idx: g_idx,
+                                tab_idx: t_idx,
+                                agent_id,
+                                working_directory: wd_str,
+                                codescope_session_id: tab.session_id.clone(),
+                                adopted: tab.adopted_session_id.clone(),
+                                fired: tab.fired_session_ids.clone(),
+                                hits,
+                            });
                         }
+                    }
+                    // Every agent session id that is already spoken
+                    // for: what the open tabs own, plus every id
+                    // persisted in `projects.json`. The persisted half
+                    // matters because closing a tab drops its `Tab`
+                    // struct — without it, a sibling in the same folder
+                    // would adopt the just-closed session's transcript
+                    // on the very next tick and stamp its id onto its
+                    // own row. Grown as this pass hands ids out, so two
+                    // tabs can't take the same transcript in one tick.
+                    let mut claimed: HashSet<String> = this
+                        .projects
+                        .projects
+                        .iter()
+                        .flat_map(|p| p.sessions.iter())
+                        .filter_map(|s| s.agent_session_id.clone())
+                        .chain(this.groups.iter().flat_map(|g| g.tabs.iter()).flat_map(|t| {
+                            t.adopted_session_id
+                                .iter()
+                                .chain(t.fired_session_ids.iter())
+                                .cloned()
+                        }))
+                        .collect();
+                    // Tabs that own nothing yet choose first. A tab
+                    // that already has a live transcript would
+                    // otherwise "rotate" onto a brand-new one minted by
+                    // the neighbour it shares a working directory with
+                    // — stealing the conversation *and*, now that
+                    // claims are exclusive, locking the rightful tab
+                    // out for good. Stable sort, so iteration order
+                    // still decides within each class.
+                    let mut order: Vec<usize> = (0..scans.len()).collect();
+                    order.sort_by_key(|&i| scans[i].adopted.is_some());
+                    let mut found = Vec::new();
+                    for i in order {
+                        let s = &scans[i];
+                        let Some(sid) =
+                            select_adoption(&s.hits, &s.fired, s.adopted.as_deref(), &claimed)
+                        else {
+                            continue;
+                        };
+                        claimed.insert(sid.clone());
+                        found.push(Found {
+                            group_idx: s.group_idx,
+                            tab_idx: s.tab_idx,
+                            agent_id: s.agent_id,
+                            previous_agent_session_id: s.adopted.clone(),
+                            new_agent_session_id: sid,
+                            working_directory: s.working_directory.clone(),
+                            codescope_session_id: s.codescope_session_id.clone(),
+                        });
                     }
                     for f in found {
                         if let Some(prev) = f.previous_agent_session_id.as_deref()
@@ -3290,6 +3402,30 @@ impl AppShell {
             persist_agent_id.as_ref().map(|s| s.to_string()),
             restore_session_id,
         );
+        // Claim the persisted transcript from the first discovery tick
+        // on the restore paths (launch rehydrate / reopen from history):
+        // the tab is resuming that conversation by id, so no sibling tab
+        // in the same working directory may adopt it. `None` for fresh
+        // spawns — the row `allocate_session_id` just wrote carries no
+        // `agent_session_id` yet.
+        //
+        // Stores written before the claim rule landed can hold the same
+        // `agent_session_id` on several rows (that was the bug). Only
+        // the first tab to come up seeds it; the rest start unclaimed
+        // and adopt their own transcript on the next `/clear` or
+        // re-invocation, rather than all firing one id — which would
+        // have them fight over a single telemetry tail and re-persist
+        // the duplicate forever.
+        let adopted_session_id = self
+            .lookup_session_by_id(&session_id)
+            .and_then(|s| s.agent_session_id)
+            .filter(|sid| {
+                !self
+                    .groups
+                    .iter()
+                    .flat_map(|g| g.tabs.iter())
+                    .any(|t| t.adopted_session_id.as_deref() == Some(sid.as_str()))
+            });
         let group_idx = self.focused_group;
         let group = &mut self.groups[group_idx];
         // Capture the entity so the fallback `auto_type` job below can
@@ -3315,7 +3451,7 @@ impl AppShell {
             terminal,
             working_directory: working_directory_for_tab,
             spawned_at: SystemTime::now(),
-            adopted_session_id: None,
+            adopted_session_id,
             fired_session_ids: std::collections::HashSet::new(),
             agent_id,
         });
@@ -8429,6 +8565,96 @@ fn classify_activity_transition(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── select_adoption ───────────────────────────────────────────
+    //
+    // Two tabs on the same project path share one
+    // `~/.claude/projects/<encoded-cwd>/` listing, so the claim set is
+    // the only thing keeping their transcripts apart. When it fails,
+    // `persist_agent_session_id` stamps one Claude session onto several
+    // `projects.json` rows and every one of them resumes the same
+    // conversation on the next launch.
+
+    const SID_A: &str = "11111111-2222-3333-4444-555555555555";
+    const SID_B: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+    fn at(secs: u64) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(secs)
+    }
+
+    fn ids(v: &[&str]) -> HashSet<String> {
+        v.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn select_adoption_takes_newest_unclaimed() {
+        let hits = vec![(SID_A.to_owned(), at(10)), (SID_B.to_owned(), at(20))];
+        assert_eq!(
+            select_adoption(&hits, &ids(&[]), None, &ids(&[])),
+            Some(SID_B.to_owned())
+        );
+    }
+
+    #[test]
+    fn select_adoption_skips_transcripts_owned_by_another_tab() {
+        // The sibling tab's transcript is the newest one — a fresh tab
+        // in the same folder must still come back empty-handed rather
+        // than steal it.
+        let hits = vec![(SID_A.to_owned(), at(10)), (SID_B.to_owned(), at(20))];
+        assert_eq!(
+            select_adoption(&hits, &ids(&[]), None, &ids(&[SID_B])),
+            Some(SID_A.to_owned())
+        );
+        assert_eq!(
+            select_adoption(&hits, &ids(&[]), None, &ids(&[SID_A, SID_B])),
+            None
+        );
+    }
+
+    #[test]
+    fn select_adoption_allows_own_adopted_id_through_the_claim_set() {
+        // Restore path: the tab carries its persisted id from spawn, so
+        // that id is in `claimed` — as *its own* claim. It must still
+        // fire once the resumed transcript is written, otherwise the
+        // telemetry tail never registers.
+        let hits = vec![(SID_A.to_owned(), at(10))];
+        assert_eq!(
+            select_adoption(&hits, &ids(&[]), Some(SID_A), &ids(&[SID_A])),
+            Some(SID_A.to_owned())
+        );
+    }
+
+    #[test]
+    fn unadopted_tab_wins_the_new_transcript_over_an_adopted_sibling() {
+        // Two tabs on one path: A already owns SID_A, B has nothing
+        // yet, and B's agent has just written SID_B (the newest file
+        // in the shared directory). The caller's two rounds must hand
+        // SID_B to B — if A picked first it would "rotate" onto its
+        // neighbour's conversation and, with claims exclusive, leave B
+        // locked out permanently.
+        let hits = vec![(SID_A.to_owned(), at(10)), (SID_B.to_owned(), at(20))];
+        let mut claimed = ids(&[SID_A]);
+
+        // Round 1 — tabs with no adoption yet.
+        let picked = select_adoption(&hits, &ids(&[]), None, &claimed);
+        assert_eq!(picked, Some(SID_B.to_owned()));
+        claimed.insert(picked.unwrap());
+
+        // Round 2 — A, which already fired SID_A, finds nothing left.
+        assert_eq!(
+            select_adoption(&hits, &ids(&[SID_A]), Some(SID_A), &claimed),
+            None
+        );
+    }
+
+    #[test]
+    fn select_adoption_skips_already_fired_ids() {
+        let hits = vec![(SID_A.to_owned(), at(10))];
+        assert_eq!(
+            select_adoption(&hits, &ids(&[SID_A]), Some(SID_A), &ids(&[SID_A])),
+            None
+        );
+    }
 
     // ─── normalise_group_weights ───────────────────────────────────
     //

--- a/src/app.rs
+++ b/src/app.rs
@@ -173,12 +173,21 @@ struct Tab {
 /// first — so a tab that already owns a transcript can't rotate onto
 /// the one its neighbour just minted.
 ///
-/// Remaining ceilings, both needing the agent to report its own id
-/// back to us before they can close:
+/// Remaining ceilings. The first two are the same gap — the rounds
+/// separate adopted tabs from unadopted ones, but *within* a round
+/// nothing distinguishes same-cwd tabs, so iteration order decides.
+/// Closing either needs the agent to report its own session id back to
+/// us:
 ///
-/// * Several same-cwd tabs that *all* already own a transcript: a
-///   `/clear` rotation in one of them is taken by whichever comes
-///   first in iteration order.
+/// * Same-cwd tabs that *all* already own a transcript: a `/clear`
+///   rotation in one of them goes to whichever comes first.
+/// * Same-cwd tabs that *none* of which have adopted yet: the first
+///   transcript to appear goes to the first tab, which is only right
+///   because tab order follows spawn order and an agent normally
+///   writes its transcript at startup. If the second tab's agent
+///   writes first, the two tabs end up holding each other's ids.
+///   Both still get exactly one transcript — this crosses the mapping,
+///   it does not starve a tab.
 /// * The dev build and the installed build share
 ///   `~/.claude/projects/` but keep separate `projects.json` stores,
 ///   so neither sees the other's claims. A tab in one instance can


### PR DESCRIPTION
## The bug

Reopening an old session could resume the wrong conversation, because
several CodeScope sessions ended up mapped to a single agent session id.

Found in a real store — 4 groups of rows sharing one `agentSessionId`,
including three distinct sessions in one project all pointing at the
same Claude conversation:

```
DUP 88480323-…  (3 rows, D:\Sync\Werk)
   … | Nascholing
   … | Email
   … | Nieuwsbrief
```

The most recent duplicate was minted on v0.5.2, so this is live.

## Root cause

`start_agent_discovery_poll` picks, per tab, the newest transcript in
the tab's cwd that *that tab* has not fired yet. There was no exclusion
between tabs. Two tabs on the same working directory — the normal case,
since "new session" opens another tab on the project's primary path —
scan the same `~/.claude/projects/<encoded-cwd>/` listing, so a tab
whose own agent has not written anything yet adopts its neighbour's
transcript. `persist_agent_session_id` writes that id onto the wrong
row, and `build_resume_auto_type` later resumes it.

Rehydrated tabs made it worse: they started with
`adopted_session_id: None`, so even a correctly persisted mapping was
not a claim and could be taken by a sibling on the first tick.

## The fix

* `select_adoption` — pure helper that skips candidates claimed by
  another tab; a tab's own adopted id stays exempt so a restored tab can
  re-fire the transcript it is resuming.
* The claim set is built from every `agent_session_id` in
  `projects.json` plus the open tabs, and grows within a tick. Closing a
  tab therefore does not release its transcript to a sibling, and two
  tabs cannot take the same id in one pass.
* Selection runs in two rounds, tabs with no adoption first — otherwise
  a tab that already owns a transcript rotates onto the one its
  neighbour just minted, stealing the conversation and (with claims
  exclusive) locking the rightful tab out permanently.
* `spawn_tab_in` seeds `Tab::adopted_session_id` from the persisted row
  via the existing `lookup_session_by_id`, so rehydrate and
  reopen-from-history claim from tick zero. Only the first tab to claim
  a given id seeds it, so stores that already carry duplicates converge
  instead of having every tab fight over one telemetry tail.

## What this guarantees — and what it doesn't

**Guaranteed: uniqueness.** No two rows end up carrying the same
`agentSessionId`, and no tab is starved of a transcript. That is the
duplicate-mapping bug this PR closes.

**Not guaranteed: ownership.** Nothing in the diff proves a transcript
was minted by the tab that adopts it. Selection runs in two rounds
(unadopted tabs first), but *within* a round nothing distinguishes
same-cwd tabs, so iteration order decides. Three cases remain:

* Same-cwd tabs that all already own a transcript: a `/clear` rotation
  in one of them goes to whichever comes first.
* Same-cwd tabs none of which have adopted yet: the first transcript to
  appear goes to the first tab. That is right only because tab order
  follows spawn order and an agent normally writes its transcript at
  startup — if the second tab's agent writes first, the two tabs end up
  holding each other's ids. Each still gets exactly one transcript, so
  this crosses two mappings rather than collapsing them onto one.
* The dev build shares `~/.claude/projects/` with the installed build
  but keeps a separate store, so neither sees the other's claims.

All three need the agent to report its own session id back to us, which
is the only thing that turns this into an ownership guarantee. Until
then the honest contract is uniqueness, which is why the title says
"sharing" rather than "stealing".

## Not in this PR

Rows already carrying duplicate ids are not repaired — which of the
duplicates is the "real" owner is not reconstructable. The fix stops new
ones and keeps the existing ones from multiplying.

## Verification

* `cargo test --workspace` — 136 (`codescope`, 5 new) / 481 (core) / 53
  (terminal), all green.
* `cargo clippy --bin codescope --all-targets` — no new warnings on the
  changed lines.
* Not yet exercised against a running build; a dev run with two tabs on
  one folder is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

