### PR TITLE
fix: worktree names showed random hex (detached-HEAD SHAs and UUID fallbacks) 

### DIFF
--- a/core/src/git.rs
+++ b/core/src/git.rs
@@ -371,6 +371,13 @@ pub struct GitStatus {
     /// Detached-HEAD worktrees get the 7-char short SHA instead
     /// (e.g. `"abc1234"`), matching the C# build's fallback.
     pub branch: String,
+    /// `true` when HEAD is detached — `branch` then carries the
+    /// short-SHA stand-in, not a real ref name. Display code that
+    /// wants "a branch name or nothing" should go through
+    /// [`GitStatus::branch_name`] so a detached worktree falls back
+    /// to its persisted branch / folder leaf instead of showing a
+    /// random-looking hex string (#319).
+    pub detached: bool,
     /// Lines added relative to HEAD across all modified files
     /// (sum of the first column from `git diff --numstat HEAD`).
     pub added: u32,
@@ -388,6 +395,16 @@ pub struct GitStatus {
     /// ahead/behind segment should be hidden rather than showing
     /// `0 / 0`.
     pub has_upstream: bool,
+}
+
+impl GitStatus {
+    /// The live branch name, or `None` on a detached HEAD (where
+    /// [`Self::branch`] holds the short-SHA stand-in). Label code
+    /// should prefer this over reading `branch` directly so hex
+    /// stand-ins never become user-facing worktree names.
+    pub fn branch_name(&self) -> Option<&str> {
+        if self.detached { None } else { Some(&self.branch) }
+    }
 }
 
 /// Collect the three git status signals for a single worktree at
@@ -446,7 +463,7 @@ pub fn git_status(repo: &Path) -> Result<Option<GitStatus>> {
     }
 
     // ── 1. Current branch ──────────────────────────────────────────
-    let branch = current_branch(repo);
+    let (branch, detached) = current_branch(repo);
 
     // ── 2. numstat diff against HEAD ───────────────────────────────
     let (added, removed, has_changes) = numstat_summary(repo);
@@ -454,28 +471,29 @@ pub fn git_status(repo: &Path) -> Result<Option<GitStatus>> {
     // ── 3. Ahead / behind upstream ─────────────────────────────────
     let (ahead, behind, has_upstream) = ahead_behind(repo);
 
-    Ok(Some(GitStatus { branch, added, removed, has_changes, ahead, behind, has_upstream }))
+    Ok(Some(GitStatus { branch, detached, added, removed, has_changes, ahead, behind, has_upstream }))
 }
 
-/// `git symbolic-ref --short HEAD` → short branch name.
-/// Falls back to the 7-char short SHA on detached HEAD.
-/// Returns `"?"` only if both git calls fail (not a repo, etc.).
-fn current_branch(repo: &Path) -> String {
+/// `git symbolic-ref --short HEAD` → `(short branch name, false)`.
+/// Falls back to `(7-char short SHA, true)` on detached HEAD.
+/// Returns `("?", true)` only if both git calls fail (not a repo,
+/// etc.) — "?" is no more a branch name than a SHA is.
+fn current_branch(repo: &Path) -> (String, bool) {
     // Happy path: attached HEAD.
     if let Ok(out) = run_git(repo, &["symbolic-ref", "--short", "HEAD"]) {
         let name = String::from_utf8_lossy(&out.stdout).trim().to_string();
         if !name.is_empty() {
-            return name;
+            return (name, false);
         }
     }
     // Detached HEAD: fall back to short SHA.
     if let Ok(out) = run_git(repo, &["rev-parse", "--short", "HEAD"]) {
         let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
         if !sha.is_empty() {
-            return sha;
+            return (sha, true);
         }
     }
-    "?".to_string()
+    ("?".to_string(), true)
 }
 
 /// `git diff --numstat HEAD` → `(added, removed, has_changes)`.
@@ -1148,6 +1166,24 @@ some-future-field foo bar\n";
         assert!(!status.has_upstream, "has_upstream without upstream");
         assert_eq!(status.ahead, 0);
         assert_eq!(status.behind, 0);
+        assert!(!status.detached, "attached HEAD must not report detached");
+        assert_eq!(status.branch_name(), Some("main"));
+    }
+
+    #[test]
+    fn git_status_detached_head_sets_detached_and_hides_branch_name() {
+        let Some((_guard, repo, _wts)) = init_repo() else { return };
+        // Detach HEAD at the current commit — `branch` degrades to the
+        // short SHA, and `branch_name()` must hide it so worktree
+        // labels don't turn into random-looking hex (#319).
+        run(&repo, &["checkout", "--detach", "-q"]);
+
+        let status = git_status(&repo).expect("git invocation").expect("Some");
+
+        assert!(status.detached, "detached HEAD must be flagged");
+        assert_eq!(status.branch_name(), None, "no branch name when detached");
+        assert!(!status.branch.is_empty(), "short SHA stand-in still recorded");
+        assert_ne!(status.branch, "main");
     }
 
     #[test]
@@ -1230,6 +1266,7 @@ some-future-field foo bar\n";
     ) -> GitStatus {
         GitStatus {
             branch: "main".into(),
+            detached: false,
             added,
             removed,
             has_changes,

--- a/core/src/overview.rs
+++ b/core/src/overview.rs
@@ -45,8 +45,12 @@ pub struct OverviewRow {
     /// Display name for the project that owns the session. Mirrors
     /// C# `OverviewCardViewModel.ProjectName`.
     pub project_name: String,
-    /// Branch label — falls back to the worktree id when `branch` is
-    /// `None`. Matches C# `WorktreeViewModel.DisplayBranch`'s shape.
+    /// Branch label — when the session's `branch` is `None` this
+    /// falls back to the owning worktree's branch, then the worktree
+    /// folder leaf, and only then the raw worktree id. Sessions are
+    /// persisted with `branch: None` until the first git poll lands,
+    /// so an id-first fallback rendered UUID hex as the "worktree
+    /// name" in the Overview (#319).
     pub branch_label: String,
     /// Absolute path the session was opened in. Used by the renderer
     /// to look up the matching live tab (group + tab index).
@@ -66,9 +70,19 @@ pub struct OverviewRow {
 
 impl OverviewRow {
     fn from_session(project: &Project, session: &Session) -> Self {
+        // Resolve a human-readable label: session branch → owning
+        // worktree's branch → worktree folder leaf → session path
+        // leaf → raw worktree id (last resort; a UUID, so only when
+        // every path/branch slot is empty).
+        let worktree = session.worktree_id.as_deref().and_then(|id| {
+            project.worktrees.iter().find(|wt| wt.id == id)
+        });
         let branch_label = session
             .branch
             .clone()
+            .or_else(|| worktree.and_then(|wt| wt.branch.clone()))
+            .or_else(|| worktree.and_then(|wt| path_leaf(&wt.path)))
+            .or_else(|| path_leaf(&session.worktree_path))
             .or_else(|| session.worktree_id.clone())
             .unwrap_or_default();
         let lifecycle = if session.closed_at.is_some() {
@@ -87,6 +101,19 @@ impl OverviewRow {
             lifecycle,
         }
     }
+}
+
+/// Last path component of `path`, splitting on both `/` and `\` so
+/// Windows-written `projects.json` entries resolve on every platform
+/// (mirrors the tab-title logic's tolerance for foreign separators).
+/// `None` for an empty result so callers can keep falling back.
+fn path_leaf(path: &str) -> Option<String> {
+    let leaf = path
+        .trim_end_matches(['/', '\\'])
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or_default();
+    if leaf.is_empty() { None } else { Some(leaf.to_string()) }
 }
 
 /// Build the flat row list from a [`ProjectsConfig`] snapshot —
@@ -322,9 +349,54 @@ mod tests {
     }
 
     #[test]
-    fn branch_label_falls_back_to_worktree_id() {
+    fn branch_label_falls_back_to_worktree_folder_leaf_not_id() {
+        // Sessions are persisted with `branch: None` until the first
+        // git poll backfills it — the label must resolve through the
+        // owning worktree's path, never the raw worktree id (#319).
         let mut s = mk_session("s1", None, None);
         s.branch = None;
+        s.worktree_id = Some("3f9a1c2e-77aa-4bd0-9c55-0d6f2b8e4a11".into());
+        let mut p = mk_project("p1", "alpha", vec![]);
+        p.worktrees.push(Worktree {
+            id: "3f9a1c2e-77aa-4bd0-9c55-0d6f2b8e4a11".into(),
+            path: "C:\\dev\\alpha.worktrees\\profit-wt-1".into(),
+            branch: None,
+            is_primary: false,
+        });
+        p.sessions = vec![s];
+        let cfg = ProjectsConfig { version: 1, agents: vec![], projects: vec![p] };
+
+        let rows = build_rows(&cfg);
+        assert_eq!(rows[0].branch_label, "profit-wt-1");
+    }
+
+    #[test]
+    fn branch_label_prefers_owning_worktree_branch_over_paths() {
+        let mut s = mk_session("s1", None, None);
+        s.branch = None;
+        s.worktree_id = Some("wt1".into());
+        let mut p = mk_project("p1", "alpha", vec![]);
+        p.worktrees.push(Worktree {
+            id: "wt1".into(),
+            path: "/home/u/alpha.worktrees/feat-x-dir".into(),
+            branch: Some("feat/x".into()),
+            is_primary: false,
+        });
+        p.sessions = vec![s];
+        let cfg = ProjectsConfig { version: 1, agents: vec![], projects: vec![p] };
+
+        let rows = build_rows(&cfg);
+        assert_eq!(rows[0].branch_label, "feat/x");
+    }
+
+    #[test]
+    fn branch_label_unknown_worktree_uses_session_path_leaf() {
+        // Worktree id points at nothing (stale record) — the session's
+        // own working directory still beats showing the UUID.
+        let mut s = mk_session("s1", None, None);
+        s.branch = None;
+        s.worktree_id = Some("gone-uuid".into());
+        s.worktree_path = "/home/u/alpha.worktrees/focus-wt-2".into();
         let cfg = ProjectsConfig {
             version: 1,
             agents: vec![],
@@ -332,7 +404,16 @@ mod tests {
         };
 
         let rows = build_rows(&cfg);
-        assert_eq!(rows[0].branch_label, "primary");
+        assert_eq!(rows[0].branch_label, "focus-wt-2");
+    }
+
+    #[test]
+    fn path_leaf_handles_both_separators_and_empty() {
+        assert_eq!(path_leaf("C:\\a\\b\\leaf"), Some("leaf".into()));
+        assert_eq!(path_leaf("/a/b/leaf"), Some("leaf".into()));
+        assert_eq!(path_leaf("/a/b/leaf/"), Some("leaf".into()));
+        assert_eq!(path_leaf(""), None);
+        assert_eq!(path_leaf("///"), None);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -3332,9 +3332,12 @@ impl AppShell {
                 .iter()
                 .find(|p| p.sessions.iter().any(|s| s.id == restored.id))
                 .map(|p| p.name.clone());
+            // `branch_name()` so a detached-HEAD worktree falls back
+            // to the persisted branch instead of titling the tab with
+            // the short-SHA stand-in (#319).
             let branch_label = sidebar
                 .git_status_for(&descriptor.working_directory)
-                .map(|g| g.branch.clone())
+                .and_then(|g| g.branch_name().map(str::to_string))
                 .or_else(|| restored.branch.clone());
             match (project_name, branch_label) {
                 (Some(p), Some(b)) => format!("{p} · {b}").into(),
@@ -5402,8 +5405,12 @@ impl AppShell {
         // worktree's `DisplayBranch` when available; otherwise we fall
         // back to the tab title, exactly like the C# `StatusBranch`.
         let session_cluster = active_tab.map(|_| {
-            let branch_text: SharedString = match (git.as_ref(), active_title.clone()) {
-                (Some(g), _) => g.branch.clone().into(),
+            // Detached HEAD has no branch name (`branch_name()` is
+            // `None`) — fall back to the tab title rather than the
+            // short-SHA stand-in (#319).
+            let live_branch = git.as_ref().and_then(|g| g.branch_name());
+            let branch_text: SharedString = match (live_branch, active_title.clone()) {
+                (Some(b), _) => b.to_string().into(),
                 (None, Some(t)) => t,
                 (None, None) => SharedString::from(""),
             };

--- a/src/overview.rs
+++ b/src/overview.rs
@@ -21,7 +21,6 @@
 //! newest-first by `last_opened`. Live-row decoration is folded in
 //! here by joining on `session_id` against `self.groups`.
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use codescope_core::{
@@ -615,19 +614,22 @@ fn format_duration(d: std::time::Duration) -> String {
 /// disambiguate worktrees (`codescope.worktrees/feature-x` reads
 /// better than just `feature-x`).
 fn short_path(path: &str) -> String {
-    let buf = PathBuf::from(path);
-    let comps: Vec<String> = buf
-        .components()
-        .filter_map(|c| match c {
-            std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
-            _ => None,
-        })
+    // Split on both separators (a Windows-written projects.json can
+    // surface on any platform) and echo the path's own separator back
+    // so `/home/u/wt` shortens to `…/u/wt`, not `…\u\wt`. The old
+    // `PathBuf::components()` version split on the *host* separator
+    // only, so foreign paths never shortened and the label always
+    // used `\`.
+    let sep = if path.contains('/') { '/' } else { '\\' };
+    let comps: Vec<&str> = path
+        .split(['/', '\\'])
+        .filter(|s| !s.is_empty() && !s.ends_with(':'))
         .collect();
     if comps.len() <= 2 {
         return path.to_string();
     }
     let tail = &comps[comps.len() - 2..];
-    format!("…\\{}\\{}", tail[0], tail[1])
+    format!("…{sep}{}{sep}{}", tail[0], tail[1])
 }
 
 #[cfg(test)]
@@ -675,5 +677,8 @@ mod tests {
         assert_eq!(short_path("C:\\dev\\foo\\bar"), "…\\foo\\bar");
         assert_eq!(short_path("foo\\bar"), "foo\\bar");
         assert_eq!(short_path("foo"), "foo");
+        // Unix-style paths shorten with their own separator.
+        assert_eq!(short_path("/home/u/proj/wt"), "…/proj/wt");
+        assert_eq!(short_path("/home/u"), "/home/u");
     }
 }

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1039,11 +1039,18 @@ impl Sidebar {
                             // spawned with a spawn-time branch hint
                             // gets confirmed / corrected on the first
                             // poll.
-                            let prev_branch = prev.as_ref().map(|s| s.branch.as_str());
-                            if prev_branch != Some(status.branch.as_str())
-                                && !status.branch.is_empty()
+                            // `branch_name()` (not the raw `branch`
+                            // field) so a detached HEAD — whose slot
+                            // holds the short-SHA stand-in — never
+                            // retitles tabs to a hex string (#319);
+                            // the tab keeps its last real title until
+                            // a branch is checked out again.
+                            let prev_branch = prev.as_ref().and_then(|s| s.branch_name());
+                            if let Some(name) = status.branch_name()
+                                && prev_branch != Some(name)
+                                && !name.is_empty()
                             {
-                                branch_changes.push((path.clone(), status.branch.clone()));
+                                branch_changes.push((path.clone(), name.to_string()));
                             }
                             if prev.as_ref() != Some(&status) {
                                 changed = true;
@@ -1126,7 +1133,7 @@ impl Sidebar {
                                 let branch = this
                                     .git_status
                                     .get(&path)
-                                    .map(|s| s.branch.clone())
+                                    .and_then(|s| s.branch_name().map(str::to_string))
                                     .or(persisted_branch);
                                 if let Some(branch) = branch
                                     && !branch.is_empty()
@@ -1181,7 +1188,7 @@ impl Sidebar {
                             let live_branch = this
                                 .git_status
                                 .get(&path)
-                                .map(|s| s.branch.clone())
+                                .and_then(|s| s.branch_name().map(str::to_string))
                                 .or_else(|| {
                                     this.projects
                                         .projects
@@ -1261,7 +1268,7 @@ impl Sidebar {
         let live = self
             .git_status
             .get(path)
-            .map(|s| s.branch.clone())
+            .and_then(|s| s.branch_name().map(str::to_string))
             .or_else(|| {
                 self.projects
                     .projects
@@ -1583,7 +1590,7 @@ impl Sidebar {
         let live_branch = self
             .git_status
             .get(&worktree.path)
-            .map(|s| s.branch.clone())
+            .and_then(|s| s.branch_name().map(str::to_string))
             .or_else(|| worktree.branch.clone());
 
         // Kick off a one-shot `gh pr list` lookup the first time we
@@ -3066,10 +3073,14 @@ impl Render for Sidebar {
                 // seconds of launch. Falling back to the persisted
                 // branch then to the folder leaf keeps the row
                 // useful while the first poll is still in flight.
+                // `branch_name()` skips the detached-HEAD short-SHA
+                // stand-in — a detached worktree falls through to the
+                // persisted branch / folder leaf instead of rendering
+                // a random-looking hex label (#319).
                 let wt_label: SharedString = self
                     .git_status
                     .get(&wt.path)
-                    .map(|g| g.branch.clone())
+                    .and_then(|g| g.branch_name().map(str::to_string))
                     .or_else(|| wt.branch.clone())
                     .unwrap_or_else(|| {
                         std::path::Path::new(&wt.path)
@@ -3337,7 +3348,7 @@ impl Render for Sidebar {
                     let live_branch = self
                         .git_status
                         .get(&wt.path)
-                        .map(|s| s.branch.clone())
+                        .and_then(|s| s.branch_name().map(str::to_string))
                         .or_else(|| wt.branch.clone());
                     match (live_branch.as_ref(), self.pr_urls.get(&wt.path)) {
                         (


### PR DESCRIPTION
Fixes #319.

## What broke

Worktree names rendered as random-looking hex strings, while right-clicking the same worktree showed the correct name. Removing and re-adding the project "fixed" it for a few seconds, then the hex came back.

Two independent sources of hex, both fixed here:

1. **Detached HEAD → short SHA as "branch"** (`core/src/git.rs`). `git_status`'s `current_branch` degrades to the 7-char short SHA when `symbolic-ref` fails on a detached HEAD. Every label consumer (sidebar worktree row, tab-retitle events, reopen titles, the status bar) preferred that *live* value over the persisted branch / folder leaf. That's why re-adding briefly helped: the folder name shows until the first git poll lands (~5 s), then the SHA takes over. The context menu reads the persisted name, which is why right-click looked correct.
2. **Overview label falls back to the worktree UUID** (`core/src/overview.rs`). Sessions persist with `branch: None` until a poll backfills it, and `OverviewRow`'s fallback chain went straight from `session.branch` to the raw `worktree_id` — a UUID.

## The fix

- `GitStatus` gains a `detached` flag and a `branch_name()` accessor that returns `None` for the SHA stand-in. All label paths go through it and fall back to persisted branch → folder leaf. PR lookups skip the SHA too (a SHA is never a `gh pr list --head` branch), and a worktree going detached no longer retitles its tabs.
- Overview labels resolve session branch → owning worktree's branch → worktree folder leaf → session path leaf; the UUID remains only as a dead-last resort. The leaf helper splits on `/` and `\` so Windows-written `projects.json` entries resolve everywhere.
- Drive-by: `short_path` in the Overview card split on the host separator only and hardcoded `\` in its output; its unit test could only pass on Windows. Now splits on both and echoes the path's own separator.

## Verification

- New test: detached-HEAD repo → `git_status` reports `detached: true`, `branch_name() == None` (exercises a real `git checkout --detach`).
- New tests: overview label resolves folder leaf / worktree branch / session path leaf instead of UUIDs; `path_leaf` and `short_path` separator handling.
- `cargo test --workspace`: 735 passed, 0 failed (Linux). `cargo clippy --workspace --all-targets`: no new warnings on touched lines.
- Not proven on a real detached-HEAD project in the running app — I can't reproduce the reporter's exact setup, but the mechanism (SHA-as-branch preferred over persisted name) matches every symptom including the "briefly fixed after re-add" behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZeW2VDGiamDPpQNiqYsip

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZeW2VDGiamDPpQNiqYsip)_