### PR TITLE
fix(telemetry): a question to the user is idle, not busy

### DIFF
--- a/core/src/agents/claude/telemetry.rs
+++ b/core/src/agents/claude/telemetry.rs
@@ -80,6 +80,13 @@ struct Entry {
     /// least one `{"type":"tool_result",...}` item — i.e. a tool-call
     /// answer, not a fresh user prompt.
     user_carries_tool_result: bool,
+    /// True when this is an assistant `stop_reason == "tool_use"`
+    /// entry whose tool calls are *all* user-interaction prompts
+    /// (`AskUserQuestion` / `ExitPlanMode`). The agent is blocked on
+    /// the human, not working — the busy dot must not show red
+    /// (issue #293). A mixed batch (a real tool racing a question)
+    /// still counts as working.
+    awaiting_user_input: bool,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -124,6 +131,7 @@ fn parse_line(line: &str) -> Option<Entry> {
     let mut stop_reason: Option<String> = None;
     let mut model: Option<String> = None;
     let mut user_carries_tool_result = false;
+    let mut awaiting_user_input = false;
 
     if let Some(msg) = obj.get("message").and_then(Value::as_object) {
         if let Some(usage) = msg.get("usage").and_then(Value::as_object) {
@@ -167,6 +175,29 @@ fn parse_line(line: &str) -> Option<Entry> {
                         == Some("tool_result")
                 });
             }
+
+        // Detect assistant entries blocked on the human: every
+        // tool_use block is a user-interaction prompt. See the
+        // field doc on `Entry::awaiting_user_input`.
+        if kind == EntryKind::Assistant
+            && stop_reason.as_deref() == Some("tool_use")
+            && let Some(content) = msg.get("content").and_then(Value::as_array) {
+                let tool_names: Vec<&str> = content
+                    .iter()
+                    .filter_map(|item| {
+                        let o = item.as_object()?;
+                        if o.get("type").and_then(Value::as_str) == Some("tool_use") {
+                            o.get("name").and_then(Value::as_str)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                awaiting_user_input = !tool_names.is_empty()
+                    && tool_names
+                        .iter()
+                        .all(|n| matches!(*n, "AskUserQuestion" | "ExitPlanMode"));
+            }
     }
 
     Some(Entry {
@@ -179,6 +210,7 @@ fn parse_line(line: &str) -> Option<Entry> {
         model,
         timestamp_secs,
         user_carries_tool_result,
+        awaiting_user_input,
     })
 }
 
@@ -364,6 +396,13 @@ pub fn process_new_lines(
             }
             EntryKind::Assistant => {
                 state = match entry.stop_reason.as_deref() {
+                    // A "tool call" that is really a question to the
+                    // human (AskUserQuestion / plan approval) blocks
+                    // until they answer — that is idle time, not work
+                    // (issue #293). The answer arrives as a
+                    // tool-result user entry, which flips the state
+                    // back to `Busy` on its own.
+                    Some("tool_use") if entry.awaiting_user_input => SessionState::Idle,
                     Some("tool_use") => SessionState::PendingToolUse,
                     Some("end_turn") => SessionState::Idle,
                     _ => state,
@@ -762,6 +801,90 @@ mod tests {
         read_lines(&path.to_path_buf(), &mut tail, &mut snap, &mut last_user_ts);
 
         assert_eq!(snap.unwrap().state, SessionState::PendingToolUse);
+    }
+
+    #[test]
+    fn ask_user_question_is_idle_not_busy() {
+        // Issue #293: the agent asking the human a question blocks
+        // until they answer — the red dot lied for the whole wait.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        write_lines(
+            &path,
+            &[
+                r#"{"type":"user","sessionId":"s","timestamp":"2026-04-22T08:00:00Z","message":{"role":"user","content":"do it"}}"#,
+                r#"{"type":"assistant","sessionId":"s","timestamp":"2026-04-22T08:01:00Z","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","id":"t1","name":"AskUserQuestion","input":{}}],"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#,
+            ],
+        );
+
+        let mut tail = FileTail::default();
+        let mut snap: Option<TelemetrySnapshot> = None;
+        let mut last_user_ts = None;
+        read_lines(&path.to_path_buf(), &mut tail, &mut snap, &mut last_user_ts);
+
+        assert_eq!(snap.unwrap().state, SessionState::Idle);
+    }
+
+    #[test]
+    fn plan_approval_is_idle_not_busy() {
+        // ExitPlanMode blocks on the user the same way.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        write_lines(
+            &path,
+            &[
+                r#"{"type":"assistant","sessionId":"s","timestamp":"2026-04-22T08:01:00Z","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","id":"t1","name":"ExitPlanMode","input":{}}],"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#,
+            ],
+        );
+
+        let mut tail = FileTail::default();
+        let mut snap: Option<TelemetrySnapshot> = None;
+        let mut last_user_ts = None;
+        read_lines(&path.to_path_buf(), &mut tail, &mut snap, &mut last_user_ts);
+
+        assert_eq!(snap.unwrap().state, SessionState::Idle);
+    }
+
+    #[test]
+    fn question_racing_a_real_tool_stays_pending() {
+        // A batch mixing AskUserQuestion with a real tool call means
+        // work is still running — that is not idle.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        write_lines(
+            &path,
+            &[
+                r#"{"type":"assistant","sessionId":"s","timestamp":"2026-04-22T08:01:00Z","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}},{"type":"tool_use","id":"t2","name":"AskUserQuestion","input":{}}],"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#,
+            ],
+        );
+
+        let mut tail = FileTail::default();
+        let mut snap: Option<TelemetrySnapshot> = None;
+        let mut last_user_ts = None;
+        read_lines(&path.to_path_buf(), &mut tail, &mut snap, &mut last_user_ts);
+
+        assert_eq!(snap.unwrap().state, SessionState::PendingToolUse);
+    }
+
+    #[test]
+    fn answering_the_question_goes_back_to_busy() {
+        // The answer arrives as a tool-result user entry.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        write_lines(
+            &path,
+            &[
+                r#"{"type":"assistant","sessionId":"s","timestamp":"2026-04-22T08:01:00Z","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","id":"t1","name":"AskUserQuestion","input":{}}],"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#,
+                r#"{"type":"user","sessionId":"s","timestamp":"2026-04-22T08:05:00Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"picked option A"}]}}"#,
+            ],
+        );
+
+        let mut tail = FileTail::default();
+        let mut snap: Option<TelemetrySnapshot> = None;
+        let mut last_user_ts = None;
+        read_lines(&path.to_path_buf(), &mut tail, &mut snap, &mut last_user_ts);
+
+        assert_eq!(snap.unwrap().state, SessionState::Busy);
     }
 
     #[test]

--- a/core/src/agents/claude/telemetry.rs
+++ b/core/src/agents/claude/telemetry.rs
@@ -178,25 +178,30 @@ fn parse_line(line: &str) -> Option<Entry> {
 
         // Detect assistant entries blocked on the human: every
         // tool_use block is a user-interaction prompt. See the
-        // field doc on `Entry::awaiting_user_input`.
+        // field doc on `Entry::awaiting_user_input`. Single pass, no
+        // allocation; a tool_use block with a missing or non-string
+        // `name` counts as a real tool, so a malformed batch never
+        // classifies as idle (Copilot review on PR #299).
         if kind == EntryKind::Assistant
             && stop_reason.as_deref() == Some("tool_use")
             && let Some(content) = msg.get("content").and_then(Value::as_array) {
-                let tool_names: Vec<&str> = content
-                    .iter()
-                    .filter_map(|item| {
-                        let o = item.as_object()?;
-                        if o.get("type").and_then(Value::as_str) == Some("tool_use") {
-                            o.get("name").and_then(Value::as_str)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                awaiting_user_input = !tool_names.is_empty()
-                    && tool_names
-                        .iter()
-                        .all(|n| matches!(*n, "AskUserQuestion" | "ExitPlanMode"));
+                let mut any_tool_use = false;
+                let mut all_user_prompts = true;
+                for item in content {
+                    let Some(o) = item.as_object() else { continue };
+                    if o.get("type").and_then(Value::as_str) != Some("tool_use") {
+                        continue;
+                    }
+                    any_tool_use = true;
+                    if !matches!(
+                        o.get("name").and_then(Value::as_str),
+                        Some("AskUserQuestion" | "ExitPlanMode")
+                    ) {
+                        all_user_prompts = false;
+                        break;
+                    }
+                }
+                awaiting_user_input = any_tool_use && all_user_prompts;
             }
     }
 
@@ -855,6 +860,28 @@ mod tests {
             &path,
             &[
                 r#"{"type":"assistant","sessionId":"s","timestamp":"2026-04-22T08:01:00Z","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}},{"type":"tool_use","id":"t2","name":"AskUserQuestion","input":{}}],"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#,
+            ],
+        );
+
+        let mut tail = FileTail::default();
+        let mut snap: Option<TelemetrySnapshot> = None;
+        let mut last_user_ts = None;
+        read_lines(&path.to_path_buf(), &mut tail, &mut snap, &mut last_user_ts);
+
+        assert_eq!(snap.unwrap().state, SessionState::PendingToolUse);
+    }
+
+    #[test]
+    fn unnamed_tool_use_block_never_classifies_as_idle() {
+        // A tool_use block missing its name must count as a real
+        // tool — a malformed batch must not read as "waiting on the
+        // user" (Copilot review on PR #299).
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        write_lines(
+            &path,
+            &[
+                r#"{"type":"assistant","sessionId":"s","timestamp":"2026-04-22T08:01:00Z","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","id":"t1"},{"type":"tool_use","id":"t2","name":"AskUserQuestion","input":{}}],"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#,
             ],
         );
 


### PR DESCRIPTION
The busy indicator stayed red while Claude was blocked on an `AskUserQuestion` prompt (#293). From the transcript's point of view that is a plain `stop_reason: "tool_use"` assistant entry, which the state machine mapped to `PendingToolUse` — i.e. busy — even though nothing is running until the human answers.

## Fix

`parse_line` now flags assistant `tool_use` entries whose tool calls are **all** user-interaction prompts (`AskUserQuestion` / `ExitPlanMode`, verified against real transcript entries). The state machine maps those to `Idle`:

- The sidebar dot and taskbar badge stop showing red while the agent waits for input, and the existing went-idle notification path draws attention to the tab — which is exactly when the user's attention is needed.
- The answer arrives as a tool-result user entry, which already flips the state back to `Busy` on its own — no new transition needed.
- A parallel batch mixing a question with a real tool call (e.g. `Bash` + `AskUserQuestion`) still counts as `PendingToolUse`: work is genuinely running.
- The pending-subagents guard (#289) still wins: a session with live background agents stays busy even while the main agent asks a question.

Known ceiling: a plain *permission* prompt (harness asking to approve a dangerous tool) is indistinguishable from a long-running tool in the transcript — no entry exists to key on. Claude-backend only; the other three backends' transcripts have no comparable marker.

## Tests

Four new unit tests: question → Idle, plan approval → Idle, question racing a real tool → still pending, answered question → back to Busy. Core suite: 500 passing.

Fixes #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)