### PR TITLE
release: bump version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "codescope"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
Cuts the 0.6.1 release — a fixes-plus-two-features follow-up to 0.6.0.

## Since 0.6.0

- **fix**: worktree names no longer render as random hex — detached-HEAD short SHAs and worktree-UUID fallbacks are resolved to real branch/folder names everywhere (#330, fixes #319)
- **terminal**: a 4.5:1 minimum contrast floor keeps opposite-polarity TUI themes (e.g. claude-code's "Light mode (ANSI colors only)") readable (#331, fixes #320)
- **agents**: Google Gemini CLI joins the built-in agents — new-session menu, default-agent setting, session labels (#332, fixes #324)
- **sidebar**: remote-shell projects gained an "Edit command…" action, no more remove + re-add to fix a typo'd host (#333, part 1 of #327)

## Verification

`cargo test --workspace` on the merged tree: 746 passed, 0 failed (Linux) — including the previously platform-dependent `short_path` test, now fixed.

After merge: tag `v0.6.1` on the merge commit to trigger the cargo-dist release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZeW2VDGiamDPpQNiqYsip

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZeW2VDGiamDPpQNiqYsip)_