### PR TITLE
feat(agents): add Google Gemini CLI as a built-in agent

### DIFF
--- a/core/src/agent.rs
+++ b/core/src/agent.rs
@@ -173,6 +173,10 @@ mod tests {
             agent_id_from_auto_type(Some("\tcopilot --workspace .")),
             Some(AgentId::Copilot),
         );
+        assert_eq!(
+            agent_id_from_auto_type(Some("gemini --foo")),
+            Some(AgentId::Gemini),
+        );
     }
 
     #[test]

--- a/core/src/agent.rs
+++ b/core/src/agent.rs
@@ -17,13 +17,14 @@
 //! Anything else (plain `pwsh`, no auto-type, an unknown agent) maps
 //! to `None`, leaving the tab telemetry-less just like a shell tab.
 
-/// One of the five supported agent backends. Names match the
+/// One of the six supported agent backends. Names match the
 /// `agentId` strings the C# `MainViewModel` branches on; keep them
 /// stable so on-disk session records (which carry `AgentId` as a
 /// plain string) round-trip cleanly between builds. Codex was added
 /// alongside the [`crate::agent_registry::AgentRegistry`] port — the
 /// telemetry/discovery layer for it is a follow-up, but the id needs
-/// to round-trip now so registry consumers can use it.
+/// to round-trip now so registry consumers can use it. Gemini
+/// (#324) ships in the same registry-first state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AgentId {
     Claude,
@@ -31,6 +32,7 @@ pub enum AgentId {
     Copilot,
     OpenCode,
     Pi,
+    Gemini,
 }
 
 impl AgentId {
@@ -43,6 +45,7 @@ impl AgentId {
             AgentId::Copilot => "copilot",
             AgentId::OpenCode => "opencode",
             AgentId::Pi => "pi",
+            AgentId::Gemini => "gemini",
         }
     }
 
@@ -73,6 +76,8 @@ impl AgentId {
             Some(AgentId::OpenCode)
         } else if s.eq_ignore_ascii_case("pi") {
             Some(AgentId::Pi)
+        } else if s.eq_ignore_ascii_case("gemini") {
+            Some(AgentId::Gemini)
         } else {
             None
         }
@@ -109,6 +114,7 @@ mod tests {
             AgentId::Copilot,
             AgentId::OpenCode,
             AgentId::Pi,
+            AgentId::Gemini,
         ] {
             assert_eq!(AgentId::from_str(id.as_str()), Some(id));
         }
@@ -121,14 +127,18 @@ mod tests {
         assert_eq!(AgentId::from_str("Copilot"), Some(AgentId::Copilot));
         assert_eq!(AgentId::from_str("OPENCODE"), Some(AgentId::OpenCode));
         assert_eq!(AgentId::from_str("Pi"), Some(AgentId::Pi));
+        assert_eq!(AgentId::from_str("GEMINI"), Some(AgentId::Gemini));
     }
 
     #[test]
     fn from_str_rejects_unknown() {
         assert_eq!(AgentId::from_str(""), None);
-        assert_eq!(AgentId::from_str("gemini"), None);
+        assert_eq!(AgentId::from_str("bard"), None);
         assert_eq!(AgentId::from_str("pwsh"), None);
         assert_eq!(AgentId::from_str("claudeflare"), None);
+        // `geminipro` must NOT match Gemini — same anti-substring
+        // rule the claude/claudeflare pair pins.
+        assert_eq!(AgentId::from_str("geminipro"), None);
     }
 
     #[test]
@@ -146,6 +156,7 @@ mod tests {
         assert_eq!(agent_id_from_auto_type(Some("copilot")), Some(AgentId::Copilot));
         assert_eq!(agent_id_from_auto_type(Some("opencode")), Some(AgentId::OpenCode));
         assert_eq!(agent_id_from_auto_type(Some("pi")), Some(AgentId::Pi));
+        assert_eq!(agent_id_from_auto_type(Some("gemini")), Some(AgentId::Gemini));
     }
 
     #[test]
