### PR TITLE
fix(window): key the display-change guard on HMONITOR, not rcWork

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -102,10 +102,10 @@ struct PendingWindowSave {
 struct WindowPlacement {
     maximized: bool,
     minimized: bool,
-    /// Work area of the monitor the window is on, or `None` where the
-    /// platform can't tell us (everything except Windows, plus the
-    /// rare Win32 failure).
-    work_area: Option<(i32, i32, i32, i32)>,
+    /// `HMONITOR` the window is on, or `None` where the platform
+    /// can't tell us (everything except Windows, plus the rare Win32
+    /// failure).
+    monitor: Option<isize>,
 }
 
 /// True when the window came out of minimized at a plain restored
@@ -145,22 +145,36 @@ fn unminimized_without_maximize(
 /// *because the desktop was reconfigured under it*, not because the
 /// user asked for it.
 ///
-/// Locking the PC drops the external monitors, and Windows
-/// un-maximizes the window while re-enumerating them. From gpui that
-/// is indistinguishable from a user restore-down — both arrive as
-/// `WindowBounds::Windowed` with `is_maximized() == false`. The
-/// monitor work area is the discriminator: it changes on the same
-/// tick as the reconfiguration and stays put for a user gesture.
+/// Locking the PC drops the monitors, and gpui's `WM_DISPLAYCHANGE`
+/// handler answers that by calling `ShowWindow(SW_SHOWNORMAL)` —
+/// which takes the window out of maximized. From the bounds observer
+/// that is indistinguishable from a user restore-down: both arrive as
+/// `WindowBounds::Windowed` with `is_maximized() == false`.
 ///
-/// Two rows from the reporter's `window-diag.log` (issue #279):
+/// The `HMONITOR` is the discriminator, because it is the same test
+/// gpui makes — it only fires that `ShowWindow` when the window's
+/// previous handle is no longer connected. A user gesture never
+/// changes the handle.
+///
+/// The first cut of this compared `MONITORINFO.rcWork` instead, which
+/// held for the case that motivated it:
 ///
 /// ```text
 /// 17:32:26 Maximized rcWork=(-841,1440,4279,2880)  ← two monitors
 /// 17:43:47 Windowed  rcWork=(0,0,3440,1392)        ← lock, one monitor
 /// ```
 ///
-/// The window stayed restored after the monitors came back, until the
-/// user maximized it by hand 42 minutes later.
+/// and then missed the very next one, where the monitors came back at
+/// an identical resolution and position so the rectangle never moved:
+///
+/// ```text
+/// 17:50:11 Maximized rcWork=(0,0,3440,1392)
+/// 18:01:32 Windowed  rcWork=(0,0,3440,1392)  ← same rect, new handle
+/// ```
+///
+/// Geometry describes the desktop; the handle describes the device.
+/// Only the second one answers "is this still the monitor gpui was
+/// holding on to".
 ///
 /// Sibling case: [`unminimized_without_maximize`], when the window
 /// was already minimized as the monitors went away.
@@ -168,9 +182,9 @@ fn unmaximized_by_display_change(prev: &WindowPlacement, now: &WindowPlacement) 
     prev.maximized
         && !now.maximized
         && !now.minimized
-        && prev.work_area.is_some()
-        && now.work_area.is_some()
-        && prev.work_area != now.work_area
+        && prev.monitor.is_some()
+        && now.monitor.is_some()
+        && prev.monitor != now.monitor
 }
 
 /// One tab = one terminal session.
@@ -1273,7 +1287,7 @@ impl AppShell {
                 let placement = WindowPlacement {
                     maximized: window.is_maximized(),
                     minimized: window_is_minimized(window),
-                    work_area: window_work_area(window),
+                    monitor: window_monitor(window),
                 };
                 let prev = this.last_window_placement;
                 if placement.minimized && !prev.is_some_and(|p| p.minimized) {
@@ -8524,8 +8538,8 @@ fn append_window_diag(paths: &AppPaths, event: &str, window: &Window) {
     // success path. The earlier `win32=unavailable` / `win32=n/a`
     // placeholders had asymmetric keys and broke field-level greps
     // — Copilot review on PR #222.
-    const WIN32_MISSING: &str =
-        "hwnd_rect=? zoomed=? showCmd=? rcNormal=? ptMaxPos=? flags=? rcMonitor=? rcWork=? dpi=?";
+    const WIN32_MISSING: &str = "hwnd_rect=? zoomed=? showCmd=? rcNormal=? ptMaxPos=? flags=? \
+         hmon=? rcMonitor=? rcWork=? dpi=?";
     #[cfg(target_os = "windows")]
     let win32 = crate::win32_titlebar::diag_snapshot(window)
         .unwrap_or_else(|| WIN32_MISSING.to_string());
@@ -8586,14 +8600,14 @@ fn window_is_minimized(window: &Window) -> bool {
     }
 }
 
-/// Work area of the monitor the window is on. `None` off Windows —
-/// no other platform is known to un-maximize the window behind the
-/// user's back, and [`unmaximized_by_display_change`] never fires
-/// without a value on both sides.
-fn window_work_area(window: &Window) -> Option<(i32, i32, i32, i32)> {
+/// `HMONITOR` the window is on. `None` off Windows — no other
+/// platform is known to un-maximize the window behind the user's
+/// back, and [`unmaximized_by_display_change`] never fires without a
+/// value on both sides.
+fn window_monitor(window: &Window) -> Option<isize> {
     #[cfg(target_os = "windows")]
     {
-        crate::win32_titlebar::work_area(window)
+        crate::win32_titlebar::monitor_handle(window)
     }
     #[cfg(not(target_os = "windows"))]
     {
@@ -8603,7 +8617,7 @@ fn window_work_area(window: &Window) -> Option<(i32, i32, i32, i32)> {
 }
 
 /// Ask the platform to maximize the window again. No-op off Windows,
-/// which is the only caller path — see [`window_work_area`].
+/// which is the only caller path — see [`window_monitor`].
 fn request_maximize(window: &Window) {
     #[cfg(target_os = "windows")]
     {
@@ -8777,38 +8791,47 @@ mod tests {
 
     // ─── unmaximized_by_display_change (issue #279) ────────────────
 
-    /// The two work areas from the reporter's `window-diag.log`:
-    /// both monitors, then the single one a session lock leaves.
-    const TWO_MONITORS: Option<(i32, i32, i32, i32)> = Some((-841, 1440, 4279, 2880));
-    const ONE_MONITOR: Option<(i32, i32, i32, i32)> = Some((0, 0, 3440, 1392));
+    /// Two distinct `HMONITOR`s. The values are arbitrary — all that
+    /// matters is that the handle before the lock differs from the
+    /// one after it.
+    const MON_A: Option<isize> = Some(0x0001_0007);
+    const MON_B: Option<isize> = Some(0x0002_0009);
 
-    fn placement(
-        maximized: bool,
-        minimized: bool,
-        work_area: Option<(i32, i32, i32, i32)>,
-    ) -> WindowPlacement {
+    fn placement(maximized: bool, minimized: bool, monitor: Option<isize>) -> WindowPlacement {
         WindowPlacement {
             maximized,
             minimized,
-            work_area,
+            monitor,
         }
     }
 
     #[test]
-    fn lock_dropping_a_monitor_counts_as_a_display_change() {
+    fn lock_cycling_the_monitor_counts_as_a_display_change() {
         assert!(unmaximized_by_display_change(
-            &placement(true, false, TWO_MONITORS),
-            &placement(false, false, ONE_MONITOR),
+            &placement(true, false, MON_A),
+            &placement(false, false, MON_B),
         ));
     }
 
     #[test]
     fn user_restore_down_is_left_alone() {
-        // Same desktop on both ticks — the user clicked restore, and
-        // re-maximizing here would fight them.
+        // Same monitor on both ticks — the user restored the window,
+        // and re-maximizing here would fight them.
         assert!(!unmaximized_by_display_change(
-            &placement(true, false, TWO_MONITORS),
-            &placement(false, false, TWO_MONITORS),
+            &placement(true, false, MON_A),
+            &placement(false, false, MON_A),
+        ));
+    }
+
+    #[test]
+    fn same_geometry_on_a_new_handle_still_counts() {
+        // The case that broke the first cut of this rule: the monitor
+        // came back at an identical resolution and position, so
+        // `rcWork` never moved — but the handle is new, which is what
+        // gpui keys on.
+        assert!(unmaximized_by_display_change(
+            &placement(true, false, MON_A),
+            &placement(false, false, MON_B),
         ));
     }
 
@@ -8817,8 +8840,8 @@ mod tests {
         // A lock that minimizes instead is handled by skipping the
         // save, not by re-maximizing a window the user can't see.
         assert!(!unmaximized_by_display_change(
-            &placement(true, false, TWO_MONITORS),
-            &placement(false, true, ONE_MONITOR),
+            &placement(true, false, MON_A),
+            &placement(false, true, MON_B),
         ));
     }
 
@@ -8827,21 +8850,21 @@ mod tests {
         // Plugging a monitor into a deliberately windowed app must
         // not maximize it.
         assert!(!unmaximized_by_display_change(
-            &placement(false, false, TWO_MONITORS),
-            &placement(false, false, ONE_MONITOR),
+            &placement(false, false, MON_A),
+            &placement(false, false, MON_B),
         ));
     }
 
     #[test]
-    fn missing_work_area_never_triggers() {
+    fn missing_monitor_never_triggers() {
         // Non-Windows, or a Win32 read that failed: no information is
         // not evidence of a reconfiguration.
         assert!(!unmaximized_by_display_change(
             &placement(true, false, None),
-            &placement(false, false, ONE_MONITOR),
+            &placement(false, false, MON_B),
         ));
         assert!(!unmaximized_by_display_change(
-            &placement(true, false, TWO_MONITORS),
+            &placement(true, false, MON_A),
             &placement(false, false, None),
         ));
     }
@@ -8853,8 +8876,8 @@ mod tests {
         // The 13:07 maximized → 13:09 minimized → 17:20 restored-flat
         // cycle from the reporter's log.
         assert!(unminimized_without_maximize(
-            &placement(false, true, ONE_MONITOR),
-            &placement(false, false, ONE_MONITOR),
+            &placement(false, true, MON_A),
+            &placement(false, false, MON_A),
             true,
         ));
     }
@@ -8863,8 +8886,8 @@ mod tests {
     fn unminimizing_a_windowed_window_is_left_alone() {
         // Minimized from a normal size — it must come back normal.
         assert!(!unminimized_without_maximize(
-            &placement(false, true, ONE_MONITOR),
-            &placement(false, false, ONE_MONITOR),
+            &placement(false, true, MON_A),
+            &placement(false, false, MON_A),
             false,
         ));
     }
@@ -8872,8 +8895,8 @@ mod tests {
     #[test]
     fn unminimizing_straight_back_to_maximized_needs_no_help() {
         assert!(!unminimized_without_maximize(
-            &placement(false, true, ONE_MONITOR),
-            &placement(true, false, ONE_MONITOR),
+            &placement(false, true, MON_A),
+            &placement(true, false, MON_A),
             true,
         ));
     }
@@ -8884,8 +8907,8 @@ mod tests {
         // un-maximizing, and the flag is stale-proofed by clearing it
         // whenever the window is not minimized.
         assert!(!unminimized_without_maximize(
-            &placement(true, false, ONE_MONITOR),
-            &placement(false, false, ONE_MONITOR),
+            &placement(true, false, MON_A),
+            &placement(false, false, MON_A),
             true,
         ));
     }

--- a/src/win32_titlebar.rs
+++ b/src/win32_titlebar.rs
@@ -199,30 +199,28 @@ pub fn is_minimized(window: &Window) -> bool {
     unsafe { IsIconic(hwnd).as_bool() }
 }
 
-/// Work area (`MONITORINFO.rcWork`) of the monitor the window sits
-/// on, as `(left, top, right, bottom)`.
+/// `HMONITOR` of the monitor the window sits on, as a plain integer
+/// so callers can compare it across ticks without carrying a Win32
+/// type around.
 ///
-/// The bounds observer keeps the previous tick's value to tell a
-/// display reconfiguration — monitors dropping away on a session
-/// lock — apart from a user restore-down; both arrive as the same
-/// "no longer maximized" gpui event (issue #279).
+/// This is the handle gpui itself keys on: its `WM_DISPLAYCHANGE`
+/// handler calls `ShowWindow(SW_SHOWNORMAL)` — which drops the
+/// maximized state — exactly when the window's previous `HMONITOR`
+/// is no longer connected. Comparing handles is therefore the same
+/// test gpui makes, and it catches monitors that come back at an
+/// identical resolution and position (where `rcWork` is unchanged
+/// but the handle is new).
 ///
-/// `None` when the HWND or the monitor info can't be read; the caller
-/// treats that as "no information" and never acts on it.
-pub fn work_area(window: &Window) -> Option<(i32, i32, i32, i32)> {
+/// `None` when the HWND can't be resolved or Windows reports no
+/// monitor; the caller treats that as "no information" and never
+/// acts on it.
+pub fn monitor_handle(window: &Window) -> Option<isize> {
     let hwnd = hwnd(window)?;
-    unsafe {
-        let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-        let mut mi = MONITORINFO {
-            cbSize: std::mem::size_of::<MONITORINFO>() as u32,
-            ..Default::default()
-        };
-        if !GetMonitorInfoW(monitor, &mut mi).as_bool() {
-            return None;
-        }
-        let w = mi.rcWork;
-        Some((w.left, w.top, w.right, w.bottom))
+    let monitor = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
+    if monitor.is_invalid() {
+        return None;
     }
+    Some(monitor.0 as isize)
 }
 
 /// Post `SC_MAXIMIZE`. Used to put the window back after Windows
@@ -327,12 +325,13 @@ pub fn diag_snapshot(window: &Window) -> Option<String> {
             let m = mi.rcMonitor;
             let w = mi.rcWork;
             format!(
-                "rcMonitor=({},{},{},{}) rcWork=({},{},{},{})",
+                "hmon={:#x} rcMonitor=({},{},{},{}) rcWork=({},{},{},{})",
+                monitor.0 as isize,
                 m.left, m.top, m.right, m.bottom,
                 w.left, w.top, w.right, w.bottom,
             )
         } else {
-            "rcMonitor=? rcWork=?".to_string()
+            "hmon=? rcMonitor=? rcWork=?".to_string()
         };
 
         let dpi = GetDpiForWindow(hwnd);


### PR DESCRIPTION
Follow-up to #288 / #290 (issue #279). The reporter locked again and the window came back small **again** — through a fourth shape that both merged guards miss.

## What the tape shows

```
17:50:11 Maximized rcWork=(0,0,3440,1392)
18:01:32 Windowed  rcWork=(0,0,3440,1392)   ← spontaneous, identical rect
18:45:04 maximize_clicked_pre               ← user maximizes it by hand
```

Three rows, all the same geometry — a snap, not a drag (a drag writes dozens of 1 px rows). No minimize, so #290's rule stays quiet. And `rcWork` never moved, so #288's rule stays quiet too: the monitors came back at the same resolution in the same position.

## Why rcWork was the wrong key

Geometry describes the desktop. gpui's condition is about the *device*:

```rust
let previous_monitor = self.state.borrow().display;
if WindowsDisplay::is_connected(previous_monitor.handle) {
    return None;          // we are fine, other display changed
}
// display disconnected
unsafe { let _ = ShowWindow(handle, SW_SHOWNORMAL); };
```

It fires that `ShowWindow` — the call that drops our maximized state — exactly when the window's previous `HMONITOR` is no longer connected. A monitor that power-cycles comes back as a new handle even when it reports the same rectangle. So the handle is the discriminator, and comparing it is the same test gpui makes. A user gesture never changes it.

## Changes

- `win32_titlebar::work_area` → `monitor_handle`, returning the `HMONITOR` as an `isize` so the observer can compare it across ticks.
- `WindowPlacement.work_area` → `monitor`; `unmaximized_by_display_change` compares handles.
- `diag_snapshot` logs `hmon=` next to `rcMonitor` / `rcWork`, so the next occurrence records the handle change rather than leaving it inferred. The `WIN32_MISSING` placeholder gains the same key, keeping field-level greps symmetric.

`unminimized_without_maximize` (#290) is untouched — it never looked at the display.

## Verification

Live on a dev build:

| case | expected | result |
|---|---|---|
| maximize → `SW_SHOWNORMAL`, same monitor | left alone | `showCmd=1` ✓ |
| maximize → minimize → `SW_SHOWNORMAL` | corrected | `showCmd=3` ✓ |

The first is the user-restore-down guard: with an unchanged handle we must not fight the user, and we don't. The second confirms #290's path still works. `hmon=0x31057` now appears in the tape.

The handle-change branch itself cannot be driven synthetically — it needs a real display event. That it fires on one is an inference from gpui's own condition, which is why `hmon=` is now logged: the reporter's next lock will show the handle before and after.

6 unit tests on the pure predicate, including the case that broke the previous cut (same geometry, new handle) and the user restore-down (same handle) that must stay untouched.

- `cargo test --workspace` — green (146 / 495 / 53 / 1 doctest).
- `cargo clippy --workspace --all-targets` — warning counts unchanged.
- `rustfmt --check` — 89 / 6 diffs with and without this change (existing version skew), no new deviations.