### PR TITLE
ci(release): credit issue reporters in the published release notes

### DIFF
--- a/.github/scripts/issue-credits.sh
+++ b/.github/scripts/issue-credits.sh
@@ -123,6 +123,11 @@ fi
 
 # --- 6. build the section ----------------------------------------------------
 
+# Numeric on both keys so a PR closing #9 and #10 lists them in that order, and
+# `-u` on (pr, issue) rather than the whole line: an issue has exactly one
+# author, so that pair is already the identity of a credit line.
+sort -u -t$'\t' -k1,1n -k2,2n "$work/credits" > "$work/credits-sorted"
+
 {
     echo "$MARKER_START"
     echo
@@ -130,12 +135,9 @@ fi
     echo
     echo "This release fixes issues reported by the community — thank you:"
     echo
-    # Dedupe whole lines first (-u on a keyed sort would collapse two issues
-    # closed by the same PR), then order by PR number, stably.
-    sort -u "$work/credits" | sort -t$'\t' -k1,1n -s \
-    | while IFS=$'\t' read -r pr issue author; do
+    while IFS=$'\t' read -r pr issue author; do
         echo "- #$pr — thanks @$author for reporting #$issue"
-    done
+    done < "$work/credits-sorted"
     echo
     echo "$MARKER_END"
 } > "$work/section"
@@ -153,12 +155,25 @@ fi
 
 gh release view "$TAG" --repo "$REPO" --json body --jq '.body' > "$work/body"
 
-# Drop a previous block so re-runs replace instead of stacking.
-awk -v s="$MARKER_START" -v e="$MARKER_END" '
-    $0 == s { skip = 1 }
-    !skip   { print }
-    $0 == e { skip = 0 }
-' "$work/body" > "$work/body-clean"
+# Drop a previous block so re-runs replace instead of stacking — but only when
+# both markers are there to bound it. With a start marker and no end marker
+# (someone hand-edited the notes and clipped it), the strip would run to EOF
+# and silently truncate the published release notes, so leave the body alone
+# and let the operator sort out the stray marker.
+if grep -qF "$MARKER_START" "$work/body" && grep -qF "$MARKER_END" "$work/body"; then
+    awk -v s="$MARKER_START" -v e="$MARKER_END" '
+        $0 == s { skip = 1 }
+        !skip   { print }
+        $0 == e { skip = 0 }
+    ' "$work/body" > "$work/body-clean"
+elif grep -qF "$MARKER_START" "$work/body"; then
+    echo "warning: '$MARKER_START' present without its end marker — appending" >&2
+    echo "         a fresh block instead of stripping, to avoid truncating the" >&2
+    echo "         notes. Remove the stray marker by hand." >&2
+    cp "$work/body" "$work/body-clean"
+else
+    cp "$work/body" "$work/body-clean"
+fi
 
 {
     # Command substitution strips trailing newlines, so stripping a previous
@@ -168,4 +183,4 @@ awk -v s="$MARKER_START" -v e="$MARKER_END" '
 } > "$work/body-new"
 
 gh release edit "$TAG" --repo "$REPO" --notes-file "$work/body-new"
-echo "release notes for $TAG updated with $(sort -u "$work/credits" | wc -l) credit line(s)"
+echo "release notes for $TAG updated with $(wc -l < "$work/credits-sorted") credit line(s)"

