### PR TITLE
fix(terminal): stop ctrl+click on a link opening it twice

### DIFF
--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -139,6 +139,12 @@ pub struct TerminalView {
     /// mouse-move; we only `cx.notify()` when the value flips so
     /// motion across non-hyperlink cells doesn't repaint the world.
     hovered_link: Option<Arc<str>>,
+    /// Set when a Ctrl/Cmd-click opened a hyperlink, cleared by the
+    /// matching mouse-up. Without it we swallow the press but still
+    /// report the *release* to a TUI in mouse-reporting mode — and
+    /// `claude-code` treats that lone release as its own click, so
+    /// the URL opens a second time in the browser.
+    link_click_consumed: bool,
 }
 
 impl TerminalView {
@@ -256,6 +262,7 @@ impl TerminalView {
             selecting: false,
             blink_phase,
             hovered_link: None,
+            link_click_consumed: false,
         }
     }
 
@@ -414,6 +421,7 @@ impl TerminalView {
             && let Some((row, col)) = self.visible_rc(event.position)
                 && let Some(uri) = self.snapshot.hyperlink_at(row, col) {
                     let _ = open::that_detached(uri.as_ref());
+                    self.link_click_consumed = true;
                     return;
                 }
 
@@ -487,6 +495,12 @@ impl TerminalView {
         _window: &mut Window,
         _cx: &mut Context<Self>,
     ) {
+        // The press opened a hyperlink and never reached the TUI —
+        // don't hand it the orphaned release either.
+        if std::mem::take(&mut self.link_click_consumed) {
+            self.selecting = false;
+            return;
+        }
         if let Some(button) = to_mouse_button(event.button)
             && self.try_report_mouse(
                 MouseEventKind::Release,

--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -496,8 +496,10 @@ impl TerminalView {
         _cx: &mut Context<Self>,
     ) {
         // The press opened a hyperlink and never reached the TUI —
-        // don't hand it the orphaned release either.
-        if std::mem::take(&mut self.link_click_consumed) {
+        // don't hand it the orphaned release either. Gated on Left so
+        // a right/middle release mid-drag can't eat the flag and let
+        // the real release through.
+        if event.button == MouseButton::Left && std::mem::take(&mut self.link_click_consumed) {
             self.selecting = false;
             return;
         }


### PR DESCRIPTION
## Problem

Ctrl+clicking a URL in a terminal tab opened the link **twice** in the browser (two tabs). File-path links were unaffected.

## Root cause

`TerminalView::on_mouse_down` short-circuits a Ctrl/Cmd-click on a hyperlink: it opens the URI and returns *without* forwarding the press to the TUI. `on_mouse_up` had no matching short-circuit, so it still ran `try_report_mouse(Release, …)`.

When the TUI has mouse reporting on — `claude-code` does; measured `mouse_mode=true` in an instrumented dev build — it receives an orphaned release, treats it as its own click on the link, and opens the URL again through its own opener. File paths never doubled because the TUI doesn't linkify those.

## Fix

Remember that the press was consumed (`link_click_consumed`) and swallow the matching release. Not `claude-code`-specific: no mouse-mode app (tmux, vim, codex, …) should ever see half a click.

## Verification

Instrumented dev build, live `claude-code` session, synthetic Ctrl+click via `SendInput`:

- **before** — one `mouse_down`, one `open link`, yet two Tweakers tabs in Firefox
- **after** — three Ctrl+clicks, three single opens, release swallowed each time

`cargo clippy -p codescope-terminal --all-targets` clean; `cargo test -p codescope-terminal` 53 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)