### PR TITLE
feat(sidebar): "Edit command…" for remote-shell projects

### DIFF
--- a/core/src/projects.rs
+++ b/core/src/projects.rs
@@ -318,8 +318,14 @@ pub fn set_remote_shell_command(
     new_command: &str,
 ) -> Result<bool> {
     let trimmed = new_command.trim();
-    if !is_valid_remote_shell_command(trimmed) {
+    // Split the two `is_valid_remote_shell_command` conditions so the
+    // surfaced error names the actual problem — a multi-line paste
+    // shouldn't be told it's "empty".
+    if trimmed.is_empty() {
         anyhow::bail!("command cannot be empty");
+    }
+    if !is_valid_remote_shell_command(trimmed) {
+        anyhow::bail!("command must be a single line");
     }
     let project = cfg
         .projects
@@ -819,8 +825,17 @@ mod tests {
         let mut cfg =
             ProjectsConfig { version: 1, agents: vec![], projects: vec![remote, local] };
 
-        assert!(set_remote_shell_command(&mut cfg, &remote_id, "   ").is_err());
-        assert!(set_remote_shell_command(&mut cfg, &remote_id, "ssh a\nssh b").is_err());
+        // Each rejection names its actual cause — a multi-line paste
+        // must not be reported as "empty".
+        let empty_err = set_remote_shell_command(&mut cfg, &remote_id, "   ")
+            .expect_err("blank command must be rejected");
+        assert!(format!("{empty_err:#}").contains("empty"), "{empty_err:#}");
+        let multiline_err = set_remote_shell_command(&mut cfg, &remote_id, "ssh a\nssh b")
+            .expect_err("multi-line command must be rejected");
+        assert!(
+            format!("{multiline_err:#}").contains("single line"),
+            "{multiline_err:#}"
+        );
         assert!(set_remote_shell_command(&mut cfg, "nope", "ssh x").is_err());
         assert!(set_remote_shell_command(&mut cfg, &local_id, "ssh x").is_err());
         // Nothing was mutated by the failed calls.

--- a/core/src/projects.rs
+++ b/core/src/projects.rs
@@ -300,6 +300,42 @@ pub fn rename_project(
     Ok(true)
 }
 
+/// Update a remote-shell project's stored base command (#327). Trims
+/// whitespace, validates through [`is_valid_remote_shell_command`]
+/// (non-empty, single-line), and refuses non-remote-shell projects —
+/// a local project's `command` slot is meaningless and writing it
+/// would only confuse a later migration. Returns `Ok(true)` when the
+/// command actually changed (callers should persist), `Ok(false)` for
+/// a no-op, and `Err` for an unknown id, invalid command, or a
+/// project of the wrong kind.
+///
+/// Tabs already running keep their old command — the edit applies to
+/// the next session opened from the sidebar row, same as editing the
+/// command by remove + re-add did before this existed.
+pub fn set_remote_shell_command(
+    cfg: &mut ProjectsConfig,
+    project_id: &str,
+    new_command: &str,
+) -> Result<bool> {
+    let trimmed = new_command.trim();
+    if !is_valid_remote_shell_command(trimmed) {
+        anyhow::bail!("command cannot be empty");
+    }
+    let project = cfg
+        .projects
+        .iter_mut()
+        .find(|p| p.id == project_id)
+        .ok_or_else(|| anyhow::anyhow!("project '{project_id}' not found"))?;
+    if !project.is_remote_shell() {
+        anyhow::bail!("project '{project_id}' is not a remote-shell project");
+    }
+    if project.command.as_deref() == Some(trimmed) {
+        return Ok(false);
+    }
+    project.command = Some(trimmed.to_string());
+    Ok(true)
+}
+
 /// One git worktree under a [`Project`]. Every project carries an
 /// explicit primary row (`is_primary: true`) pointing at
 /// `Project::path` plus zero or more additional worktrees with
@@ -760,6 +796,36 @@ mod tests {
         assert_eq!(p.remote_shell_command(), None);
         p.command = None;
         assert_eq!(p.remote_shell_command(), None);
+    }
+
+    #[test]
+    fn set_remote_shell_command_updates_and_reports_change() {
+        let p = Project::new_remote_shell("dev".into(), "ssh old".into(), None);
+        let id = p.id.clone();
+        let mut cfg = ProjectsConfig { version: 1, agents: vec![], projects: vec![p] };
+
+        assert!(set_remote_shell_command(&mut cfg, &id, "  ssh new-box  ").expect("update"));
+        assert_eq!(cfg.projects[0].remote_shell_command(), Some("ssh new-box"));
+        // Same trimmed value again → no-op.
+        assert!(!set_remote_shell_command(&mut cfg, &id, "ssh new-box").expect("no-op"));
+    }
+
+    #[test]
+    fn set_remote_shell_command_rejects_empty_unknown_and_local() {
+        let remote = Project::new_remote_shell("dev".into(), "ssh box".into(), None);
+        let remote_id = remote.id.clone();
+        let local = Project::new("C:\\repo".into());
+        let local_id = local.id.clone();
+        let mut cfg =
+            ProjectsConfig { version: 1, agents: vec![], projects: vec![remote, local] };
+
+        assert!(set_remote_shell_command(&mut cfg, &remote_id, "   ").is_err());
+        assert!(set_remote_shell_command(&mut cfg, &remote_id, "ssh a\nssh b").is_err());
+        assert!(set_remote_shell_command(&mut cfg, "nope", "ssh x").is_err());
+        assert!(set_remote_shell_command(&mut cfg, &local_id, "ssh x").is_err());
+        // Nothing was mutated by the failed calls.
+        assert_eq!(cfg.projects[0].remote_shell_command(), Some("ssh box"));
+        assert_eq!(cfg.projects[1].command, None);
     }
 
     #[test]

--- a/src/dialogs/rename.rs
+++ b/src/dialogs/rename.rs
@@ -85,7 +85,11 @@ impl RenameDialogState {
         }
     }
 
-    /// Rename is allowed when the trimmed name is non-empty. The
+    /// Rename is allowed when the trimmed name is non-empty; the
+    /// remote-command target additionally holds the buffer to
+    /// `is_valid_remote_shell_command` (single-line) — the same rule
+    /// the Add-project dialog applies, so the Save button can't claim
+    /// a multi-line paste is fine only for submit to reject it. The
     /// "no-op when unchanged" rule mirrors the C# build's
     /// `string.Equals(newLeaf, currentLeaf, StringComparison.Ordinal)`
     /// guard — handled at submit time so the button stays enabled
@@ -94,7 +98,12 @@ impl RenameDialogState {
     /// in returning `bool` rather than `Result` so the render path
     /// stays branch-free.
     pub fn is_valid(&self) -> bool {
-        !self.name.text().trim().is_empty()
+        match &self.target {
+            RenameRequest::RemoteCommand { .. } => {
+                codescope_core::projects::is_valid_remote_shell_command(self.name.text())
+            }
+            _ => !self.name.text().trim().is_empty(),
+        }
     }
 
     /// Per-target chrome strings — (eyebrow, hint, field label, OK

--- a/src/dialogs/rename.rs
+++ b/src/dialogs/rename.rs
@@ -86,10 +86,11 @@ impl RenameDialogState {
     }
 
     /// Rename is allowed when the trimmed name is non-empty; the
-    /// remote-command target additionally holds the buffer to
-    /// `is_valid_remote_shell_command` (single-line) — the same rule
-    /// the Add-project dialog applies, so the Save button can't claim
-    /// a multi-line paste is fine only for submit to reject it. The
+    /// remote-command target additionally validates the buffer
+    /// through `is_valid_remote_shell_command` (single-line) — the
+    /// same rule the Add-project dialog applies, so the Save button
+    /// can't claim a multi-line paste is fine only for submit to
+    /// reject it. The
     /// "no-op when unchanged" rule mirrors the C# build's
     /// `string.Equals(newLeaf, currentLeaf, StringComparison.Ordinal)`
     /// guard — handled at submit time so the button stays enabled

--- a/src/dialogs/rename.rs
+++ b/src/dialogs/rename.rs
@@ -73,6 +73,7 @@ impl RenameDialogState {
         let title: SharedString = match &target {
             RenameRequest::Project { .. } => "Rename project".into(),
             RenameRequest::Session { .. } => "Rename session".into(),
+            RenameRequest::RemoteCommand { .. } => "Edit remote command".into(),
         };
         Self {
             focus_handle,
@@ -94,6 +95,28 @@ impl RenameDialogState {
     /// stays branch-free.
     pub fn is_valid(&self) -> bool {
         !self.name.text().trim().is_empty()
+    }
+
+    /// Per-target chrome strings — (eyebrow, hint, field label, OK
+    /// button). The dialog started as a rename primitive; the
+    /// remote-command editor (#327) reuses its skeleton with editing
+    /// vocabulary so the header doesn't claim a "rename".
+    fn chrome(&self) -> (&'static str, &'static str, &'static str, &'static str) {
+        match &self.target {
+            RenameRequest::RemoteCommand { .. } => (
+                "EDIT",
+                "Change the command this project runs (e.g. `ssh dev`). \
+                 Open tabs keep the old command; the next session uses the new one.",
+                "COMMAND",
+                "Save",
+            ),
+            _ => (
+                "RENAME",
+                "Enter a new name. Press Enter to confirm.",
+                "NEW NAME",
+                "Rename",
+            ),
+        }
     }
 }
 
@@ -140,7 +163,10 @@ impl AppShell {
         let trimmed = state.name.text().trim().to_string();
         if trimmed.is_empty() {
             if let Some(state) = self.rename_dialog.as_mut() {
-                state.error = Some("Name cannot be empty".into());
+                state.error = Some(match &state.target {
+                    RenameRequest::RemoteCommand { .. } => "Command cannot be empty".into(),
+                    _ => "Name cannot be empty".into(),
+                });
             }
             cx.notify();
             return;
@@ -179,6 +205,34 @@ impl AppShell {
                 };
                 if !changed {
                     // No-op — close silently. Matches the C# guard.
+                    self.rename_dialog = None;
+                    cx.notify();
+                    return;
+                }
+                if let Err(err) = self.projects.save(self.paths_ref().as_ref()) {
+                    if let Some(state) = self.rename_dialog.as_mut() {
+                        state.error = Some(format!("Failed to save: {err:#}"));
+                    }
+                    cx.notify();
+                    return;
+                }
+            }
+            RenameRequest::RemoteCommand { project_id } => {
+                let changed = match codescope_core::projects::set_remote_shell_command(
+                    &mut self.projects,
+                    &project_id,
+                    &trimmed,
+                ) {
+                    Ok(changed) => changed,
+                    Err(err) => {
+                        if let Some(state) = self.rename_dialog.as_mut() {
+                            state.error = Some(format!("{err:#}"));
+                        }
+                        cx.notify();
+                        return;
+                    }
+                };
+                if !changed {
                     self.rename_dialog = None;
                     cx.notify();
                     return;
@@ -249,6 +303,7 @@ impl AppShell {
 
         let focus_handle = state.focus_handle.clone();
         let title = state.title.clone();
+        let (eyebrow, hint, field_label_text, ok_label) = state.chrome();
         let valid = state.is_valid();
         let error_msg: Option<SharedString> = state.error.clone().map(Into::into);
         let blink_phase = self.text_blink_phase;
@@ -264,20 +319,20 @@ impl AppShell {
                 div()
                     .text_size(px(11.0))
                     .text_color(accent)
-                    .child("RENAME"),
+                    .child(eyebrow),
             )
             .child(div().text_size(px(20.0)).text_color(ink).child(title))
             .child(
                 div()
                     .text_size(px(12.0))
                     .text_color(ink_muted)
-                    .child("Enter a new name. Press Enter to confirm."),
+                    .child(hint),
             );
 
         let field_label = div()
             .text_size(px(11.0))
             .text_color(ink_ghost)
-            .child("NEW NAME");
+            .child(field_label_text);
 
         // Single-line text input. Always focused (only one field), so
         // the caret is always painted — blink phase still flips it on
@@ -369,7 +424,7 @@ impl AppShell {
                     }),
                 );
             }
-            btn.child("Rename")
+            btn.child(ok_label)
         };
 
         let footer_buttons = div()

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -388,6 +388,10 @@ pub enum RenameRequest {
     /// Rename a session's display-name override (live or closed).
     /// Mirrors C# `RenameSessionCommand`.
     Session { session_id: String },
+    /// Edit a remote-shell project's stored base command (#327).
+    /// Reuses the rename dialog as the single-input editor; submit
+    /// goes through `codescope_core::projects::set_remote_shell_command`.
+    RemoteCommand { project_id: String },
 }
 
 /// Toast severity emitted by the sidebar. AppShell maps these to its
@@ -4367,6 +4371,14 @@ impl Sidebar {
         let command_for_copy = self.agent_registry.assemble_remote_command(project);
         let project_id_rename = project.id.clone();
         let current_name = project.name.clone();
+        // Edit pre-fills with the stored *base* command (`ssh dev`),
+        // not the assembled one with the agent wrapper — the wrapper
+        // is derived and would get double-applied if saved back.
+        let project_id_edit = project.id.clone();
+        let current_command = project
+            .remote_shell_command()
+            .unwrap_or_default()
+            .to_string();
 
         let menu_body = div()
             .flex()
@@ -4427,6 +4439,24 @@ impl Sidebar {
                 false,
                 Box::new(move |this, _window, cx| {
                     cx.write_to_clipboard(ClipboardItem::new_string(command_for_copy.clone()));
+                    this.close_menu(cx);
+                }),
+            ))
+            // "Edit command…" — change the stored base command without
+            // remove + re-add (#327). Reuses the rename dialog as the
+            // single-input editor; running tabs keep their old
+            // command, the next opened session uses the new one.
+            .child(item(
+                "remote-menu-edit-command",
+                "Edit command…",
+                false,
+                Box::new(move |this, _window, cx| {
+                    cx.emit(SidebarEvent::OpenRenameDialog {
+                        target: RenameRequest::RemoteCommand {
+                            project_id: project_id_edit.clone(),
+                        },
+                        current_name: current_command.clone(),
+                    });
                     this.close_menu(cx);
                 }),
             ))


### PR DESCRIPTION
Part 1 of #327 — the "Edit command…" action. (Part 2, the remote busy/ready indicator, is a separate and much larger piece; the agent-picker half of the edit flow is also left for a follow-up, see below.)

## What this adds

A remote-shell project's context menu gains an **"Edit command…"** row (between "Copy command" and "Rename project…"). It opens the existing single-input dialog, retitled "Edit remote command", pre-filled with the stored **base** command (`ssh dev`) — deliberately not the assembled form with the `-t '$SHELL -lic "…"'` agent wrapper, which is derived at launch time and would get double-applied if saved back.

Submit goes through a new core helper, `projects::set_remote_shell_command`: trims, validates via the same `is_valid_remote_shell_command` rule the Add-project dialog uses (non-empty, single-line), refuses non-remote-shell projects, no-ops on an unchanged value, and persists `projects.json` on success. Open tabs keep the command they were spawned with; the next session opened from the row uses the new one (noted in the dialog hint).

## Scope choices

- **Agent picker not included.** The issue proposes editing the selected agent too. That needs a dropdown in the dialog (a different primitive than the single-input rename skeleton); the command edit covers the sharpest pain — a typo'd host or changed SSH alias no longer means remove + re-add. Left open on #327 alongside part 2.
- The dialog chrome (eyebrow/hint/label/button) is parameterized per target so the reused rename dialog doesn't claim to be renaming anything.

## Verification

- Core tests: update + change-reporting + no-op on same value; rejects empty, multi-line, unknown id, and local (non-remote-shell) projects, and proves failed calls mutate nothing.
- `cargo test --workspace`: all green except the pre-existing platform-dependent `short_path_keeps_two_tail_segments` failure on Linux (fixed separately in #330). `cargo clippy --workspace --all-targets`: no errors, no new warnings.
- Dialog flow not exercised in the running app (headless environment); it reuses the rename dialog's render/submit skeleton verbatim, with the submit branch mirroring the project-rename branch line for line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZeW2VDGiamDPpQNiqYsip

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZeW2VDGiamDPpQNiqYsip)_