@@ -173,7 +184,7 @@ mod tests {
     #[test]
     fn auto_type_rejects_unknown_binaries() {
         assert_eq!(agent_id_from_auto_type(Some("pwsh")), None);
-        assert_eq!(agent_id_from_auto_type(Some("gemini --foo")), None);
+        assert_eq!(agent_id_from_auto_type(Some("bard --foo")), None);
         assert_eq!(agent_id_from_auto_type(Some("notclaude")), None);
         // `claudeflare` must NOT match Claude — same anti-substring rule
         // `is_claude_auto_type` enforced.

--- a/core/src/agent_registry.rs
+++ b/core/src/agent_registry.rs
@@ -601,6 +601,19 @@ mod tests {
     }
 
     #[test]
+    fn from_settings_default_agent_gemini_promotes_the_new_built_in() {
+        // `"defaultAgent": "gemini"` must promote the Rust-port-only
+        // built-in and demote Claude, same as any C#-era agent id.
+        let mut settings = Settings::default();
+        settings.default_agent = "gemini".into();
+        let reg = AgentRegistry::from_settings(&settings);
+        let def = reg.get_default().expect("default present");
+        assert_eq!(def.id, "gemini");
+        assert!(def.is_default);
+        assert!(!reg.get_by_id("claude").unwrap().is_default);
+    }
+
+    #[test]
     fn gemini_new_session_and_resume_are_bare_command() {
         // No resume verbs are baked yet (see the profile comment) —
         // both shapes must come out as plain `gemini` so a relaunch

--- a/core/src/agent_registry.rs
+++ b/core/src/agent_registry.rs
@@ -8,8 +8,9 @@
 //! Rust sidebar / new-session menu can consume it 1:1.
 //!
 //! The registry is read-only after construction. Built-in defaults
-//! cover the five agents shipped in the C# build:
-//! `claude`, `codex`, `opencode`, `copilot`, `pi`.
+//! cover the five agents shipped in the C# build —
+//! `claude`, `codex`, `opencode`, `copilot`, `pi` — plus `gemini`,
+//! added in the Rust port (#324).
 //!
 //! Built defaults intentionally match the C# arrays — argv, session-id
 //! flags, resume-by-id args, icons, and context-window tokens — byte
@@ -99,8 +100,9 @@ impl AgentRegistry {
     }
 
     /// Construct the registry with the shipped built-in defaults
-    /// (claude / codex / opencode / copilot / pi). Equivalent to the
-    /// C# parameterless `new AgentRegistry()` constructor.
+    /// (claude / codex / opencode / copilot / pi / gemini).
+    /// Equivalent to the C# parameterless `new AgentRegistry()`
+    /// constructor.
     pub fn with_built_ins() -> Self {
         Self::new(built_in_defaults())
     }
@@ -291,6 +293,28 @@ pub fn built_in_defaults() -> Vec<AgentProfile> {
             icon: Some("π".into()),
             context_window_tokens: 0,
         },
+        AgentProfile {
+            id: "gemini".into(),
+            display_name: "Gemini CLI".into(),
+            command: "gemini".into(),
+            // Fresh launches: bare `gemini` (#324). Resume args stay
+            // empty for now — the CLI's session-resume surface
+            // (`/chat resume` inside the REPL) has no stable
+            // command-line shape we can bake without risking a broken
+            // launch; a wrong flag here would fail every relaunch.
+            // Like Codex, discovery/telemetry is a follow-up — the
+            // registry entry gives the new-session menu, settings
+            // default-agent picker, and session records the id today.
+            resume_args: vec![],
+            new_session_args: vec![],
+            session_id_flag: None,
+            resume_by_id_args: vec![],
+            is_default: false,
+            icon: Some("✦".into()),
+            // Gemini CLI defaults to Gemini 2.5 Pro, whose standard
+            // context window is 1M tokens.
+            context_window_tokens: 1_000_000,
+        },
     ]
 }
 
@@ -428,10 +452,10 @@ mod tests {
     }
 
     #[test]
-    fn built_in_defaults_cover_all_five_agents() {
+    fn built_in_defaults_cover_all_built_in_agents() {
         let defaults = built_in_defaults();
         let ids: Vec<&str> = defaults.iter().map(|a| a.id.as_str()).collect();
-        assert_eq!(ids, vec!["claude", "codex", "opencode", "copilot", "pi"]);
+        assert_eq!(ids, vec!["claude", "codex", "opencode", "copilot", "pi", "gemini"]);
     }
 
     #[test]
@@ -486,7 +510,8 @@ mod tests {
         assert_eq!(reg.get_by_id("CLAUDE").unwrap().id, "claude");
         assert_eq!(reg.get_by_id("Codex").unwrap().id, "codex");
         assert_eq!(reg.get_by_id("PI").unwrap().id, "pi");
-        assert!(reg.get_by_id("gemini").is_none());
+        assert_eq!(reg.get_by_id("Gemini").unwrap().id, "gemini");
+        assert!(reg.get_by_id("bard").is_none());
     }
 
     #[test]
@@ -567,9 +592,24 @@ mod tests {
         // user should still get Claude back when they fat-finger an
         // unknown id.
         let mut settings = Settings::default();
-        settings.default_agent = "gemini".into();
+        settings.default_agent = "bard".into();
         let reg = AgentRegistry::from_settings(&settings);
         assert_eq!(reg.get_default().unwrap().id, "claude");
+    }
+
+    #[test]
+    fn gemini_new_session_and_resume_are_bare_command() {
+        // No resume verbs are baked yet (see the profile comment) —
+        // both shapes must come out as plain `gemini` so a relaunch
+        // never types a flag the CLI might reject.
+        let profile = registry_profile("gemini");
+        assert_eq!(build_new_session_auto_type(&profile), Some("gemini".into()));
+        assert_eq!(build_resume_auto_type(&profile, None), Some("gemini".into()));
+        assert_eq!(
+            build_resume_auto_type(&profile, Some("some-id")),
+            Some("gemini".into()),
+            "an adopted id must not invent a resume flag"
+        );
     }
 
     #[test]

--- a/core/src/agent_registry.rs
+++ b/core/src/agent_registry.rs
@@ -12,10 +12,13 @@
 //! `claude`, `codex`, `opencode`, `copilot`, `pi` — plus `gemini`,
 //! added in the Rust port (#324).
 //!
-//! Built defaults intentionally match the C# arrays — argv, session-id
-//! flags, resume-by-id args, icons, and context-window tokens — byte
-//! for byte so on-disk session records stay round-trippable between
-//! the C# build and the Rust port.
+//! For the five agents the C# build shipped, the built defaults
+//! intentionally match its arrays — argv, session-id flags,
+//! resume-by-id args, icons, and context-window tokens — byte for
+//! byte so on-disk session records stay round-trippable between the
+//! C# build and the Rust port. `gemini` is Rust-port-only (#324) and
+//! has no C# counterpart to match; a C# build reading a config that
+//! references it simply won't resolve the id.
 
 use serde::{Deserialize, Serialize};
 

--- a/core/src/agent_registry.rs
+++ b/core/src/agent_registry.rs
@@ -103,9 +103,10 @@ impl AgentRegistry {
     }
 
     /// Construct the registry with the shipped built-in defaults
-    /// (claude / codex / opencode / copilot / pi / gemini).
-    /// Equivalent to the C# parameterless `new AgentRegistry()`
-    /// constructor.
+    /// (claude / codex / opencode / copilot / pi / gemini). Matches
+    /// the C# parameterless `new AgentRegistry()` constructor for
+    /// the five legacy agents; `gemini` is a Rust-port addition
+    /// (#324) with no C# counterpart.
     pub fn with_built_ins() -> Self {
         Self::new(built_in_defaults())
     }

--- a/core/src/overview.rs
+++ b/core/src/overview.rs
@@ -52,7 +52,7 @@ pub struct OverviewRow {
     /// to look up the matching live tab (group + tab index).
     pub working_directory: String,
     /// The persisted `agent_id` ("claude", "codex", "copilot",
-    /// "opencode", "pi") or `None` for plain shell sessions.
+    /// "opencode", "pi", "gemini") or `None` for plain shell sessions.
     pub agent_id: Option<String>,
     /// `closed_at` raw ISO 8601 string. `None` for live rows; the
     /// renderer formats this via

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -234,7 +234,7 @@ pub fn format_closed_at_relative(closed_at_iso: Option<&str>, now_iso: &str) -> 
 ///   exist. For Claude that directory is derived from the worktree
 ///   path, so a moved or renamed worktree lands here and keeps its
 ///   rows instead of losing them;
-/// * the agent is Pi, OpenCode or Codex. Pi and OpenCode can only be
+/// * the agent is Pi, OpenCode, Codex or Gemini. Pi and OpenCode can only be
 ///   located by walking their trees (Pi matches `*_<sid>.jsonl`
 ///   recursively; OpenCode's `storage/` slug is derived from the
 ///   project path and not predictable), and Codex has no layout wired
@@ -293,7 +293,10 @@ pub(crate) fn transcript_presence(session: &Session) -> Option<bool> {
                 |m| m.is_dir(),
             )
         }
-        crate::AgentId::Pi | crate::AgentId::OpenCode | crate::AgentId::Codex => None,
+        crate::AgentId::Pi
+        | crate::AgentId::OpenCode
+        | crate::AgentId::Codex
+        | crate::AgentId::Gemini => None,
     }
 }
 
