### PR TITLE
release: bump version to 0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "codescope"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
Version bump for the v0.5.4 release.

Carries #305 — the in-app updater on Windows was downloading GitHub's asset **metadata JSON** instead of the archive, because the hand-rolled downloader introduced in #249 never sent `Accept: application/octet-stream` to the API asset URL. Every in-app update since then failed instantly with `Could not find EOCD`.

This release matters more than a normal patch: **v0.5.3 and earlier cannot update themselves to it.** Users have to run `CodeScope-v0.5.4-setup.exe` once by hand; after that the in-app updater works against a real release for the first time.

Only `Cargo.toml` + `Cargo.lock` change here.

Before announcing, run the new **RELEASE-VALIDATION §6c** against the freshly-published v0.5.4 asset — it is the only check that exercises the real GitHub API asset URL rather than a localhost file server, which is exactly the blind spot that let this ship three times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
