### PR TITLE
fix(discovery): skip SDK-spawned Claude transcripts during session adoption

### DIFF
--- a/core/src/agents/claude/discovery.rs
+++ b/core/src/agents/claude/discovery.rs
@@ -132,14 +132,24 @@ pub enum TranscriptOrigin {
 /// multi-megabyte file on every 350 ms poll.
 const ORIGIN_PEEK_LINES: usize = 64;
 
+/// Bytes to inspect before giving up. `BufRead::lines` buffers a whole
+/// line, so without a byte ceiling a corrupt or hostile transcript with
+/// no newline in it would be read into memory in full on every poll.
+/// The decisive line is the *first* `user` turn, and for SDK reviews
+/// that line carries the entire diff under review — the largest one in
+/// the reporting store is ~380 KiB — so the cap sits an order of
+/// magnitude above that. A transcript whose decisive line straddles
+/// the cap classifies as `Unknown` (torn JSON), i.e. adoptable.
+const ORIGIN_PEEK_BYTES: u64 = 4 * 1024 * 1024;
+
 /// Classify a transcript by the first `entrypoint` field within its
 /// head. See [`TranscriptOrigin`] for what each variant means.
 pub fn transcript_origin(path: &Path) -> TranscriptOrigin {
-    use std::io::{BufRead, BufReader};
+    use std::io::{BufRead, BufReader, Read};
     let Ok(file) = std::fs::File::open(path) else {
         return TranscriptOrigin::Unknown;
     };
-    let reader = BufReader::new(file);
+    let reader = BufReader::new(file.take(ORIGIN_PEEK_BYTES));
     for line in reader.lines().take(ORIGIN_PEEK_LINES) {
         // A read error (or invalid UTF-8) ends the peek; whatever we
         // saw before it wasn't decisive, so fall through to Unknown.
@@ -418,6 +428,33 @@ mod tests {
         body.push_str(SDK_HEAD);
         let path = write_transcript(tmp.path(), SID_A, &body);
         assert_eq!(transcript_origin(&path), TranscriptOrigin::Unknown);
+    }
+
+    #[test]
+    fn origin_gives_up_after_byte_cap() {
+        let tmp = TempDir::new().unwrap();
+        // One newline-free line past the cap, followed by a decisive
+        // SDK head we must never reach. Buffered `lines()` would
+        // otherwise slurp the whole thing.
+        let mut body = "{\"type\":\"mode\",\"pad\":\"".to_owned();
+        body.push_str(&"x".repeat(ORIGIN_PEEK_BYTES as usize + 1));
+        body.push_str("\"}\n");
+        body.push_str(SDK_HEAD);
+        let path = write_transcript(tmp.path(), SID_A, &body);
+        assert_eq!(transcript_origin(&path), TranscriptOrigin::Unknown);
+    }
+
+    #[test]
+    fn origin_classifies_large_sdk_first_turn_under_cap() {
+        let tmp = TempDir::new().unwrap();
+        // A review of a big diff: ~1 MiB user line, well inside the
+        // cap, with `entrypoint` after the payload as Claude writes it.
+        let body = format!(
+            "{{\"type\":\"user\",\"message\":{{\"content\":\"{}\"}},\"entrypoint\":\"sdk-py\"}}\n",
+            "d".repeat(1024 * 1024)
+        );
+        let path = write_transcript(tmp.path(), SID_A, &body);
+        assert_eq!(transcript_origin(&path), TranscriptOrigin::Sdk);
     }
 
     #[test]

--- a/core/src/agents/claude/discovery.rs
+++ b/core/src/agents/claude/discovery.rs
@@ -15,6 +15,9 @@
 //! does this inside `WatchHandle._fired`); we return *every* eligible
 //! file each call so the caller can dedupe by id and keep the watch
 //! alive across `/clear` rotations.
+//!
+//! Transcripts written by *headless* `claude` processes spawned through
+//! the Agent SDK are skipped — see [`TranscriptOrigin`] and issue #336.
 
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -46,6 +49,11 @@ pub struct AdoptionCandidate {
 /// Filenames must parse as UUIDs (Claude Code v2.x uses 8-4-4-4-12 hex
 /// digits) — anything else is silently skipped. Mirrors C#
 /// `WatchHandle.IsValidSessionId`.
+///
+/// Transcripts whose head identifies them as SDK-spawned
+/// ([`TranscriptOrigin::Sdk`]) are skipped too — they live in the same
+/// directory as the interactive session's transcript and would
+/// otherwise win the "newest file" race (issue #336).
 pub fn scan(
     projects_root: &Path,
     working_directory: &str,
@@ -76,12 +84,84 @@ pub fn scan(
         if !eligible {
             continue;
         }
+        if transcript_origin(&path) == TranscriptOrigin::Sdk {
+            continue;
+        }
         out.push(AdoptionCandidate {
             session_id: stem.to_owned(),
             path,
         });
     }
     out
+}
+
+/// Who wrote a transcript, as far as its head reveals.
+///
+/// Claude Code stamps every `user` / `assistant` / `attachment` line
+/// with an `entrypoint` field: `"cli"` and `"claude-desktop"` for the
+/// interactive sessions we host in a tab, `"sdk-py"` / `"sdk-cli"` /
+/// `"sdk-ts"` for headless processes driven through the Agent SDK.
+/// Those SDK runs land in the same `~/.claude/projects/<encoded-cwd>/`
+/// directory as the interactive session — the `security-guidance`
+/// plugin, for instance, runs a background Opus review through
+/// `claude_agent_sdk.query(...)` on every `Stop` / `git commit` /
+/// `git push` hook, minting a fresh transcript each time. Without
+/// this check every such run looked like a `/clear` rotation: the tab
+/// adopted the review's uuid, persisted it, and the next resume opened
+/// "Review this change for security vulnerabilities." on Opus 4.7
+/// instead of the user's conversation (issue #336).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TranscriptOrigin {
+    /// First `entrypoint`-bearing line is not an SDK entrypoint.
+    Interactive,
+    /// First `entrypoint`-bearing line starts with `sdk`.
+    Sdk,
+    /// No `entrypoint`-bearing line within the inspected head — a
+    /// brand-new interactive transcript (which opens with `mode` /
+    /// `file-history-snapshot` lines), an older CLI without the field,
+    /// or an unreadable file. Treated as adoptable so existing
+    /// behaviour is unchanged for anything we can't classify.
+    Unknown,
+}
+
+/// Lines to inspect before giving up on classification. Interactive
+/// transcripts carry the field on their first `user` line, which sits
+/// behind a handful of bookkeeping lines; SDK transcripts put it on
+/// line 3 (two `queue-operation` lines first). 64 leaves room for
+/// `attachment` bursts and future preamble without reading a
+/// multi-megabyte file on every 350 ms poll.
+const ORIGIN_PEEK_LINES: usize = 64;
+
+/// Classify a transcript by the first `entrypoint` field within its
+/// head. See [`TranscriptOrigin`] for what each variant means.
+pub fn transcript_origin(path: &Path) -> TranscriptOrigin {
+    use std::io::{BufRead, BufReader};
+    let Ok(file) = std::fs::File::open(path) else {
+        return TranscriptOrigin::Unknown;
+    };
+    let reader = BufReader::new(file);
+    for line in reader.lines().take(ORIGIN_PEEK_LINES) {
+        // A read error (or invalid UTF-8) ends the peek; whatever we
+        // saw before it wasn't decisive, so fall through to Unknown.
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
+            // A torn line mid-write is the common case here — the
+            // next line may still be decisive.
+            continue;
+        };
+        let Some(entrypoint) = v.get("entrypoint").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        return if entrypoint.starts_with("sdk") {
+            TranscriptOrigin::Sdk
+        } else {
+            TranscriptOrigin::Interactive
+        };
+    }
+    TranscriptOrigin::Unknown
 }
 
 /// Recognise a Claude Code session id — the `.jsonl` filename without
@@ -236,5 +316,133 @@ mod tests {
         let future = SystemTime::now() + Duration::from_secs(60 * 60 * 24 * 365 * 50);
         let res = scan(tmp.path(), wd, future);
         assert!(res.is_empty(), "got {res:?}");
+    }
+
+    // --- transcript_origin ---
+
+    /// Head of a real interactive transcript (Claude Code 2.1.245):
+    /// bookkeeping lines first, `entrypoint` on the first `user` line.
+    const INTERACTIVE_HEAD: &str = concat!(
+        "{\"type\":\"mode\",\"mode\":\"default\"}\n",
+        "{\"type\":\"permission-mode\",\"mode\":\"default\"}\n",
+        "{\"type\":\"file-history-snapshot\",\"snapshot\":{}}\n",
+        "{\"type\":\"user\",\"entrypoint\":\"cli\",\"promptSource\":\"typed\",",
+        "\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+    );
+
+    /// Head of a transcript minted by the security-guidance plugin's
+    /// background review through the Python Agent SDK.
+    const SDK_HEAD: &str = concat!(
+        "{\"type\":\"queue-operation\",\"operation\":\"enqueue\"}\n",
+        "{\"type\":\"queue-operation\",\"operation\":\"dequeue\"}\n",
+        "{\"type\":\"user\",\"entrypoint\":\"sdk-py\",\"promptSource\":\"sdk\",",
+        "\"message\":{\"role\":\"user\",\"content\":",
+        "\"Review this change for security vulnerabilities.\"}}\n",
+    );
+
+    fn write_transcript(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let path = dir.join(format!("{name}.jsonl"));
+        std::fs::write(&path, body.as_bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn origin_of_interactive_transcript_is_interactive() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_transcript(tmp.path(), SID_A, INTERACTIVE_HEAD);
+        assert_eq!(transcript_origin(&path), TranscriptOrigin::Interactive);
+    }
+
+    #[test]
+    fn origin_of_claude_desktop_transcript_is_interactive() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_transcript(
+            tmp.path(),
+            SID_A,
+            "{\"type\":\"user\",\"entrypoint\":\"claude-desktop\"}\n",
+        );
+        assert_eq!(transcript_origin(&path), TranscriptOrigin::Interactive);
+    }
+
+    #[test]
+    fn origin_of_sdk_transcript_is_sdk() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_transcript(tmp.path(), SID_A, SDK_HEAD);
+        assert_eq!(transcript_origin(&path), TranscriptOrigin::Sdk);
+    }
+
+    #[test]
+    fn origin_recognises_every_sdk_flavour() {
+        let tmp = TempDir::new().unwrap();
+        for ep in ["sdk-py", "sdk-cli", "sdk-ts"] {
+            let path = write_transcript(
+                tmp.path(),
+                SID_A,
+                &format!("{{\"type\":\"user\",\"entrypoint\":\"{ep}\"}}\n"),
+            );
+            assert_eq!(transcript_origin(&path), TranscriptOrigin::Sdk, "{ep}");
+        }
+    }
+
+    #[test]
+    fn origin_is_unknown_without_entrypoint_line() {
+        let tmp = TempDir::new().unwrap();
+        // Only the bookkeeping preamble so far — the user hasn't typed.
+        let path = write_transcript(
+            tmp.path(),
+            SID_A,
+            "{\"type\":\"mode\",\"mode\":\"default\"}\n{\"type\":\"file-history-snapshot\"}\n",
+        );
+        assert_eq!(transcript_origin(&path), TranscriptOrigin::Unknown);
+        // Empty file and missing file behave the same.
+        let empty = write_transcript(tmp.path(), SID_B, "");
+        assert_eq!(transcript_origin(&empty), TranscriptOrigin::Unknown);
+        assert_eq!(
+            transcript_origin(&tmp.path().join("missing.jsonl")),
+            TranscriptOrigin::Unknown
+        );
+    }
+
+    #[test]
+    fn origin_skips_torn_lines_and_keeps_reading() {
+        let tmp = TempDir::new().unwrap();
+        let body = format!("{{\"type\":\"mode\",\"mo\n{SDK_HEAD}");
+        let path = write_transcript(tmp.path(), SID_A, &body);
+        assert_eq!(transcript_origin(&path), TranscriptOrigin::Sdk);
+    }
+
+    #[test]
+    fn origin_gives_up_after_peek_window() {
+        let tmp = TempDir::new().unwrap();
+        let mut body = "{\"type\":\"attachment\"}\n".repeat(ORIGIN_PEEK_LINES);
+        body.push_str(SDK_HEAD);
+        let path = write_transcript(tmp.path(), SID_A, &body);
+        assert_eq!(transcript_origin(&path), TranscriptOrigin::Unknown);
+    }
+
+    #[test]
+    fn scan_skips_sdk_transcripts() {
+        let tmp = TempDir::new().unwrap();
+        let wd = "/some/project";
+        let dir = working_dir_layout(&tmp, wd);
+        write_transcript(&dir, SID_A, INTERACTIVE_HEAD);
+        write_transcript(&dir, SID_B, SDK_HEAD);
+
+        let res = scan(tmp.path(), wd, SystemTime::UNIX_EPOCH);
+        let ids: Vec<_> = res.iter().map(|c| c.session_id.as_str()).collect();
+        assert_eq!(ids, vec![SID_A], "SDK transcript must not be a candidate");
+    }
+
+    #[test]
+    fn scan_still_returns_unclassifiable_transcripts() {
+        let tmp = TempDir::new().unwrap();
+        let wd = "/some/project";
+        let dir = working_dir_layout(&tmp, wd);
+        // The existing `write_jsonl` helper writes a bare `user` line
+        // with no `entrypoint` — the pre-#336 shape every other scan
+        // test relies on. It must keep adopting.
+        write_jsonl(&dir, SID_A);
+        let res = scan(tmp.path(), wd, SystemTime::UNIX_EPOCH);
+        assert_eq!(res.len(), 1);
     }
 }


### PR DESCRIPTION
Closes #336

## What broke

Resuming a Claude session from the sidebar sometimes opened a different conversation: first turn `Review this change for security vulnerabilities. …`, model badge Opus 4.7, no trace of the user's actual session.

## Root cause

The `security-guidance` plugin (`claude-plugins-official`) runs a background LLM review on the `Stop`, `git commit` and `git push` hooks. It does that via the Python Agent SDK (`claude_agent_sdk.query(...)`, hard-coded `model="claude-opus-4-7"`), which spawns a headless `claude` process **in the same cwd**. That process writes an ordinary transcript to `~/.claude/projects/<encoded-cwd>/<new-uuid>.jsonl`.

`codescope_core::agents::claude::discovery::scan` + `select_adoption` (`src/app.rs`) pick the newest unclaimed `.jsonl` modified after the tab spawned and never look inside. Each review run therefore looks exactly like a `/clear` rotation: the tab rotates onto the review transcript, `persist_agent_session_id` stores its uuid on the session row, and the next launch runs `claude --resume <review-uuid>`. Telemetry (model badge, tokens) is poisoned the same way.

On the reporting machine 45 of the 52 transcripts under `C--dev-codescope-public` — 298 of 363 across all projects — are such review runs.

## Fix

Every `user` / `assistant` / `attachment` line carries an `entrypoint` field: `"cli"` / `"claude-desktop"` for interactive sessions, `"sdk-py"` / `"sdk-cli"` / `"sdk-ts"` for SDK-driven processes. New `transcript_origin(path)` peeks the first 64 lines for that field and `scan` drops candidates classified as `TranscriptOrigin::Sdk`.

- `Unknown` (no `entrypoint` line yet — a fresh interactive transcript opens with `mode` / `file-history-snapshot` lines; or an older CLI) keeps today's behaviour and is still adoptable, so nothing that adopted before stops adopting.
- Torn lines mid-write are skipped rather than treated as decisive.
- The peek is bounded (64 lines) because it runs on every 350 ms poll for every eligible file.

## Verification

- `cargo test -p codescope-core claude::discovery` — 21 tests pass (12 existing + 9 new: interactive / claude-desktop / every sdk flavour / preamble-only / empty / missing / torn line / peek window / scan filters sdk / scan keeps unclassifiable).
- `cargo clippy -p codescope-core --all-targets` — no warnings in the touched file (the pre-existing `from_str` / `sort_by_key` / `field_reassign_with_default` warnings elsewhere are untouched).
- Re-implemented the same classification in a throwaway script and ran it over the real `~/.claude/projects/` store (363 transcripts): 298 Sdk, 61 Interactive, 4 Unknown. The first `entrypoint` line was never later than line 14, so the 64-line window has ample margin.

## Left unproven

- Not exercised live in a running dev build — the fix is in the pure `scan` path, which the unit tests cover directly, and the classification was checked against the real store instead.
- Session rows in `projects.json` that already point at a review uuid are not repaired; they self-heal the next time that tab adopts a real transcript (`/clear` or a new session). The user can also fix one manually by resuming with `claude -r` and picking the right conversation.
- The ms-wide window between the SDK transcript's creation and its first `user` line being written would still classify as `Unknown` → adoptable. In the observed transcripts those lines land within 6 ms of each other, well inside one poll tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
