### PR TITLE
fix(window): re-maximize when a lock un-minimizes us flat

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -108,26 +108,6 @@ struct WindowPlacement {
     work_area: Option<(i32, i32, i32, i32)>,
 }
 
-/// True when the window went from maximized to a plain restored size
-/// *because the desktop was reconfigured under it*, not because the
-/// user asked for it.
-///
-/// Locking the PC drops the external monitors, and Windows
-/// un-maximizes the window while re-enumerating them. From gpui that
-/// is indistinguishable from a user restore-down — both arrive as
-/// `WindowBounds::Windowed` with `is_maximized() == false`. The
-/// monitor work area is the discriminator: it changes on the same
-/// tick as the reconfiguration and stays put for a user gesture.
-///
-/// Two rows from the reporter's `window-diag.log` (issue #279):
-///
-/// ```text
-/// 17:32:26 Maximized rcWork=(-841,1440,4279,2880)  ← two monitors
-/// 17:43:47 Windowed  rcWork=(0,0,3440,1392)        ← lock, one monitor
-/// ```
-///
-/// The window stayed restored after the monitors came back, until the
-/// user maximized it by hand 42 minutes later.
 /// True when the window came out of minimized at a plain restored
 /// size even though it was maximized when it went in.
 ///
@@ -161,6 +141,29 @@ fn unminimized_without_maximize(
     prev.minimized && !now.minimized && !now.maximized && maximized_before_minimize
 }
 
