### PR TITLE
release: bump version to 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "codescope"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
Version bump for the v0.5.5 tag. Ships the three fixes merged since v0.5.4:

| PR | Issue | Fix |
|---|---|---|
| #311 | #309 | Ctrl+click on a URL opened the browser twice — the orphaned mouse-release still reached the mouse-mode TUI, which opened the link itself |
| #313 | #306 | `sha256.sum` published as a single newline since v0.5.0; Windows artifacts had no digest at all |
| #314 | #308 | Diff viewer: drag-resizable file list, and untracked files no longer mis-flagged binary when the session dir sits below the repo root |

⚠️ **Watch the `Checksums` step in the `host` job on this tag.** #313 rewrote it and this is its first real run. It is built to fail the release rather than publish a checksum file that verifies nothing, so a red step there is a genuine finding — the error message names what is missing.

Build verified locally at the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)