### PR TITLE
feat: remote-shell projects — a sidebar entry that runs a saved command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ scratch/
 # Tool-state directories surfaced by AI / automation runners
 .claude/
 .playwright-cli/
+
+# Dev build output (separate target dir used for side-by-side dev runs)
+/target-dev/

--- a/core/src/agent_registry.rs
+++ b/core/src/agent_registry.rs
@@ -170,6 +170,28 @@ impl AgentRegistry {
             .iter()
             .find(|a| a.id.eq_ignore_ascii_case(id))
     }
+
+    /// Assemble the command a remote-shell project (#323) actually
+    /// runs. Returns the project's base command as-is, unless the
+    /// project names an agent — then the agent's new-session
+    /// invocation is appended via
+    /// [`crate::projects::remote_command_with_agent`] (`<command> -t
+    /// <agent>`) so the tab lands straight in the agent on the far
+    /// end. Platform-neutral: the same string is used whether the tab
+    /// boots through `pwsh -Command` (Windows) or is auto-typed into
+    /// the login shell (macOS / Linux).
+    ///
+    /// An unknown / removed agent id, or an agent whose `command` is
+    /// blank, degrades to the raw command — never to a broken launch.
+    pub fn assemble_remote_command(&self, project: &crate::projects::Project) -> String {
+        let base = project.remote_shell_command().unwrap_or_default();
+        let agent_launch = project
+            .remote_agent_id
+            .as_deref()
+            .and_then(|id| self.get_by_id(id))
+            .and_then(build_new_session_auto_type);
+        crate::projects::remote_command_with_agent(base, agent_launch.as_deref())
+    }
 }
 
 /// Built-in profiles shipped with the app. Mirrors the C#