+/// True when the window went from maximized to a plain restored size
+/// *because the desktop was reconfigured under it*, not because the
+/// user asked for it.
+///
+/// Locking the PC drops the external monitors, and Windows
+/// un-maximizes the window while re-enumerating them. From gpui that
+/// is indistinguishable from a user restore-down — both arrive as
+/// `WindowBounds::Windowed` with `is_maximized() == false`. The
+/// monitor work area is the discriminator: it changes on the same
+/// tick as the reconfiguration and stays put for a user gesture.
+///
+/// Two rows from the reporter's `window-diag.log` (issue #279):
+///
+/// ```text
+/// 17:32:26 Maximized rcWork=(-841,1440,4279,2880)  ← two monitors
+/// 17:43:47 Windowed  rcWork=(0,0,3440,1392)        ← lock, one monitor
+/// ```
+///
+/// The window stayed restored after the monitors came back, until the
+/// user maximized it by hand 42 minutes later.
+///
+/// Sibling case: [`unminimized_without_maximize`], when the window
+/// was already minimized as the monitors went away.
 fn unmaximized_by_display_change(prev: &WindowPlacement, now: &WindowPlacement) -> bool {
     prev.maximized
         && !now.maximized

--- a/src/app.rs
+++ b/src/app.rs
@@ -128,6 +128,39 @@ struct WindowPlacement {
 ///
 /// The window stayed restored after the monitors came back, until the
 /// user maximized it by hand 42 minutes later.
+/// True when the window came out of minimized at a plain restored
+/// size even though it was maximized when it went in.
+///
+/// Windows never does this on its own: `SC_RESTORE` on a window that
+/// was minimized from maximized brings it back **maximized**
+/// (measured — `showCmd` 2 → 3), and there is no user gesture that
+/// un-minimizes to a normal size. The one thing that does it is
+/// gpui's `WM_DISPLAYCHANGE` handler
+/// (`platform/windows/events.rs`), which reacts to our monitor
+/// disappearing by calling `ShowWindow(SW_SHOWNORMAL)` to
+/// de-minimize — and `SW_SHOWNORMAL` throws the restore-to-maximized
+/// state away where `SW_RESTORE` would have honoured it.
+///
+/// That is what a session lock looks like when the screens power
+/// down while the window is minimized (issue #279):
+///
+/// ```text
+/// 13:07:37 showCmd=3  ← maximized
+/// 13:09:30 showCmd=2  ← lock, minimized
+/// 17:20:47 showCmd=1  ← unlock, restored *flat*
+/// ```
+///
+/// `WINDOWPLACEMENT.flags` is no help in telling this apart:
+/// `WPF_RESTORETOMAXIMIZED` was set on every single tick of that
+/// window's life, including plain restore-downs.
+fn unminimized_without_maximize(
+    prev: &WindowPlacement,
+    now: &WindowPlacement,
+    maximized_before_minimize: bool,
+) -> bool {
+    prev.minimized && !now.minimized && !now.maximized && maximized_before_minimize
+}
+
 fn unmaximized_by_display_change(prev: &WindowPlacement, now: &WindowPlacement) -> bool {
     prev.maximized
         && !now.maximized
@@ -782,6 +815,10 @@ pub struct AppShell {
     /// Placement seen on the previous bounds-observer tick. Feeds
     /// [`unmaximized_by_display_change`]; `None` until the first tick.
     last_window_placement: Option<WindowPlacement>,
+    /// Whether the window was maximized when it was last minimized.
+    /// Feeds [`unminimized_without_maximize`]; cleared once the
+    /// window is out of minimized again so it can't go stale.
+    maximized_before_minimize: bool,
     /// Window-coordinate bounds of the bell button as recorded by the
     /// `canvas` overlay child during the most recent layout pass.
     /// Used by `render_notifications_popover` to position the popover
@@ -1212,8 +1249,8 @@ impl AppShell {
             move |this, window, cx| {
                 append_window_diag(&diag_paths, "bounds_changed", window);
 
-                // Two ways a session lock takes the window out of
-                // maximized behind the user's back (issue #279), both
+                // Three ways a session lock takes the window out of
+                // maximized behind the user's back (issue #279), all
                 // of which gpui reports as a plain
                 // `Windowed(<restore bounds>)` with
                 // `is_maximized() == false`:
@@ -1224,23 +1261,33 @@ impl AppShell {
                 //    500 ms debounce flushed it to `window.json` —
                 //    so the *next launch* is windowed.
                 // 2. The monitors drop away and Windows un-maximizes
-                //    the window while re-enumerating them. This one
-                //    the user sees immediately: the window stays
-                //    restored after the unlock.
+                //    the window while re-enumerating them.
+                // 3. The window was minimized when the monitors
+                //    dropped, and it comes back at a plain restored
+                //    size instead of maximized.
                 //
-                // Skip the save in both cases, and undo the second.
+                // Skip the save in all three, and undo 2 and 3.
                 let placement = WindowPlacement {
                     maximized: window.is_maximized(),
                     minimized: window_is_minimized(window),
                     work_area: window_work_area(window),
                 };
-                let display_change = this
-                    .last_window_placement
+                let prev = this.last_window_placement;
+                if placement.minimized && !prev.is_some_and(|p| p.minimized) {
+                    this.maximized_before_minimize = prev.is_some_and(|p| p.maximized);
+                }
+                let display_change = prev
                     .as_ref()
                     .is_some_and(|prev| unmaximized_by_display_change(prev, &placement));
+                let flat_unminimize = prev.as_ref().is_some_and(|prev| {
+                    unminimized_without_maximize(prev, &placement, this.maximized_before_minimize)
+                });
+                if !placement.minimized {
+                    this.maximized_before_minimize = false;
+                }
                 this.last_window_placement = Some(placement);
 
-                if display_change {
+                if display_change || flat_unminimize {
                     append_window_diag(&diag_paths, "remaximize_after_display_change", window);
                     request_maximize(window);
                 } else if !placement.minimized {
@@ -1501,6 +1548,7 @@ impl AppShell {
             window_active_cached: true,
             telemetry_tails: HashMap::new(),
             last_window_placement: None,
+            maximized_before_minimize: false,
             bell_bounds: None,
             projects: projects_for_sessions,
             agent_registry,
@@ -8792,6 +8840,50 @@ mod tests {
         assert!(!unmaximized_by_display_change(
             &placement(true, false, TWO_MONITORS),
             &placement(false, false, None),
+        ));
+    }
+
+    // ─── unminimized_without_maximize (issue #279) ─────────────────
+
+    #[test]
+    fn lock_returning_a_maximized_window_flat_is_corrected() {
+        // The 13:07 maximized → 13:09 minimized → 17:20 restored-flat
+        // cycle from the reporter's log.
+        assert!(unminimized_without_maximize(
+            &placement(false, true, ONE_MONITOR),
+            &placement(false, false, ONE_MONITOR),
+            true,
+        ));
+    }
+
+    #[test]
+    fn unminimizing_a_windowed_window_is_left_alone() {
+        // Minimized from a normal size — it must come back normal.
+        assert!(!unminimized_without_maximize(
+            &placement(false, true, ONE_MONITOR),
+            &placement(false, false, ONE_MONITOR),
+            false,
+        ));
+    }
+
+    #[test]
+    fn unminimizing_straight_back_to_maximized_needs_no_help() {
+        assert!(!unminimized_without_maximize(
+            &placement(false, true, ONE_MONITOR),
+            &placement(true, false, ONE_MONITOR),
+            true,
+        ));
+    }
+
+    #[test]
+    fn restore_down_without_a_minimize_is_left_alone() {
+        // No minimize on the previous tick — this is the user
+        // un-maximizing, and the flag is stale-proofed by clearing it
+        // whenever the window is not minimized.
+        assert!(!unminimized_without_maximize(
+            &placement(true, false, ONE_MONITOR),
+            &placement(false, false, ONE_MONITOR),
+            true,
         ));
     }
 


### PR DESCRIPTION
Follow-up to #288 (issue #279). The reporter locked the PC right after that merge and hit a **third** shape of the same bug — the one that had been eluding us all along, because it needs the window to be minimized *and* the monitors to drop.

## What happened

```
13:07:37 showCmd=3   maximized
13:09:30 showCmd=2   lock, minimized
17:20:47 showCmd=1   unlock, restored *flat*
```

Neither guard from #288 catches it: the window is not minimized any more when it comes back, and `rcWork` is unchanged (the monitor came back identical), so the display-change rule stays quiet.

## Root cause

Windows does not do this on its own. Measured on a live window:

```
SC_MINIMIZE -> showCmd=2
SC_RESTORE  -> showCmd=3     ← comes back maximized, unprompted
```

and there is no user gesture that un-minimizes to a normal size. The one thing that produces `2 → 1` is gpui's `WM_DISPLAYCHANGE` handler, `platform/windows/events.rs`:

```rust
// display disconnected
// in this case, the OS will move our window to another monitor, and minimize it.
// we deminimize the window and query the monitor after moving
unsafe { let _ = ShowWindow(handle, SW_SHOWNORMAL); };
```

`SW_SHOWNORMAL` throws away the restore-to-maximized state; `SW_RESTORE` would have honoured it.

## Fix

Remember whether the window was maximized when it went into minimize, and post `SC_MAXIMIZE` if it comes back out without it. The flag is cleared as soon as the window is not minimized, so it cannot go stale into a later restore-down.

`WINDOWPLACEMENT.flags` looked like the obvious discriminator and is not: `WPF_RESTORETOMAXIMIZED` (`0x2`) was set on **every** tick of the reporter's window, including plain restore-downs and while maximized. Measured across a full maximize / restore-down / minimize / restore cycle before ruling it out.

## Verification

Live A/B on a dev build, driving `SW_SHOWNORMAL` at a minimized-from-maximized window — the exact call gpui makes:

| step | merged `main` | this branch |
|---|---|---|
| maximize | `showCmd=3` | `showCmd=3` |
| minimize | `showCmd=2` | `showCmd=2` |
| `SW_SHOWNORMAL` | **`showCmd=1`** | **`showCmd=3`** |

Tape from the fixed run, all inside one second:

```
17:28:53 showCmd=2
17:28:54 showCmd=1
17:28:54 remaximize_after_display_change
17:28:54 showCmd=3
```

`window.json` stayed on `maximised: true` throughout.

4 new unit tests on the pure `unminimized_without_maximize`: the lock cycle fires; a window minimized from a normal size does not; an un-minimize that already lands maximized does not; a restore-down with no minimize on the previous tick does not.

- `cargo test --workspace` — green (145 / 495 / 53 / 1 doctest).
- `cargo clippy --workspace --all-targets` — warning counts unchanged.
- `rustfmt --check src/app.rs` — 89 diffs with and without this change (existing version skew), no new deviations.