### PR TITLE
fix(git): never take index.lock from the status/diff pollers

### DIFF
--- a/core/src/process.rs
+++ b/core/src/process.rs
@@ -49,8 +49,19 @@ const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 /// Call this for `git`, `gh`, or any other tool we shell out to for
 /// machine-readable output — i.e. anything where the user must never
 /// see a flashing console window.
+///
+/// Also sets `GIT_OPTIONAL_LOCKS=0` (issue #294): our status/diff
+/// pollers run `git status` about once a second across all open
+/// projects, and by default every one of those refreshes the index —
+/// taking `index.lock` — as a side effect. Agents committing in the
+/// same worktree lose that race and their commits fail. The env var
+/// skips only *optional* lock-taking (the opportunistic index
+/// refresh); mandatory locks for real writes (`commit`, `worktree
+/// add`, …) are unaffected. Set here at the shared choke point so
+/// every current and future git spawn inherits it; `gh` ignores it.
 pub fn no_window_command(program: impl AsRef<OsStr>) -> Command {
     let mut cmd = Command::new(program);
+    cmd.env("GIT_OPTIONAL_LOCKS", "0");
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
@@ -72,5 +83,17 @@ mod tests {
     fn returns_command_for_program() {
         let cmd = no_window_command("git");
         assert_eq!(cmd.get_program(), "git");
+    }
+
+    /// Polled `git status` must never take `index.lock` (issue #294)
+    /// — the env var that guarantees it has to be present on every
+    /// spawned command.
+    #[test]
+    fn disables_optional_git_locks() {
+        let cmd = no_window_command("git");
+        assert!(
+            cmd.get_envs()
+                .any(|(k, v)| k == "GIT_OPTIONAL_LOCKS" && v == Some(OsStr::new("0")))
+        );
     }
 }


### PR DESCRIPTION
The reporter's trace in #294 shows the failure: CodeScope's per-project pollers spawn `git status --porcelain` and `git diff --numstat HEAD` roughly once a second in aggregate, and by default every `git status` opportunistically refreshes the index — taking `index.lock` — even though it is a read. An agent committing in the same worktree loses that race and its commit fails.

## Fix

`GIT_OPTIONAL_LOCKS=0` on `no_window_command`, the shared choke point every machine-readable spawn (`git` in `git.rs`, `diff.rs`, `attachments.rs`) already goes through. Per `git(1)` this skips only *optional* sub-operations that need a lock — exactly the `git status` index refresh. Mandatory locks for real writes (`commit`, `worktree add`, checkout) are unaffected, so all existing write paths behave identically. `gh` ignores the variable.

One line at the choke point rather than a `--no-optional-locks` flag on each call site, so future git spawns inherit the guarantee. A unit test asserts the env var is present on every spawned command.

The polling cadence itself is unchanged — with optional locks off, a once-a-second read-only poll holds no locks and blocks nobody. If the process-spawn overhead itself ever becomes a complaint, batching/cadence is a separate follow-up.

Fixes #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)