@@ -918,7 +921,7 @@ mod tests {
 
     #[test]
     fn presence_is_undecidable_for_agents_without_a_predictable_layout() {
-        for agent in ["pi", "opencode", "codex"] {
+        for agent in ["pi", "opencode", "codex", "gemini"] {
             let mut s = closed_agent_session("s1", "sid");
             s.agent_id = Some(agent.to_string());
             assert_eq!(transcript_presence(&s), None, "agent {agent}");

--- a/src/app.rs
+++ b/src/app.rs
@@ -1897,14 +1897,15 @@ impl AppShell {
                     session_id.clone(),
                 ))
             }
-            codescope_core::AgentId::Codex => {
-                // Codex telemetry isn't wired in the Rust port yet (the
-                // AgentRegistry entry exists ahead of the discovery
-                // layer); skip registration so the rest of the agent
-                // surface keeps working until the dedicated Codex
-                // discovery / telemetry modules land.
+            codescope_core::AgentId::Codex | codescope_core::AgentId::Gemini => {
+                // Codex / Gemini telemetry isn't wired in the Rust
+                // port yet (the AgentRegistry entries exist ahead of
+                // the discovery layer); skip registration so the rest
+                // of the agent surface keeps working until the
+                // dedicated discovery / telemetry modules land.
                 eprintln!(
-                    "[telemetry] codex telemetry not yet wired — skipping registration for {session_id}"
+                    "[telemetry] {} telemetry not yet wired — skipping registration for {session_id}",
+                    agent_id.as_str()
                 );
                 return;
             }
@@ -2191,15 +2192,19 @@ impl AppShell {
                         for (t_idx, tab) in group.tabs.iter().enumerate() {
                             let Some(agent_id) = tab.agent_id else { continue };
                             let Some(ref wd) = tab.working_directory else { continue };
-                            // Codex has no discovery wired in the Rust
-                            // port yet — skip before flipping
-                            // `any_active`, otherwise an all-Codex
-                            // workspace would pin the poll at the
-                            // 350 ms active rate while the loop does
-                            // no work. Drop it through with the same
-                            // "no agent" handling so the cadence
-                            // relaxes to the 5 s idle interval.
-                            if matches!(agent_id, codescope_core::AgentId::Codex) {
+                            // Codex / Gemini have no discovery wired
+                            // in the Rust port yet — skip before
+                            // flipping `any_active`, otherwise an
+                            // all-Codex workspace would pin the poll
+                            // at the 350 ms active rate while the
+                            // loop does no work. Drop them through
+                            // with the same "no agent" handling so
+                            // the cadence relaxes to the 5 s idle
+                            // interval.
+                            if matches!(
+                                agent_id,
+                                codescope_core::AgentId::Codex | codescope_core::AgentId::Gemini
+                            ) {
                                 continue;
                             }
                             any_active = true;
@@ -2262,7 +2267,8 @@ impl AppShell {
                                     .map(|c| (c.session_id, c.session_dir))
                                     .collect()
                                 }
-                                codescope_core::AgentId::Codex => {
+                                codescope_core::AgentId::Codex
+                                | codescope_core::AgentId::Gemini => {
                                     // Unreachable: short-circuited
                                     // above so the active-poll rate
                                     // doesn't stay pinned for an

--- a/src/app.rs
+++ b/src/app.rs
@@ -2194,13 +2194,13 @@ impl AppShell {
                             let Some(ref wd) = tab.working_directory else { continue };
                             // Codex / Gemini have no discovery wired
                             // in the Rust port yet — skip before
-                            // flipping `any_active`, otherwise an
-                            // all-Codex workspace would pin the poll
-                            // at the 350 ms active rate while the
-                            // loop does no work. Drop them through
-                            // with the same "no agent" handling so
-                            // the cadence relaxes to the 5 s idle
-                            // interval.
+                            // flipping `any_active`, otherwise a
+                            // workspace of only Codex/Gemini tabs
+                            // would pin the poll at the 350 ms active
+                            // rate while the loop does no work. Drop
+                            // them through with the same "no agent"
+                            // handling so the cadence relaxes to the
+                            // 5 s idle interval.
                             if matches!(
                                 agent_id,
                                 codescope_core::AgentId::Codex | codescope_core::AgentId::Gemini
@@ -2271,10 +2271,11 @@ impl AppShell {
                                 | codescope_core::AgentId::Gemini => {
                                     // Unreachable: short-circuited
                                     // above so the active-poll rate
-                                    // doesn't stay pinned for an
-                                    // all-Codex workspace. Kept as a
-                                    // belt-and-braces fallback in case
-                                    // someone removes the early skip.
+                                    // doesn't stay pinned for a
+                                    // Codex/Gemini-only workspace.
+                                    // Kept as a belt-and-braces
+                                    // fallback in case someone
+                                    // removes the early skip.
                                     continue;
                                 }
                             };

--- a/src/overview.rs
+++ b/src/overview.rs
@@ -37,8 +37,8 @@ use gpui::{
 use crate::app::AppShell;
 use crate::theme;
 
-/// Display name for one of the five supported agent ids. Mirrors
-/// `OverviewViewModel.ResolveAgentDisplay`. The five built-in agent
+/// Display name for one of the built-in agent ids. Mirrors
+/// `OverviewViewModel.ResolveAgentDisplay`. The built-in agent
 /// ids are stable so a small lookup is enough for parity with the
 /// C# build's `AgentRegistry`-threaded label resolution.
 fn agent_display(agent_id: Option<&str>) -> SharedString {
@@ -48,6 +48,7 @@ fn agent_display(agent_id: Option<&str>) -> SharedString {
         Some("copilot") => SharedString::new_static("Copilot CLI"),
         Some("opencode") => SharedString::new_static("OpenCode"),
         Some("pi") => SharedString::new_static("Pi"),
+        Some("gemini") => SharedString::new_static("Gemini CLI"),
         Some(other) if !other.is_empty() => SharedString::from(other.to_string()),
         _ => SharedString::new_static("shell"),
     }
@@ -655,7 +656,9 @@ mod tests {
         // Unknown ids round-trip verbatim so a future agent id without
         // a built-in label still reads as something instead of just
         // "shell".
-        assert_eq!(agent_display(Some("gemini")), "gemini");
+        assert_eq!(agent_display(Some("gemini")), "Gemini CLI");
+        // Unknown ids still round-trip verbatim.
+        assert_eq!(agent_display(Some("bard")), "bard");
     }
 
     #[test]

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -454,7 +454,7 @@ fn history_agent_display_name(agent_id: &str) -> Option<&'static str> {
     let profile = registry.get_by_id(first_token)?;
     // Match the agent id back to a `&'static str` literal so the
     // closed-row label can stay a non-allocating return type — the
-    // five built-in defaults are stable strings, and any custom
+    // built-in defaults are stable strings, and any custom
     // override would arrive via a different code path.
     Some(match profile.id.as_str() {
         "claude" => "Claude Code",
@@ -462,6 +462,7 @@ fn history_agent_display_name(agent_id: &str) -> Option<&'static str> {
         "opencode" => "OpenCode",
         "pi" => "Pi",
         "codex" => "Codex",
+        "gemini" => "Gemini CLI",
         _ => return None,
     })
 }
@@ -5676,8 +5677,13 @@ mod tests {
     #[test]
     fn history_agent_label_unknown_returns_none() {
         assert_eq!(history_agent_display_name(""), None);
-        assert_eq!(history_agent_display_name("gemini"), None);
+        assert_eq!(history_agent_display_name("bard"), None);
         assert_eq!(history_agent_display_name("-"), None);
+    }
+
+    #[test]
+    fn history_agent_label_gemini_resolves() {
+        assert_eq!(history_agent_display_name("gemini"), Some("Gemini CLI"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #324.

## What this adds

`gemini` joins the built-in agent registry, following the exact precedent Codex set (registry entry first, discovery/telemetry as a follow-up):

- **Registry profile** (`core/src/agent_registry.rs`): id `gemini`, display name "Gemini CLI", command `gemini`, icon ✦, context window 1M tokens (Gemini CLI defaults to Gemini 2.5 Pro). This lights up the sidebar's "New Gemini CLI session" submenu row, the settings default-agent picker (`"defaultAgent": "gemini"`), and per-session agent persistence — all of those are registry-driven, so no UI changes were needed.
- **`AgentId::Gemini`** (`core/src/agent.rs`): the id round-trips through session records and `auto_type` detection (`gemini --foo` classifies, `geminipro` doesn't).
- **Telemetry/discovery**: skipped cleanly like Codex — the discovery loop doesn't pin the active poll rate for Gemini tabs, and `register_telemetry` logs and no-ops. Tab labels, history rows, and Overview cards show "Gemini CLI".

## Deliberate choices

- **No resume flags baked.** Gemini CLI's session resume lives in the REPL (`/chat resume`) and its command-line resume surface isn't stable enough to bake; a wrong flag would break every relaunch. Both new-session and resume shapes are the bare `gemini` — a test pins that an adopted session id must not invent a resume flag. Easy to fill in later when the flag shape is confirmed.
- **No busy/idle telemetry yet** — that needs a dedicated transcript-tail module per the other agents (`core/src/agents/*`); Codex has been in the same state since the registry port. Filed intent is in the profile comment.

## Verification

- `cargo test --workspace`: all green except the pre-existing platform-dependent `short_path_keeps_two_tail_segments` failure on Linux, which is fixed separately in #330. New/updated tests cover registry ordering, id round-trip, case-insensitive lookup, bare-command launch shapes, label resolution, and transcript-presence undecidability.
- `cargo clippy --workspace --all-targets`: no errors, no new warnings.
- Not verified against a live `gemini` binary in the running app (headless environment) — the launch shape is a bare command typed into the terminal, same mechanism as the other five agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZeW2VDGiamDPpQNiqYsip

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZeW2VDGiamDPpQNiqYsip)_