### PR TITLE
feat(sidebar): recognise plain-folder projects and drop their git UI

### DIFF
--- a/core/src/git.rs
+++ b/core/src/git.rs
@@ -422,22 +422,51 @@ impl GitStatus {
 /// Typical total under 30 ms on local repos.
 pub fn git_status(repo: &Path) -> Result<Option<GitStatus>> {
     // ── 0. Early repo probe ────────────────────────────────────────
-    // `rev-parse --is-inside-work-tree` exits 0 / prints "true" only
-    // inside an actual worktree. We want three outcomes here:
-    //   * Ok(None)  — git ran, but this path isn't inside a worktree
-    //                  (covers "not a repo", "missing dir", and the
-    //                  default-status "false" case).
-    //   * Err       — git itself failed to start (binary missing).
-    //   * Ok(Some)  — happy path, fall through.
-    // We can't go through `run_git` because it wraps non-zero exit as
-    // `Err`, which would collapse "not a worktree" into the I/O bucket.
-    //
-    // Both "git missing" and "cwd doesn't exist" can surface as
-    // `ErrorKind::NotFound` from `Command::output()` — pre-checking
-    // the directory disambiguates them so we don't misclassify a
-    // missing repo path as a missing git binary.
-    if !repo.is_dir() {
+    // Gates the three follow-up queries; see `is_work_tree` for the
+    // outcome mapping. `Ok(false)` becomes `Ok(None)` here so callers
+    // keep one "nothing to show" shape.
+    if !is_work_tree(repo)? {
         return Ok(None);
+    }
+
+    // ── 1. Current branch ──────────────────────────────────────────
+    let (branch, detached) = current_branch(repo);
+
+    // ── 2. numstat diff against HEAD ───────────────────────────────
+    let (added, removed, has_changes) = numstat_summary(repo);
+
+    // ── 3. Ahead / behind upstream ─────────────────────────────────
+    let (ahead, behind, has_upstream) = ahead_behind(repo);
+
+    Ok(Some(GitStatus { branch, detached, added, removed, has_changes, ahead, behind, has_upstream }))
+}
+
+/// `git rev-parse --is-inside-work-tree` — is `repo` inside a git
+/// working tree at all?
+///
+/// Three outcomes:
+/// * `Ok(true)` — git ran and printed `true`.
+/// * `Ok(false)` — git ran but this path isn't inside a worktree
+///   (covers "not a repo", a missing directory, and the `false` git
+///   prints inside a bare `.git`), or git couldn't look at the path
+///   (permissions).
+/// * `Err` — git itself failed to start (binary missing).
+///
+/// We can't go through `run_git` because it wraps non-zero exit as
+/// `Err`, which would collapse "not a worktree" into the I/O bucket.
+/// Both "git missing" and "cwd doesn't exist" can surface as
+/// `ErrorKind::NotFound` from `Command::output()` — pre-checking the
+/// directory disambiguates them so a missing repo path isn't
+/// misclassified as a missing git binary.
+///
+/// The sidebar runs this once when a project is added and the
+/// git-status poller re-runs it on a slow cadence, so a project that
+/// is a plain folder — a home directory, a sync folder with repos
+/// nested one level down — stops being polled and loses its git-only
+/// UI (#338).
+pub fn is_work_tree(repo: &Path) -> Result<bool> {
+    if !repo.is_dir() {
+        return Ok(false);
     }
     let probe = match no_window_command("git")
         .args(["rev-parse", "--is-inside-work-tree"])
@@ -452,26 +481,12 @@ pub fn git_status(repo: &Path) -> Result<Option<GitStatus>> {
         // Other spawn errors (PermissionDenied, etc) are also "git
         // can't look at this path" — caller treats that the same as
         // "not a worktree" and retries on the next poll tick.
-        Err(_) => return Ok(None),
+        Err(_) => return Ok(false),
     };
     if !probe.status.success() {
-        return Ok(None);
+        return Ok(false);
     }
-    let probe_stdout = String::from_utf8_lossy(&probe.stdout);
-    if probe_stdout.trim() != "true" {
-        return Ok(None);
-    }
-
-    // ── 1. Current branch ──────────────────────────────────────────
-    let (branch, detached) = current_branch(repo);
-
-    // ── 2. numstat diff against HEAD ───────────────────────────────
-    let (added, removed, has_changes) = numstat_summary(repo);
-
-    // ── 3. Ahead / behind upstream ─────────────────────────────────
-    let (ahead, behind, has_upstream) = ahead_behind(repo);
-
-    Ok(Some(GitStatus { branch, detached, added, removed, has_changes, ahead, behind, has_upstream }))
+    Ok(String::from_utf8_lossy(&probe.stdout).trim() == "true")
 }
 
 /// `git symbolic-ref --short HEAD` → `(short branch name, false)`.
@@ -822,6 +837,26 @@ some-future-field foo bar\n";
     /// Returns the tempdir guard (drop = cleanup), the absolute repo
     /// path, and the absolute worktrees-root path (already created so
     /// `git worktree add` doesn't have to).
+    /// A plain folder is not a worktree; a freshly initialised repo
+    /// is; a path that doesn't exist is reported as "not a worktree"
+    /// rather than as a git failure (#338).
+    #[test]
+    fn is_work_tree_distinguishes_folder_repo_and_missing() {
+        let Some((dir, repo, _)) = init_repo() else { return };
+        assert!(is_work_tree(&repo).unwrap());
+        let plain = dir.path().join("plain");
+        std::fs::create_dir_all(&plain).unwrap();
+        assert!(!is_work_tree(&plain).unwrap());
+        assert!(!is_work_tree(&dir.path().join("missing")).unwrap());
+        // Nested one level below a plain folder doesn't make the
+        // parent a worktree — git only walks *upwards*.
+        let parent = dir.path().join("parent");
+        std::fs::create_dir_all(parent.join("nested")).unwrap();
+        run(&parent.join("nested"), &["init", "-q"]);
+        assert!(!is_work_tree(&parent).unwrap());
+        assert!(is_work_tree(&parent.join("nested")).unwrap());
+    }
+
     fn init_repo() -> Option<(TempDir, std::path::PathBuf, std::path::PathBuf)> {
         if no_window_command("git").arg("--version").output().is_err() {
             eprintln!("skipping: `git` not on PATH");

--- a/src/app.rs
+++ b/src/app.rs
@@ -8177,14 +8177,22 @@ impl AppShell {
                     .branch
                     .clone()
                     .unwrap_or_else(|| project.default_branch.clone());
+                // A plain-folder project has no branch to show; the
+                // `default_branch` fallback would title it `name ·
+                // main` and invent a branch that doesn't exist (#338).
+                let title: SharedString = if sidebar.is_non_repo(&wt.path) {
+                    project.name.clone().into()
+                } else {
+                    format!("{} · {}", project.name, branch).into()
+                };
                 out.push(PaletteAction {
                     kind: PaletteActionKind::Worktree {
                         working_directory: std::path::PathBuf::from(&wt.path),
-                        title: format!("{} · {}", project.name, branch).into(),
+                        title: title.clone(),
                         branch: branch.clone(),
                         project_name: project.name.clone(),
                     },
-                    title: format!("Open: {} · {}", project.name, branch).into(),
+                    title: format!("Open: {title}").into(),
                     subtitle: Some(wt.path.clone().into()),
                     group: PaletteGroup::Worktrees,
                 });
@@ -8291,6 +8299,14 @@ impl AppShell {
             .filter(|p| !p.is_remote_shell())
             .map(|p| p.path.clone())
             .filter(|path| !path.is_empty())
+    }
+
+    /// `true` when the sidebar's git-status poller has ruled `path`
+    /// out as a git working tree (a plain-folder project, #338).
+    /// Thin accessor so sibling modules (`diff_viewer`) can ask
+    /// without reaching into the private `sidebar` entity.
+    pub(crate) fn path_is_non_repo(&self, path: &std::path::Path, cx: &App) -> bool {
+        self.sidebar.read(cx).is_non_repo(&path.to_string_lossy())
     }
 
     /// Active tab's working directory as a `String`. Used by the

--- a/src/diff_viewer.rs
+++ b/src/diff_viewer.rs
@@ -87,6 +87,21 @@ impl AppShell {
             );
             return;
         };
+        // A plain-folder project has nothing to diff — say so instead
+        // of rendering the raw `fatal: not a git repository` in the
+        // panel (#338).
+        if self.path_is_non_repo(&worktree, cx) {
+            self.push_toast(
+                ToastKind::Info,
+                SharedString::new_static("Not a git repository"),
+                Some(SharedString::from(format!(
+                    "{} is a plain folder; there are no changes to show.",
+                    worktree.display()
+                ))),
+                cx,
+            );
+            return;
+        }
 
         // The diff viewer and the Overview occupy the same work-area
         // slot; opening one dismisses the other.

--- a/src/diff_viewer.rs
+++ b/src/diff_viewer.rs
@@ -87,15 +87,17 @@ impl AppShell {
             );
             return;
         };
-        // A plain-folder project has nothing to diff — say so instead
-        // of rendering the raw `fatal: not a git repository` in the
-        // panel (#338).
+        // A path git doesn't recognise as a working tree has nothing
+        // to diff — say so instead of rendering the raw `fatal: not a
+        // git repository` in the panel (#338). The verdict also covers
+        // a missing or unreadable directory, so the copy states the
+        // observable outcome rather than guessing at the cause.
         if self.path_is_non_repo(&worktree, cx) {
             self.push_toast(
                 ToastKind::Info,
                 SharedString::new_static("Not a git repository"),
                 Some(SharedString::from(format!(
-                    "{} is a plain folder; there are no changes to show.",
+                    "{} is not inside a git working tree; there are no changes to show.",
                     worktree.display()
                 ))),
                 cx,

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -27,7 +27,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use codescope_core::{
     AgentProfile, AgentRegistry, AppPaths, LayoutState, Project, ProjectsConfig, Theme,
@@ -54,6 +54,14 @@ use crate::theme;
 /// thousand-file repos. Mirrors the C# build's
 /// `WorktreePoller.Interval`.
 const DIRTY_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How long a "not a git working tree" verdict in
+/// `Sidebar::non_repo_paths` stands before the git-status poller
+/// probes the path again. Long enough that a plain folder costs one
+/// `rev-parse` a minute instead of two `git` spawns every 5 s; short
+/// enough that a `git init` in that folder shows up without a
+/// restart (#338).
+const NON_REPO_REPROBE: Duration = Duration::from_secs(60);
 
 /// How often the PR-status poller wakes up. 60 s matches the C# build's
 /// `PullRequestStatusPoller.Interval` baseline (the C# build then layers
@@ -536,6 +544,15 @@ pub struct Sidebar {
     /// C# build's `WorktreePoller` but adds the richer data the
     /// status bar needs.
     git_status: HashMap<String, GitStatus>,
+    /// Worktree paths git has told us are *not* inside a working
+    /// tree, with the time of that verdict. A project added on a home
+    /// directory or a sync folder (repos nested a level down, or none
+    /// at all) has nothing for the git pollers, the worktree menus,
+    /// or the branch labels to work with — this map gates all of
+    /// them. Runtime only, never persisted: the user can `git init`
+    /// later, so the git-status poller re-probes entries older than
+    /// [`NON_REPO_REPROBE`] and drops them once git says yes (#338).
+    non_repo_paths: HashMap<String, Instant>,
     /// Cached "open PR URL for this worktree" lookup, keyed by the
     /// worktree's absolute path. The value tracks both the branch
     /// the lookup ran against (so a branch switch invalidates the
@@ -676,6 +693,7 @@ impl Sidebar {
             dirty_state: HashMap::new(),
             remote_live_project_ids: HashSet::new(),
             git_status: HashMap::new(),
+            non_repo_paths: HashMap::new(),
             pr_urls: HashMap::new(),
             collapsed_projects,
             expanded_worktrees: HashSet::new(),
@@ -899,9 +917,14 @@ impl Sidebar {
                             // empty path and no worktrees — the
                             // `is_empty` filter keeps them out so we
                             // never shell out to git against "".
+                            // Paths git has already ruled out as
+                            // working trees are skipped too — the
+                            // git-status poller owns the slow
+                            // re-probe (#338).
                             std::iter::once(p.path.clone())
                                 .chain(p.worktrees.iter().map(|wt| wt.path.clone()))
                                 .filter(|path| !path.is_empty())
+                                .filter(|path| !this.non_repo_paths.contains_key(path))
                         })
                         .collect()
                 }) {
@@ -970,39 +993,66 @@ impl Sidebar {
     /// coordinating with each other.
     pub fn start_git_status_poll(&self, cx: &mut Context<Self>) {
         cx.spawn(async move |this, cx| {
+            // The first tick runs without waiting so a freshly
+            // launched window learns which projects aren't
+            // repositories (and every branch label) right away
+            // instead of after a 5 s blank; later ticks keep the
+            // shared cadence.
+            let mut first_tick = true;
             loop {
-                cx.background_executor().timer(DIRTY_POLL_INTERVAL).await;
+                if !first_tick {
+                    cx.background_executor().timer(DIRTY_POLL_INTERVAL).await;
+                }
+                first_tick = false;
                 if this.upgrade().is_none() {
                     break;
                 }
                 // Snapshot every worktree path into a de-duplicated set
                 // (same de-dup + empty-path rationale as
-                // start_dirty_poll).
-                let paths: HashSet<String> = match this.update(cx, |this, _| {
-                    this.projects
-                        .projects
-                        .iter()
-                        .flat_map(|p| {
-                            std::iter::once(p.path.clone())
-                                .chain(p.worktrees.iter().map(|wt| wt.path.clone()))
-                                .filter(|path| !path.is_empty())
-                        })
-                        .collect()
-                }) {
-                    Ok(p) => p,
-                    Err(_) => break,
-                };
-                let known: HashSet<String> = paths.clone();
-                let updates: Vec<(String, GitStatus)> = cx
+                // start_dirty_poll). `known` is the full set — it
+                // prunes the caches — while `paths` drops non-repo
+                // verdicts younger than `NON_REPO_REPROBE` so a plain
+                // folder costs one probe a minute, not one per tick.
+                let (known, paths): (HashSet<String>, HashSet<String>) =
+                    match this.update(cx, |this, _| {
+                        let now = Instant::now();
+                        let known: HashSet<String> = this
+                            .projects
+                            .projects
+                            .iter()
+                            .flat_map(|p| {
+                                std::iter::once(p.path.clone())
+                                    .chain(p.worktrees.iter().map(|wt| wt.path.clone()))
+                                    .filter(|path| !path.is_empty())
+                            })
+                            .collect();
+                        let paths: HashSet<String> = known
+                            .iter()
+                            .filter(|path| {
+                                this.non_repo_paths.get(*path).is_none_or(|probed| {
+                                    now.duration_since(*probed) >= NON_REPO_REPROBE
+                                })
+                            })
+                            .cloned()
+                            .collect();
+                        (known, paths)
+                    }) {
+                        Ok(p) => p,
+                        Err(_) => break,
+                    };
+                let updates: Vec<(String, Option<GitStatus>)> = cx
                     .background_spawn(async move {
                         paths
                             .into_iter()
                             .filter_map(|p| {
-                                // Fail-soft: I/O errors and "not a worktree" both
-                                // skip the entry; the next poll tick will retry.
+                                // Fail-soft on I/O errors (git binary
+                                // missing): skip the entry, the next
+                                // tick retries. `Ok(None)` — "not a
+                                // worktree" — is a real answer and is
+                                // carried through so the path lands in
+                                // `non_repo_paths` (#338).
                                 codescope_core::git::git_status(std::path::Path::new(&p))
                                     .ok()
-                                    .flatten()
                                     .map(|s| (p, s))
                             })
                             .collect()
@@ -1025,7 +1075,33 @@ impl Sidebar {
                         if this.git_status.len() != prev_len {
                             changed = true;
                         }
+                        let prev_len = this.non_repo_paths.len();
+                        this.non_repo_paths.retain(|path, _| known.contains(path));
+                        if this.non_repo_paths.len() != prev_len {
+                            changed = true;
+                        }
                         for (path, status) in updates {
+                            let Some(status) = status else {
+                                // Not a working tree. Record (or
+                                // refresh) the verdict and drop any
+                                // status a previous life of this path
+                                // left behind — `git init` undone, a
+                                // `.git` moved away.
+                                let fresh = this
+                                    .non_repo_paths
+                                    .insert(path.clone(), Instant::now())
+                                    .is_none();
+                                if fresh || this.git_status.remove(&path).is_some() {
+                                    changed = true;
+                                }
+                                continue;
+                            };
+                            // A path git now recognises again — the
+                            // user ran `git init` since the last
+                            // verdict — leaves the non-repo set.
+                            if this.non_repo_paths.remove(&path).is_some() {
+                                changed = true;
+                            }
                             // Single hash lookup: `insert` returns the
                             // prior value (if any), which we both
                             // compare for change-detection and read
@@ -1256,6 +1332,15 @@ impl Sidebar {
         self.git_status.get(path)
     }
 
+    /// `true` when git has told us `path` is not inside a working
+    /// tree — a project added on a plain folder. Callers use it to
+    /// drop git-only UI (branch suffixes, diff viewer) for that path;
+    /// the sidebar's own menus and pollers read the map directly.
+    /// `false` while the verdict is still unknown (#338).
+    pub(crate) fn is_non_repo(&self, path: &str) -> bool {
+        self.non_repo_paths.contains_key(path)
+    }
+
     /// Resolve the cached "open PR URL" for the worktree rooted at
     /// `path`. Returns `Some(url)` only when the cached `gh pr list`
     /// lookup landed on a `Resolved { info: Some(_) }` whose branch
@@ -1318,6 +1403,10 @@ impl Sidebar {
         path: String,
         cx: &mut Context<Self>,
     ) {
+        if self.non_repo_paths.contains_key(&path) {
+            // Plain folder: there is no `origin` to resolve (#338).
+            return;
+        }
         let project_path = self
             .projects
             .projects
@@ -1396,6 +1485,8 @@ impl Sidebar {
                 }
             }
         }
+        // A plain folder isn't a worktree either (#338).
+        paths.retain(|p| !self.non_repo_paths.contains_key(*p));
         let total = paths.len();
         let dirty = paths
             .iter()
@@ -2517,6 +2608,15 @@ impl Sidebar {
         // matching the pre-existing behaviour.
         project.adopt_existing_worktrees();
         let new_id = project.id.clone();
+        // Probe once, synchronously, so the new row renders with its
+        // `no git` slug and trimmed menu immediately instead of after
+        // the poller's next tick. One `rev-parse`, a few ms; an
+        // `Err` (git missing) leaves the verdict to the poller (#338).
+        let non_repo_path = matches!(
+            codescope_core::git::is_work_tree(std::path::Path::new(&project.path)),
+            Ok(false)
+        )
+        .then(|| project.path.clone());
         // Clone-then-save: failure leaves `self.projects` untouched.
         let mut next = self.projects.clone();
         next.projects.push(project);
@@ -2526,6 +2626,9 @@ impl Sidebar {
         }
         // Disk is committed; now mirror the change in memory.
         self.projects = next;
+        if let Some(path) = non_repo_path {
+            self.non_repo_paths.insert(path, Instant::now());
+        }
         let new_idx = self.projects.projects.len() - 1;
         self.selected = Some(new_idx);
         self.layout.selected_project_id = Some(new_id);
@@ -3373,13 +3476,19 @@ impl Render for Sidebar {
                 // `Fig.Font.Mono` at 10 pt with a dim `ink_ghost`
                 // foreground. `busy` (active agent) is still TODO —
                 // the Rust port has no per-tab session model yet.
-                let status_slug = self
-                    .git_status
-                    .get(&wt.path)
-                    .map(|s| {
-                        codescope_core::git::worktree_status_label_with_ci(s, ci_status)
-                    })
-                    .unwrap_or_default();
+                // A plain folder gets a `no git` slug in the same slot
+                // — the one visible cue that this project has no
+                // branch, diff, or worktrees to offer (#338).
+                let status_slug = if self.non_repo_paths.contains_key(&wt.path) {
+                    "no git".to_string()
+                } else {
+                    self.git_status
+                        .get(&wt.path)
+                        .map(|s| {
+                            codescope_core::git::worktree_status_label_with_ci(s, ci_status)
+                        })
+                        .unwrap_or_default()
+                };
                 let wt_row = if status_slug.is_empty() {
                     wt_row
                 } else {
@@ -4524,6 +4633,7 @@ impl Sidebar {
         let ink_ghost = theme::ink_ghost(theme);
         let frost = theme::frost_10(theme);
         let danger = theme::danger();
+        let is_repo = !self.non_repo_paths.contains_key(&project.path);
 
         // Precompute the "New session ▸" parent row before the menu
         // chain — the `item` closure below holds an immutable borrow
@@ -4606,34 +4716,38 @@ impl Sidebar {
             // project scope. Clicking the parent fires the default
             // agent on the project's primary worktree path.
             .child(new_session_parent_row)
-            .child(div().h_px().bg(divider).my_1())
-            .child(item(
-                "menu-new-worktree",
-                "New worktree from branch…",
-                false,
-                Box::new(move |this, window, cx| {
-                    this.open_new_worktree_dialog(idx, window, cx);
-                }),
-            ))
-            // ── Git ─────────────────────────────────────────────
-            // Fetch + Open remote. Mirrors C# BuildProjectMenu
-            // Git section. "Set default agent" submenu lands when
-            // we have a submenu primitive.
-            .child(div().h_px().bg(divider).my_1())
-            .child(item(
-                "menu-fetch-all",
-                "Fetch all (prune)",
-                false,
-                Box::new(move |this, _window, cx| this.fetch_all_for_project(idx, cx)),
-            ))
-            .child(item(
-                "menu-open-remote",
-                "Open remote in browser",
-                false,
-                Box::new(move |this, _window, cx| {
-                    this.open_project_remote_in_browser(idx, cx);
-                }),
-            ))
+            // Worktree + Git rows only make sense on a repository; a
+            // plain-folder project (#338) goes straight to Reveal.
+            .when(is_repo, |menu| {
+                menu.child(div().h_px().bg(divider).my_1())
+                    .child(item(
+                        "menu-new-worktree",
+                        "New worktree from branch…",
+                        false,
+                        Box::new(move |this, window, cx| {
+                            this.open_new_worktree_dialog(idx, window, cx);
+                        }),
+                    ))
+                    // ── Git ─────────────────────────────────────
+                    // Fetch + Open remote. Mirrors C# BuildProjectMenu
+                    // Git section. "Set default agent" submenu lands
+                    // when we have a submenu primitive.
+                    .child(div().h_px().bg(divider).my_1())
+                    .child(item(
+                        "menu-fetch-all",
+                        "Fetch all (prune)",
+                        false,
+                        Box::new(move |this, _window, cx| this.fetch_all_for_project(idx, cx)),
+                    ))
+                    .child(item(
+                        "menu-open-remote",
+                        "Open remote in browser",
+                        false,
+                        Box::new(move |this, _window, cx| {
+                            this.open_project_remote_in_browser(idx, cx);
+                        }),
+                    ))
+            })
             // ── Reveal ──────────────────────────────────────────
             .child(div().h_px().bg(divider).my_1())
             .child(item(
@@ -4768,6 +4882,7 @@ impl Sidebar {
             project.name, branch_label
         ));
         let is_primary = worktree.is_primary;
+        let is_repo = !self.non_repo_paths.contains_key(&worktree.path);
 
         // Precompute the "New session ▸" parent row up-front so we
         // don't try to re-borrow `cx` mutably inside the menu_body
@@ -4907,31 +5022,37 @@ impl Sidebar {
             // browser. The dirty-state aware Rebase + Discard rows
             // from the C# build land when the worktree polling infra
             // does; these are stateless enough to ship now.
-            .child(div().h_px().bg(divider).my_1())
-            .child({
-                let path_for_diff = PathBuf::from(&worktree.path);
-                item(
-                    "wt-menu-view-changes",
-                    "View changes",
-                    false,
-                    Box::new(move |this, _window, cx| {
-                        cx.emit(SidebarEvent::OpenDiff {
-                            worktree_path: path_for_diff.clone(),
-                        });
-                        this.close_menu(cx);
-                    }),
-                )
-            })
-            .child({
-                let id_for_pull = worktree_id.clone();
-                item(
-                    "wt-menu-pull",
-                    "Pull (fast-forward)",
-                    false,
-                    Box::new(move |this, _window, cx| {
-                        this.pull_worktree(project_idx, &id_for_pull, cx);
-                    }),
-                )
+            // Every row in this section is hidden for a plain-folder
+            // project (#338) — the branch-gated ones fall out on
+            // their own (no branch), these two need the explicit
+            // `is_repo` gate.
+            .when(is_repo, |menu| {
+                menu.child(div().h_px().bg(divider).my_1())
+                    .child({
+                        let path_for_diff = PathBuf::from(&worktree.path);
+                        item(
+                            "wt-menu-view-changes",
+                            "View changes",
+                            false,
+                            Box::new(move |this, _window, cx| {
+                                cx.emit(SidebarEvent::OpenDiff {
+                                    worktree_path: path_for_diff.clone(),
+                                });
+                                this.close_menu(cx);
+                            }),
+                        )
+                    })
+                    .child({
+                        let id_for_pull = worktree_id.clone();
+                        item(
+                            "wt-menu-pull",
+                            "Pull (fast-forward)",
+                            false,
+                            Box::new(move |this, _window, cx| {
+                                this.pull_worktree(project_idx, &id_for_pull, cx);
+                            }),
+                        )
+                    })
             })
             // "Rebase onto origin/<default>" — mirrors the C#
             // `RebaseOntoDefaultCommand` row. Visible only when the
@@ -5063,16 +5184,16 @@ impl Sidebar {
                 }
                 rows
             })
-            .child({
+            .when(is_repo, |menu| {
                 let id_for_remote = worktree_id.clone();
-                item(
+                menu.child(item(
                     "wt-menu-open-remote",
                     "Open remote in browser",
                     false,
                     Box::new(move |this, _window, cx| {
                         this.open_worktree_remote_in_browser(project_idx, &id_for_remote, cx);
                     }),
-                )
+                ))
             })
             // "Discard changes…" — only surface when the dirty
             // poller has flagged this worktree as having changes;

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -2606,17 +2606,22 @@ impl Sidebar {
         // a non-git folder, missing `git` binary, or a permission
         // hiccup just lands the project with its primary row alone,
         // matching the pre-existing behaviour.
-        project.adopt_existing_worktrees();
-        let new_id = project.id.clone();
         // Probe once, synchronously, so the new row renders with its
         // `no git` slug and trimmed menu immediately instead of after
         // the poller's next tick. One `rev-parse`, a few ms; an
         // `Err` (git missing) leaves the verdict to the poller (#338).
+        // Runs before the worktree adoption below so a plain folder
+        // doesn't also pay for a `git worktree list` that can only
+        // fail.
         let non_repo_path = matches!(
             codescope_core::git::is_work_tree(std::path::Path::new(&project.path)),
             Ok(false)
         )
         .then(|| project.path.clone());
+        if non_repo_path.is_none() {
+            project.adopt_existing_worktrees();
+        }
+        let new_id = project.id.clone();
         // Clone-then-save: failure leaves `self.projects` untouched.
         let mut next = self.projects.clone();
         next.projects.push(project);


### PR DESCRIPTION
Closes #338

## What was wrong

Some sidebar projects are plain folders — a home directory, a sync folder, a parent with several repos nested one level down. CodeScope treated every `Local` project as a repository:

- `start_dirty_poll` and `start_git_status_poll` each spawned `git` against the folder every 5 s; the `not a git repository` result was discarded and never cached
- the primary row showed the folder leaf styled like a branch, nothing hinted there was no repo
- project menu: **New worktree from branch…**, **Fetch all (prune)**, **Open remote in browser**; worktree menu: **View changes**, **Pull (fast-forward)**, **Open remote in browser** — all ended in a toast with the raw git fatal
- command palette titled the worktree row `name · main` (the `default_branch` fallback) and *Toggle diff viewer* rendered `error: git status --porcelain -z: … not a git repository` in the panel
- the status bar's worktree count included the folder

## Change

**core** — `git::is_work_tree(path) -> Result<bool>` is the `rev-parse --is-inside-work-tree` probe extracted from `git_status` (which now calls it). `Ok(false)` covers "not a repo", missing dir, permission denied; `Err` only when the git binary is missing.

**sidebar** — new runtime-only `non_repo_paths: HashMap<String, Instant>` (not persisted: the user may `git init` later).
- Filled synchronously in `add_project` (one `rev-parse`, a few ms) so the new row renders correctly right away, and by the git-status poller, which now carries `Ok(None)` through instead of dropping it.
- The git-status poller's first tick runs immediately instead of after 5 s — a fresh window learns branch labels and non-repo verdicts without a blank period.
- Non-repo verdicts are re-probed every 60 s (`NON_REPO_REPROBE`) and cleared as soon as git says yes; the dirty poller skips them entirely.
- Worktree row: `no git` in the status-slug slot (where `chg` / `idle` / `↑1 ↓2` go).
- Project menu hides the worktree + git section; worktree menu hides View changes / Pull / Open remote (the branch-gated rows already fell out on their own).
- `worktree_counts` excludes them; `open_remote_in_browser_for_path` no-ops for them.
- `is_non_repo(path)` accessor for the app shell.

**app / diff_viewer** — palette worktree rows drop the ` · <branch>` suffix for non-repos; `open_diff_viewer` refuses with an info toast ("Not a git repository") instead of an error panel. `AppShell::path_is_non_repo` bridges the private `sidebar` field for the `diff_viewer` module.

Out of scope (noted in #338): discovering the repos nested *below* such a folder and listing them as worktrees.

## Verification

- `cargo test -p codescope-core git::` — 52 pass, including the new `is_work_tree_distinguishes_folder_repo_and_missing` (repo → true, plain folder → false, missing path → false, parent of a nested repo → false, nested repo → true).
- `cargo test --bin codescope` — 160 pass.
- `cargo clippy --workspace --all-targets` — no warnings in the touched hunks (the `large size difference between variants` at `src/app.rs:688` is pre-existing; checked against a stash).
- Dev build (`CODESCOPE_DEV=1`, dev store seeded with a `plain` fixture folder containing a nested `git init` repo and a docs folder), screenshot via PrintWindow:
  - `plain` row renders with the `no git` slug immediately at launch
  - status bar reads `5 worktrees · 1 dirty` — the five `alpha` worktrees only
  - `alpha`'s `chg` slug is present on the first frame, confirming the immediate first tick

## Left unproven

- Context-menu gating and the diff-viewer toast were not clicked through in the dev build (no gpui-driver instrumentation on this branch); they are gpui `.when(is_repo, …)` wraps and an early-return guard, covered by reading rather than by a UI test.
- The 60 s re-probe after a `git init` was not exercised live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
