### PR TITLE
fix(release): publish checksums that actually verify something

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -465,6 +465,55 @@ jobs:
           rm -f artifacts/*-dist-manifest.json
           echo "After flatten:"
           find artifacts -type f | sort
+      # Rebuild the checksums over what is actually about to be
+      # released. Two reasons cargo-dist's own `sha256.sum` can't be
+      # trusted here:
+      #
+      #   * It ships EMPTY (one `\n`) on every release so far —
+      #     `dist build --artifacts=global` has no access to the local
+      #     artifacts' digests, so every global artifact derived from
+      #     them comes out blank. Upstream bug, open since v0.27:
+      #     https://github.com/axodotdev/cargo-dist/issues/1672.
+      #     A `sha256sum -c` against it trivially "passes" while
+      #     verifying nothing, which is worse than shipping no file.
+      #   * Even fixed it would be incomplete: the Windows zip and
+      #     installer come from the `windows-package` job, outside
+      #     cargo-dist's matrix, and `build-global-artifacts` doesn't
+      #     even depend on that job.
+      #
+      # This step runs after the flatten, so every asset is on disk.
+      - name: Checksums
+        working-directory: artifacts
+        run: |
+          rm -f sha256.sum
+          # Everything that isn't itself a checksum file.
+          payloads=$(find . -maxdepth 1 -type f ! -name '*.sha256' ! -name 'sha256.sum' -printf '%P\n' | sort)
+          if [ -z "$payloads" ]; then
+            echo "::error::no release payloads found to checksum"
+            exit 1
+          fi
+          # `--binary` gives `<hex> *<name>`, the form cargo-dist
+          # already uses for the per-tarball siblings.
+          echo "$payloads" | xargs -d '\n' sha256sum --binary > sha256.sum
+
+          # Per-artifact siblings for the Windows pair, which had no
+          # digest at all. Missing files are a packaging failure, not
+          # something to skip past.
+          for f in CodeScope-v*-windows.zip CodeScope-v*-setup.exe; do
+            if [ ! -f "$f" ]; then
+              echo "::error::expected Windows artifact missing: $f"
+              exit 1
+            fi
+            sha256sum --binary "$f" > "$f.sha256"
+          done
+
+          # Fail the release rather than publish a checksum file that
+          # verifies nothing: the digests must check out, and the file
+          # must list every payload — no silent omissions.
+          sha256sum -c sha256.sum
+          diff <(echo "$payloads") <(sed 's/^[0-9a-f]\{64\} \*//' sha256.sum | sort)
+          echo "sha256.sum:"
+          cat sha256.sum
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -494,7 +494,7 @@ jobs:
           fi
           # `--binary` gives `<hex> *<name>`, the form cargo-dist
           # already uses for the per-tarball siblings.
-          echo "$payloads" | xargs -d '\n' sha256sum --binary > sha256.sum
+          printf '%s\n' "$payloads" | xargs -d '\n' sha256sum --binary -- > sha256.sum
 
           # Per-artifact siblings for the Windows pair, which had no
           # digest at all. Missing files are a packaging failure, not
@@ -504,14 +504,14 @@ jobs:
               echo "::error::expected Windows artifact missing: $f"
               exit 1
             fi
-            sha256sum --binary "$f" > "$f.sha256"
+            sha256sum --binary -- "$f" > "$f.sha256"
           done
 
           # Fail the release rather than publish a checksum file that
           # verifies nothing: the digests must check out, and the file
           # must list every payload — no silent omissions.
-          sha256sum -c sha256.sum
-          diff <(echo "$payloads") <(sed 's/^[0-9a-f]\{64\} \*//' sha256.sum | sort)
+          sha256sum -c -- sha256.sum
+          diff <(printf '%s\n' "$payloads") <(sed 's/^[0-9a-f]\{64\} \*//' sha256.sum | sort)
           echo "sha256.sum:"
           cat sha256.sum
       - name: Create GitHub Release


### PR DESCRIPTION
Closes #306.

## What was wrong

**1. `sha256.sum` is one newline on every release** (v0.5.0 → v0.5.4, all 1 B). Anyone following the obvious path — `sha256sum -c sha256.sum` — gets a no-op that passes. That is worse than shipping nothing.

Root cause is upstream, not local config: `dist build --artifacts=global` runs without the local artifacts' digests, so every global artifact derived from them is emitted blank. Same bug as [axodotdev/cargo-dist#1672](https://github.com/axodotdev/cargo-dist/issues/1672) (Homebrew formula with no sha256), open since v0.27. Confirmed in the v0.5.4 run: `build-global-artifacts` logs `building artifacts: sha256.sum`, uploads it, and the asset is 1 byte.

**2. The Windows artifacts had no digest at all.** `CodeScope-v*-windows.zip` and `-setup.exe` come from the `windows-package` job, outside cargo-dist's matrix — and `build-global-artifacts` doesn't even depend on that job, so no upstream fix could ever include them.

## What this does

Rebuilds the checksums in `host`, after the flatten, where every asset that is about to be released is on disk:

- `sha256.sum` regenerated over every payload (excluding checksum files themselves), in the `<hex> *<name>` form cargo-dist already uses.
- `.sha256` siblings emitted for the Windows zip and installer.
- Three guards, each failing the release rather than publishing a file that verifies nothing:
  - `sha256sum -c sha256.sum` — the digests must check out
  - a set-diff of payloads against the entries — no silent omissions
  - both Windows artifacts must exist

cargo-dist still emits its empty aggregate; this overwrites it before upload, so the published asset is the real one.

## Verification

The step was run verbatim against a mock flattened `artifacts/` tree (three tarballs, an existing tarball sibling, the Windows pair, `dist-manifest.json`, and cargo-dist's 1-byte `sha256.sum`):

| case | result |
|---|---|
| happy path | 6 payloads listed, all `OK`, set-diff clean |
| Windows zip absent | `::error::expected Windows artifact missing`, exit 1 |
| payload tampered after write | `dist-manifest.json: FAILED`, exit 1 |
| entry omitted from aggregate | set-diff reports it, exit 1 |

Workflow YAML re-parsed after the edit. Can't be exercised end to end without cutting a tag — the next release is the real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)