@@ -372,6 +394,35 @@ pub fn build_new_session_auto_type(profile: &AgentProfile) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn assemble_remote_command_appends_selected_agent() {
+        let reg = AgentRegistry::with_built_ins();
+        let p = crate::projects::Project::new_remote_shell(
+            "dev".into(),
+            "ssh dev".into(),
+            Some("claude".into()),
+        );
+        assert_eq!(reg.assemble_remote_command(&p), "ssh dev -t claude");
+    }
+
+    #[test]
+    fn assemble_remote_command_without_agent_is_raw() {
+        let reg = AgentRegistry::with_built_ins();
+        let p = crate::projects::Project::new_remote_shell("dev".into(), "ssh dev".into(), None);
+        assert_eq!(reg.assemble_remote_command(&p), "ssh dev");
+    }
+
+    #[test]
+    fn assemble_remote_command_unknown_agent_degrades_to_raw() {
+        let reg = AgentRegistry::with_built_ins();
+        let p = crate::projects::Project::new_remote_shell(
+            "dev".into(),
+            "ssh dev".into(),
+            Some("no-such-agent".into()),
+        );
+        assert_eq!(reg.assemble_remote_command(&p), "ssh dev");
+    }
 
     #[test]
     fn built_in_defaults_cover_all_five_agents() {

--- a/core/src/agent_registry.rs
+++ b/core/src/agent_registry.rs
@@ -403,7 +403,10 @@ mod tests {
             "ssh dev".into(),
             Some("claude".into()),
         );
-        assert_eq!(reg.assemble_remote_command(&p), "ssh dev -t claude");
+        assert_eq!(
+            reg.assemble_remote_command(&p),
+            "ssh dev -t '$SHELL -lic \"claude\"'"
+        );
     }
 
     #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -62,6 +62,7 @@ pub use overview::{
 pub use paths::AppPaths;
 pub use projects::{
     Project, ProjectKind, ProjectsConfig, Session, Worktree, is_valid_remote_shell_command,
+    remote_command_with_agent,
 };
 pub use session::{
     RetentionPolicy, SessionDescriptor, SessionManager, build_agent_shell_args,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -60,9 +60,12 @@ pub use overview::{
     build_rows_for_live as build_overview_rows_for_live,
 };
 pub use paths::AppPaths;
-pub use projects::{Project, ProjectsConfig, Session, Worktree};
+pub use projects::{
+    Project, ProjectKind, ProjectsConfig, Session, Worktree, is_valid_remote_shell_command,
+};
 pub use session::{
-    RetentionPolicy, SessionDescriptor, SessionManager, build_agent_shell_args, now_iso8601,
+    RetentionPolicy, SessionDescriptor, SessionManager, build_agent_shell_args,
+    build_remote_shell_args, now_iso8601,
 };
 pub use settings::{CursorSettings, CursorShape, DEFAULT_AGENT_ID, FontSettings, Settings};
 pub use tab_drag::{TabRect, compute_drop_index};

--- a/core/src/overview.rs
+++ b/core/src/overview.rs
@@ -204,7 +204,7 @@ fn cmp_desc_with_none_last(a: Option<f64>, b: Option<f64>) -> std::cmp::Ordering
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::projects::{Project, Session, Worktree};
+    use crate::projects::{Project, ProjectKind, Session, Worktree};
 
     fn mk_project(id: &str, name: &str, sessions: Vec<Session>) -> Project {
         Project {
@@ -213,6 +213,8 @@ mod tests {
             path: format!("C:\\dev\\{name}"),
             default_branch: "main".into(),
             worktree_root: None,
+            kind: ProjectKind::Local,
+            command: None,
             default_agent_id: None,
             sessions,
             worktrees: vec![Worktree {

--- a/core/src/overview.rs
+++ b/core/src/overview.rs
@@ -215,6 +215,7 @@ mod tests {
             worktree_root: None,
             kind: ProjectKind::Local,
             command: None,
+            remote_agent_id: None,
             default_agent_id: None,
             sessions,
             worktrees: vec![Worktree {

--- a/core/src/projects.rs
+++ b/core/src/projects.rs
@@ -25,7 +25,23 @@ use crate::paths::AppPaths;
 /// stay at the same version.
 pub const CURRENT_VERSION: u32 = 1;
 
-/// One git repository as it appears in the sidebar.
+/// What a sidebar project *is*. Almost everything is a `Local` git
+/// checkout; `RemoteShell` is the escape hatch for "I work on a box
+/// over SSH and just want a tab that runs `ssh host -t claude`" —
+/// no path, no worktrees, no git pollers, no telemetry (#323).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ProjectKind {
+    /// A local directory (normally a git repository).
+    #[default]
+    Local,
+    /// A saved command line, run in a fresh local shell with no
+    /// working directory. The `Project::command` field carries it.
+    RemoteShell,
+}
+
+/// One git repository (or remote-shell command) as it appears in the
+/// sidebar.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Project {
@@ -33,8 +49,17 @@ pub struct Project {
     pub id: String,
     /// Display name in the sidebar. Usually the folder leaf.
     pub name: String,
-    /// Absolute path to the primary working tree.
+    /// Absolute path to the primary working tree. Empty for
+    /// [`ProjectKind::RemoteShell`] projects.
     pub path: String,
+    /// See [`ProjectKind`]. Missing in files written before #323 —
+    /// those are all `Local`.
+    #[serde(default)]
+    pub kind: ProjectKind,
+    /// Command line to run for [`ProjectKind::RemoteShell`] projects
+    /// (e.g. `ssh dev@box -t claude`). `None` for local projects.
+    #[serde(default)]
+    pub command: Option<String>,
     /// Default branch — used as the base when creating new worktrees.
     #[serde(default = "default_branch", alias = "default_branch")]
     pub default_branch: String,
@@ -88,6 +113,8 @@ impl Project {
             id: uuid::Uuid::new_v4().to_string(),
             name,
             path,
+            kind: ProjectKind::Local,
+            command: None,
             default_branch: default_branch(),
             worktree_root: None,
             default_agent_id: None,
@@ -96,6 +123,56 @@ impl Project {
         }
     }
 
+    /// Build a [`ProjectKind::RemoteShell`] project: a named command
+    /// line with no path and no worktrees. Both arguments are
+    /// trimmed; the caller is expected to have rejected empty values
+    /// already (see [`is_valid_remote_shell_command`]).
+    pub fn new_remote_shell(name: String, command: String) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            name: name.trim().to_string(),
+            path: String::new(),
+            kind: ProjectKind::RemoteShell,
+            command: Some(command.trim().to_string()),
+            default_branch: default_branch(),
+            worktree_root: None,
+            default_agent_id: None,
+            sessions: Vec::new(),
+            worktrees: Vec::new(),
+        }
+    }
+
+    /// `true` for [`ProjectKind::RemoteShell`] projects. Callers use
+    /// this to skip every path-shaped feature (git pollers, worktree
+    /// menus, reveal-in-explorer, telemetry) — the only thing such a
+    /// project can do is open a tab running its command.
+    pub fn is_remote_shell(&self) -> bool {
+        self.kind == ProjectKind::RemoteShell
+    }
+
+    /// The saved command for a remote-shell project, if it has one.
+    /// `None` for local projects and for malformed rows (kind says
+    /// remote but the command is missing or blank).
+    pub fn remote_shell_command(&self) -> Option<&str> {
+        if !self.is_remote_shell() {
+            return None;
+        }
+        self.command
+            .as_deref()
+            .map(str::trim)
+            .filter(|c| !c.is_empty())
+    }
+}
+
+/// Validation for the Add-project dialog's remote-shell mode: the
+/// command must be non-blank and single-line. Anything else is the
+/// user's business — we hand the string to `pwsh -Command` verbatim.
+pub fn is_valid_remote_shell_command(command: &str) -> bool {
+    let trimmed = command.trim();
+    !trimmed.is_empty() && !trimmed.contains(['\n', '\r'])
+}
+
+impl Project {
     /// Effective worktree root for this project. Mirrors the C# rule
     /// in `NewWorktreeDialog`: explicit `worktree_root` wins, otherwise
     /// fall back to `"{path}.worktrees"` next to the primary tree.
@@ -121,6 +198,9 @@ impl Project {
     /// skipped — `Project::new` already seeded that row; the branch
     /// backfill is the `WorktreeStatusPoller`'s job, not ours.
     pub fn adopt_existing_worktrees(&mut self) {
+        if self.is_remote_shell() {
+            return;
+        }
         let Ok(found) = crate::git::list_worktrees(Path::new(&self.path)) else {
             return;
         };
@@ -449,6 +529,8 @@ mod tests {
                 path: "C:\\repos\\repo".into(),
                 default_branch: "main".into(),
                 worktree_root: Some("C:\\repos\\repo.worktrees".into()),
+                kind: ProjectKind::Local,
+                command: None,
                 default_agent_id: Some("claude-code".into()),
                 sessions: vec![Session {
                     id: "s1".into(),
@@ -587,6 +669,8 @@ mod tests {
                 path: String::new(),
                 default_branch: "main".into(),
                 worktree_root: None,
+                kind: ProjectKind::Local,
+                command: None,
                 default_agent_id: None,
                 sessions: Vec::new(),
                 worktrees: Vec::new(),
@@ -594,6 +678,111 @@ mod tests {
         };
         cfg.migrate();
         assert!(cfg.projects[0].worktrees.is_empty());
+    }
+
+    #[test]
+    fn remote_shell_project_has_no_path_and_no_worktrees() {
+        let p = Project::new_remote_shell("  devbox ".into(), " ssh dev@box -t claude ".into());
+        assert_eq!(p.name, "devbox");
+        assert_eq!(p.path, "");
+        assert_eq!(p.kind, ProjectKind::RemoteShell);
+        assert!(p.is_remote_shell());
+        assert_eq!(p.remote_shell_command(), Some("ssh dev@box -t claude"));
+        assert!(p.worktrees.is_empty());
+        assert!(p.sessions.is_empty());
+    }
+
+    #[test]
+    fn local_project_never_reports_a_remote_shell_command() {
+        let mut p = Project::new("C:/repo".into());
+        assert!(!p.is_remote_shell());
+        assert_eq!(p.remote_shell_command(), None);
+        // Even a stray `command` on a local row is ignored — `kind`
+        // is the discriminator, not the presence of the string.
+        p.command = Some("ssh somewhere".into());
+        assert_eq!(p.remote_shell_command(), None);
+    }
+
+    #[test]
+    fn remote_shell_with_blank_command_is_treated_as_missing() {
+        let mut p = Project::new_remote_shell("x".into(), "ssh box".into());
+        p.command = Some("   ".into());
+        assert_eq!(p.remote_shell_command(), None);
+        p.command = None;
+        assert_eq!(p.remote_shell_command(), None);
+    }
+
+    #[test]
+    fn remote_shell_command_validation() {
+        assert!(is_valid_remote_shell_command("ssh dev@box -t claude"));
+        assert!(is_valid_remote_shell_command("  wsl.exe -d Ubuntu  "));
+        assert!(!is_valid_remote_shell_command(""));
+        assert!(!is_valid_remote_shell_command("   \t "));
+        assert!(!is_valid_remote_shell_command("ssh box\nrm -rf /"));
+        assert!(!is_valid_remote_shell_command("ssh box\r\nclaude"));
+    }
+
+    #[test]
+    fn migrate_leaves_remote_shell_projects_without_a_primary() {
+        // A remote-shell project has an empty path, so `migrate`
+        // must not synthesise a primary worktree for it — that row
+        // would point at "" and the pollers would shell out to git
+        // against it every tick.
+        let mut cfg = ProjectsConfig {
+            version: CURRENT_VERSION,
+            agents: Vec::new(),
+            projects: vec![Project::new_remote_shell("box".into(), "ssh box".into())],
+        };
+        cfg.migrate();
+        assert!(cfg.projects[0].worktrees.is_empty());
+        assert!(cfg.projects[0].is_remote_shell());
+    }
+
+    #[test]
+    fn adopt_existing_worktrees_is_a_no_op_for_remote_shell() {
+        let mut p = Project::new_remote_shell("box".into(), "ssh box".into());
+        p.adopt_existing_worktrees();
+        assert!(p.worktrees.is_empty());
+    }
+
+    #[test]
+    fn remote_shell_project_round_trips_with_camelcase_kind() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("projects.json");
+        let cfg = ProjectsConfig {
+            version: CURRENT_VERSION,
+            agents: Vec::new(),
+            projects: vec![Project::new_remote_shell("box".into(), "ssh box -t claude".into())],
+        };
+        cfg.save_to(&path).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("\"kind\": \"remoteShell\""), "{written}");
+        assert!(written.contains("\"command\": \"ssh box -t claude\""), "{written}");
+
+        let loaded = ProjectsConfig::load_from(&path).unwrap();
+        let p = &loaded.projects[0];
+        assert_eq!(p.kind, ProjectKind::RemoteShell);
+        assert_eq!(p.remote_shell_command(), Some("ssh box -t claude"));
+        assert!(p.worktrees.is_empty(), "migrate must not add a primary");
+    }
+
+    #[test]
+    fn project_without_kind_field_loads_as_local() {
+        // Every projects.json written before #323 lacks `kind`; those
+        // rows are all local checkouts and must keep behaving as such.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("projects.json");
+        std::fs::write(
+            &path,
+            r#"{"version":1,"projects":[{"id":"p1","name":"Repo","path":"C:/repo"}]}"#,
+        )
+        .unwrap();
+        let loaded = ProjectsConfig::load_from(&path).unwrap();
+        let p = &loaded.projects[0];
+        assert_eq!(p.kind, ProjectKind::Local);
+        assert_eq!(p.command, None);
+        assert!(!p.is_remote_shell());
+        assert!(p.worktrees.iter().any(|wt| wt.is_primary), "migrate still seeds the primary");
     }
 
     #[test]
@@ -692,6 +881,8 @@ mod tests {
                 path: "C:\\repo".into(),
                 default_branch: "main".into(),
                 worktree_root: Some("C:\\repo.worktrees".into()),
+                kind: ProjectKind::Local,
+                command: None,
                 default_agent_id: Some("claude".into()),
                 sessions: vec![Session {
                     id: "s1".into(),

--- a/core/src/projects.rs
+++ b/core/src/projects.rs
@@ -191,16 +191,31 @@ pub fn is_valid_remote_shell_command(command: &str) -> bool {
 /// is the agent's own invocation on the far end (e.g. `claude`), or
 /// `None` for a bare remote shell.
 ///
-/// When an agent is present it is appended as `<command> -t <agent>`:
-/// `-t` forces a pty so the interactive CLI renders, and everything
-/// after the host is run as the remote command by `ssh`. This is
-/// deliberately ssh-shaped — the agent field only makes sense for an
+/// When an agent is present the result is
+/// `<command> -t '$SHELL -lic "<agent>"'`. Three things matter here:
+///
+/// - `-t` forces a pty so the interactive CLI renders.
+/// - `$SHELL -lic` runs the agent through the remote user's **login +
+///   interactive** shell. A bare `ssh host -t claude` runs `claude`
+///   in ssh's non-login command shell, whose `PATH` is the stock
+///   `/usr/bin:/bin` — agents installed under `~/.local/bin`, nvm,
+///   Homebrew, etc. (the common case) are not found and the launch
+///   silently fails. Sourcing the login + rc files fixes the `PATH`.
+///   `$SHELL` (not a hard-coded `bash`) generalises to zsh on macOS.
+/// - The single-quote wrapper keeps `$SHELL` from being expanded
+///   locally: it survives both the Windows `pwsh -Command "& { … }"`
+///   boot and the macOS/Linux auto-type-into-login-shell path
+///   unchanged, and only expands on the far end. The agent is
+///   double-quoted inside so an agent invocation with args stays one
+///   `-c` string.
+///
+/// Deliberately ssh-shaped — the agent field only makes sense for an
 /// ssh (or ssh-like) base command, which is the whole point of a
 /// remote-shell project. A blank `agent_launch` is treated as absent.
 pub fn remote_command_with_agent(command: &str, agent_launch: Option<&str>) -> String {
     let base = command.trim();
     match agent_launch.map(str::trim).filter(|a| !a.is_empty()) {
-        Some(agent) => format!("{base} -t {agent}"),
+        Some(agent) => format!("{base} -t '$SHELL -lic \"{agent}\"'"),
         None => base.to_string(),
     }
 }
@@ -748,15 +763,29 @@ mod tests {
     }
 
     #[test]
-    fn remote_command_with_agent_appends_dash_t() {
+    fn remote_command_with_agent_wraps_in_login_shell() {
+        // The agent runs through the remote login+interactive shell so
+        // it inherits the user's real PATH (`~/.local/bin`, nvm, …) —
+        // a bare `-t claude` would miss it. See the fn doc for why.
         assert_eq!(
             remote_command_with_agent("ssh dev", Some("claude")),
-            "ssh dev -t claude"
+            "ssh dev -t '$SHELL -lic \"claude\"'"
         );
         // Trims both sides before joining.
         assert_eq!(
             remote_command_with_agent("  ssh dev  ", Some("  claude  ")),
-            "ssh dev -t claude"
+            "ssh dev -t '$SHELL -lic \"claude\"'"
+        );
+    }
+
+    #[test]
+    fn remote_command_with_agent_keeps_agent_args_in_one_c_string() {
+        // Double-quoting the agent inside keeps a multi-token launch
+        // (`claude --resume x`) as a single `-c` argument on the far
+        // end rather than splitting into positional params.
+        assert_eq!(
+            remote_command_with_agent("ssh dev", Some("claude --resume x")),
+            "ssh dev -t '$SHELL -lic \"claude --resume x\"'"
         );
     }
 

--- a/core/src/projects.rs
+++ b/core/src/projects.rs
@@ -57,9 +57,19 @@ pub struct Project {
     #[serde(default)]
     pub kind: ProjectKind,
     /// Command line to run for [`ProjectKind::RemoteShell`] projects
-    /// (e.g. `ssh dev@box -t claude`). `None` for local projects.
+    /// (e.g. `ssh dev`). `None` for local projects. When
+    /// [`Self::remote_agent_id`] is set, the agent's launch command is
+    /// appended as `<command> -t <agent>` so the tab lands straight in
+    /// the agent on the far end.
     #[serde(default)]
     pub command: Option<String>,
+    /// Agent profile id to launch on the remote for a
+    /// [`ProjectKind::RemoteShell`] project (#323). `None` = run the
+    /// command as-is (a bare remote shell). The id is resolved against
+    /// the live `AgentRegistry` at spawn time, so an id whose profile
+    /// no longer exists degrades gracefully to the raw command.
+    #[serde(default)]
+    pub remote_agent_id: Option<String>,
     /// Default branch — used as the base when creating new worktrees.
     #[serde(default = "default_branch", alias = "default_branch")]
     pub default_branch: String,
@@ -115,6 +125,7 @@ impl Project {
             path,
             kind: ProjectKind::Local,
             command: None,
+            remote_agent_id: None,
             default_branch: default_branch(),
             worktree_root: None,
             default_agent_id: None,
@@ -124,16 +135,19 @@ impl Project {
     }
 
     /// Build a [`ProjectKind::RemoteShell`] project: a named command
-    /// line with no path and no worktrees. Both arguments are
-    /// trimmed; the caller is expected to have rejected empty values
-    /// already (see [`is_valid_remote_shell_command`]).
-    pub fn new_remote_shell(name: String, command: String) -> Self {
+    /// line with no path and no worktrees, optionally launching
+    /// `agent_id` on the far end. `name`/`command` are trimmed; the
+    /// caller is expected to have rejected empty values already (see
+    /// [`is_valid_remote_shell_command`]). `agent_id` `None` runs the
+    /// command as a bare remote shell.
+    pub fn new_remote_shell(name: String, command: String, agent_id: Option<String>) -> Self {
         Self {
             id: uuid::Uuid::new_v4().to_string(),
             name: name.trim().to_string(),
             path: String::new(),
             kind: ProjectKind::RemoteShell,
             command: Some(command.trim().to_string()),
+            remote_agent_id: agent_id.filter(|s| !s.trim().is_empty()),
             default_branch: default_branch(),
             worktree_root: None,
             default_agent_id: None,
@@ -170,6 +184,25 @@ impl Project {
 pub fn is_valid_remote_shell_command(command: &str) -> bool {
     let trimmed = command.trim();
     !trimmed.is_empty() && !trimmed.contains(['\n', '\r'])
+}
+
+/// Assemble the command a remote-shell tab actually runs (#323).
+/// `command` is the user's base line (e.g. `ssh dev`); `agent_launch`
+/// is the agent's own invocation on the far end (e.g. `claude`), or
+/// `None` for a bare remote shell.
+///
+/// When an agent is present it is appended as `<command> -t <agent>`:
+/// `-t` forces a pty so the interactive CLI renders, and everything
+/// after the host is run as the remote command by `ssh`. This is
+/// deliberately ssh-shaped — the agent field only makes sense for an
+/// ssh (or ssh-like) base command, which is the whole point of a
+/// remote-shell project. A blank `agent_launch` is treated as absent.
+pub fn remote_command_with_agent(command: &str, agent_launch: Option<&str>) -> String {
+    let base = command.trim();
+    match agent_launch.map(str::trim).filter(|a| !a.is_empty()) {
+        Some(agent) => format!("{base} -t {agent}"),
+        None => base.to_string(),
+    }
 }
 
 impl Project {
@@ -531,6 +564,7 @@ mod tests {
                 worktree_root: Some("C:\\repos\\repo.worktrees".into()),
                 kind: ProjectKind::Local,
                 command: None,
+                remote_agent_id: None,
                 default_agent_id: Some("claude-code".into()),
                 sessions: vec![Session {
                     id: "s1".into(),
@@ -671,6 +705,7 @@ mod tests {
                 worktree_root: None,
                 kind: ProjectKind::Local,
                 command: None,
+                remote_agent_id: None,
                 default_agent_id: None,
                 sessions: Vec::new(),
                 worktrees: Vec::new(),
@@ -682,7 +717,7 @@ mod tests {
 
     #[test]
     fn remote_shell_project_has_no_path_and_no_worktrees() {
-        let p = Project::new_remote_shell("  devbox ".into(), " ssh dev@box -t claude ".into());
+        let p = Project::new_remote_shell("  devbox ".into(), " ssh dev@box -t claude ".into(), None);
         assert_eq!(p.name, "devbox");
         assert_eq!(p.path, "");
         assert_eq!(p.kind, ProjectKind::RemoteShell);
@@ -705,11 +740,39 @@ mod tests {
 
     #[test]
     fn remote_shell_with_blank_command_is_treated_as_missing() {
-        let mut p = Project::new_remote_shell("x".into(), "ssh box".into());
+        let mut p = Project::new_remote_shell("x".into(), "ssh box".into(), None);
         p.command = Some("   ".into());
         assert_eq!(p.remote_shell_command(), None);
         p.command = None;
         assert_eq!(p.remote_shell_command(), None);
+    }
+
+    #[test]
+    fn remote_command_with_agent_appends_dash_t() {
+        assert_eq!(
+            remote_command_with_agent("ssh dev", Some("claude")),
+            "ssh dev -t claude"
+        );
+        // Trims both sides before joining.
+        assert_eq!(
+            remote_command_with_agent("  ssh dev  ", Some("  claude  ")),
+            "ssh dev -t claude"
+        );
+    }
+
+    #[test]
+    fn remote_command_with_agent_no_agent_is_verbatim_trimmed() {
+        assert_eq!(remote_command_with_agent("ssh dev", None), "ssh dev");
+        assert_eq!(remote_command_with_agent("ssh dev", Some("   ")), "ssh dev");
+        assert_eq!(remote_command_with_agent("  ssh dev ", None), "ssh dev");
+    }
+
+    #[test]
+    fn new_remote_shell_stores_and_blank_agent_becomes_none() {
+        let p = Project::new_remote_shell("dev".into(), "ssh dev".into(), Some("claude".into()));
+        assert_eq!(p.remote_agent_id.as_deref(), Some("claude"));
+        let p2 = Project::new_remote_shell("dev".into(), "ssh dev".into(), Some("  ".into()));
+        assert_eq!(p2.remote_agent_id, None);
     }
 
     #[test]
@@ -731,7 +794,7 @@ mod tests {
         let mut cfg = ProjectsConfig {
             version: CURRENT_VERSION,
             agents: Vec::new(),
-            projects: vec![Project::new_remote_shell("box".into(), "ssh box".into())],
+            projects: vec![Project::new_remote_shell("box".into(), "ssh box".into(), None)],
         };
         cfg.migrate();
         assert!(cfg.projects[0].worktrees.is_empty());
@@ -740,7 +803,7 @@ mod tests {
 
     #[test]
     fn adopt_existing_worktrees_is_a_no_op_for_remote_shell() {
-        let mut p = Project::new_remote_shell("box".into(), "ssh box".into());
+        let mut p = Project::new_remote_shell("box".into(), "ssh box".into(), None);
         p.adopt_existing_worktrees();
         assert!(p.worktrees.is_empty());
     }
@@ -752,7 +815,7 @@ mod tests {
         let cfg = ProjectsConfig {
             version: CURRENT_VERSION,
             agents: Vec::new(),
-            projects: vec![Project::new_remote_shell("box".into(), "ssh box -t claude".into())],
+            projects: vec![Project::new_remote_shell("box".into(), "ssh box -t claude".into(), None)],
         };
         cfg.save_to(&path).unwrap();
         let written = std::fs::read_to_string(&path).unwrap();
@@ -883,6 +946,7 @@ mod tests {
                 worktree_root: Some("C:\\repo.worktrees".into()),
                 kind: ProjectKind::Local,
                 command: None,
+                remote_agent_id: None,
                 default_agent_id: Some("claude".into()),
                 sessions: vec![Session {
                     id: "s1".into(),

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -791,6 +791,7 @@ mod tests {
             worktree_root: None,
             kind: ProjectKind::Local,
             command: None,
+            remote_agent_id: None,
             default_agent_id: None,
             sessions: Vec::new(),
             worktrees: vec![Worktree {

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -157,6 +157,20 @@ pub fn build_agent_shell_args(agent_command: &str, working_directory: &str) -> V
     ]
 }
 
+/// Sibling of [`build_agent_shell_args`] for remote-shell projects
+/// (#323): same `-NoExit -NoLogo -Command "& { <command> }"` shape,
+/// but **no** `-WorkingDirectory` — the command (typically `ssh …`)
+/// carries its own notion of where it runs, and the project has no
+/// local path to offer anyway. pwsh starts in its default location.
+pub fn build_remote_shell_args(command: &str) -> Vec<String> {
+    vec![
+        "-NoExit".into(),
+        "-NoLogo".into(),
+        "-Command".into(),
+        format!("& {{ {command} }}"),
+    ]
+}
+
 /// Format a closed-session timestamp as a short relative string —
 /// `just now` / `Nm ago` / `Nh ago` / `yesterday` / `Nd ago` / `MMM d`
 /// (older). Mirrors C# `SessionTabViewModel.ClosedAtRelative`.
@@ -757,7 +771,7 @@ impl SessionManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::projects::{Project, Session, Worktree};
+    use crate::projects::{Project, ProjectKind, Session, Worktree};
     use crate::time::iso8601_from_unix_secs;
 
     fn fixed_now() -> &'static str { "2026-05-10T12:00:00Z" }
@@ -775,6 +789,8 @@ mod tests {
             path: "C:\\repo".into(),
             default_branch: "main".into(),
             worktree_root: None,
+            kind: ProjectKind::Local,
+            command: None,
             default_agent_id: None,
             sessions: Vec::new(),
             worktrees: vec![Worktree {
@@ -1189,6 +1205,24 @@ mod tests {
         assert_eq!(args[1], "-NoLogo");
         assert_eq!(args[2], "-WorkingDirectory");
         assert_eq!(args[4], "-Command");
+    }
+
+    #[test]
+    fn build_remote_shell_args_has_no_working_directory() {
+        // Remote-shell projects (#323) have no local path: the argv
+        // is the agent layout minus the `-WorkingDirectory <wd>` pair.
+        let args = build_remote_shell_args("ssh dev@box -t claude");
+        assert_eq!(
+            args,
+            vec!["-NoExit", "-NoLogo", "-Command", "& { ssh dev@box -t claude }"]
+        );
+        assert!(!args.iter().any(|a| a == "-WorkingDirectory"));
+    }
+
+    #[test]
+    fn build_remote_shell_args_preserves_command_verbatim() {
+        let args = build_remote_shell_args("ssh -p 2222 'dev user'@box -t \"claude --resume\"");
+        assert_eq!(args[3], "& { ssh -p 2222 'dev user'@box -t \"claude --resume\" }");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -3662,9 +3662,17 @@ impl AppShell {
 
     fn spawn_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         // Only auto-type the default agent when we actually have a
-        // working directory to land the agent in — a plain shell
-        // fallback keeps the empty / no-project state usable.
-        let has_project_context = self.sidebar.read(cx).active_project().is_some();
+        // local working directory to land the agent in — a plain shell
+        // fallback keeps the empty / no-project state usable. A
+        // remote-shell project (#323) has no local path, so Ctrl+Shift+T
+        // with one selected must NOT fire the default agent locally (it
+        // would run `claude` on this machine); the remote project is
+        // opened through its own row / menu instead.
+        let has_project_context = self
+            .sidebar
+            .read(cx)
+            .active_project()
+            .is_some_and(|p| !p.is_remote_shell() && !p.path.is_empty());
         let (agent_id, auto_type) = if has_project_context {
             match default_agent_launch_for(&self.settings) {
                 Some((id, at)) => (Some(id), at),
@@ -3740,12 +3748,18 @@ impl AppShell {
         let working_directory = if remote.is_some() {
             None
         } else {
-            working_directory.or_else(|| {
-                active_project
-                    .as_ref()
-                    .filter(|(path, _)| !path.is_empty())
-                    .map(|(path, _)| std::path::PathBuf::from(path))
-            })
+            // Drop an explicitly-supplied empty path defensively: a
+            // caller that derived cwd from a remote / path-less
+            // project could hand us `Some("")`, which would otherwise
+            // reach `-WorkingDirectory ""` and fail the spawn (#323).
+            working_directory
+                .filter(|p| !p.as_os_str().is_empty())
+                .or_else(|| {
+                    active_project
+                        .as_ref()
+                        .filter(|(path, _)| !path.is_empty())
+                        .map(|(path, _)| std::path::PathBuf::from(path))
+                })
         };
 
         // Resolve the shell + argv. When `auto_type` is set and we
@@ -8224,13 +8238,17 @@ impl AppShell {
 
     /// Active project's working directory, if any. Used by the agent
     /// action to pick `cwd` for the spawn. Returns `None` when no
-    /// project is selected — the spawn falls back to the default cwd
-    /// (whatever `spawn_tab_in` resolves from settings).
+    /// project is selected, or when it's a remote-shell project (#323)
+    /// / has an empty path — those carry no local cwd, so the palette
+    /// agent launch falls back to the default cwd instead of passing
+    /// `Some("")` (which would reach `-WorkingDirectory ""` and fail).
     fn active_project_path(&self, cx: &Context<Self>) -> Option<String> {
         self.sidebar
             .read(cx)
             .active_project()
+            .filter(|p| !p.is_remote_shell())
             .map(|p| p.path.clone())
+            .filter(|path| !path.is_empty())
     }
 
     /// Active tab's working directory as a `String`. Used by the

--- a/src/app.rs
+++ b/src/app.rs
@@ -2464,6 +2464,10 @@ impl AppShell {
             /// project id + command so the tab respawns without a cwd.
             remote: Option<RemoteShellLaunch>,
         }
+        // Borrow the registry once, disjoint from the `self.projects`
+        // iteration below, so the closure can assemble remote commands
+        // without capturing `self`.
+        let registry = &self.agent_registry;
         let entries: Vec<RehydrateEntry> = self
             .projects
             .projects
@@ -2472,9 +2476,12 @@ impl AppShell {
                 let project_name = p.name.clone();
                 // Resolve the remote-shell launch once per project —
                 // cloned into each of its live sessions below. `None`
-                // for local projects.
-                let remote_command = p.remote_shell_command().map(str::to_owned);
-                let project_id = p.id.clone();
+                // for local projects. The command is assembled with
+                // the selected agent (`ssh dev -t claude`).
+                let remote_launch = p.remote_shell_command().is_some().then(|| RemoteShellLaunch {
+                    project_id: p.id.clone(),
+                    command: registry.assemble_remote_command(p),
+                });
                 p.sessions.iter().filter_map(move |s| {
                     if s.closed_at.is_some() {
                         return None;
@@ -2485,10 +2492,7 @@ impl AppShell {
                             .find(|w| Some(&w.id) == s.worktree_id.as_ref())
                             .and_then(|w| w.branch.clone())
                     });
-                    let remote = remote_command.as_ref().map(|command| RemoteShellLaunch {
-                        project_id: project_id.clone(),
-                        command: command.clone(),
-                    });
+                    let remote = remote_launch.clone();
                     Some(RehydrateEntry {
                         session_id: s.id.clone(),
                         worktree_path: s.worktree_path.clone(),
@@ -3625,6 +3629,7 @@ impl AppShell {
             }
         }
         // Resolve the command from the sidebar's live project list.
+        let registry = &self.agent_registry;
         let launch = self
             .sidebar
             .read(cx)
@@ -3632,11 +3637,13 @@ impl AppShell {
             .projects
             .iter()
             .find(|p| p.id == project_id)
-            .and_then(|p| {
-                p.remote_shell_command().map(|command| RemoteShellLaunch {
-                    project_id: p.id.clone(),
-                    command: command.to_owned(),
-                })
+            .filter(|p| p.remote_shell_command().is_some())
+            .map(|p| RemoteShellLaunch {
+                project_id: p.id.clone(),
+                // Assemble the base command with the selected agent's
+                // launch (`ssh dev` + claude → `ssh dev -t claude`) so
+                // the tab lands straight in the agent (#323).
+                command: registry.assemble_remote_command(p),
             });
         let Some(launch) = launch else {
             eprintln!("warning: OpenRemoteShell for unknown / non-remote project {project_id}");

--- a/src/app.rs
+++ b/src/app.rs
@@ -220,8 +220,25 @@ fn monitor_changed(prev: &WindowPlacement, now: &WindowPlacement) -> bool {
 const MONITOR_CHANGE_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// One tab = one terminal session.
+/// Spawn parameters for a tab that belongs to a
+/// [`codescope_core::ProjectKind::RemoteShell`] project (#323): no
+/// working directory, no agent — just `command` run through
+/// `pwsh -NoExit -Command "& { … }"`. The session row is persisted
+/// under `project_id` so the tab rehydrates on the next launch.
+#[derive(Debug, Clone)]
+struct RemoteShellLaunch {
+    project_id: String,
+    command: String,
+}
+
 struct Tab {
     id: u64,
+    /// `Some(project id)` when this tab was spawned for a remote-shell
+    /// project. Used to focus-or-open from the sidebar row, to light
+    /// the row's live indicator, and to hard-remove (not soft-close)
+    /// the session row on close — there is nothing to resume, so a
+    /// history entry would be dead weight.
+    remote_project_id: Option<String>,
     /// The CodeScope session id — the stable identifier persisted in
     /// `projects.json` under the owning project's `sessions[]`.
     /// Allocated at spawn via [`SessionManager::open`] (or restored
@@ -1211,9 +1228,13 @@ impl AppShell {
                         effective_auto_type,
                         effective_agent_id,
                         None,
+                        None,
                         window,
                         cx,
                     );
+                }
+                SidebarEvent::OpenRemoteShell { project_id, force_new } => {
+                    this.open_remote_shell(project_id, *force_new, window, cx);
                 }
                 SidebarEvent::Toast { kind, title, detail } => {
                     let kind = match kind {
@@ -2439,6 +2460,9 @@ impl AppShell {
             agent_session_id: Option<String>,
             project_name: String,
             branch: Option<String>,
+            /// `Some` for a remote-shell session (#323) — carries the
+            /// project id + command so the tab respawns without a cwd.
+            remote: Option<RemoteShellLaunch>,
         }
         let entries: Vec<RehydrateEntry> = self
             .projects
@@ -2446,6 +2470,11 @@ impl AppShell {
             .iter()
             .flat_map(|p| {
                 let project_name = p.name.clone();
+                // Resolve the remote-shell launch once per project —
+                // cloned into each of its live sessions below. `None`
+                // for local projects.
+                let remote_command = p.remote_shell_command().map(str::to_owned);
+                let project_id = p.id.clone();
                 p.sessions.iter().filter_map(move |s| {
                     if s.closed_at.is_some() {
                         return None;
@@ -2456,6 +2485,10 @@ impl AppShell {
                             .find(|w| Some(&w.id) == s.worktree_id.as_ref())
                             .and_then(|w| w.branch.clone())
                     });
+                    let remote = remote_command.as_ref().map(|command| RemoteShellLaunch {
+                        project_id: project_id.clone(),
+                        command: command.clone(),
+                    });
                     Some(RehydrateEntry {
                         session_id: s.id.clone(),
                         worktree_path: s.worktree_path.clone(),
@@ -2463,6 +2496,7 @@ impl AppShell {
                         agent_session_id: s.agent_session_id.clone(),
                         project_name: project_name.clone(),
                         branch,
+                        remote,
                     })
                 })
             })
@@ -2508,6 +2542,35 @@ impl AppShell {
         self.suppress_layout_save = true;
 
         for entry in entries {
+            // Remote-shell sessions (#323) have no path on disk to
+            // check — they respawn by running their command. Handle
+            // them up front and skip the path-shaped rest of the loop.
+            if let Some(remote) = entry.remote.clone() {
+                let placement = placements.get(&entry.session_id);
+                let group_idx = placement
+                    .map(|p| p.group_index)
+                    .unwrap_or(0)
+                    .min(group_count.saturating_sub(1));
+                let active_in_group = placement.map(|p| p.active_in_group).unwrap_or(false);
+                self.focused_group = group_idx;
+                let title = SharedString::from(entry.project_name.clone());
+                self.spawn_tab_in(
+                    None,
+                    Some(title),
+                    None,
+                    None,
+                    Some(entry.session_id.clone()),
+                    Some(remote),
+                    window,
+                    cx,
+                );
+                spawned_any = true;
+                if active_in_group {
+                    let new_idx = self.groups[group_idx].tabs.len() - 1;
+                    active_by_group[group_idx] = Some(new_idx);
+                }
+                continue;
+            }
             let path = std::path::PathBuf::from(&entry.worktree_path);
             if !path.exists() {
                 eprintln!(
@@ -2614,6 +2677,7 @@ impl AppShell {
                 // through the `pending_backfills` flush below.
                 resolved_agent_id.clone().map(SharedString::from),
                 Some(entry.session_id.clone()),
+                entry.remote.clone(),
                 window,
                 cx,
             );
@@ -2841,11 +2905,45 @@ impl AppShell {
         working_directory: Option<&std::path::Path>,
         persist_agent_id: Option<String>,
         restore_session_id: Option<String>,
+        // `Some(project id)` for remote-shell tabs (#323): the row is
+        // persisted under that project with an empty `worktree_path`
+        // — there is no path to route by.
+        remote_project_id: Option<&str>,
     ) -> String {
         if let Some(id) = restore_session_id {
             return id;
         }
         let new_id = uuid::Uuid::new_v4().to_string();
+        if let Some(project_id) = remote_project_id {
+            match ProjectsConfig::load(&self.paths) {
+                Ok(cfg) => self.projects = cfg,
+                Err(err) => {
+                    eprintln!("warning: failed to reload projects.json before SessionManager::open: {err:#}");
+                }
+            }
+            let session = Session {
+                id: new_id.clone(),
+                worktree_path: String::new(),
+                branch: None,
+                agent_id: None,
+                display_name: None,
+                worktree_id: None,
+                last_opened: None,
+                agent_session_id: None,
+                closed_at: None,
+            };
+            match SessionManager::open(&mut self.projects, project_id, session, &now_iso8601()) {
+                Ok(_) => {
+                    if let Err(err) = self.projects.save(&self.paths) {
+                        eprintln!("warning: failed to persist session open: {err:#}");
+                    }
+                }
+                Err(err) => {
+                    eprintln!("warning: SessionManager::open rejected new session: {err:#}");
+                }
+            }
+            return new_id;
+        }
         let Some(wd) = working_directory else {
             return new_id;
         };
@@ -2968,6 +3066,36 @@ impl AppShell {
                 // silently — mirrors C#'s "session id not found is
                 // ok" branch in `CloseTabAsync` where `storedForTab`
                 // is null.
+            }
+        }
+    }
+
+    /// Permanently drop `session_id` from `projects.json` and mirror
+    /// the change into the sidebar. Used by `close_tab` for
+    /// remote-shell tabs (#323), which have no resumable transcript so
+    /// keeping a closed-history row would be dead weight. Same
+    /// reload-mutate-save-mirror discipline as
+    /// [`Self::soft_close_session`]; a missing id is a silent no-op.
+    fn hard_remove_session(&mut self, session_id: &str, cx: &mut Context<Self>) {
+        match ProjectsConfig::load(&self.paths) {
+            Ok(cfg) => self.projects = cfg,
+            Err(err) => {
+                eprintln!("warning: failed to reload projects.json before hard_remove: {err:#}");
+            }
+        }
+        match SessionManager::hard_remove(&mut self.projects, session_id) {
+            Ok(()) => {
+                if let Err(err) = self.projects.save(&self.paths) {
+                    eprintln!("warning: failed to persist session hard-remove: {err:#}");
+                }
+                let projects_for_sidebar = self.projects.clone();
+                self.sidebar.update(cx, |sidebar, cx| {
+                    sidebar.replace_projects(projects_for_sidebar);
+                    cx.notify();
+                });
+            }
+            Err(_) => {
+                // Row already gone — nothing to do.
             }
         }
     }
@@ -3255,6 +3383,7 @@ impl AppShell {
             auto_type,
             resolved_agent_id.map(SharedString::from),
             Some(restored.id),
+            None,
             window,
             cx,
         );
@@ -3473,6 +3602,57 @@ impl AppShell {
     /// to a plain shell when the active project context is missing
     /// (no folder for the agent to operate in) or when no default
     /// agent is configured.
+    /// Open (or focus) a tab for a remote-shell project (#323). Looks
+    /// the project up by id, resolves its saved command, and spawns a
+    /// tab running it. `force_new: false` focuses an existing live tab
+    /// for the same project instead of stacking a duplicate.
+    fn open_remote_shell(
+        &mut self,
+        project_id: &str,
+        force_new: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !force_new {
+            // Tier 1: focus an already-open tab for this project.
+            for (g_idx, group) in self.groups.iter().enumerate() {
+                for (t_idx, tab) in group.tabs.iter().enumerate() {
+                    if tab.remote_project_id.as_deref() == Some(project_id) {
+                        self.activate_tab(g_idx, t_idx, window, cx);
+                        return;
+                    }
+                }
+            }
+        }
+        // Resolve the command from the sidebar's live project list.
+        let launch = self
+            .sidebar
+            .read(cx)
+            .projects()
+            .projects
+            .iter()
+            .find(|p| p.id == project_id)
+            .and_then(|p| {
+                p.remote_shell_command().map(|command| RemoteShellLaunch {
+                    project_id: p.id.clone(),
+                    command: command.to_owned(),
+                })
+            });
+        let Some(launch) = launch else {
+            eprintln!("warning: OpenRemoteShell for unknown / non-remote project {project_id}");
+            return;
+        };
+        let title = self
+            .sidebar
+            .read(cx)
+            .projects()
+            .projects
+            .iter()
+            .find(|p| p.id == project_id)
+            .map(|p| SharedString::from(p.name.clone()));
+        self.spawn_tab_in(None, title, None, None, None, Some(launch), window, cx);
+    }
+
     fn spawn_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         // Only auto-type the default agent when we actually have a
         // working directory to land the agent in — a plain shell
@@ -3486,9 +3666,14 @@ impl AppShell {
         } else {
             (None, None)
         };
-        self.spawn_tab_in(None, None, auto_type, agent_id, None, window, cx);
+        self.spawn_tab_in(None, None, auto_type, agent_id, None, None, window, cx);
     }
 
+    // Spawn parameters legitimately vary along many independent axes
+    // (cwd, title, agent auto-type, persisted agent id, restore id,
+    // remote launch); bundling them into a struct would only move the
+    // noise around. Local exception to the 7-arg lint.
+    #[allow(clippy::too_many_arguments)]
     fn spawn_tab_in(
         &mut self,
         working_directory: Option<std::path::PathBuf>,
@@ -3519,6 +3704,11 @@ impl AppShell {
         // (sidebar click, dialog spawn, Ctrl+T) — those allocate a
         // fresh id and persist via `SessionManager::open`.
         restore_session_id: Option<String>,
+        // `Some` for remote-shell projects (#323): overrides the shell
+        // argv (saved command, no `-WorkingDirectory`), suppresses the
+        // active-project cwd fallback, and routes session persistence
+        // by project id instead of by path. `None` everywhere else.
+        remote: Option<RemoteShellLaunch>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -3536,11 +3726,20 @@ impl AppShell {
             .read(cx)
             .active_project()
             .map(|p| (p.path.clone(), p.name.clone()));
-        let working_directory = working_directory.or_else(|| {
-            active_project
-                .as_ref()
-                .map(|(path, _)| std::path::PathBuf::from(path))
-        });
+        // A remote-shell tab never gets a cwd: the command carries its
+        // own (`ssh` lands wherever the remote login does), and the
+        // owning project's `path` is empty anyway. Local projects with
+        // an empty path (malformed rows) are likewise not a usable cwd.
+        let working_directory = if remote.is_some() {
+            None
+        } else {
+            working_directory.or_else(|| {
+                active_project
+                    .as_ref()
+                    .filter(|(path, _)| !path.is_empty())
+                    .map(|(path, _)| std::path::PathBuf::from(path))
+            })
+        };
 
         // Resolve the shell + argv. When `auto_type` is set and we
         // have a working directory to land in *and* the default pwsh
@@ -3561,6 +3760,16 @@ impl AppShell {
         // Plain shell tabs (`auto_type = None`) and agent tabs with no
         // working directory (no project context, nothing for the agent
         // to operate against) keep the previous bare-shell shape.
+        //
+        // Remote-shell tabs (#323) take the same `-Command` route with
+        // the saved command and no `-WorkingDirectory`; on the
+        // fallback paths the command is auto-typed exactly like an
+        // agent launch would be. `auto_type` is rebound so the
+        // fallback below has a single source for "what to type".
+        let auto_type: Option<SharedString> = match remote.as_ref() {
+            Some(r) => Some(SharedString::from(r.command.clone())),
+            None => auto_type,
+        };
         let mut agent_launched_via_args = false;
         let shell = std::env::var("CODESCOPE_SHELL")
             .ok()
@@ -3568,8 +3777,13 @@ impl AppShell {
             .or_else(|| {
                 if cfg!(windows) {
                     let program = "pwsh.exe".to_string();
-                    match (auto_type.as_ref(), working_directory.as_ref()) {
-                        (Some(cmd), Some(wd)) => {
+                    match (remote.as_ref(), auto_type.as_ref(), working_directory.as_ref()) {
+                        (Some(r), _, _) => {
+                            let args = codescope_core::build_remote_shell_args(&r.command);
+                            agent_launched_via_args = true;
+                            Some(Shell::new(program, args))
+                        }
+                        (None, Some(cmd), Some(wd)) => {
                             let args = codescope_core::build_agent_shell_args(
                                 cmd.as_ref(),
                                 &wd.to_string_lossy(),
@@ -3647,6 +3861,7 @@ impl AppShell {
             working_directory_for_tab.as_deref(),
             persist_agent_id.as_ref().map(|s| s.to_string()),
             restore_session_id,
+            remote.as_ref().map(|r| r.project_id.as_str()),
         );
         // Claim the persisted transcript from the first discovery tick
         // on the restore paths (launch rehydrate / reopen from history):
@@ -3678,9 +3893,16 @@ impl AppShell {
         // write to it without re-borrowing `self.groups` after the
         // await point.
         let terminal_for_autotype = terminal.clone();
-        let agent_id = codescope_core::agent_id_from_auto_type(
-            auto_type.as_ref().map(|s| s.as_ref()),
-        );
+        // Remote-shell tabs carry no agent: the command may well start
+        // `claude` on the far end, but its transcripts live on that
+        // machine, so there is nothing for discovery / telemetry to
+        // tail here. `None` keeps the tab out of the discovery poll.
+        let agent_id = if remote.is_some() {
+            None
+        } else {
+            codescope_core::agent_id_from_auto_type(auto_type.as_ref().map(|s| s.as_ref()))
+        };
+        let remote_project_id = remote.as_ref().map(|r| r.project_id.clone());
         // `auto_type` is kept on the Tab as metadata (agent
         // detection via `agent_id_from_auto_type` + layout persistence
         // so a restart can rebuild the command). On the Windows + pwsh
@@ -3692,6 +3914,7 @@ impl AppShell {
         // post-spawn auto-type below is still the launch mechanism.
         group.tabs.push(Tab {
             id,
+            remote_project_id,
             session_id,
             title,
             terminal,
@@ -3756,21 +3979,35 @@ impl AppShell {
         // holding `&mut group` across the call. The CodeScope session
         // id we soft-close in `SessionManager` is a separate value
         // (always present, allocated at spawn) — read it here too.
-        let (adopted, codescope_session_id) = self
+        let (adopted, codescope_session_id, is_remote) = self
             .groups
             .get(group_idx)
             .and_then(|g| g.tabs.get(tab_idx))
-            .map(|t| (t.adopted_session_id.clone(), t.session_id.clone()))
+            .map(|t| {
+                (
+                    t.adopted_session_id.clone(),
+                    t.session_id.clone(),
+                    t.remote_project_id.is_some(),
+                )
+            })
             .unwrap_or_default();
         if let Some(sid) = adopted {
             self.unregister_telemetry(&sid);
         }
-        // Mark the session row as closed in `projects.json` (mirrors
-        // C# `SessionStore.SoftCloseSessionAsync`). Best-effort —
-        // failure logs and proceeds; the in-memory tab state is the
-        // source of truth for what's on screen.
+        // Persist the close in `projects.json`. A remote-shell session
+        // (#323) has nothing to resume — its transcript lives on the
+        // far end — so a soft-close would only pile up dead history
+        // rows under the project. Hard-remove it instead; local
+        // sessions soft-close as before (mirrors C#
+        // `SessionStore.SoftCloseSessionAsync`). Best-effort — failure
+        // logs and proceeds; the in-memory tab state is the source of
+        // truth for what's on screen.
         if !codescope_session_id.is_empty() {
-            self.soft_close_session(&codescope_session_id, cx);
+            if is_remote {
+                self.hard_remove_session(&codescope_session_id, cx);
+            } else {
+                self.soft_close_session(&codescope_session_id, cx);
+            }
         }
         let Some(group) = self.groups.get_mut(group_idx) else { return };
         if tab_idx >= group.tabs.len() {
@@ -5676,8 +5913,18 @@ impl AppShell {
                     }
             }
         }
+        // Remote-shell projects (#323) have no path, so they can't ride
+        // the path-keyed `active` set — collect the project ids of live
+        // remote tabs separately for the sidebar's command-row dot.
+        let remote_live: HashSet<String> = self
+            .groups
+            .iter()
+            .flat_map(|g| g.tabs.iter())
+            .filter_map(|t| t.remote_project_id.clone())
+            .collect();
         self.sidebar.update(cx, |sidebar, cx| {
             sidebar.set_session_paths(busy, active, cx);
+            sidebar.set_remote_live_project_ids(remote_live, cx);
         });
     }
 
@@ -7928,6 +8175,7 @@ impl AppShell {
             effective_auto_type,
             effective_agent_id,
             None,
+            None,
             window,
             cx,
         );
@@ -7960,6 +8208,7 @@ impl AppShell {
             Some(title),
             Some(auto_type),
             Some(agent_id),
+            None,
             None,
             window,
             cx,

--- a/src/dialogs/new_project.rs
+++ b/src/dialogs/new_project.rs
@@ -91,6 +91,10 @@ pub struct NewProjectDialogState {
     /// `pwsh -Command "& { … }"` verbatim at spawn time.
     pub remote_name: TextField,
     pub remote_command: TextField,
+    /// Agent to launch on the remote (#323). `None` = run the command
+    /// as a bare shell. Seeded to the global default agent when the
+    /// dialog opens; the user can switch it or pick "No agent".
+    pub remote_agent_id: Option<String>,
     /// `true` while a `git clone` task is in flight.
     pub busy: bool,
     /// "Cloning <name>…" caption while busy.
@@ -113,6 +117,7 @@ impl NewProjectDialogState {
             name_auto: true,
             remote_name: TextField::new(),
             remote_command: TextField::new(),
+            remote_agent_id: None,
             busy: false,
             busy_text: None,
             error: None,
@@ -475,7 +480,11 @@ impl Sidebar {
         // keystrokes routed to AppShell's chord-only handler. Same
         // primitive `activate_tab` uses (see `src/app.rs`).
         window.prevent_default();
-        let state = NewProjectDialogState::new(parent, focus_handle);
+        let mut state = NewProjectDialogState::new(parent, focus_handle);
+        // Seed the remote-shell agent picker with the global default
+        // agent so "Remote shell" mode lands you in Claude Code out of
+        // the box (#323).
+        state.remote_agent_id = self.agent_registry().get_default().map(|p| p.id.clone());
         self.set_new_project_dialog(Some(state));
         self.close_menu_no_notify();
         cx.notify();
@@ -505,6 +514,19 @@ impl Sidebar {
                 DialogMode::Clone => DialogField::Url,
                 DialogMode::RemoteShell => DialogField::RemoteName,
             };
+            state.error = None;
+            cx.notify();
+        }
+    }
+
+    /// Set the remote-shell agent selection (`None` = no agent /
+    /// bare shell). Clears any inline error so the picker feels live.
+    pub fn set_new_project_remote_agent(&mut self, id: Option<String>, cx: &mut Context<Self>) {
+        if let Some(state) = self.new_project_dialog_mut() {
+            if state.busy {
+                return;
+            }
+            state.remote_agent_id = id;
             state.error = None;
             cx.notify();
         }
@@ -687,8 +709,9 @@ impl Sidebar {
                     cx.notify();
                     return;
                 }
+                let agent_id = state.remote_agent_id.clone();
                 self.cancel_new_project_dialog(cx);
-                self.add_remote_shell_project(name, command, cx);
+                self.add_remote_shell_project(name, command, agent_id, cx);
             }
         }
     }
@@ -969,6 +992,56 @@ impl Sidebar {
                     "ssh user@host -t claude",
                     DialogField::RemoteCommand,
                 );
+                // Agent picker: "No agent" + one row per registered
+                // agent. Selecting one makes CodeScope run
+                // `<command> -t <agent>` so the tab lands straight in
+                // the agent on the remote (#323).
+                let selected_agent = state.remote_agent_id.clone();
+                let agent_row = |id: Option<String>, label: SharedString| {
+                    let is_sel = selected_agent.as_deref() == id.as_deref();
+                    let dot = if is_sel { accent } else { gpui::transparent_black() };
+                    let row_id = match id.as_deref() {
+                        Some(a) => format!("np-remote-agent-{a}"),
+                        None => "np-remote-agent-none".to_string(),
+                    };
+                    div()
+                        .id(SharedString::from(row_id))
+                        .h(px(30.0))
+                        .px_2()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap_2()
+                        .rounded(px(4.0))
+                        .text_size(px(12.5))
+                        .text_color(if is_sel { ink } else { ink_muted })
+                        .cursor_pointer()
+                        .hover(move |s| s.bg(frost))
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _, window, cx| {
+                                cx.stop_propagation();
+                                window.prevent_default();
+                                this.set_new_project_remote_agent(id.clone(), cx);
+                            }),
+                        )
+                        .child(
+                            div()
+                                .w(px(6.0))
+                                .h(px(6.0))
+                                .rounded_full()
+                                .bg(dot),
+                        )
+                        .child(label)
+                };
+                let mut agent_list = div().flex().flex_col().gap_1();
+                agent_list = agent_list.child(agent_row(None, "No agent (bare shell)".into()));
+                for profile in self.agent_registry().get_all() {
+                    agent_list = agent_list.child(agent_row(
+                        Some(profile.id.clone()),
+                        profile.display_name.clone().into(),
+                    ));
+                }
                 div()
                     .px_5()
                     .flex()
@@ -978,6 +1051,8 @@ impl Sidebar {
                     .child(name_field)
                     .child(field_label("COMMAND"))
                     .child(command_field)
+                    .child(field_label("LAUNCH AGENT ON REMOTE"))
+                    .child(agent_list)
                     .child(
                         div()
                             .text_size(px(11.0))

--- a/src/dialogs/new_project.rs
+++ b/src/dialogs/new_project.rs
@@ -44,17 +44,25 @@ use crate::theme;
 pub enum DialogMode {
     Existing,
     Clone,
+    /// Save a command line (typically `ssh host -t claude`) as a
+    /// sidebar project with no local path — see
+    /// [`codescope_core::ProjectKind::RemoteShell`] (#323). Not in
+    /// the C# build.
+    RemoteShell,
 }
 
 /// Which input field the dialog routes typed characters into. The
 /// "Existing folder" path field is read-only (Browse-only) and is
 /// therefore not represented here. Mirrors the focus semantics of the
-/// C# `Url`/`Parent`/`Name` text boxes.
+/// C# `Url`/`Parent`/`Name` text boxes; `RemoteName` / `RemoteCommand`
+/// belong to the remote-shell mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DialogField {
     Url,
     Parent,
     Name,
+    RemoteName,
+    RemoteCommand,
 }
 
 /// Live state of an open dialog. Created by
@@ -78,6 +86,11 @@ pub struct NewProjectDialogState {
     /// folder name. Once they edit it, BRANCH→NAME re-derive stops.
     /// Mirrors the C# `NameBox.Tag == NameBox.Text` heuristic.
     pub name_auto: bool,
+    /// Remote-shell-mode fields: the sidebar label and the command
+    /// line to run. Both are plain text; the command is handed to
+    /// `pwsh -Command "& { … }"` verbatim at spawn time.
+    pub remote_name: TextField,
+    pub remote_command: TextField,
     /// `true` while a `git clone` task is in flight.
     pub busy: bool,
     /// "Cloning <name>…" caption while busy.
@@ -98,6 +111,8 @@ impl NewProjectDialogState {
             parent: TextField::with_text(default_clone_parent),
             name: TextField::new(),
             name_auto: true,
+            remote_name: TextField::new(),
+            remote_command: TextField::new(),
             busy: false,
             busy_text: None,
             error: None,
@@ -130,6 +145,10 @@ impl NewProjectDialogState {
                 }
                 !name.is_empty() && !contains_invalid_filename_chars(name)
             }
+            DialogMode::RemoteShell => {
+                !self.remote_name.text().trim().is_empty()
+                    && codescope_core::is_valid_remote_shell_command(self.remote_command.text())
+            }
         }
     }
 
@@ -144,6 +163,8 @@ impl NewProjectDialogState {
             DialogField::Url => &mut self.url,
             DialogField::Parent => &mut self.parent,
             DialogField::Name => &mut self.name,
+            DialogField::RemoteName => &mut self.remote_name,
+            DialogField::RemoteCommand => &mut self.remote_command,
         }
     }
 
@@ -162,11 +183,24 @@ impl NewProjectDialogState {
             // `IsReadOnly="True"` on the path TextBox.
             return None;
         }
-        Some(match self.focused_field {
-            DialogField::Url => &mut self.url,
-            DialogField::Parent => &mut self.parent,
-            DialogField::Name => &mut self.name,
-        })
+        // A field that doesn't belong to the active mode can't be
+        // typed into — `set_new_project_mode` re-seats focus on every
+        // switch, so this only guards against a stale enum value.
+        let field = self.focused_field;
+        let belongs = match self.mode {
+            DialogMode::Existing => false,
+            DialogMode::Clone => matches!(
+                field,
+                DialogField::Url | DialogField::Parent | DialogField::Name
+            ),
+            DialogMode::RemoteShell => {
+                matches!(field, DialogField::RemoteName | DialogField::RemoteCommand)
+            }
+        };
+        if !belongs {
+            return None;
+        }
+        Some(self.field_mut_by(field))
     }
 
     /// Insert a typed character at the focused field's caret. Honours
@@ -189,6 +223,12 @@ impl NewProjectDialogState {
             DialogField::Name => {
                 self.name_auto = false;
                 self.name.insert_char(ch);
+            }
+            DialogField::RemoteName => {
+                self.remote_name.insert_char(ch);
+            }
+            DialogField::RemoteCommand => {
+                self.remote_command.insert_char(ch);
             }
         }
         self.error = None;
@@ -218,6 +258,8 @@ impl NewProjectDialogState {
                 }
                 c
             }
+            DialogField::RemoteName => self.remote_name.insert_str(s),
+            DialogField::RemoteCommand => self.remote_command.insert_str(s),
         };
         if changed {
             self.error = None;
@@ -246,6 +288,8 @@ impl NewProjectDialogState {
                 }
                 c
             }
+            DialogField::RemoteName => self.remote_name.backspace(),
+            DialogField::RemoteCommand => self.remote_command.backspace(),
         };
         if changed {
             self.error = None;
@@ -274,6 +318,8 @@ impl NewProjectDialogState {
                 }
                 c
             }
+            DialogField::RemoteName => self.remote_name.delete_forward(),
+            DialogField::RemoteCommand => self.remote_command.delete_forward(),
         };
         if changed {
             self.error = None;
@@ -457,6 +503,7 @@ impl Sidebar {
             state.focused_field = match mode {
                 DialogMode::Existing => DialogField::Url,
                 DialogMode::Clone => DialogField::Url,
+                DialogMode::RemoteShell => DialogField::RemoteName,
             };
             state.error = None;
             cx.notify();
@@ -621,6 +668,28 @@ impl Sidebar {
                 })
                 .detach();
             }
+            DialogMode::RemoteShell => {
+                let name = state.remote_name.text().trim().to_string();
+                let command = state.remote_command.text().trim().to_string();
+                // Same name twice is almost certainly a mistake (the
+                // sidebar would show two identical rows); surface it
+                // inline like the duplicate-path guard above rather
+                // than silently adding a twin.
+                let duplicate = self
+                    .projects()
+                    .projects
+                    .iter()
+                    .any(|p| p.is_remote_shell() && p.name.eq_ignore_ascii_case(&name));
+                if duplicate {
+                    if let Some(state) = self.new_project_dialog_mut() {
+                        state.error = Some(format!("Remote shell already added: {name}"));
+                    }
+                    cx.notify();
+                    return;
+                }
+                self.cancel_new_project_dialog(cx);
+                self.add_remote_shell_project(name, command, cx);
+            }
         }
     }
 
@@ -679,7 +748,7 @@ impl Sidebar {
                 div()
                     .text_size(px(12.0))
                     .text_color(ink_muted)
-                    .child("Bring a folder in, or clone a repo straight in."),
+                    .child("Bring a folder in, clone a repo, or save a remote shell command."),
             );
 
         // Segmented mode toggle.
@@ -722,7 +791,8 @@ impl Sidebar {
                     .bg(canvas)
                     .rounded(px(6.0))
                     .child(seg("np-mode-existing", "Existing folder", DialogMode::Existing))
-                    .child(seg("np-mode-clone", "Clone from URL", DialogMode::Clone)),
+                    .child(seg("np-mode-clone", "Clone from URL", DialogMode::Clone))
+                    .child(seg("np-mode-remote", "Remote shell", DialogMode::RemoteShell)),
             );
 
         // Reusable label + chrome.
@@ -797,7 +867,7 @@ impl Sidebar {
                        placeholder: &'static str,
                        this_field: DialogField|
          -> gpui::Stateful<gpui::Div> {
-            let is_focused = state.focused_field == this_field && mode == DialogMode::Clone;
+            let is_focused = state.focused_field == this_field && mode != DialogMode::Existing;
             let mut style = focused_caret_style(theme, blink_phase);
             // Suppress the caret entirely on unfocused fields; only
             // the field receiving keystrokes should advertise itself
@@ -886,6 +956,39 @@ impl Sidebar {
                     .child(name_field)
                     .into_any_element()
             }
+            DialogMode::RemoteShell => {
+                let name_field = textbox(
+                    "np-remote-name",
+                    &state.remote_name,
+                    "devbox",
+                    DialogField::RemoteName,
+                );
+                let command_field = textbox(
+                    "np-remote-command",
+                    &state.remote_command,
+                    "ssh user@host -t claude",
+                    DialogField::RemoteCommand,
+                );
+                div()
+                    .px_5()
+                    .flex()
+                    .flex_col()
+                    .gap_2()
+                    .child(field_label("NAME"))
+                    .child(name_field)
+                    .child(field_label("COMMAND"))
+                    .child(command_field)
+                    .child(
+                        div()
+                            .text_size(px(11.0))
+                            .text_color(ink_ghost)
+                            .child(
+                                "Runs in a fresh local shell. No git, worktrees or agent \
+                                 status for this project — just the tab.",
+                            ),
+                    )
+                    .into_any_element()
+            }
         };
 
         let error_block = error_msg.map(|msg| {
@@ -923,6 +1026,11 @@ impl Sidebar {
                         state.name.text().trim().to_string()
                     };
                     format!("git clone · {url} → {name}").into()
+                }
+                DialogMode::RemoteShell => {
+                    let command = state.remote_command.text().trim();
+                    let command = if command.is_empty() { "…" } else { command };
+                    format!("remote shell · {command}").into()
                 }
             }
         };
@@ -1105,13 +1213,15 @@ fn handle_key_down(
             return;
         }
         "tab" => {
-            if mode == DialogMode::Clone
+            if mode != DialogMode::Existing
                 && let Some(state) = sidebar.new_project_dialog_mut()
             {
                 state.focused_field = match state.focused_field {
                     DialogField::Url => DialogField::Parent,
                     DialogField::Parent => DialogField::Name,
                     DialogField::Name => DialogField::Url,
+                    DialogField::RemoteName => DialogField::RemoteCommand,
+                    DialogField::RemoteCommand => DialogField::RemoteName,
                 };
                 cx.notify();
             }

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -334,6 +334,13 @@ pub enum SidebarEvent {
     /// `MainViewModel.RefreshTabTitlesForWorktree` (driven by the
     /// `SessionStoreChange.WorktreeStatusUpdated` event).
     WorktreeBranchChanged { path: PathBuf, branch: String },
+    /// Open a tab for a [`codescope_core::ProjectKind::RemoteShell`]
+    /// project (#323). The host looks the project up by id, runs its
+    /// saved command in a fresh local shell with no working directory,
+    /// and persists the session under that project. `force_new: false`
+    /// is focus-or-open (double-click on the row); `true` always
+    /// spawns another tab (the context menu's "New session" row).
+    OpenRemoteShell { project_id: String, force_new: bool },
 }
 
 /// What `SidebarEvent::OpenConfirmDialog` is asking to do after the
@@ -510,6 +517,11 @@ pub struct Sidebar {
     /// to each worktree row. Mirrors the C# build's
     /// `WorktreePoller` cache.
     dirty_state: HashMap<String, bool>,
+    /// Ids of remote-shell projects (#323) that currently have at
+    /// least one live tab. Drives the accent rail + green dot on the
+    /// command row — the path-keyed `active_paths` set can't carry
+    /// them because those tabs have no working directory.
+    remote_live_project_ids: HashSet<String>,
     /// Rich per-worktree git status: branch, numstat diff, and
     /// ahead/behind counts. Keyed by absolute path, populated by
     /// `start_git_status_poll` (also every 5 s). `None` while the
@@ -657,6 +669,7 @@ impl Sidebar {
             dialog: None,
             new_project_dialog: None,
             dirty_state: HashMap::new(),
+            remote_live_project_ids: HashSet::new(),
             git_status: HashMap::new(),
             pr_urls: HashMap::new(),
             collapsed_projects,
@@ -759,6 +772,17 @@ impl Sidebar {
         }
         self.busy_paths = busy;
         self.active_paths = active;
+        cx.notify();
+    }
+
+    /// Set which remote-shell projects (#323) currently have a live
+    /// tab. No-op + no notify when unchanged, same as
+    /// [`Self::set_session_paths`].
+    pub fn set_remote_live_project_ids(&mut self, ids: HashSet<String>, cx: &mut Context<Self>) {
+        if ids == self.remote_live_project_ids {
+            return;
+        }
+        self.remote_live_project_ids = ids;
         cx.notify();
     }
 
@@ -866,10 +890,13 @@ impl Sidebar {
                             // only renders non-primary worktrees, but
                             // we still want the dirty-state cache
                             // populated for the project row's
-                            // worktree.
-                            std::iter::once(p.path.clone()).chain(
-                                p.worktrees.iter().map(|wt| wt.path.clone()),
-                            )
+                            // worktree. Remote-shell projects have an
+                            // empty path and no worktrees — the
+                            // `is_empty` filter keeps them out so we
+                            // never shell out to git against "".
+                            std::iter::once(p.path.clone())
+                                .chain(p.worktrees.iter().map(|wt| wt.path.clone()))
+                                .filter(|path| !path.is_empty())
                         })
                         .collect()
                 }) {
@@ -944,15 +971,16 @@ impl Sidebar {
                     break;
                 }
                 // Snapshot every worktree path into a de-duplicated set
-                // (same de-dup rationale as start_dirty_poll).
+                // (same de-dup + empty-path rationale as
+                // start_dirty_poll).
                 let paths: HashSet<String> = match this.update(cx, |this, _| {
                     this.projects
                         .projects
                         .iter()
                         .flat_map(|p| {
-                            std::iter::once(p.path.clone()).chain(
-                                p.worktrees.iter().map(|wt| wt.path.clone()),
-                            )
+                            std::iter::once(p.path.clone())
+                                .chain(p.worktrees.iter().map(|wt| wt.path.clone()))
+                                .filter(|path| !path.is_empty())
                         })
                         .collect()
                 }) {
@@ -1077,6 +1105,11 @@ impl Sidebar {
                         let mut seen: HashSet<String> = HashSet::new();
                         let mut out: Vec<(String, String)> = Vec::new();
                         for project in &this.projects.projects {
+                            // No path, no branch, no PR — skip
+                            // remote-shell projects outright.
+                            if project.is_remote_shell() {
+                                continue;
+                            }
                             let entries = std::iter::once((
                                 project.path.clone(),
                                 None::<String>,
@@ -2473,6 +2506,32 @@ impl Sidebar {
         self.save_layout();
         cx.notify();
     }
+
+    /// Add a [`codescope_core::ProjectKind::RemoteShell`] project
+    /// (#323). Same clone-then-save discipline as [`Self::add_project`];
+    /// no path dedup because there is no path — the dialog rejects a
+    /// duplicate *name* before it gets here.
+    pub fn add_remote_shell_project(
+        &mut self,
+        name: String,
+        command: String,
+        cx: &mut Context<Self>,
+    ) {
+        let project = Project::new_remote_shell(name, command);
+        let new_id = project.id.clone();
+        let mut next = self.projects.clone();
+        next.projects.push(project);
+        if let Err(err) = next.save(&self.paths) {
+            eprintln!("warning: failed to save projects.json: {err:#}");
+            return;
+        }
+        self.projects = next;
+        let new_idx = self.projects.projects.len() - 1;
+        self.selected = Some(new_idx);
+        self.layout.selected_project_id = Some(new_id);
+        self.save_layout();
+        cx.notify();
+    }
 }
 
 impl EventEmitter<SidebarEvent> for Sidebar {}
@@ -2878,6 +2937,86 @@ impl Render for Sidebar {
             // under an expanded project with empty `Worktrees`. Single
             // dim row, indented to align with the worktree children
             // that *would* live here.
+            // Remote-shell projects (#323) have no worktrees by
+            // construction. Instead of the "(no worktrees)" placeholder
+            // they get a single child row showing the saved command;
+            // double-click opens (or focuses) the tab, right-click
+            // opens the trimmed project menu. Same row geometry as a
+            // worktree row so the tree reads consistently.
+            let remote_command: Option<String> = self
+                .projects
+                .projects
+                .get(idx)
+                .and_then(|p| p.remote_shell_command().map(str::to_owned));
+            if let Some(command) = remote_command {
+                let frost_hover = theme::surface_elev(&theme);
+                let ink_hover = theme::ink(&theme);
+                let project_id_for_open = id.clone();
+                let project_idx_for_menu = idx;
+                let has_live_tab = self.remote_live_project_ids.contains(&id);
+                let rail_color = if has_live_tab {
+                    theme::accent(&theme)
+                } else {
+                    gpui::transparent_black()
+                };
+                let dot_color = if has_live_tab {
+                    theme::signal_ok()
+                } else {
+                    theme::ink_ghost(&theme)
+                };
+                let command_label: SharedString = command.into();
+                let remote_row = div()
+                    .id(("remote-shell", id_hash(&id)))
+                    .h(px(28.0))
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .border_l_2()
+                    .border_color(rail_color)
+                    .pl(px(32.0))
+                    .pr_3()
+                    .gap_2()
+                    .text_color(theme::ink_muted(&theme))
+                    .text_size(px(11.5))
+                    .cursor_pointer()
+                    .hover(move |s| s.bg(frost_hover).text_color(ink_hover))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, event: &MouseDownEvent, _, cx| {
+                            if is_double_click(event.click_count) {
+                                cx.emit(SidebarEvent::OpenRemoteShell {
+                                    project_id: project_id_for_open.clone(),
+                                    force_new: false,
+                                });
+                            } else {
+                                this.select(project_idx_for_menu, cx);
+                            }
+                        }),
+                    )
+                    .on_mouse_down(
+                        MouseButton::Right,
+                        cx.listener(move |this, event: &MouseDownEvent, _, cx| {
+                            this.open_project_menu(project_idx_for_menu, event.position, cx);
+                        }),
+                    )
+                    .child(
+                        div()
+                            .flex_shrink_0()
+                            .w(px(6.0))
+                            .h(px(6.0))
+                            .rounded_full()
+                            .bg(dot_color),
+                    )
+                    .child(
+                        div()
+                            .flex_grow()
+                            .truncate()
+                            .font(theme::font_mono())
+                            .child(command_label),
+                    );
+                project_and_worktree_rows.push(remote_row.into_any_element());
+                continue;
+            }
             if worktrees.is_empty() {
                 // Stable id keyed off the project id (same hash
                 // strategy `project_row` and `wt_row` use) so gpui
@@ -3658,9 +3797,13 @@ impl Render for Sidebar {
                 if let Some(project) = self.projects.projects.get(*project_idx).cloned() {
                     let project_path = project.path.clone();
                     let project_name: SharedString = project.name.clone().into();
-                    let overlay = self
-                        .render_project_menu(*project_idx, project_pos, &project, &theme, cx)
-                        .into_any_element();
+                    let overlay = if project.is_remote_shell() {
+                        self.render_remote_project_menu(*project_idx, project_pos, &project, &theme, cx)
+                            .into_any_element()
+                    } else {
+                        self.render_project_menu(*project_idx, project_pos, &project, &theme, cx)
+                            .into_any_element()
+                    };
                     root = root.child(overlay);
                     if let Some(sub) = self.open_submenu.as_ref()
                         && sub.kind == SubmenuKind::NewSession
@@ -4152,6 +4295,161 @@ impl Sidebar {
     /// the chrome instead of being clipped by the sidebar's bounds.
     /// Click outside (anywhere in the window) dismisses via
     /// `on_mouse_down_out`.
+    /// Context menu for a remote-shell project (#323). Deliberately a
+    /// separate, much shorter menu than [`Self::render_project_menu`]:
+    /// every git / worktree / path row would be a no-op here, so we
+    /// only offer Open session, New session, Copy command, Rename and
+    /// Remove. Same chrome as the regular project menu.
+    fn render_remote_project_menu(
+        &self,
+        idx: usize,
+        position: Point<Pixels>,
+        project: &Project,
+        theme: &Arc<Theme>,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let header_label: SharedString = project.name.clone().into();
+        let elevated = theme::elevated(theme);
+        let divider = theme::divider(theme);
+        let ink = theme::ink(theme);
+        let ink_dim = theme::ink_dim(theme);
+        let ink_ghost = theme::ink_ghost(theme);
+        let frost = theme::frost_10(theme);
+        let danger = theme::danger();
+
+        let item = |id: &'static str,
+                    label: &'static str,
+                    danger_row: bool,
+                    on_click: MenuItemAction|
+         -> gpui::Stateful<gpui::Div> {
+            let base_color = if danger_row { danger } else { ink_dim };
+            let hover_color = if danger_row { danger } else { ink };
+            let frost_hover = frost;
+            div()
+                .id(id)
+                .h(px(28.0))
+                .px_3()
+                .flex()
+                .flex_row()
+                .items_center()
+                .text_size(px(12.5))
+                .text_color(base_color)
+                .cursor_pointer()
+                .hover(move |s| s.bg(frost_hover).text_color(hover_color))
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, window, cx| {
+                        cx.stop_propagation();
+                        on_click(this, window, cx);
+                    }),
+                )
+                .child(label)
+        };
+
+        let project_id_open = project.id.clone();
+        let project_id_new = project.id.clone();
+        let command_for_copy = project.remote_shell_command().unwrap_or_default().to_string();
+        let project_id_rename = project.id.clone();
+        let current_name = project.name.clone();
+
+        let menu_body = div()
+            .flex()
+            .flex_col()
+            .py_1()
+            .min_w(px(220.0))
+            .bg(elevated)
+            .border_1()
+            .border_color(divider)
+            .rounded_md()
+            .shadow_lg()
+            .font(theme::font_sans())
+            .child(
+                div()
+                    .px_3()
+                    .py_2()
+                    .text_size(px(10.0))
+                    .text_color(ink_ghost)
+                    .child(
+                        div()
+                            .text_color(ink)
+                            .font(theme::font_mono())
+                            .text_size(px(11.0))
+                            .truncate()
+                            .child(header_label),
+                    )
+                    .child(div().child("remote shell")),
+            )
+            .child(div().h_px().bg(divider).my_1())
+            .child(item(
+                "remote-menu-open",
+                "Open session",
+                false,
+                Box::new(move |this, _window, cx| {
+                    cx.emit(SidebarEvent::OpenRemoteShell {
+                        project_id: project_id_open.clone(),
+                        force_new: false,
+                    });
+                    this.close_menu(cx);
+                }),
+            ))
+            .child(item(
+                "remote-menu-new",
+                "New session",
+                false,
+                Box::new(move |this, _window, cx| {
+                    cx.emit(SidebarEvent::OpenRemoteShell {
+                        project_id: project_id_new.clone(),
+                        force_new: true,
+                    });
+                    this.close_menu(cx);
+                }),
+            ))
+            .child(div().h_px().bg(divider).my_1())
+            .child(item(
+                "remote-menu-copy-command",
+                "Copy command",
+                false,
+                Box::new(move |this, _window, cx| {
+                    cx.write_to_clipboard(ClipboardItem::new_string(command_for_copy.clone()));
+                    this.close_menu(cx);
+                }),
+            ))
+            .child(div().h_px().bg(divider).my_1())
+            .child(item(
+                "remote-menu-rename",
+                "Rename project…",
+                false,
+                Box::new(move |this, _window, cx| {
+                    cx.emit(SidebarEvent::OpenRenameDialog {
+                        target: RenameRequest::Project {
+                            project_id: project_id_rename.clone(),
+                        },
+                        current_name: current_name.clone(),
+                    });
+                    this.close_menu(cx);
+                }),
+            ))
+            .child(item(
+                "remote-menu-remove",
+                "Remove project",
+                true,
+                Box::new(move |this, _window, cx| this.request_remove_project(idx, cx)),
+            ))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|_, _, _, cx| cx.stop_propagation()),
+            )
+            .on_mouse_down_out(cx.listener(|this, _, _, cx| this.close_menu(cx)));
+
+        deferred(
+            anchored()
+                .position(point(position.x, position.y))
+                .anchor(Corner::TopLeft)
+                .snap_to_window_with_margin(px(8.0))
+                .child(menu_body),
+        )
+    }
+
     fn render_project_menu(
         &self,
         idx: usize,

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1371,9 +1371,17 @@ impl Sidebar {
         let mut paths: HashSet<&str> =
             HashSet::new();
         for project in &self.projects.projects {
-            paths.insert(project.path.as_str());
+            // Skip empty paths — remote-shell projects (#323) have
+            // `path == ""` and no worktrees; counting "" would report
+            // a phantom worktree in the status bar. Same non-empty
+            // filter the dirty / git-status pollers apply.
+            if !project.path.is_empty() {
+                paths.insert(project.path.as_str());
+            }
             for wt in &project.worktrees {
-                paths.insert(wt.path.as_str());
+                if !wt.path.is_empty() {
+                    paths.insert(wt.path.as_str());
+                }
             }
         }
         let total = paths.len();

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1343,6 +1343,12 @@ impl Sidebar {
         &self.projects
     }
 
+    /// The cached agent registry — used by the Add-project dialog's
+    /// remote-shell agent picker (#323).
+    pub(crate) fn agent_registry(&self) -> &AgentRegistry {
+        &self.agent_registry
+    }
+
     /// Same as [`Self::projects`] for the path bundle. Used by the
     /// dialog to persist `projects.json` after a successful create.
     pub(crate) fn paths_ref(&self) -> &AppPaths {
@@ -2515,9 +2521,10 @@ impl Sidebar {
         &mut self,
         name: String,
         command: String,
+        agent_id: Option<String>,
         cx: &mut Context<Self>,
     ) {
-        let project = Project::new_remote_shell(name, command);
+        let project = Project::new_remote_shell(name, command, agent_id);
         let new_id = project.id.clone();
         let mut next = self.projects.clone();
         next.projects.push(project);
@@ -2947,7 +2954,8 @@ impl Render for Sidebar {
                 .projects
                 .projects
                 .get(idx)
-                .and_then(|p| p.remote_shell_command().map(str::to_owned));
+                .filter(|p| p.remote_shell_command().is_some())
+                .map(|p| self.agent_registry.assemble_remote_command(p));
             if let Some(command) = remote_command {
                 let frost_hover = theme::surface_elev(&theme);
                 let ink_hover = theme::ink(&theme);
@@ -4348,7 +4356,7 @@ impl Sidebar {
 
         let project_id_open = project.id.clone();
         let project_id_new = project.id.clone();
-        let command_for_copy = project.remote_shell_command().unwrap_or_default().to_string();
+        let command_for_copy = self.agent_registry.assemble_remote_command(project);
         let project_id_rename = project.id.clone();
         let current_name = project.name.clone();
 


### PR DESCRIPTION
Closes #323.

## What & why

Working on a remote box today means opening a plain shell tab and typing `ssh user@host` then `claude` by hand — it works, but there's no sidebar entry to click and the tab doesn't survive a restart. A full remote integration (git worktrees, telemetry tails, diff viewer over SSH) is out of reach: every one of those subsystems assumes a local filesystem. This PR delivers the small, useful slice instead — **a sidebar project that stores a command line and runs it in a local shell.**

## Design

- `Project.kind: Local | RemoteShell` (`#[serde(default)]` → `Local`, so existing `projects.json` loads unchanged) and `Project.command: Option<String>`.
- Remote-shell projects have an empty `path` and no worktrees; `migrate` / `adopt_existing_worktrees` skip them, and the dirty / git-status / PR pollers exclude empty paths.
- Opening a session runs `pwsh -NoExit -NoLogo -Command "& { <command> }"` with **no** working directory (new `build_remote_shell_args`, sibling of `build_agent_shell_args`). No agent telemetry, no busy indicator.
- Live tabs persist as sessions under the project (keyed by project id, empty `worktree_path`) so they rehydrate on restart; the `path.exists()` rehydrate guard is bypassed for this kind. Closing a remote tab **hard-removes** the row — there's nothing to resume, so a history entry would be dead weight.
- Add-project dialog gains a third **Remote shell** mode (name + command). The project context menu is trimmed to Open / New session / Copy command / Rename / Remove.

## Explicitly not included

Git integration, busy/ready indicator, diff viewer, file links, reveal-in-explorer for remote projects. These are called out in the dialog UI ("No git, worktrees or agent status for this project — just the tab.").

## Verification

- `cargo build` and `cargo clippy` clean on changed files (added a scoped `#[allow(too_many_arguments)]` on `spawn_tab_in`, whose parameters vary along genuinely independent axes).
- `cargo test` green: core **515** passed (new tests: serde round-trip with camelCase `remoteShell`, `kind`-less legacy load → `Local`, migrate/adopt skip, command validation, arg-builder shape), bin **152** passed.
- **Not yet click-tested in the running app.** The dev build isn't compiled with the `driver` feature so gpui-driver can't reach it, and it shares a window rect with the installed build, which makes screen-capture verification unreliable. Manual click-through of the dialog + sidebar row + restart is the one open item for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)