### PR TITLE
fix(diff): resizable file list, and stop mis-flagging new files binary

### DIFF
--- a/core/src/diff.rs
+++ b/core/src/diff.rs
@@ -17,7 +17,7 @@
 //! viewer that drops one exotic header is useful, one that errors on
 //! it is not.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result};
 
@@ -485,6 +485,19 @@ pub fn worktree_diff(worktree: &Path) -> Result<Vec<DiffFile>> {
         Vec::new()
     };
 
+    // Every path git reports is relative to the *repo root*, not to
+    // the directory we ran it in — and `worktree` is a session's
+    // working directory, which can be any subfolder the user added as
+    // a project. Resolve untracked reads against the root or they all
+    // fail to open and get mis-flagged binary. Falls back to
+    // `worktree` when git can't answer (already-degraded case; the
+    // status call below would have failed too).
+    let root = run_git(worktree, &["rev-parse", "--show-toplevel"])
+        .ok()
+        .map(|out| PathBuf::from(String::from_utf8_lossy(&out.stdout).trim().to_string()))
+        .filter(|p| p.is_dir())
+        .unwrap_or_else(|| worktree.to_path_buf());
+
     // `-z`: NUL-terminated entries with RAW paths — no C-style
     // quoting/escaping to undo, so names with spaces, quotes, or
     // backslash escapes resolve on disk exactly as git reported them.
@@ -509,7 +522,7 @@ pub fn worktree_diff(worktree: &Path) -> Result<Vec<DiffFile>> {
             let _ = fields.next();
         }
         if code == "?? " {
-            untracked.push(untracked_file_entry(worktree, path));
+            untracked.push(untracked_file_entry(&root, path));
         }
     }
     untracked.sort_by(|a, b| a.path.cmp(&b.path));
