### PR TITLE
fix(release): credit each issue once, not once per closing PR

### DIFF
--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -311,10 +311,14 @@ while read -r pr; do
     done < "$work/issues"
 done < "$work/prs"
 
-# Numeric on both keys so a PR closing #9 and #10 lists them in that order, and
-# `-u` on (pr, issue) rather than the whole line: an issue has exactly one
-# author, so that pair is already the identity of a credit line.
-sort -u -t$'\t' -k1,1n -k2,2n "$work/credits" > "$work/credits-sorted"
+# One line per issue, not per (pr, issue): the release-bump PR repeats the
+# whole changelog in its body, so every issue in the release gets closed a
+# second time by that PR and would be thanked twice. Keep the lowest PR per
+# issue — the fix always merges before the bump. Numeric keys so a PR closing
+# #9 and #10 lists them in that order.
+sort -t$'\t' -k2,2n -k1,1n "$work/credits" \
+    | awk -F'\t' '!seen[$2]++' \
+    | sort -t$'\t' -k1,1n -k2,2n > "$work/credits-sorted"
 
 : > "$work/thanks"
 if [[ -s "$work/credits-sorted" ]]; then


### PR DESCRIPTION
## What broke

The v0.6.1 credits block thanked every reporter twice:

```
- #330 — thanks @maxim12358 for reporting #319
- #331 — thanks @maxim12358 for reporting #320
- #332 — thanks @alo1979 for reporting #324
- #334 — thanks @maxim12358 for reporting #319
- #334 — thanks @maxim12358 for reporting #320
- #334 — thanks @alo1979 for reporting #324
```

## Root cause

`release-notes.sh` builds credit lines from each PR's
`closingIssuesReferences` and deduped with `sort -u` on the
`(pr, issue)` key pair. The release-bump PR (#334) repeats the whole
changelog in its body, so GitHub records it as closing all three
issues as well. Both `(330, 319)` and `(334, 319)` are distinct under
that key, so both survived — the dedup never had a chance.

Confirmed against the API: #330 closes #319; #334 closes #319, #320
*and* #324.

## Fix

Dedup on the issue number alone and keep the lowest PR number. The
fix for an issue always merges before the release bump that follows
it, so the lowest PR is the one worth crediting.

## Verification

- `bash -n` clean.
- Dedup pipeline unit-checked on the real v0.6.1 credit rows (6 rows
  in → the 3 correct lines out), on a single PR closing #9 and #10
  (numeric order preserved, both kept — they are different issues),
  and on empty input (0 lines, no `pipefail` trip).
- Full `--dry-run` against v0.6.1: the summary and download blocks come
  out byte-identical to what is published; only the three duplicate
  credit lines disappear.
- Ran live against the published v0.6.1 release. The resulting diff of
  the release body is exactly those three deletions and nothing else,
  so the already-shipped notes are now correct too.

## Not proven

The GraphQL step still cannot be exercised from a Claude cloud/web
session (documented in the script header); this was verified from a
local terminal.
