### PR TITLE
fix(update): ask GitHub for the raw asset bytes, not its metadata

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -29,13 +29,69 @@
 **Branch:** `claude/release-issue-credits-q2k3sw` (session 55, pushed to origin, **no PR opened yet**). Session-54 PRs all merged.
 **Head:** `main` at `265589a`. Session-54 merges: #295 monitor-swap grace window, #296 badge repaint after display change, #297 `GIT_OPTIONAL_LOCKS=0`, #298 explorer backslashes, #299 AskUserQuestion → Idle. Issues #279 (re-opened for the burst race), #292, #293, #294 all closed. Session 53 merged #285 adoption claims + #286 dangling-transcript prune (details below). Session 52 merged #280 modifier encoding + faint rendering, #281 `[dev]` window title / titlebar badge. Earlier: #287–#291 (sessions 53b/54a window+telemetry), #275–#277 (v0.5.1), #262–#274 (v0.5.0).
 **Release:** **`v0.5.1` is published** (pipeline run 27406124661). It's a patch over v0.5.0 carrying the in-app updater robustness fix. **`v0.5.0` is also still up** but its updater can mis-handle a truncated download — see below.
-**The v0.5.0 update bug (root-caused + fixed this session):** the user's installed v0.4.0 → v0.5.0 in-app update failed (twice) with `Extract failed: … ZipError: invalid Zip archive: Could not find EOCD`. EOCD-missing = the downloaded zip was **truncated**. The published v0.5.0 artifact is **fine** (verified end-to-end: full GitHub download, valid `PK\x03\x04`, extracts cleanly with identical code + dep pins). Root cause was in `src/update.rs`'s downloader: the read loop broke on the first `Ok(0)` EOF and proceeded to extract **without checking `received == Content-Length`**, so a TLS-inspecting proxy / AV middlebox clipping the HTTPS download (a *clean* early EOF) silently produced a short zip. Fix (#275): `verify_complete` (pure, unit-tested) + `download_once` + `download_archive` (3 attempts, linear backoff). A short download now fails as honest "Download incomplete: received N of M bytes" and self-heals on retry. #276 added `dist/truncating_server.py` + RELEASE-VALIDATION §6b to guard it (§6 served from localhost, which never truncates — that's why the bug shipped).
-**⚠ The user is behind a network that truncates** large HTTPS downloads, so the v0.4.0/v0.5.0 in-app updater fails for them. Path forward given to them: run `CodeScope-v0.5.1-setup.exe` from the release directly (bypasses the updater) to land on the build that *has* the fix; after that the in-app updater self-heals. The verified-complete `CodeScope-v0.5.0-setup.exe` was earlier downloaded to `C:\Users\maui\Downloads\`.
-**Diagnostic logging gap (open):** the installer writes update failures only to a transient toast (auto-dismissed) and the temp dir (`tempfile::tempdir()` under `%TEMP%`, auto-deleted on return) — nothing persists to disk, so "do you have logs?" came up empty. Worth a follow-up: log the update flow + full error chain to `%LOCALAPPDATA%\CodeScope\update.log`. Not yet filed.
+**⚠ The "Could not find EOCD" update bug was MISDIAGNOSED TWICE — real root cause found in session 56 (#305).** It is **not** truncation and **not** a timeout: the updater was downloading GitHub's *API asset URL* without `Accept: application/octet-stream`, so it wrote ~1.6 KB of asset **metadata JSON** to disk and handed that to the zip extractor. See the session-56 entry below. The earlier theories are kept here only so nobody re-derives them: #275 (truncation → `verify_complete` + retries) and #301 (timeouts) are both real hardening and stay, but neither was the cause. **The user is NOT behind a truncating network** — that claim, carried in this file since session 51c, was wrong; their machine downloads the release asset cleanly (verified: 200, exact byte count, valid zip, no proxy, stock Defender).
+**Diagnostic logging (closed in #301):** the installer now appends to `%LOCALAPPDATA%\CodeScope\update.log`. Note it only ships from **v0.5.3**, which is why the failing v0.5.2 install left zero evidence behind.
 **Build status:** ✅ workspace builds clean; suite green on `main` — 53 in `codescope-terminal`, 501 in `codescope-core` (+5 this session), 147 in `codescope` (+11 across sessions 53b–54). Clippy: 0 errors, only the pre-existing warnings (`app.rs` `map_or` / `spawn_tab_in` arg count / large enum variant, `core` `from_str` / `sort_by_key`, `taskbar_badge.rs` `gy` loop indexing, `opencode` arg count).
 **Uncommitted work:** none.
 **⚠ Manual step still outstanding:** the published **v0.5.3 notes credit nobody**. Running the credit logic over the real v0.5.2..v0.5.3 range gives four lines, all @maxim12358: #289←#284, #297←#294, #298←#292, #299←#293. Note **#289←#284 (subagents keep a session busy) is not in the release bullets at all** — it merged after v0.5.2 and shipped in v0.5.3, which is very likely the missing seventh of "Seven fixes". #279 was self-filed so it correctly drops out; the taskbar-badge (#296) and updater (#301) fixes came from informal reports with no issue, so there is nobody to credit. The automation only runs on future releases, so v0.5.3 needs a hand edit — and **release editing is blocked from cloud sessions** (`Creating, editing, or deleting releases is not permitted for this session type`), so it cannot be done from a web session at all. Paste-ready body was handed to the user.
 **Open issues:** none — all four open issues were closed this session (#292, #293, #294, plus #279 re-opened and re-closed). **⚠ Heads-up:** the local rustfmt (1.9.0-stable) reformats the *entire* tree — do **NOT** run repo-wide `cargo fmt`, and note that even `cargo fmt -- src/app.rs` (with a file argument!) reformatted all 59 files this session; hand-format changed hunks, always. See the session-47 note.
+
+### Session 56 — the real EOCD root cause (#305)
+
+The user's installed **v0.5.2 → v0.5.3** in-app update failed *instantly*
+with `Extract failed: extract archive: ZipError: invalid zip archive:
+Could not find EOCD` — the same message sessions 51c and 54 chased.
+
+**Root cause.** `ReleaseInfo::archive_url` is GitHub's **API** asset URL
+(`api.github.com/repos/…/releases/assets/{id}`): `self_update`'s GitHub
+backend reads `asset["url"]`, *not* `browser_download_url`
+(`self_update-0.41.0/src/backends/github.rs:24` →
+`core/src/update_check.rs:146`). That URL serves the archive only when
+the request carries `Accept: application/octet-stream` —
+`self_update`'s own downloader sets it
+(`self_update-0.41.0/src/update.rs:234`). #249 replaced that downloader
+with a hand-rolled reqwest stream to drive byte-progress and **dropped
+the header**. GitHub then answers the bare GET with **200 +
+`application/json`, 1,651 bytes of asset metadata**. Reproduced with
+curl against the live v0.5.3 asset:
+
+```
+only User-Agent        → 200 application/json         1651 bytes  {"url":"https://api.github.com/…
++ Accept: octet-stream → 200 application/octet-stream 5922247     PK\x03\x04
+```
+
+Every symptom follows: 1.6 KB arrives **instantly**;
+`error_for_status` sees 200; `verify_complete` sees `received ==
+Content-Length` so **no retry fires**; the extractor is the first thing
+to notice, and reports EOCD.
+
+**Why it survived two fixes.** RELEASE-VALIDATION §6/§6b both drive the
+installer through `CODESCOPE_DEV_UPDATE_URL` at a localhost file
+server, which structurally cannot exercise the API URL. So the dev loop
+always passed and production always failed — the Windows in-app update
+has plausibly **never** worked against a real release.
+
+**Fix (#305).** One header in `download_once`, plus two guards so this
+class of failure can't hide again:
+- `verify_archive_magic` — second gate after `verify_complete`: a
+  *complete* download of the wrong content (JSON, HTML block page) now
+  fails as "Downloaded file is not a zip archive (starts with …)"
+  instead of reaching the extractor. Closes the `total: None` hole in
+  `verify_complete`, which accepts anything when there's no
+  Content-Length.
+- `download_asks_github_for_the_raw_asset_bytes` — a `TcpListener`
+  server that mimics GitHub (raw bytes with the header, metadata JSON
+  without). Verified to fail when the header is removed.
+- RELEASE-VALIDATION **§6c** (mandatory): fetch the real API asset URL
+  of the freshly-published release with the header and assert
+  `application/octet-stream` + `PK`. Explicitly forbids substituting
+  the `releases/download/…` browser URL, which works *without* the
+  header and would re-open the blind spot.
+
+**Loose end (not fixed here):** the `sha256.sum` release asset is **1
+byte** (just `\n`) on both v0.5.2 and v0.5.3 — a broken pipeline step.
+Harmless for the updater (it fetches the `-windows.zip` directly), but
+worth its own issue.
 
 ### Session 55 — release notes credit the issue reporters
 

--- a/docs/RELEASE-VALIDATION.md
+++ b/docs/RELEASE-VALIDATION.md
@@ -183,8 +183,50 @@ python dist/truncating_server.py dist/CodeScope-v99.0.0-windows.zip `
 > truncated / over-read / unknown-length wording; this manual pass
 > proves the wiring end-to-end against a real socket.
 
+### 6c. Real GitHub asset URL (MANDATORY)
+
+Why this exists: §6 and §6b both drive the installer through
+`CODESCOPE_DEV_UPDATE_URL`, which points it at a plain localhost file
+server. That **structurally bypasses the URL the shipped app actually
+downloads from** — `ReleaseInfo::archive_url` is GitHub's *API* asset
+URL (`api.github.com/repos/…/releases/assets/{id}`, from
+`self_update`'s `asset["url"]`, not `browser_download_url`). That URL
+serves the archive only when the request carries
+`Accept: application/octet-stream`; without it, it answers **200 with
+~1.6 KB of asset metadata JSON**. The hand-rolled downloader added in
+#249 never sent the header, so every in-app update on a real release
+downloaded JSON and died at extract with "Could not find EOCD" — the
+symptom that was twice misdiagnosed (as middlebox truncation in #275,
+as a timeout in #301) precisely because these localhost-only checks
+could never reproduce it. Fixed in #305.
+
+`download_asks_github_for_the_raw_asset_bytes` in `src/update.rs`
+pins the header against a server that mimics GitHub's behaviour, but
+run this one-liner against the **real** freshly-published asset too —
+GitHub's API contract is theirs to change, not ours:
+
+```pwsh
+# Grab the API asset URL for this release's Windows zip …
+$asset = (gh release view $TAG --repo maui1911/CodeScope --json assets `
+  | ConvertFrom-Json).assets | Where-Object name -like '*-windows.zip'
+$url = "https://api.github.com/repos/maui1911/CodeScope/releases/assets/$($asset.id)"
+
+# … and fetch it the way the app does.
+curl.exe -sL -H "Accept: application/octet-stream" -o $env:TEMP\rv.zip `
+  -w "%{http_code} %{size_download} %{content_type}`n" $url
+```
+
+- [ ] The output is `200 <size> application/octet-stream` with `<size>`
+      equal to the asset's published size — **not**
+      `application/json`. The first two bytes of `$env:TEMP\rv.zip`
+      are `PK`.
+
+> Do not substitute the `github.com/…/releases/download/…` browser URL
+> here: it works without the header and would re-create exactly the
+> blind spot this check exists to close.
+
 ### Sign-off
 
-When all checks (1-6b) pass, the release is OK to announce. Push the
+When all checks (1-6c) pass, the release is OK to announce. Push the
 release notes to the GitHub release body, mention any breaking
 changes, and link relevant PRs.

--- a/src/update.rs
+++ b/src/update.rs
@@ -244,6 +244,36 @@ fn verify_complete(received: u64, total: Option<u64>) -> Result<(), String> {
     }
 }
 
+/// Second gate on a finished download: does the file actually *look*
+/// like the archive we asked for? `verify_complete` only proves we
+/// received every byte the server promised — a complete download of
+/// the *wrong content* (a JSON error body, an HTML block page) passes
+/// it and then dies in the extractor as "Could not find EOCD", which
+/// tells the user nothing. Pure so the rule is unit-testable.
+#[cfg(not(target_os = "macos"))]
+fn verify_archive_magic(archive_path: &std::path::Path, head: &[u8]) -> Result<(), String> {
+    let (magic, kind): (&[u8], &str) = match archive_path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default()
+    {
+        "zip" => (b"PK\x03\x04", "zip"),
+        // `.tar.gz` — `Path::extension` gives us the `gz` half.
+        "gz" => (&[0x1f, 0x8b], "gzip"),
+        // Unrecognised suffix: we have no expectation to check, and
+        // `self_update`'s extractor rejects it on its own terms.
+        _ => return Ok(()),
+    };
+    if head.starts_with(magic) {
+        return Ok(());
+    }
+    Err(format!(
+        "Downloaded file is not a {kind} archive (starts with {head:02x?}) — \
+         the server returned something other than the release asset. Retry; \
+         if it persists, report this with update.log."
+    ))
+}
+
 /// Download `url` into `archive_path`, streaming byte-progress into
 /// `state`, with completeness verification and a small retry budget.
 /// Returns the user-facing failure message on the final failure.
@@ -290,8 +320,19 @@ fn download_once(
         format!("Could not create archive file {}: {err:#}", archive_path.display())
     })?;
 
+    // `Accept: application/octet-stream` is MANDATORY, not decoration.
+    // `ReleaseInfo::archive_url` is GitHub's *API* asset URL
+    // (`api.github.com/repos/…/releases/assets/{id}`) — `self_update`'s
+    // GitHub backend reads `asset["url"]`, not `browser_download_url`.
+    // Without this header that URL answers 200 with ~1.6 KB of asset
+    // *metadata JSON*, which sails past `error_for_status` and
+    // `verify_complete` (received == Content-Length) and only blows up
+    // in the extractor as "Could not find EOCD". `self_update`'s own
+    // downloader sets the same header; we lost it when we replaced it
+    // with this hand-rolled stream to drive byte-progress.
     let mut response = client
         .get(url)
+        .header(reqwest::header::ACCEPT, "application/octet-stream")
         .send()
         .map_err(|err| format!("Download request failed: {err:#}"))?;
     response
@@ -318,7 +359,17 @@ fn download_once(
         .map_err(|err| format!("Flush error: {err:#}"))?;
     drop(archive_file); // close before Extract reads it
 
-    verify_complete(received, total)
+    verify_complete(received, total)?;
+
+    // Read the header back rather than tracking it through the stream
+    // loop — one 4-byte read of a file we just wrote, against a 6 MB
+    // download. A short read on a regular file would fail the magic
+    // check below, which is the honest outcome anyway.
+    let mut head = [0u8; 4];
+    let read = std::fs::File::open(archive_path)
+        .and_then(|mut file| std::io::Read::read(&mut file, &mut head))
+        .map_err(|err| format!("Could not re-read the downloaded archive: {err:#}"))?;
+    verify_archive_magic(archive_path, &head[..read])
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -494,7 +545,8 @@ pub fn open_releases_page() -> anyhow::Result<()> {
 
 #[cfg(all(test, not(target_os = "macos")))]
 mod tests {
-    use super::verify_complete;
+    use super::{download_once, new_state, verify_archive_magic, verify_complete};
+    use std::path::Path;
 
     #[test]
     fn full_download_is_complete() {
@@ -524,5 +576,103 @@ mod tests {
         let err = verify_complete(6_000_000, Some(5_717_213)).unwrap_err();
         assert!(err.contains("size mismatch"), "{err}");
         assert!(!err.to_lowercase().contains("incomplete"), "{err}");
+    }
+
+    #[test]
+    fn zip_magic_is_accepted() {
+        let path = Path::new("CodeScope-v1.2.3-windows.zip");
+        assert!(verify_archive_magic(path, b"PK\x03\x04").is_ok());
+    }
+
+    #[test]
+    fn gzip_magic_is_accepted() {
+        let path = Path::new("codescope-x86_64-unknown-linux-gnu.tar.gz");
+        assert!(verify_archive_magic(path, &[0x1f, 0x8b, 0x08, 0x00]).is_ok());
+    }
+
+    #[test]
+    fn github_asset_metadata_json_is_rejected_before_extract() {
+        // The regression this whole guard exists for: GitHub's API
+        // asset URL answers a header-less GET with 200 + metadata JSON.
+        // That body is *complete*, so `verify_complete` passes it —
+        // this must catch it and say something true, not leave the
+        // extractor to report "Could not find EOCD".
+        let path = Path::new("CodeScope-v1.2.3-windows.zip");
+        let err = verify_archive_magic(path, br#"{"ur"#).unwrap_err();
+        assert!(err.contains("not a zip archive"), "{err}");
+    }
+
+    #[test]
+    fn unknown_extension_is_not_second_guessed() {
+        assert!(verify_archive_magic(Path::new("payload.bin"), b"junk").is_ok());
+    }
+
+    /// Body a GitHub asset URL returns for a GET that does *not* ask
+    /// for the raw bytes — trimmed, but byte-for-byte in shape.
+    const ASSET_METADATA_JSON: &[u8] =
+        br#"{"url":"https://api.github.com/repos/o/r/releases/assets/1","id":1}"#;
+    /// Stand-in for the real archive. `download_once` only inspects the
+    /// magic, so four bytes plus filler is a faithful enough zip here.
+    const ARCHIVE_BYTES: &[u8] = b"PK\x03\x04and then some payload";
+
+    /// One-shot HTTP server that mimics GitHub's asset endpoint: raw
+    /// bytes when the request carries `Accept: application/octet-stream`,
+    /// asset metadata JSON when it doesn't. Returns the URL to GET.
+    fn spawn_github_like_asset_server() -> String {
+        use std::io::{BufRead as _, Write as _};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let url = format!("http://{}/assets/1", listener.local_addr().expect("addr"));
+        std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            let mut reader = std::io::BufReader::new(stream.try_clone().expect("clone"));
+            let mut wants_raw_bytes = false;
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 || line == "\r\n" {
+                    break;
+                }
+                let line = line.to_ascii_lowercase();
+                if line.starts_with("accept:") && line.contains("application/octet-stream") {
+                    wants_raw_bytes = true;
+                }
+            }
+            let (content_type, body) = if wants_raw_bytes {
+                ("application/octet-stream", ARCHIVE_BYTES)
+            } else {
+                ("application/json", ASSET_METADATA_JSON)
+            };
+            let mut stream = stream;
+            let _ = write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(body);
+            let _ = stream.flush();
+        });
+        url
+    }
+
+    #[test]
+    fn download_asks_github_for_the_raw_asset_bytes() {
+        // End-to-end regression guard for the "Could not find EOCD"
+        // reports: drop the `Accept: application/octet-stream` header
+        // from `download_once` and this server hands back metadata
+        // JSON instead of the archive, failing the assertions below —
+        // which is exactly what shipped in v0.5.0 through v0.5.3.
+        let url = spawn_github_like_asset_server();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let archive_path = dir.path().join("CodeScope-v99.0.0-windows.zip");
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .expect("build client");
+
+        download_once(&client, &url, &archive_path, &new_state()).expect("download succeeds");
+
+        let written = std::fs::read(&archive_path).expect("read archive");
+        assert_eq!(written, ARCHIVE_BYTES, "server served the metadata JSON path");
     }
 }


### PR DESCRIPTION
## The bug

Every in-app update on Windows fails, instantly, with:

```
Extract failed: extract archive: ZipError: invalid zip archive: Could not find EOCD
```

## Root cause

`ReleaseInfo::archive_url` is GitHub's **API** asset URL
(`api.github.com/repos/…/releases/assets/{id}`) — `self_update`'s GitHub backend reads
`asset["url"]`, not `browser_download_url`
([`backends/github.rs:24`](https://docs.rs/self_update/0.41.0/src/self_update/backends/github.rs.html) →
`core/src/update_check.rs:146`).

That URL serves the archive **only** when the request carries `Accept: application/octet-stream`.
`self_update`'s own downloader sets it. #249 replaced that downloader with a hand-rolled `reqwest`
stream to drive byte-progress, and dropped the header. GitHub answers the bare GET with **200 +
`application/json`, ~1.6 KB of asset metadata**, which gets written to disk and handed to the zip
extractor.

Reproduced against the live v0.5.3 Windows asset:

```
only User-Agent        → 200 application/json         1651 bytes   {"url":"https://api.github.com/…
+ Accept: octet-stream → 200 application/octet-stream 5922247      PK\x03\x04
```

Every symptom follows from that:

| Symptom | Why |
|---|---|
| Fails **instantly** | 1.6 KB downloads in milliseconds |
| No retry | `verify_complete` sees `received == Content-Length` → success |
| Passes `error_for_status` | It really is a 200 |
| EOCD | `ZipArchive::new` on JSON |

## Why it survived two previous fixes

RELEASE-VALIDATION §6 and §6b both drive the installer through `CODESCOPE_DEV_UPDATE_URL` at a
localhost file server, which **structurally cannot exercise the API URL**. The dev loop always
passed and production always failed, so the same symptom was misdiagnosed as middlebox truncation
(#275) and as a timeout (#301). Both are genuine hardening and stay, but neither was the cause —
the Windows in-app update has plausibly never worked against a real release.

## The fix

1. **The header** — one line in `download_once`. `reqwest` preserves `Accept` across GitHub's 302 to
   the CDN (verified with `curl -L`).
2. **`verify_archive_magic`** — a second gate after `verify_complete`. A *complete* download of the
   wrong content (JSON, an HTML block page) now fails with `Downloaded file is not a zip archive
   (starts with …)` instead of reaching the extractor. This also closes the `total: None` hole in
   `verify_complete`, which accepts any body when the server sends no `Content-Length`.
3. **`download_asks_github_for_the_raw_asset_bytes`** — a `TcpListener` server mimicking GitHub
   (raw bytes with the header, metadata JSON without). Confirmed to fail when the header is
   removed:
   ```
   panicked: download succeeds: "Downloaded file is not a zip archive
   (starts with [7b, 22, 75, 72]) — …"        // 7b 22 75 72 == {"ur
   ```
4. **RELEASE-VALIDATION §6c (mandatory)** — fetch the real API asset URL of the freshly-published
   release with the header, assert `application/octet-stream` and a `PK` prefix. Explicitly forbids
   substituting the `releases/download/…` browser URL, which works *without* the header and would
   re-create this exact blind spot.
5. **HANDOFF** — corrects the standing "the user is behind a truncating network" claim, which was
   wrong. Their machine downloads the release asset cleanly (200, exact byte count, valid zip, no
   proxy, stock Defender).

## Verification

- `cargo test --bin codescope` → **152 passed, 0 failed** (was 147; +5 here).
- Regression test proven to fail with the header removed, pass with it restored.
- `cargo clippy --bin codescope --all-targets` → no new warnings; zero hits in `src/update.rs`.
- Published `CodeScope-v0.5.3-windows.zip` independently verified healthy: 5,922,247 bytes,
  `PK\x03\x04`, `testzip()` clean — the artifact was never the problem.

## Not fixed here

The `sha256.sum` release asset is **1 byte** (just `\n`) on both v0.5.2 and v0.5.3 — a broken
pipeline step. Harmless for the updater, which fetches the `-windows.zip` directly, but it deserves
its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
