### PR TITLE
fix(telemetry): encode every non-alphanumeric cwd char as '-'

### DIFF
--- a/core/src/agents/claude/telemetry.rs
+++ b/core/src/agents/claude/telemetry.rs
@@ -48,14 +48,43 @@ pub fn transcript_path(projects_root: &Path, working_directory: &str, session_id
 /// Encode an absolute path to the `~/.claude/projects/<name>` directory
 /// name used by Claude Code.
 ///
-/// Claude replaces `:`, `\`, `/`, and `.` with `-`.
-/// E.g. `C:\dev\codescope` → `C--dev-codescope`.
+/// **Every character outside `[a-zA-Z0-9]` becomes `-`** — not just the
+/// separators. Claude Code's own encoder, lifted from its bundle:
+///
+/// ```js
+/// function Uso(e){ return e.replace(/[^a-zA-Z0-9]/g,"-") }
+/// function vv(e){ let t=Uso(e); if(t.length<=BZ) return t;
+///                 return `${t.slice(0,BZ)}-${VNg(e)}` }   // BZ = 200
+/// function Vz(e){ return join(join(claudeDir(),"projects"), vv(e)) }
+/// ```
+///
+/// This used to list only `:`, `\`, `/`, `.` — an under-generalisation
+/// from paths that happened to contain nothing else. **Spaces were the
+/// one that bit:** a session in
+/// `D:\Dev\...\Web Object Projects\Profit Connector` had us looking in
+/// `D--Dev-...-Web Object Projects-Profit Connector` while Claude wrote
+/// to `…-Web-Object-Projects-Profit-Connector`. The directory never
+/// resolved, so transcript discovery found nothing, no
+/// `agent_session_id` was ever persisted, and reopening the session
+/// gave a blank terminal even though `claude -r` could still find the
+/// conversation. Telemetry (model / tokens / turns / busy) was dark for
+/// the same reason.
+///
+/// Verified against the user's real `~/.claude/projects/` by aligning
+/// each transcript's `cwd` field with its containing directory name,
+/// character for character: space, `.`, `:` and `\` all map to `-`,
+/// alphanumerics and `-` map to themselves.
+///
+/// **Known gap:** the `BZ = 200` truncate-and-append-hash branch is not
+/// implemented — `VNg` is a base36 string hash we'd have to reproduce
+/// bit-exactly to be useful, and guessing it wrong is worse than not
+/// having it. Encoded names over 200 chars therefore still miss. No
+/// path in the user's store comes close (longest is 68), so this is
+/// latent, not live; a directory scan comparing each candidate's
+/// `cwd` would be the robust fix if it ever bites.
 pub fn encode_cwd(path: &str) -> String {
     path.chars()
-        .map(|c| match c {
-            ':' | '\\' | '/' | '.' => '-',
-            other => other,
-        })
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
         .collect()
 }
 
@@ -719,6 +748,34 @@ mod tests {
             encode_cwd("/home/user/myrepo"),
             "-home-user-myrepo"
         );
+    }
+
+    #[test]
+    fn encode_cwd_replaces_spaces() {
+        // The regression this rule was widened for. Path and expected
+        // directory name are both copied from the user's real machine:
+        // the session was live, its transcripts existed, and CodeScope
+        // could not see them.
+        assert_eq!(
+            encode_cwd(r"D:\Dev\profit\src\Anta\Projects\Web Object Projects\Profit Connector"),
+            "D--Dev-profit-src-Anta-Projects-Web-Object-Projects-Profit-Connector"
+        );
+    }
+
+    #[test]
+    fn encode_cwd_replaces_every_non_alphanumeric() {
+        // Claude's encoder is `[^a-zA-Z0-9] -> '-'`, so underscores,
+        // parens and `#` go too — a hyphen is the only punctuation that
+        // survives, and only because replacing it yields itself.
+        assert_eq!(
+            encode_cwd(r"C:\dev\my_repo (copy)\v#2"),
+            "C--dev-my-repo--copy--v-2"
+        );
+        // Non-ASCII is outside the class as well: JS `[a-zA-Z0-9]` does
+        // not match `é`, so neither does `is_ascii_alphanumeric`.
+        assert_eq!(encode_cwd("/tmp/café"), "-tmp-caf-");
+        // Hyphens and digits are preserved verbatim.
+        assert_eq!(encode_cwd(r"D:\Dev\online.worktrees\worktree-2"), "D--Dev-online-worktrees-worktree-2");
     }
 
     // --- parse_iso8601 ---

