### PR TITLE
release: bump version to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "codescope"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "codescope-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ windows = "0.61"
 
 [package]
 name = "codescope"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 publish = false
 description = "CodeScope: gpui shell that orchestrates parallel AI coding agent CLI sessions with Git worktree isolation."


### PR DESCRIPTION
Cuts the 0.6.2 release — two fixes on top of 0.6.1.

## Since 0.6.1

- **fix**: resuming a Claude session no longer lands in a "Review this change for security vulnerabilities." conversation on Opus 4.7. Session adoption now skips transcripts written by headless Agent-SDK processes (`entrypoint: sdk-*`) — the `security-guidance` plugin's background reviews were being adopted as `/clear` rotations and persisted as the session's id (#337, fixes #336)
- **sidebar**: projects that are not git repositories (a home directory, a sync folder with repos nested a level down) are recognised — `no git` slug on the row, git-only menu rows hidden, pollers stop spawning `git` against them, palette rows drop the invented `· main`, diff viewer answers with a toast, worktree count excludes them. A later `git init` is picked up within a minute (#339, fixes #338)

## Verification

`cargo test --workspace` on the release commit (Windows): 761 passed, 0 failed (160 bin + 542 core + 58 terminal + 1 doc).

After merge: tag `v0.6.2` on the merge commit to trigger the cargo-dist release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
