### PR TITLE
fix(sidebar): backslash the path handed to explorer.exe

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -5108,8 +5108,14 @@ async fn commit_worktree_removal(
 /// status since the user sees the result on their desktop. Also called
 /// from the tab right-click menu in `app.rs`.
 pub(crate) fn reveal_path_in_file_browser(path: &str) {
+    // explorer.exe silently opens the Documents folder when handed a
+    // path with forward slashes — which is exactly what `git worktree
+    // list --porcelain` emits on Windows, and what
+    // `adopt_existing_worktrees` stores verbatim (issue #292).
     #[cfg(target_os = "windows")]
-    let result = Command::new("explorer.exe").arg(path).spawn();
+    let result = Command::new("explorer.exe")
+        .arg(path.replace('/', "\\"))
+        .spawn();
     #[cfg(target_os = "macos")]
     let result = Command::new("open").arg(path).spawn();
     #[cfg(all(unix, not(target_os = "macos")))]


### PR DESCRIPTION
"Reveal in File Explorer" on a worktree opened the Documents folder instead (#292).

## Cause

`explorer.exe` silently falls back to Documents when the argument path contains forward slashes. Worktrees created *outside* CodeScope (agents running `git worktree add`) are discovered through `git worktree list --porcelain`, which emits `C:/dev/...`-style paths on Windows, and `adopt_existing_worktrees` stores them verbatim. Worktrees created through CodeScope's own dialog get backslashed paths — which is why the project row and dialog-created worktrees never showed the bug.

## Fix

Replace `/` with `\` at the shared `reveal_path_in_file_browser` helper, so every caller (project row, worktree row, tab context menu) and every path already sitting in existing `projects.json` stores is covered. Non-Windows paths are untouched — the replace only runs in the `target_os = "windows"` arm.

`Open in Windows Terminal` and `Copy path` are unaffected: `wt -d` and the clipboard both handle forward slashes fine.

Fixes #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)