--- a/core/src/agents/claude/telemetry.rs
+++ b/core/src/agents/claude/telemetry.rs
@@ -75,6 +75,9 @@ pub fn transcript_path(projects_root: &Path, working_directory: &str, session_id
 /// character for character: space, `.`, `:` and `\` all map to `-`,
 /// alphanumerics and `-` map to themselves.
 ///
+/// Note the regex carries **no `u` flag**, so it matches per UTF-16
+/// code unit — a non-BMP character becomes *two* dashes. See the body.
+///
 /// **Known gap:** the `BZ = 200` truncate-and-append-hash branch is not
 /// implemented — `VNg` is a base36 string hash we'd have to reproduce
 /// bit-exactly to be useful, and guessing it wrong is worse than not
@@ -83,9 +86,24 @@ pub fn transcript_path(projects_root: &Path, working_directory: &str, session_id
 /// latent, not live; a directory scan comparing each candidate's
 /// `cwd` would be the robust fix if it ever bites.
 pub fn encode_cwd(path: &str) -> String {
-    path.chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect()
+    let mut out = String::with_capacity(path.len());
+    for c in path.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+        } else {
+            // One dash per UTF-16 code unit, not per code point. JS
+            // strings are UTF-16 and the regex carries no `u` flag, so
+            // the negated class matches each half of a surrogate pair
+            // separately: `"🚀".replace(/[^a-zA-Z0-9]/g,"-")` is `"--"`.
+            // A `chars()`-shaped one-dash-per-char version silently
+            // under-counts for any non-BMP character and lands us back
+            // on a directory Claude never wrote.
+            for _ in 0..c.len_utf16() {
+                out.push('-');
+            }
+        }
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -776,6 +794,27 @@ mod tests {
         assert_eq!(encode_cwd("/tmp/café"), "-tmp-caf-");
         // Hyphens and digits are preserved verbatim.
         assert_eq!(encode_cwd(r"D:\Dev\online.worktrees\worktree-2"), "D--Dev-online-worktrees-worktree-2");
+    }
+
+    #[test]
+    fn encode_cwd_counts_utf16_code_units_not_code_points() {
+        // Claude's regex has no `u` flag, so it matches per UTF-16 code
+        // unit and a surrogate pair yields *two* dashes. Every vector
+        // here was produced by running the real encoder under node:
+        //
+        //   s.replace(/[^a-zA-Z0-9]/g, "-")
+        //
+        //   "🚀"        -> "--"
+        //   "a🚀b"      -> "a--b"
+        //   "café"      -> "caf-"
+        //   "𝔘nicode"   -> "--nicode"
+        assert_eq!(encode_cwd("🚀"), "--");
+        assert_eq!(encode_cwd("a🚀b"), "a--b");
+        assert_eq!(encode_cwd("𝔘nicode"), "--nicode");
+        // BMP non-ASCII is a single code unit, so a single dash — the
+        // distinction only bites above U+FFFF.
+        assert_eq!(encode_cwd("café"), "caf-");
+        assert_eq!(encode_cwd(r"D:\x\🚀 dir"), "D--x----dir");
     }
 
     // --- parse_iso8601 ---


### PR DESCRIPTION
Closes the "sessions don't come back" report for any project whose path contains a space.

## Symptom

A live Claude session in `D:\Dev\profit\src\Anta\Projects\Web Object Projects\Profit Connector`:

- End the session → blank terminal. `claude -r` **does** restore the right conversation.
- Close the tab and reopen → session is empty.

## Root cause

`encode_cwd` replaced only `:`, `\`, `/` and `.`. Claude Code replaces **everything outside `[a-zA-Z0-9]`**, spaces included. So:

| | directory |
|---|---|
| CodeScope looked in | `D--Dev-…-Web Object Projects-Profit Connector` |
| Claude actually wrote to | `D--Dev-…-Web-Object-Projects-Profit-Connector` |

The directory never resolved, so transcript discovery found nothing, `persist_agent_session_id` never fired, and both `claude` rows for that path carry `agentSessionId: null` — including the one from today. `claude -r` works because the CLI reads its own directory and never consults ours.

Nice control in the same store: the **`pi` rows on the identical path do have session ids**, because Pi's discovery walks the tree instead of computing a name. That isolates the bug to this one function. The other agents have no path-encoding logic at all, so Claude was the only one exposed.

Second symptom, same cause: `transcript_path` feeds the telemetry tail, so model / tokens / turns / busy state were dark for that project too. The retention probe (#286) was **not** affected — a missing directory is `None` (undecidable) there, which keeps rows rather than deleting them.

## Ground truth for the rule

Two independent sources, because the previous rule was a guess that held for years:

1. **Claude Code's own bundle** (`bin/claude.exe`):
   ```js
   function Uso(e){ return e.replace(/[^a-zA-Z0-9]/g,"-") }
   function vv(e){ let t=Uso(e); if(t.length<=BZ) return t; return `${t.slice(0,BZ)}-${VNg(e)}` }  // BZ = 200
   function Vz(e){ return join(join(claudeDir(),"projects"), vv(e)) }
   ```
2. **Character-for-character alignment** of each transcript's own `cwd` field against its containing directory name across the 7 real project dirs: space, `.`, `:` and `\` all map to `-`; alphanumerics and `-` map to themselves.

## Verification

Beyond the 5 unit tests (existing 3 unchanged + spaces + the full non-alphanumeric set incl. `_`, parens, `#`, non-ASCII), a throwaway example ran the **real** `encode_cwd` over every `worktreePath` in the installed store against the real `~/.claude/projects/`:

```
7 hit / 7 miss over 14 paths
```

The Profit Connector path flipped miss → hit; nothing that resolved before stopped resolving. The 7 remaining misses are paths with no Claude transcript directory at all.

`cargo test -p codescope-core`: 503 passed. (The `path_canon` doctest failure is pre-existing on `main` — its identical assertions pass as unit tests in the same file.)

## Deliberately not fixed

The `BZ = 200` truncate-and-append-hash branch. `VNg` is a base36 string hash we'd have to reproduce bit-exactly; guessing it wrong is worse than not having it, and the longest encoded name in the store is 68 chars. Documented on the function, with a note that a directory scan comparing each candidate's `cwd` is the robust fix if it ever bites.

## What this does *not* retro-fix

Existing rows keep `agentSessionId: null` — nothing back-fills them on load. On next open, discovery will adopt the newest unclaimed transcript in that directory. For the live session that is almost certainly the right one; for the **older July row** it may adopt a different conversation, since that directory holds 8 transcripts and nothing proves which tab minted which (the documented `select_adoption` ceiling from #285).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
