### PR TITLE
Apply font changes to running terminals immediately

### DIFF
--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -84,7 +84,7 @@ impl Default for Settings {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct FontSettings {
     /// Primary font family. Empty string falls back to the binary's

--- a/src/app.rs
+++ b/src/app.rs
@@ -3520,6 +3520,11 @@ impl AppShell {
         // the Settings dialog appears to do nothing for agent choice.
         let agent_registry =
             codescope_core::AgentRegistry::from_settings(&settings);
+        // Compare before the swap: a font edit should reach running
+        // terminals (see `push_font_to_terminals`), but pushing on
+        // every apply would stage a pointless re-measure + PTY resize
+        // per tab for theme-only changes and live previews.
+        let font_changed = self.settings.font != settings.font;
         self.settings = Arc::new(settings);
         self.theme = theme.clone();
         self.sidebar.update(cx, |sidebar, cx| {
@@ -3527,6 +3532,9 @@ impl AppShell {
             sidebar.apply_agent_registry(agent_registry, cx);
         });
         self.push_palette_to_terminals(cx);
+        if font_changed {
+            self.push_font_to_terminals(cx);
+        }
         cx.notify();
     }
 
@@ -3560,6 +3568,24 @@ impl AppShell {
                 let palette = palette.clone();
                 tab.terminal.update(cx, |view, cx| {
                     view.set_palette(palette, cx);
+                });
+            }
+        }
+    }
+
+    /// Rebuild the terminal font config from the live settings and
+    /// push it into every open tab's `TerminalView` — the font
+    /// counterpart of [`Self::push_palette_to_terminals`]. Each view
+    /// re-measures and stages a grid resize on its next frame, so a
+    /// Save in the Settings dialog restyles running terminals in
+    /// place instead of only affecting freshly-spawned tabs.
+    fn push_font_to_terminals(&mut self, cx: &mut Context<Self>) {
+        let font = build_font_config(&self.settings);
+        for group in &self.groups {
+            for tab in &group.tabs {
+                let font = font.clone();
+                tab.terminal.update(cx, |view, cx| {
+                    view.set_font(font, cx);
                 });
             }
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -3509,8 +3509,10 @@ impl AppShell {
     /// settings and theme `Arc`s, and forwards the new theme to the
     /// sidebar so its chrome repaints in the same frame. Running
     /// terminals get the new palette pushed via
-    /// `push_palette_to_terminals` so the grid recolours live too;
-    /// font changes still take effect on next spawn only.
+    /// `push_palette_to_terminals` so the grid recolours live too,
+    /// and a changed font is pushed via `push_font_to_terminals` so
+    /// the grids restyle in place; scrollback still applies to new
+    /// tabs only.
     pub(crate) fn apply_settings(&mut self, settings: Settings, cx: &mut Context<Self>) {
         let theme = Arc::new(codescope_core::theme::builtin::by_name(&settings.theme));
         // Rebuild the AgentRegistry from the new settings so the

--- a/src/dialogs/settings.rs
+++ b/src/dialogs/settings.rs
@@ -441,11 +441,12 @@ impl AppShell {
         }
         self.settings_dialog = None;
         // Reuse the existing live-reload pathway so theme + chrome
-        // swap atomically and the sidebar repaints. Terminals that
-        // are already running keep their baked-in palette / font /
-        // scrollback — only new tabs pick up font + scrollback
-        // changes. Theme + cursor take effect for chrome on the next
-        // frame; cursor-style changes apply to freshly-spawned tabs.
+        // swap atomically and the sidebar repaints. Palette and font
+        // changes are pushed into running terminals in place
+        // (`push_palette_to_terminals` / `push_font_to_terminals`);
+        // scrollback still applies to new tabs only. Theme + cursor
+        // take effect for chrome on the next frame; cursor-style
+        // changes apply to freshly-spawned tabs.
         self.apply_settings(new_settings, cx);
     }
 

--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -300,6 +300,27 @@ impl TerminalView {
         self.refresh_snapshot(cx);
     }
 
+    /// Swap the font config on a running terminal. The palette
+    /// counterpart of [`Self::set_palette`] — the app shell calls
+    /// this for every open tab when the user saves a font change in
+    /// Settings, so the grids re-render in the new face immediately
+    /// instead of keeping their spawn-time font until the tab is
+    /// reopened.
+    ///
+    /// No re-measure happens here: the canvas layout pass shapes the
+    /// probe glyph with `self.font` on every frame anyway, so the
+    /// next render picks up the new face, recomputes cell metrics,
+    /// and stages a PTY grid resize through the existing debounce.
+    /// Zeroing `last_size` forces that pass to see a dimension diff
+    /// even when the new font's metrics land on the same cols × rows,
+    /// so the measured `cell_width` / `line_height` written back into
+    /// `self.font` (used by mouse hit-testing) never go stale.
+    pub fn set_font(&mut self, font: FontConfig, cx: &mut Context<Self>) {
+        self.font = font;
+        *self.last_size.lock() = (0, 0);
+        cx.notify();
+    }
+
     /// Snap the cursor to its visible phase. Called whenever the user
     /// types so the cursor never disappears mid-keystroke.
     fn show_cursor_now(&self) {

--- a/terminal/src/view.rs
+++ b/terminal/src/view.rs
@@ -300,7 +300,7 @@ impl TerminalView {
         self.refresh_snapshot(cx);
     }
 
-    /// Swap the font config on a running terminal. The palette
+    /// Swap the font config on a running terminal. The font
     /// counterpart of [`Self::set_palette`] — the app shell calls
     /// this for every open tab when the user saves a font change in
     /// Settings, so the grids re-render in the new face immediately


### PR DESCRIPTION
## What broke

Saving a font change in the Settings dialog (#326) only affected freshly-spawned tabs. Running terminals kept their spawn-time `FontConfig` until the tab was reopened, so actually seeing a new font meant starting a new session.

## Root cause

`TerminalView` receives its `FontConfig` once at construction and had no pathway to replace it afterwards — the same gap running terminals had for theme colours before #257 added `set_palette` / `push_palette_to_terminals`.

Crucially, the font is not deeply baked in: the canvas layout pass already re-shapes the `│` probe glyph with `self.font` on **every frame**, recomputes cell metrics, and stages a debounced PTY grid resize when the computed dimensions change. Only the config swap was missing.

## The fix

Mirrors the #257 live-recolor pathway:

- **`TerminalView::set_font()`** (next to `set_palette()`): swaps the `FontConfig` and zeroes `last_size`. No explicit re-measure needed — the next frame shapes with the new face and the existing resize machinery adapts the grid. Zeroing `last_size` forces the layout pass to see a dimension diff even when the new font's metrics land on the same cols × rows, so the measured `cell_width` / `line_height` written back for mouse hit-testing never go stale.
- **`AppShell::push_font_to_terminals()`**: rebuilds the font config from live settings and pushes it into every open tab — the font counterpart of `push_palette_to_terminals`.
- **`apply_settings`** compares `FontSettings` before the swap (`PartialEq` newly derived in core) and pushes only on a real font change, so theme-only applies and the dialog's live theme preview don't stage pointless per-tab re-measures + resizes.
- Dialog comments updated: palette + font now reach running terminals in place; scrollback remains new-tabs-only (that one genuinely needs a PTY respawn).

## How it was verified

- `cargo clippy --workspace --all-targets`: no new warnings (the remaining ones pre-date this change, in #325's code).
- `cargo test --workspace`: 157 passed; the single failure (`overview::short_path_keeps_two_tail_segments`) is the pre-existing Windows-path test that also fails on a clean tree on Linux.

## Left unproven

Not verified visually — the session container has no display server. Worth a quick check in a dev build (`CODESCOPE_DEV=1 cargo run`): save a font change with tabs open and confirm the swap is smooth, in particular that ConPTY on Windows doesn't dump viewport content into scrollback on the metrics-only resize after a font switch (the debounce should absorb it, but that path is Windows-only behaviour this change newly exercises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X49jBGy7vLF9T5coDyVCK2

---
_Generated by [Claude Code](https://claude.ai/code/session_01X49jBGy7vLF9T5coDyVCK2)_