@@ -520,7 +533,7 @@ pub fn worktree_diff(worktree: &Path) -> Result<Vec<DiffFile>> {
 /// Build the synthetic all-added [`DiffFile`] for an untracked path.
 /// Reads from disk with byte/line caps; a read failure or NUL byte in
 /// the prefix marks the entry binary instead of erroring the diff.
-fn untracked_file_entry(worktree: &Path, rel_path: &str) -> DiffFile {
+fn untracked_file_entry(repo_root: &Path, rel_path: &str) -> DiffFile {
     let mut entry = DiffFile {
         path: rel_path.to_string(),
         old_path: None,
@@ -535,7 +548,7 @@ fn untracked_file_entry(worktree: &Path, rel_path: &str) -> DiffFile {
     // Bounded read: pull at most cap+1 bytes off disk (the +1 tells
     // truncation apart from an exactly-cap-sized file) so a multi-GB
     // untracked artifact never lands in memory just to be previewed.
-    let abs = worktree.join(rel_path);
+    let abs = repo_root.join(rel_path);
     let bytes = {
         use std::io::Read as _;
         let Ok(file) = std::fs::File::open(&abs) else {
@@ -868,6 +881,32 @@ Binary files a/img.png and b/img.png differ
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, name);
         assert_eq!(files[0].status, FileStatus::Modified);
+        assert_eq!(files[0].added, 1);
+    }
+
+    /// A session's working directory can be a *subdirectory* of the
+    /// repo (any folder can be added as a project). `git status
+    /// --porcelain` always reports paths relative to the repo root,
+    /// so joining them onto the session directory looks for
+    /// `sub/sub/notes.md`, the open fails, and every untracked file
+    /// gets mis-flagged binary.
+    #[test]
+    fn untracked_paths_resolve_from_a_subdirectory() {
+        let Some((_guard, repo)) = init_repo() else { return };
+        std::fs::write(repo.join("seed.txt"), "a\n").unwrap();
+        run(&repo, &["add", "-A"]);
+        run(&repo, &["commit", "-m", "seed", "-q"]);
+        let sub = repo.join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(sub.join("notes.md"), "# hi\n").unwrap();
+
+        let files = worktree_diff(&sub).expect("diff succeeds");
+        assert_eq!(files.len(), 1, "got: {files:#?}");
+        assert_eq!(files[0].path, "sub/notes.md");
+        assert!(
+            !files[0].binary,
+            "untracked path resolved against the session dir, not the repo root"
+        );
         assert_eq!(files[0].added, 1);
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -443,7 +443,7 @@ fn normalise_group_weights(weights: &mut [f32]) {
 /// itself uses `DIVIDER_VISUAL_WIDTH`; the extra width comes from
 /// an absolute-positioned overlay centered on the visible line that
 /// extends `(HIT - VISUAL) / 2` pixels into each adjacent pane.
-const SPLITTER_HIT_WIDTH: f32 = 6.0;
+pub(crate) const SPLITTER_HIT_WIDTH: f32 = 6.0;
 
 /// Visible width of the splitter / sidebar-handle / strip-divider
 /// line. Kept at 1 px for a clean, single-pixel rule between panes;
@@ -456,7 +456,14 @@ const SPLITTER_HIT_WIDTH: f32 = 6.0;
 /// pane splitters, `begin_splitter_drag`'s sidebar-pixels subtraction)
 /// uses *this* width so both rows divide the same horizontal extent
 /// by the same `weight` factor.
-const DIVIDER_VISUAL_WIDTH: f32 = 1.0;
+pub(crate) const DIVIDER_VISUAL_WIDTH: f32 = 1.0;
+
+/// Diff viewer file-list width: starting value and drag clamps. The
+/// floor keeps a path fragment plus its badge readable; the ceiling
+/// stops the list from crowding out the diff it exists to navigate.
+const DIFF_LIST_DEFAULT_WIDTH: f32 = 300.0;
+const DIFF_LIST_MIN_WIDTH: f32 = 180.0;
+const DIFF_LIST_MAX_WIDTH: f32 = 720.0;
 
 /// Width of the right-side caption-controls cluster in the title
 /// bar (split + min + max + close, each 46 px). The rightmost
@@ -731,6 +738,15 @@ pub struct AppShell {
     /// In-flight sidebar drag, if any. Same shape as `splitter_drag`
     /// but specific to the sidebar's right edge.
     sidebar_drag: Option<SidebarDrag>,
+    /// Width of the diff viewer's file list (its "sidebar"). Kept on
+    /// the shell rather than in `DiffViewerState` so a resize survives
+    /// closing and re-opening the panel. Deliberately *not* persisted
+    /// to `layout.json` — it resets to the default on restart, which
+    /// nobody has asked to change.
+    pub(crate) diff_list_width: f32,
+    /// In-flight diff-viewer file-list drag. Same shape and lifecycle
+    /// as `sidebar_drag`.
+    diff_list_drag: Option<SidebarDrag>,
     /// Open tab right-click menu, if any.
     tab_menu: Option<TabMenu>,
     /// In-flight tab drag-hover state. `Some` between an `on_drag_move`
@@ -1592,6 +1608,8 @@ impl AppShell {
             sidebar_width,
             sidebar_visible,
             sidebar_drag: None,
+            diff_list_width: DIFF_LIST_DEFAULT_WIDTH,
+            diff_list_drag: None,
             tab_menu: None,
             tab_drag_hover: None,
             tab_rects: HashMap::new(),
@@ -4079,6 +4097,35 @@ impl AppShell {
     fn end_sidebar_drag(&mut self, cx: &mut Context<Self>) {
         if self.sidebar_drag.take().is_some() {
             self.save_layout();
+            cx.notify();
+        }
+    }
+
+    /// Begin a diff-viewer file-list resize from the mouse-down on the
+    /// handle between the list and the detail pane.
+    pub(crate) fn begin_diff_list_drag(&mut self, cursor_x: gpui::Pixels) {
+        self.diff_list_drag = Some(SidebarDrag {
+            start_x: cursor_x,
+            start_width: self.diff_list_width,
+        });
+    }
+
+    /// Update the file-list width during an in-flight drag, clamped
+    /// between [`DIFF_LIST_MIN_WIDTH`] and [`DIFF_LIST_MAX_WIDTH`].
+    fn update_diff_list_drag(&mut self, cursor_x: gpui::Pixels, cx: &mut Context<Self>) {
+        let Some(drag) = self.diff_list_drag.as_ref() else { return };
+        let dx: f32 = (cursor_x - drag.start_x).into();
+        let new_width = (drag.start_width + dx).clamp(DIFF_LIST_MIN_WIDTH, DIFF_LIST_MAX_WIDTH);
+        if (new_width - self.diff_list_width).abs() > 0.1 {
+            self.diff_list_width = new_width;
+            cx.notify();
+        }
+    }
+
+    /// Nothing to persist — the width is session-scoped — so this only
+    /// clears the in-flight drag.
+    fn end_diff_list_drag(&mut self, cx: &mut Context<Self>) {
+        if self.diff_list_drag.take().is_some() {
             cx.notify();
         }
     }
@@ -7423,6 +7470,9 @@ impl Render for AppShell {
                 if this.sidebar_drag.is_some() {
                     this.update_sidebar_drag(event.position.x, cx);
                 }
+                if this.diff_list_drag.is_some() {
+                    this.update_diff_list_drag(event.position.x, cx);
+                }
                 if this.titlebar_press.is_some() {
                     this.update_titlebar_drag(event, window, cx);
                 }
@@ -7432,6 +7482,7 @@ impl Render for AppShell {
                 cx.listener(|this, _, _, cx| {
                     this.end_splitter_drag(cx);
                     this.end_sidebar_drag(cx);
+                    this.end_diff_list_drag(cx);
                     this.titlebar_press = None;
                 }),
             )

--- a/src/diff_viewer.rs
+++ b/src/diff_viewer.rs
@@ -369,16 +369,44 @@ impl AppShell {
         }
         let mut file_list = div()
             .id("diff-file-list")
-            .w(px(300.0))
+            .w(px(self.diff_list_width))
             .flex_shrink_0()
             .flex()
             .flex_col()
             .overflow_y_scroll()
-            .border_r_1()
-            .border_color(divider)
             .py(px(6.0))
             .children(file_rows);
         file_list.style().min_size.height = Some(gpui::Length::Definite(px(0.0).into()));
+
+        // Resize handle between list and detail — same 1 px line with
+        // a wider absolute-positioned hit-target as the main sidebar's
+        // handle (see `sidebar_handle` in `app.rs`). It replaces the
+        // list's old right border, so there's still exactly one line.
+        let hit_overhang = (crate::app::SPLITTER_HIT_WIDTH - crate::app::DIVIDER_VISUAL_WIDTH) / 2.0;
+        let list_handle = div()
+            .id("diff-list-resize-handle")
+            .relative()
+            .w(px(crate::app::DIVIDER_VISUAL_WIDTH))
+            .flex_shrink_0()
+            .h_full()
+            .bg(divider)
+            .child(
+                div()
+                    .absolute()
+                    .top_0()
+                    .left(px(-hit_overhang))
+                    .w(px(crate::app::SPLITTER_HIT_WIDTH))
+                    .h_full()
+                    .cursor_col_resize()
+                    .on_mouse_down(
+                        gpui::MouseButton::Left,
+                        cx.listener(|this, event: &gpui::MouseDownEvent, _, cx| {
+                            cx.stop_propagation();
+                            this.begin_diff_list_drag(event.position.x);
+                            cx.notify();
+                        }),
+                    ),
+            );
 
         // ── Detail pane ──────────────────────────────────────────
         let mut detail = div()
@@ -395,6 +423,7 @@ impl AppShell {
             .flex_row()
             .flex_grow()
             .child(file_list)
+            .child(list_handle)
             .child(detail);
         body.style().min_size.height = Some(gpui::Length::Definite(px(0.0).into()));
 


### PR DESCRIPTION
Closes #308 — both halves.

## 1. `.md` / `.sql` (and every other new file) shown as binary

`git status --porcelain` reports paths relative to the **repo root**; the untracked entries were being resolved against the *session's working directory*. Any project pointing at a subfolder of a repo therefore looked for `sub/sub/notes.md`, `File::open` failed, and `untracked_file_entry`'s read-failure branch flagged the entry binary — so every newly added file rendered as "Binary file — no preview." Nothing to do with the extension; `.md` and `.sql` just happened to be the new files.

Fixed by resolving against `git rev-parse --show-toplevel`, falling back to the session dir when git can't answer (already-degraded case — the status call would have failed too).

Test written first, and it failed on the old code with exactly the reported symptom:

```
untracked path resolved against the session dir, not the repo root
```

## 2. File list didn't resize

It was a hard-coded `w(px(300.0))` with `flex_shrink_0()` and no handle. Added one mirroring the main sidebar's splitter: 1 px line, 6 px hit target, `cursor_col_resize`, drag state on the shell, clamped to 180–720 px. It replaces the list's old right border, so there's still exactly one line.

The width lives on `AppShell` rather than in `DiffViewerState`, so a resize survives closing and re-opening the panel. Deliberately **not** persisted to `layout.json` — that would mean a new serialized field and two exact-JSON round-trip tests to update, for behaviour nobody asked for.

`SPLITTER_HIT_WIDTH` / `DIVIDER_VISUAL_WIDTH` went `pub(crate)` so the viewer can reuse the same geometry instead of re-declaring it.

## Verification

- `cargo test`: 505 in `codescope-core` (+1 new), 152 in `codescope`, all green. Clippy clean on both crates.
- Resize confirmed working in a dev build by the reporter.
- Diff viewer re-checked visually in the dev build: untracked `src/untracked.rs` renders its content (`U +2 −0`), and a genuinely binary `assets/logo.bin` still shows the `bin` badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)