### PR TITLE
release: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "codescope"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope"
-version = "0.5.5"
+version = "0.6.0"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
Cuts the **0.6.0** release.

## Changes since 0.5.5

- **Remote-shell projects (#323)** — a sidebar project kind that runs a saved command (e.g. `ssh dev`) in a local tab, with no git/worktree/telemetry baggage. Optional agent field launches the agent on the far end via the remote login shell (`ssh dev -t '$SHELL -lic "claude"'`), so you land straight in Claude Code; works on Windows (Windows OpenSSH + agent) and macOS/Linux (native ssh + login shell). Follow-ups tracked in #327.
- **Installed-fonts settings dropdown (#326)** — replaces the font-family text box.

## Release mechanics

Version bumped in `Cargo.toml` + `Cargo.lock` only (same minimal shape as previous bumps). After this merges to `main`, pushing tag `v0.6.0` triggers the cargo-dist release workflow (`.github/workflows/release.yml`, which fires on `v*.*.*` tags) — builds the cross-platform artifacts, the Inno Setup installer (version passed via `MyAppVersion`), checksums, and the generated release notes.

Verified: `cargo build` compiles as `codescope v0.6.0`, lockfile consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)