--- a/.github/scripts/issue-credits.sh
+++ b/.github/scripts/issue-credits.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# Append an "issue reporters" credits section to a published GitHub release.
+#
+# Every fix that shipped because somebody outside the repo took the time to
+# file an issue gets a thank-you line on the release page. Issues filed by the
+# repo owner are skipped — self-credit is noise.
+#
+# How it finds the reporters:
+#
+#   1. previous release tag  -> the commit range this release covers
+#   2. `compare` API         -> the commits in that range
+#   3. trailing `(#123)` in  -> the PR each commit came from. Every commit on
+#      the commit subject       `main` is a squash merge, so GitHub's own
+#                               "(#123)" suffix is the PR number.
+#   4. `closingIssuesReferences` (GraphQL) -> the issues each PR closes
+#   5. issue author, minus the repo owner and bots -> the credit lines
+#
+# Re-running is safe: the section is delimited by HTML markers and a previous
+# block is replaced rather than duplicated. Hand-edits outside the markers are
+# preserved, which matters because release notes here get polished by hand
+# after the workflow publishes them.
+#
+# Usage:
+#   issue-credits.sh <tag> [--dry-run]
+#
+# Env:
+#   GH_TOKEN     required — needs contents:write, pull-requests:read, issues:read
+#   GITHUB_REPOSITORY  owner/repo (set by Actions; override for local runs)
+
+set -euo pipefail
+
+MARKER_START='<!-- issue-credits:start -->'
+MARKER_END='<!-- issue-credits:end -->'
+
+TAG="${1:-}"
+DRY_RUN=false
+[[ "${2:-}" == "--dry-run" ]] && DRY_RUN=true
+
+if [[ -z "$TAG" ]]; then
+    echo "usage: $0 <tag> [--dry-run]" >&2
+    exit 2
+fi
+
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set (owner/repo)}"
+OWNER="${REPO%%/*}"
+REPO_NAME="${REPO##*/}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# --- 1. the previous release, which bounds the commit range -------------------
+
+# The releases API returns newest first, and this release already exists by the
+# time we run, so the first non-draft entry that isn't us is the predecessor.
+# No --paginate: with --jq, gh applies the filter per page, so a paginated
+# `first` would emit one line per page. The newest page is all we need.
+prev_tag="$(gh api "repos/$REPO/releases?per_page=100" \
+    --jq "[.[] | select(.draft == false) | select(.tag_name != \"$TAG\") | .tag_name] | first // empty")"
+
+if [[ -z "$prev_tag" ]]; then
+    echo "no previous release found — nothing to diff against, skipping credits"
+    exit 0
+fi
+
+echo "crediting reporters for $prev_tag..$TAG"
+
+# --- 2/3. commits in range -> PR numbers -------------------------------------
+
+# Match `(#N)` only at the end of the subject line: a squash merge always puts
+# it there, while a subject that *mentions* other PRs mid-sentence (e.g. the
+# HANDOFF commit "sessions 48-50 ... (#262-#266) (#267)") must resolve to #267
+# alone.
+gh api "repos/$REPO/compare/$prev_tag...$TAG" \
+    --jq '.commits[].commit.message | split("\n")[0]' \
+    | sed -nE 's/.*\(#([0-9]+)\)$/\1/p' \
+    | sort -un > "$work/prs"
+
+if [[ ! -s "$work/prs" ]]; then
+    echo "no squash-merged PRs in range — skipping credits"
+    exit 0
+fi
+
+echo "PRs in range: $(tr '\n' ' ' < "$work/prs")"
+
+# --- 4/5. PR -> closed issues -> reporters -----------------------------------
+
+: > "$work/credits"
+
+while read -r pr; do
+    # A PR that closes nothing is the common case, and a number that turns out
+    # not to be a PR at all (a stray subject suffix) must not fail the release
+    # — both just yield no lines.
+    gh api graphql \
+        -f query='
+          query($owner: String!, $repo: String!, $pr: Int!) {
+            repository(owner: $owner, name: $repo) {
+              pullRequest(number: $pr) {
+                closingIssuesReferences(first: 20) {
+                  nodes { number author { login } }
+                }
+              }
+            }
+          }' \
+        -F owner="$OWNER" -F repo="$REPO_NAME" -F pr="$pr" \
+        --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]
+              | select(.author != null)
+              | "\(.number)\t\(.author.login)"' > "$work/issues" 2>/dev/null || true
+
+    while IFS=$'\t' read -r issue author; do
+        [[ -z "${author:-}" ]] && continue
+        # Skip self-filed issues and bot accounts — neither wants thanking.
+        [[ "$author" == "$OWNER" ]] && continue
+        [[ "$author" == *"[bot]" ]] && continue
+        printf '%s\t%s\t%s\n' "$pr" "$issue" "$author" >> "$work/credits"
+    done < "$work/issues"
+done < "$work/prs"
+
+if [[ ! -s "$work/credits" ]]; then
+    echo "no externally-filed issues closed in this release — nothing to credit"
+    exit 0
+fi
+
+# --- 6. build the section ----------------------------------------------------
+
+{
+    echo "$MARKER_START"
+    echo
+    echo "## Thanks"
+    echo
+    echo "This release fixes issues reported by the community — thank you:"
+    echo
+    # Dedupe whole lines first (-u on a keyed sort would collapse two issues
+    # closed by the same PR), then order by PR number, stably.
+    sort -u "$work/credits" | sort -t$'\t' -k1,1n -s \
+    | while IFS=$'\t' read -r pr issue author; do
+        echo "- #$pr — thanks @$author for reporting #$issue"
+    done
+    echo
+    echo "$MARKER_END"
+} > "$work/section"
+
+echo "--- credits section ---"
+cat "$work/section"
+echo "-----------------------"
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo "(dry run — release notes not modified)"
+    exit 0
+fi
+
+# --- 7. splice it into the release notes -------------------------------------
+
+gh release view "$TAG" --repo "$REPO" --json body --jq '.body' > "$work/body"
+
+# Drop a previous block so re-runs replace instead of stacking.
+awk -v s="$MARKER_START" -v e="$MARKER_END" '
+    $0 == s { skip = 1 }
+    !skip   { print }
+    $0 == e { skip = 0 }
+' "$work/body" > "$work/body-clean"
+
+{
+    # Command substitution strips trailing newlines, so stripping a previous
+    # block never leaves a growing pile of blank lines behind.
+    printf '%s\n\n' "$(cat "$work/body-clean")"
+    cat "$work/section"
+} > "$work/body-new"
+
+gh release edit "$TAG" --repo "$REPO" --notes-file "$work/body-new"
+echo "release notes for $TAG updated with $(sort -u "$work/credits" | wc -l) credit line(s)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@
 name: Release
 permissions:
   "contents": "write"
+  # Read-only, for the issue-credits step in `host`: it walks each merged PR's
+  # `closingIssuesReferences` to find who reported the bug it fixed. Naming a
+  # `permissions` block at all zeroes every scope not listed, so these two have
+  # to be spelled out.
+  "pull-requests": "read"
+  "issues": "read"
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -474,6 +480,17 @@ jobs:
           printf '%s' "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+      # Thank the people who reported the bugs this release fixes. Runs after
+      # the release exists because it edits the published notes in place; a
+      # failure here must not fail an otherwise-good release, hence
+      # `continue-on-error` — the notes can be fixed up by hand.
+      - name: "Credit issue reporters"
+        continue-on-error: true
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          chmod +x .github/scripts/issue-credits.sh
+          .github/scripts/issue-credits.sh "${{ needs.plan.outputs.tag }}"
 
   announce:
     needs:

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -25,8 +25,8 @@
 > `.github/workflows/release.yml` (was `rs--release.yml`) and now
 > triggers on plain `v*` tags.
 
-**Last updated:** 2026-08-10 (session 54 — five user-reported fixes: window re-maximize burst race, taskbar badge after display change, git index.lock contention, reveal-in-explorer slashes, waiting-on-input shown as busy)
-**Branch:** `main`; all session-54 PRs merged, no open PRs.
+**Last updated:** 2026-08-11 (session 55 — release notes now credit the people who reported the issues a release fixes)
+**Branch:** `claude/release-issue-credits-q2k3sw` (session 55, pushed, **no PR opened yet**). Session-54 PRs all merged.
 **Head:** `main` at `265589a`. Session-54 merges: #295 monitor-swap grace window, #296 badge repaint after display change, #297 `GIT_OPTIONAL_LOCKS=0`, #298 explorer backslashes, #299 AskUserQuestion → Idle. Issues #279 (re-opened for the burst race), #292, #293, #294 all closed. Session 53 merged #285 adoption claims + #286 dangling-transcript prune (details below). Session 52 merged #280 modifier encoding + faint rendering, #281 `[dev]` window title / titlebar badge. Earlier: #287–#291 (sessions 53b/54a window+telemetry), #275–#277 (v0.5.1), #262–#274 (v0.5.0).
 **Release:** **`v0.5.1` is published** (pipeline run 27406124661). It's a patch over v0.5.0 carrying the in-app updater robustness fix. **`v0.5.0` is also still up** but its updater can mis-handle a truncated download — see below.
 **The v0.5.0 update bug (root-caused + fixed this session):** the user's installed v0.4.0 → v0.5.0 in-app update failed (twice) with `Extract failed: … ZipError: invalid Zip archive: Could not find EOCD`. EOCD-missing = the downloaded zip was **truncated**. The published v0.5.0 artifact is **fine** (verified end-to-end: full GitHub download, valid `PK\x03\x04`, extracts cleanly with identical code + dep pins). Root cause was in `src/update.rs`'s downloader: the read loop broke on the first `Ok(0)` EOF and proceeded to extract **without checking `received == Content-Length`**, so a TLS-inspecting proxy / AV middlebox clipping the HTTPS download (a *clean* early EOF) silently produced a short zip. Fix (#275): `verify_complete` (pure, unit-tested) + `download_once` + `download_archive` (3 attempts, linear backoff). A short download now fails as honest "Download incomplete: received N of M bytes" and self-heals on retry. #276 added `dist/truncating_server.py` + RELEASE-VALIDATION §6b to guard it (§6 served from localhost, which never truncates — that's why the bug shipped).
@@ -34,7 +34,42 @@
 **Diagnostic logging gap (open):** the installer writes update failures only to a transient toast (auto-dismissed) and the temp dir (`tempfile::tempdir()` under `%TEMP%`, auto-deleted on return) — nothing persists to disk, so "do you have logs?" came up empty. Worth a follow-up: log the update flow + full error chain to `%LOCALAPPDATA%\CodeScope\update.log`. Not yet filed.
 **Build status:** ✅ workspace builds clean; suite green on `main` — 53 in `codescope-terminal`, 501 in `codescope-core` (+5 this session), 147 in `codescope` (+11 across sessions 53b–54). Clippy: 0 errors, only the pre-existing warnings (`app.rs` `map_or` / `spawn_tab_in` arg count / large enum variant, `core` `from_str` / `sort_by_key`, `taskbar_badge.rs` `gy` loop indexing, `opencode` arg count).
 **Uncommitted work:** none.
+**⚠ Manual step still outstanding:** the published **v0.5.3 notes do not credit @maxim12358**, who reported #292, #293 and #294 (fixed by #298, #299, #297). The new automation only runs on future releases — v0.5.3 has to be edited by hand on the release page. #279 was self-filed, so it correctly gets no credit; the taskbar-badge (#296) and updater (#301) fixes came from informal reports with no issue, so there is nobody to credit for them.
 **Open issues:** none — all four open issues were closed this session (#292, #293, #294, plus #279 re-opened and re-closed). **⚠ Heads-up:** the local rustfmt (1.9.0-stable) reformats the *entire* tree — do **NOT** run repo-wide `cargo fmt`, and note that even `cargo fmt -- src/app.rs` (with a file argument!) reformatted all 59 files this session; hand-format changed hunks, always. See the session-47 note.
+
+### Session 55 — release notes credit the issue reporters
+
+v0.5.3 shipped three fixes for issues filed by @maxim12358 and thanked
+nobody. Rather than only patching that release by hand, the credit is
+now generated as part of the release pipeline.
+
+**`.github/scripts/issue-credits.sh`** (new) walks: previous release
+tag → `compare` API → commits in range → the trailing `(#N)` squash
+marker on each subject → each PR's GraphQL `closingIssuesReferences`
+→ the issue authors. Authors equal to the repo owner and `*[bot]`
+accounts are dropped, so self-filed issues stay uncredited (that was
+the explicit ask). The result is spliced into the published notes
+between `<!-- issue-credits:start/end -->` markers — re-running
+replaces the block instead of stacking it, and hand-polish outside the
+markers survives, which matters because these notes get edited by hand
+after publish.
+
+**`release.yml`**: a `Credit issue reporters` step in the `host` job,
+right after `gh release create`, `continue-on-error: true` so a credits
+failure never fails an otherwise-good release. The top-level
+`permissions:` block gained `pull-requests: read` + `issues: read` —
+naming a permissions block zeroes every scope not listed, so the
+GraphQL walk would 403 without them.
+
+Verified offline against real repo data: PR extraction over the
+v0.5.2..v0.5.3 range yields exactly 295–302, the awkward
+`… (#262–#266) (#267)` subject resolves to #267 alone, and the
+marker-strip/dedupe/ordering logic round-trips. **Not yet exercised
+against a live release** — the first real proof is the next tag push.
+
+Local run to preview or backfill a release:
+`GITHUB_REPOSITORY=maui1911/CodeScope .github/scripts/issue-credits.sh v0.5.3 --dry-run`
+(drop `--dry-run` to actually edit the notes).
 
 ### Session 54 — five user-reported fixes (#295–#299)
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -39,7 +39,7 @@
 
 ### Session 55 — release notes credit the issue reporters
 
-v0.5.3 shipped three fixes for issues filed by @maxim12358 and thanked
+v0.5.3 shipped four fixes for issues filed by @maxim12358 and thanked
 nobody. Rather than only patching that release by hand, the credit is
 now generated as part of the release pipeline.
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -26,7 +26,7 @@
 > triggers on plain `v*` tags.
 
 **Last updated:** 2026-08-11 (session 55 — release notes now credit the people who reported the issues a release fixes)
-**Branch:** `claude/release-issue-credits-q2k3sw` (session 55, pushed, **no PR opened yet**). Session-54 PRs all merged.
+**Branch:** `claude/release-issue-credits-q2k3sw` (session 55, pushed to origin, **no PR opened yet**). Session-54 PRs all merged.
 **Head:** `main` at `265589a`. Session-54 merges: #295 monitor-swap grace window, #296 badge repaint after display change, #297 `GIT_OPTIONAL_LOCKS=0`, #298 explorer backslashes, #299 AskUserQuestion → Idle. Issues #279 (re-opened for the burst race), #292, #293, #294 all closed. Session 53 merged #285 adoption claims + #286 dangling-transcript prune (details below). Session 52 merged #280 modifier encoding + faint rendering, #281 `[dev]` window title / titlebar badge. Earlier: #287–#291 (sessions 53b/54a window+telemetry), #275–#277 (v0.5.1), #262–#274 (v0.5.0).
 **Release:** **`v0.5.1` is published** (pipeline run 27406124661). It's a patch over v0.5.0 carrying the in-app updater robustness fix. **`v0.5.0` is also still up** but its updater can mis-handle a truncated download — see below.
 **The v0.5.0 update bug (root-caused + fixed this session):** the user's installed v0.4.0 → v0.5.0 in-app update failed (twice) with `Extract failed: … ZipError: invalid Zip archive: Could not find EOCD`. EOCD-missing = the downloaded zip was **truncated**. The published v0.5.0 artifact is **fine** (verified end-to-end: full GitHub download, valid `PK\x03\x04`, extracts cleanly with identical code + dep pins). Root cause was in `src/update.rs`'s downloader: the read loop broke on the first `Ok(0)` EOF and proceeded to extract **without checking `received == Content-Length`**, so a TLS-inspecting proxy / AV middlebox clipping the HTTPS download (a *clean* early EOF) silently produced a short zip. Fix (#275): `verify_complete` (pure, unit-tested) + `download_once` + `download_archive` (3 attempts, linear backoff). A short download now fails as honest "Download incomplete: received N of M bytes" and self-heals on retry. #276 added `dist/truncating_server.py` + RELEASE-VALIDATION §6b to guard it (§6 served from localhost, which never truncates — that's why the bug shipped).
@@ -34,7 +34,7 @@
 **Diagnostic logging gap (open):** the installer writes update failures only to a transient toast (auto-dismissed) and the temp dir (`tempfile::tempdir()` under `%TEMP%`, auto-deleted on return) — nothing persists to disk, so "do you have logs?" came up empty. Worth a follow-up: log the update flow + full error chain to `%LOCALAPPDATA%\CodeScope\update.log`. Not yet filed.
 **Build status:** ✅ workspace builds clean; suite green on `main` — 53 in `codescope-terminal`, 501 in `codescope-core` (+5 this session), 147 in `codescope` (+11 across sessions 53b–54). Clippy: 0 errors, only the pre-existing warnings (`app.rs` `map_or` / `spawn_tab_in` arg count / large enum variant, `core` `from_str` / `sort_by_key`, `taskbar_badge.rs` `gy` loop indexing, `opencode` arg count).
 **Uncommitted work:** none.
-**⚠ Manual step still outstanding:** the published **v0.5.3 notes do not credit @maxim12358**, who reported #292, #293 and #294 (fixed by #298, #299, #297). The new automation only runs on future releases — v0.5.3 has to be edited by hand on the release page. #279 was self-filed, so it correctly gets no credit; the taskbar-badge (#296) and updater (#301) fixes came from informal reports with no issue, so there is nobody to credit for them.
+**⚠ Manual step still outstanding:** the published **v0.5.3 notes credit nobody**. Running the credit logic over the real v0.5.2..v0.5.3 range gives four lines, all @maxim12358: #289←#284, #297←#294, #298←#292, #299←#293. Note **#289←#284 (subagents keep a session busy) is not in the release bullets at all** — it merged after v0.5.2 and shipped in v0.5.3, which is very likely the missing seventh of "Seven fixes". #279 was self-filed so it correctly drops out; the taskbar-badge (#296) and updater (#301) fixes came from informal reports with no issue, so there is nobody to credit. The automation only runs on future releases, so v0.5.3 needs a hand edit — and **release editing is blocked from cloud sessions** (`Creating, editing, or deleting releases is not permitted for this session type`), so it cannot be done from a web session at all. Paste-ready body was handed to the user.
 **Open issues:** none — all four open issues were closed this session (#292, #293, #294, plus #279 re-opened and re-closed). **⚠ Heads-up:** the local rustfmt (1.9.0-stable) reformats the *entire* tree — do **NOT** run repo-wide `cargo fmt`, and note that even `cargo fmt -- src/app.rs` (with a file argument!) reformatted all 59 files this session; hand-format changed hunks, always. See the session-47 note.
 
 ### Session 55 — release notes credit the issue reporters
@@ -61,11 +61,21 @@ failure never fails an otherwise-good release. The top-level
 naming a permissions block zeroes every scope not listed, so the
 GraphQL walk would 403 without them.
 
-Verified offline against real repo data: PR extraction over the
-v0.5.2..v0.5.3 range yields exactly 295–302, the awkward
+Verified offline against real repo data: the awkward
 `… (#262–#266) (#267)` subject resolves to #267 alone, and the
-marker-strip/dedupe/ordering logic round-trips. **Not yet exercised
-against a live release** — the first real proof is the next tag push.
+marker-strip/dedupe/ordering logic round-trips. Then re-run against
+the live API: the v0.5.2..v0.5.3 range is PRs #285–#302 (not just the
+#295–#301 the notes mention), #297/#298/#299 do carry `Fixes #294.` /
+`Fixes #292.` / `Fixes #293.` in their bodies, so
+`closingIssuesReferences` will resolve them, and the filter correctly
+drops the self-filed #279. **Still not exercised end-to-end** — the
+first real proof is the next tag push.
+
+**Caveat for local dry-runs:** the GraphQL step cannot be validated
+from a cloud/web session — `api.github.com/graphql` there answers
+`This GraphQL query is not enabled for this session`. That is a
+sandbox restriction, not a script bug; `gh api graphql` in Actions
+hits real GitHub. Dry-run from a normal local terminal instead.
 
 Local run to preview or backfill a release:
 `GITHUB_REPOSITORY=maui1911/CodeScope .github/scripts/issue-credits.sh v0.5.3 --dry-run`


### PR DESCRIPTION
v0.5.3 shipped fixes for four issues filed by @maxim12358 and thanked nobody. Rather than only patching that release by hand, the credit is now generated as part of the release pipeline.

## How it works

New `.github/scripts/issue-credits.sh` resolves reporters from the release range:

previous release tag → `compare` API → commits in range → the trailing `(#N)` squash marker on each subject → each PR's GraphQL `closingIssuesReferences` → the issue authors.

Issues filed by the repo owner and by `*[bot]` accounts are dropped, so self-filed issues stay uncredited. The result is spliced into the published notes between `<!-- issue-credits:start/end -->` markers, so a re-run replaces the block instead of stacking it and hand-polish outside the markers survives — these notes get edited by hand after publish.

`release.yml` gains a `Credit issue reporters` step in the `host` job, right after `gh release create`, with `continue-on-error: true` so a credits failure never fails an otherwise-good release. The top-level `permissions:` block gains `pull-requests: read` and `issues: read`: naming a permissions block zeroes every scope not listed, so the GraphQL walk would 403 without them.

## What it would have produced for v0.5.3

```
- #289 — thanks @maxim12358 for reporting #284
- #297 — thanks @maxim12358 for reporting #294
- #298 — thanks @maxim12358 for reporting #292
- #299 — thanks @maxim12358 for reporting #293
```

Note the range is PRs #285–#302, wider than the #295–#301 the hand-written notes mention — #289 ← #284 ("keep a session busy while its subagents run") is missing from the bullets entirely, and is very likely the missing seventh of "Seven fixes". #279 is self-filed and correctly drops out.

## Testing

Verified against real repo data:

- PR extraction over `v0.5.2..v0.5.3` yields #285–#302; the awkward `… (#262–#266) (#267)` subject resolves to #267 alone
- #297/#298/#299 do carry `Fixes #294.` / `Fixes #292.` / `Fixes #293.` in their bodies, so `closingIssuesReferences` resolves them
- marker-strip, dedupe and ordering round-trip, including two issues closed by one PR

Not yet exercised end-to-end — the first real proof is the next tag push. A dry-run has to be done from a local terminal: cloud sessions get `This GraphQL query is not enabled for this session` from `api.github.com/graphql`.

```bash
GITHUB_REPOSITORY=maui1911/CodeScope .github/scripts/issue-credits.sh v0.5.3 --dry-run
```

## Still manual

The published v0.5.3 notes are unchanged — editing a release is blocked from cloud sessions (`Creating, editing, or deleting releases is not permitted for this session type`). The paste-ready body was handed over separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLSeWqMZCGvWh5wQ9o8ZL4)_