### PR TITLE
fix(window): survive the session lock un-maximizing the window

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -95,6 +95,48 @@ struct PendingWindowSave {
     set_at: Instant,
 }
 
+/// What the platform window looked like on one bounds-observer tick.
+/// Kept from tick to tick so the next one can tell *why* the window
+/// stopped being maximized — see [`unmaximized_by_display_change`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct WindowPlacement {
+    maximized: bool,
+    minimized: bool,
+    /// Work area of the monitor the window is on, or `None` where the
+    /// platform can't tell us (everything except Windows, plus the
+    /// rare Win32 failure).
+    work_area: Option<(i32, i32, i32, i32)>,
+}
+
+/// True when the window went from maximized to a plain restored size
+/// *because the desktop was reconfigured under it*, not because the
+/// user asked for it.
+///
+/// Locking the PC drops the external monitors, and Windows
+/// un-maximizes the window while re-enumerating them. From gpui that
+/// is indistinguishable from a user restore-down — both arrive as
+/// `WindowBounds::Windowed` with `is_maximized() == false`. The
+/// monitor work area is the discriminator: it changes on the same
+/// tick as the reconfiguration and stays put for a user gesture.
+///
+/// Two rows from the reporter's `window-diag.log` (issue #279):
+///
+/// ```text
+/// 17:32:26 Maximized rcWork=(-841,1440,4279,2880)  ← two monitors
+/// 17:43:47 Windowed  rcWork=(0,0,3440,1392)        ← lock, one monitor
+/// ```
+///
+/// The window stayed restored after the monitors came back, until the
+/// user maximized it by hand 42 minutes later.
+fn unmaximized_by_display_change(prev: &WindowPlacement, now: &WindowPlacement) -> bool {
+    prev.maximized
+        && !now.maximized
+        && !now.minimized
+        && prev.work_area.is_some()
+        && now.work_area.is_some()
+        && prev.work_area != now.work_area
+}
+
 /// One tab = one terminal session.
 struct Tab {
     id: u64,
@@ -737,6 +779,9 @@ pub struct AppShell {
     /// `MainViewModel.RegisterAgentTelemetry` / `UnregisterAgentTelemetry`
     /// dispatching to four distinct `*TelemetryService` instances.
     telemetry_tails: HashMap<String, AgentTail>,
+    /// Placement seen on the previous bounds-observer tick. Feeds
+    /// [`unmaximized_by_display_change`]; `None` until the first tick.
+    last_window_placement: Option<WindowPlacement>,
     /// Window-coordinate bounds of the bell button as recorded by the
     /// `canvas` overlay child during the most recent layout pass.
     /// Used by `render_notifications_popover` to position the popover
@@ -1164,19 +1209,41 @@ impl AppShell {
         cx.observe_window_bounds(window, {
             let pending = pending_window_save.clone();
             let diag_paths = paths.clone();
-            move |_, window, cx| {
+            move |this, window, cx| {
                 append_window_diag(&diag_paths, "bounds_changed", window);
-                // Never let a minimized window overwrite the saved
-                // geometry (issue #279). Windows minimizes the window
-                // on some session switches — a lock/unlock cycle shows
-                // up in `window-diag.log` as `showCmd=2` with
-                // `is_maximized=false`, and gpui reports plain
-                // `Windowed(<restore bounds>)` for it, so
-                // `window_state_from_window` records `maximised:
-                // false`. The 500 ms debounce flushes that to
-                // `window.json` long before the unlock restores the
-                // real state, and the next launch comes back windowed.
-                if !window_is_minimized(window) {
+
+                // Two ways a session lock takes the window out of
+                // maximized behind the user's back (issue #279), both
+                // of which gpui reports as a plain
+                // `Windowed(<restore bounds>)` with
+                // `is_maximized() == false`:
+                //
+                // 1. It minimizes the window. The window itself comes
+                //    back on unlock, but `window_state_from_window`
+                //    already recorded `maximised: false` and the
+                //    500 ms debounce flushed it to `window.json` —
+                //    so the *next launch* is windowed.
+                // 2. The monitors drop away and Windows un-maximizes
+                //    the window while re-enumerating them. This one
+                //    the user sees immediately: the window stays
+                //    restored after the unlock.
+                //
+                // Skip the save in both cases, and undo the second.
+                let placement = WindowPlacement {
+                    maximized: window.is_maximized(),
+                    minimized: window_is_minimized(window),
+                    work_area: window_work_area(window),
+                };
+                let display_change = this
+                    .last_window_placement
+                    .as_ref()
+                    .is_some_and(|prev| unmaximized_by_display_change(prev, &placement));
+                this.last_window_placement = Some(placement);
+
+                if display_change {
+                    append_window_diag(&diag_paths, "remaximize_after_display_change", window);
+                    request_maximize(window);
+                } else if !placement.minimized {
                     let state = window_state_from_window(window);
                     *pending.lock() = Some(PendingWindowSave {
                         state,
@@ -1433,6 +1500,7 @@ impl AppShell {
             idle_notifier: crate::idle_notifier::IdleNotifier::new(),
             window_active_cached: true,
             telemetry_tails: HashMap::new(),
+            last_window_placement: None,
             bell_bounds: None,
             projects: projects_for_sessions,
             agent_registry,
@@ -8467,6 +8535,35 @@ fn window_is_minimized(window: &Window) -> bool {
     }
 }
 
+/// Work area of the monitor the window is on. `None` off Windows —
+/// no other platform is known to un-maximize the window behind the
+/// user's back, and [`unmaximized_by_display_change`] never fires
+/// without a value on both sides.
+fn window_work_area(window: &Window) -> Option<(i32, i32, i32, i32)> {
+    #[cfg(target_os = "windows")]
+    {
+        crate::win32_titlebar::work_area(window)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = window;
+        None
+    }
+}
+
+/// Ask the platform to maximize the window again. No-op off Windows,
+/// which is the only caller path — see [`window_work_area`].
+fn request_maximize(window: &Window) {
+    #[cfg(target_os = "windows")]
+    {
+        crate::win32_titlebar::maximize(window);
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = window;
+    }
+}
+
 /// Snapshot the platform window into the on-disk `WindowState`. We
 /// always store the *restore* bounds so unmaximising lands at a
 /// sensible size; `maximised` is a separate flag the loader uses to
@@ -8626,6 +8723,77 @@ fn classify_activity_transition(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── unmaximized_by_display_change (issue #279) ────────────────
+
+    /// The two work areas from the reporter's `window-diag.log`:
+    /// both monitors, then the single one a session lock leaves.
+    const TWO_MONITORS: Option<(i32, i32, i32, i32)> = Some((-841, 1440, 4279, 2880));
+    const ONE_MONITOR: Option<(i32, i32, i32, i32)> = Some((0, 0, 3440, 1392));
+
+    fn placement(
+        maximized: bool,
+        minimized: bool,
+        work_area: Option<(i32, i32, i32, i32)>,
+    ) -> WindowPlacement {
+        WindowPlacement {
+            maximized,
+            minimized,
+            work_area,
+        }
+    }
+
+    #[test]
+    fn lock_dropping_a_monitor_counts_as_a_display_change() {
+        assert!(unmaximized_by_display_change(
+            &placement(true, false, TWO_MONITORS),
+            &placement(false, false, ONE_MONITOR),
+        ));
+    }
+
+    #[test]
+    fn user_restore_down_is_left_alone() {
+        // Same desktop on both ticks — the user clicked restore, and
+        // re-maximizing here would fight them.
+        assert!(!unmaximized_by_display_change(
+            &placement(true, false, TWO_MONITORS),
+            &placement(false, false, TWO_MONITORS),
+        ));
+    }
+
+    #[test]
+    fn minimize_is_not_a_display_change() {
+        // A lock that minimizes instead is handled by skipping the
+        // save, not by re-maximizing a window the user can't see.
+        assert!(!unmaximized_by_display_change(
+            &placement(true, false, TWO_MONITORS),
+            &placement(false, true, ONE_MONITOR),
+        ));
+    }
+
+    #[test]
+    fn display_change_while_already_windowed_is_left_alone() {
+        // Plugging a monitor into a deliberately windowed app must
+        // not maximize it.
+        assert!(!unmaximized_by_display_change(
+            &placement(false, false, TWO_MONITORS),
+            &placement(false, false, ONE_MONITOR),
+        ));
+    }
+
+    #[test]
+    fn missing_work_area_never_triggers() {
+        // Non-Windows, or a Win32 read that failed: no information is
+        // not evidence of a reconfiguration.
+        assert!(!unmaximized_by_display_change(
+            &placement(true, false, None),
+            &placement(false, false, ONE_MONITOR),
+        ));
+        assert!(!unmaximized_by_display_change(
+            &placement(true, false, TWO_MONITORS),
+            &placement(false, false, None),
+        ));
+    }
 
     // ─── select_adoption ───────────────────────────────────────────
     //

--- a/src/app.rs
+++ b/src/app.rs
@@ -1166,11 +1166,23 @@ impl AppShell {
             let diag_paths = paths.clone();
             move |_, window, cx| {
                 append_window_diag(&diag_paths, "bounds_changed", window);
-                let state = window_state_from_window(window);
-                *pending.lock() = Some(PendingWindowSave {
-                    state,
-                    set_at: Instant::now(),
-                });
+                // Never let a minimized window overwrite the saved
+                // geometry (issue #279). Windows minimizes the window
+                // on some session switches — a lock/unlock cycle shows
+                // up in `window-diag.log` as `showCmd=2` with
+                // `is_maximized=false`, and gpui reports plain
+                // `Windowed(<restore bounds>)` for it, so
+                // `window_state_from_window` records `maximised:
+                // false`. The 500 ms debounce flushes that to
+                // `window.json` long before the unlock restores the
+                // real state, and the next launch comes back windowed.
+                if !window_is_minimized(window) {
+                    let state = window_state_from_window(window);
+                    *pending.lock() = Some(PendingWindowSave {
+                        state,
+                        set_at: Instant::now(),
+                    });
+                }
                 // Force a re-render so the entity tree picks up the
                 // new viewport bounds (otherwise the terminal panes
                 // keep their pre-transition layout until something
@@ -8435,6 +8447,23 @@ fn fmt_bytes(bytes: u64) -> String {
         format!("{:.0} KB", b / KB)
     } else {
         format!("{bytes} B")
+    }
+}
+
+/// True while the window is minimized. Only Windows is known to
+/// minimize the window behind the user's back (session switch /
+/// lock), and it is the only platform with a cheap query for it, so
+/// every other target keeps the pre-#279 behaviour of persisting
+/// whatever the bounds observer reports.
+fn window_is_minimized(window: &Window) -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        crate::win32_titlebar::is_minimized(window)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = window;
+        false
     }
 }
 

--- a/src/win32_titlebar.rs
+++ b/src/win32_titlebar.rs
@@ -31,7 +31,7 @@ use windows::Win32::UI::Input::KeyboardAndMouse::ReleaseCapture;
 use windows::Win32::UI::Shell::ShellExecuteW;
 use windows::Win32::UI::HiDpi::GetDpiForWindow;
 use windows::Win32::UI::WindowsAndMessaging::{
-    GetCursorPos, GetWindowPlacement, GetWindowRect, HTCAPTION, IsZoomed, PostMessageW,
+    GetCursorPos, GetWindowPlacement, GetWindowRect, HTCAPTION, IsIconic, IsZoomed, PostMessageW,
     SC_CLOSE, SC_MAXIMIZE, SC_MINIMIZE, SC_RESTORE, SW_SHOWNORMAL, SetWindowPlacement,
     WINDOWPLACEMENT, WM_NCLBUTTONDOWN, WM_SYSCOMMAND,
 };
@@ -180,6 +180,23 @@ unsafe fn reposition_for_restore_under_cursor(hwnd: HWND) {
         };
         let _ = SetWindowPlacement(hwnd, &placement);
     }
+}
+
+/// True while the window is minimized (`SW_SHOWMINIMIZED`).
+///
+/// gpui has no equivalent accessor: a minimized window reports
+/// `WindowBounds::Windowed(<restore bounds>)` and `is_maximized() ==
+/// false`, which is indistinguishable from a user restore-down. The
+/// window-state persister needs the difference — see the caller in
+/// `app.rs` (issue #279).
+///
+/// Returns `false` when the HWND can't be resolved; the caller then
+/// behaves exactly as it did before this guard existed.
+pub fn is_minimized(window: &Window) -> bool {
+    let Some(hwnd) = hwnd(window) else {
+        return false;
+    };
+    unsafe { IsIconic(hwnd).as_bool() }
 }
 
 /// Toggle maximize ↔ restore via `WM_SYSCOMMAND`. `IsZoomed` is the

--- a/src/win32_titlebar.rs
+++ b/src/win32_titlebar.rs
@@ -199,6 +199,48 @@ pub fn is_minimized(window: &Window) -> bool {
     unsafe { IsIconic(hwnd).as_bool() }
 }
 
+/// Work area (`MONITORINFO.rcWork`) of the monitor the window sits
+/// on, as `(left, top, right, bottom)`.
+///
+/// The bounds observer keeps the previous tick's value to tell a
+/// display reconfiguration — monitors dropping away on a session
+/// lock — apart from a user restore-down; both arrive as the same
+/// "no longer maximized" gpui event (issue #279).
+///
+/// `None` when the HWND or the monitor info can't be read; the caller
+/// treats that as "no information" and never acts on it.
+pub fn work_area(window: &Window) -> Option<(i32, i32, i32, i32)> {
+    let hwnd = hwnd(window)?;
+    unsafe {
+        let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        let mut mi = MONITORINFO {
+            cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+            ..Default::default()
+        };
+        if !GetMonitorInfoW(monitor, &mut mi).as_bool() {
+            return None;
+        }
+        let w = mi.rcWork;
+        Some((w.left, w.top, w.right, w.bottom))
+    }
+}
+
+/// Post `SC_MAXIMIZE`. Used to put the window back after Windows
+/// un-maximized it behind the user's back — see the caller in
+/// `app.rs`. Posts rather than sends for the same re-entrancy reason
+/// as [`start_drag`].
+pub fn maximize(window: &Window) {
+    let Some(hwnd) = hwnd(window) else { return };
+    unsafe {
+        let _ = PostMessageW(
+            Some(hwnd),
+            WM_SYSCOMMAND,
+            WPARAM(SC_MAXIMIZE as usize),
+            LPARAM(0),
+        );
+    }
+}
+
 /// Toggle maximize ↔ restore via `WM_SYSCOMMAND`. `IsZoomed` is the
 /// canonical "is this window maximized?" check; we post
 /// `SC_RESTORE` when it is and `SC_MAXIMIZE` otherwise. Posts so


### PR DESCRIPTION
## Problem

Issue #279: after locking and unlocking the PC, CodeScope is no longer maximized.

The `window-diag.log` from the reporter's installed build shows **two** distinct paths, and they need different fixes.

### 1. The lock minimizes the window

```
12:04:31 bounds=Windowed((1038,1678,1536,857)) is_maximized=false showCmd=2 hwnd_rect=(-32000,-32000,…)
12:04:34 bounds=Maximized((1038,1678,1536,857)) is_maximized=true  showCmd=3
```

`showCmd=2` / `hwnd_rect` at -32000 is a minimized window. gpui reports it as plain `WindowBounds::Windowed(<restore bounds>)` with `is_maximized() == false`, so `window_state_from_window` records `maximised: false` and the 500 ms debounce writes it to `window.json`. The *window* recovers on unlock — the saved state does not, so the next launch comes back windowed. One such stretch in the log lasted 25 minutes.

### 2. The lock drops the monitors, and Windows un-maximizes the window

```
17:32:26 Maximized rcWork=(-841,1440,4279,2880)   ← two monitors
17:43:47 Windowed  rcWork=(0,0,3440,1392)         ← lock, one monitor
18:25:52 maximize_clicked_pre                     ← user maximizes it by hand
```

This is the one the user actually sees: the window stays restored after the monitors come back — once for 42 minutes, once overnight — because nothing puts it back. Not minimized, genuinely restore-down, so an `IsIconic` guard does not see it.

## Fix

- **Path 1** — skip persisting window state while `IsIconic`. gpui has no `is_minimized`, so the check goes through the existing `win32_titlebar` bridge next to the `IsZoomed` already there.
- **Path 2** — the bounds observer keeps the previous tick's placement (maximized / minimized / monitor work area). On maximized → restored **with a changed work area**, it posts `SC_MAXIMIZE` and skips the save. From gpui the reconfiguration and a user restore-down are the same event; the work area is the discriminator, since it moves on the same tick as the reconfiguration and stays put for a user gesture.

Non-Windows targets report no work area, so path 2 can never fire there, and path 1 falls through to the previous behaviour.

## Verification

**A/B on a dev build** (`CODESCOPE_DEV=1`), same `ShowWindow` calls against `main` and this branch:

| step | `main` | this branch |
|---|---|---|
| maximize | `maximised: true` | `maximised: true` |
| minimize | **`false`** | `true` |
| restore | — | `true` |
| genuine restore-down | — | `false` (still persisted) |
| maximize again | — | `true` |

End-to-end on this branch: maximize → minimize → quit while minimized → relaunch comes back **maximized** (`IsZoomed=True`).

Path 2 is covered by 5 unit tests on the pure `unmaximized_by_display_change`, using the two work areas from the log above as fixtures: the lock case fires; a user restore-down on the same desktop does not; a minimize does not; a display change while already windowed does not; a missing work area on either side does not.

- `cargo test --workspace` — green (141 / 495 / 53 / 1 doctest); the bin went 136 → 141.
- `cargo clippy --workspace --all-targets` — warning counts unchanged.
- `rustfmt --check src/app.rs` reports 89 diffs both with and without this change — no new deviations (the tree carries a known rustfmt version skew).

A live lock/unlock still wants a human: whether a given lock takes path 1 or path 2 depends on whether the monitors actually power down.

Fixes #279