### PR TITLE
release: bump version to 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "codescope"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
Version bump for the v0.5.3 patch release. Ships seven fixes since v0.5.2:

- #295 — window stays maximized across a session lock / monitor swap (#279, burst race)
- #296 — taskbar agent badge repaints after a display change
- #297 — pollers never take `index.lock` (`GIT_OPTIONAL_LOCKS=0`), agent commits stop failing (#294)
- #298 — "Reveal in File Explorer" opens the worktree, not Documents (#292)
- #299 — waiting on an AskUserQuestion prompt shows idle, not busy (#293)
- #301 — updater survives CDN stalls up to 120 s and logs the install flow to `update.log`
- #291 (already tagged base) — display-change guard keyed on HMONITOR

🤖 Generated with [Claude Code](https://claude.com/claude-code)